### PR TITLE
Allow ` ~ to be typed in console & chat if not listed in cl_consoleKeys.

### DIFF
--- a/src/engine/client/cl_keys.c
+++ b/src/engine/client/cl_keys.c
@@ -1619,9 +1619,6 @@ void CL_CharEvent( int key ) {
 	// fretn - this should be fixed in Com_EventLoop
 	// but I can't be arsed to leave this as is
 
-	if ( key == (unsigned char) '`' || key == (unsigned char) '~' || key == (unsigned char) '¬' ) {
-		return;
-	}
 
 	// distribute the key down event to the apropriate handler
 	if ( cls.keyCatchers & KEYCATCH_CONSOLE ) {

--- a/src/gamelogic/base/src/ui/ui_shared.c
+++ b/src/gamelogic/base/src/ui/ui_shared.c
@@ -3774,8 +3774,6 @@ qboolean Item_Bind_HandleKey(itemDef_t *item, int key, qboolean down) {
         g_bindItem = NULL;
         return qtrue;
 
-      case '`':
-        return qtrue;
     }
   }
 

--- a/src/gamelogic/etmain/src/ui/ui_shared.c
+++ b/src/gamelogic/etmain/src/ui/ui_shared.c
@@ -5704,8 +5704,6 @@ qboolean Item_Bind_HandleKey(itemDef_t * item, int key, qboolean down)
 				g_bindItem = NULL;
 				return qtrue;
 
-			case '`':
-				return qtrue;
 		}
 	}
 

--- a/src/gamelogic/gpp/src/ui/ui_shared.c
+++ b/src/gamelogic/gpp/src/ui/ui_shared.c
@@ -5283,8 +5283,6 @@ qboolean Item_Bind_HandleKey( itemDef_t *item, int key, qboolean down )
         g_bindItem = NULL;
         return qtrue;
 
-      case '`':
-        return qtrue;
     }
   }
 


### PR DESCRIPTION
Trivial change…
