### PR TITLE
Took advantage of chaining with getcwd() which also solves a warning giv...

### DIFF
--- a/src/engine/snd_openal/qal.c
+++ b/src/engine/snd_openal/qal.c
@@ -173,9 +173,8 @@ qboolean QAL_Init(const char *libname)
 		return qfalse;
 #else
 		char fn[1024];
-		getcwd(fn, sizeof(fn));
-		strncat(fn, "/", sizeof(fn));
-		strncat(fn, libname, sizeof(fn));
+		strncat(getcwd(fn, sizeof(fn)), "/", sizeof(fn)-strlen(fn)-1);
+		strncat(fn, libname, sizeof(fn)-strlen(fn)-1);
 
 		if( (OpenALLib = OBJLOAD(fn)) == 0 )
 		{


### PR DESCRIPTION
...en by -Wall.

Also, I changed the n value passed to strncat to take string growth into account (which happens to cause another warning if you do not).
