### PR TITLE
qal.c: Remove various warnings. 

### DIFF
--- a/src/engine/snd_openal/qal.c
+++ b/src/engine/snd_openal/qal.c
@@ -173,9 +173,8 @@ qboolean QAL_Init(const char *libname)
 		return qfalse;
 #else
 		char fn[1024];
-		getcwd(fn, sizeof(fn));
-		strncat(fn, "/", sizeof(fn));
-		strncat(fn, libname, sizeof(fn));
+		strncat(fn, "/", sizeof(fn)-strlen(getcwd(fn, sizeof(fn)))-1);
+		strncat(fn, libname, sizeof(fn)-strlen(fn)-1);
 
 		if( (OpenALLib = OBJLOAD(fn)) == 0 )
 		{


### PR DESCRIPTION
1) Defines how to handle the return value of getcwd().
2) Takes string growth into account which helps prevent issues with destination buffer overflow (which causes a C warning "by default").
