### PR TITLE
Fixed various warnings in src/engine/qcommon

### DIFF
--- a/src/engine/qcommon/cm_load.c
+++ b/src/engine/qcommon/cm_load.c
@@ -2,9 +2,9 @@
 ===========================================================================
 
 Daemon GPL Source Code
-Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company. 
+Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).  
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
 
 Daemon Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -19,14 +19,14 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms. 
-You should have received a copy of these additional terms immediately following the 
-terms and conditions of the GNU General Public License which accompanied the Daemon 
-Source Code.  If not, please request a copy in writing from id Software at the address 
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
-If you have questions concerning this license or the applicable additional terms, you 
-may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, 
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
 Maryland 20850 USA.
 
 ===========================================================================
@@ -188,7 +188,7 @@ void CMod_LoadSubmodels(lump_t * l)
 #ifdef USE_PHYSICS
 		CMod_PhysicsAddBSPModel(i, in->firstSurface, in->numSurfaces);
 #endif
-		
+
 		// make a "leaf" just to hold the model's brushes and surfaces
 		out->leaf.numLeafBrushes = LittleLong(in->numBrushes);
 		indexes = Hunk_Alloc(out->leaf.numLeafBrushes * 4, h_high);
@@ -810,9 +810,9 @@ void CMod_LoadSurfaces(lump_t * surfs, lump_t * verts, lump_t * indexesLump)
 		}
 		else if(LittleLong(in->surfaceType) == MST_PATCH)
 		{
-			int j = 0, k = 0;
-            int rowLimit = in->patchHeight - 1;
-            int colLimit = in->patchWidth - 1;
+			int j = 0;
+//           int rowLimit = in->patchHeight - 1;
+//            int colLimit = in->patchWidth - 1;
 
 			// FIXME: check for non-colliding patches
 			cm.surfaces[i] = surface = Hunk_Alloc(sizeof(*surface), h_high);
@@ -841,10 +841,12 @@ void CMod_LoadSurfaces(lump_t * surfs, lump_t * verts, lump_t * indexesLump)
 
 			// create the internal facet structure
 			surface->sc = CM_GeneratePatchCollide(width, height, vertexes);
-            
+
 #ifdef USE_PHYSICS
             for ( j = 0; j < rowLimit; ++j )
             {
+                int k;
+
                 for ( k = 0; k < colLimit; ++k )
                 {
                     VectorCopy (dv[in->firstVert + (j * in->patchWidth) + k].xyz, v[0]);

--- a/src/engine/qcommon/cm_trace.c
+++ b/src/engine/qcommon/cm_trace.c
@@ -2,9 +2,9 @@
 ===========================================================================
 
 Daemon GPL Source Code
-Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company. 
+Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).  
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
 
 Daemon Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -19,14 +19,14 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms. 
-You should have received a copy of these additional terms immediately following the 
-terms and conditions of the GNU General Public License which accompanied the Daemon 
-Source Code.  If not, please request a copy in writing from id Software at the address 
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
-If you have questions concerning this license or the applicable additional terms, you 
-may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, 
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
 Maryland 20850 USA.
 
 ===========================================================================
@@ -1534,7 +1534,7 @@ get the first intersection of the ray with the sphere
 void CM_TraceThroughSphere(traceWork_t * tw, vec3_t origin, float radius, vec3_t start, vec3_t end)
 {
 	float           l1, l2, length, scale, fraction;
-	float           a, b, c, d, sqrtd;
+	float           b, c, d, sqrtd;
 	vec3_t          v1, dir, intersection;
 
 	// if inside the sphere
@@ -1573,7 +1573,7 @@ void CM_TraceThroughSphere(traceWork_t * tw, vec3_t origin, float radius, vec3_t
 	//
 	VectorSubtract(start, origin, v1);
 	// dir is normalized so a = 1
-	a = 1.0f;					//dir[0] * dir[0] + dir[1] * dir[1] + dir[2] * dir[2];
+	//dir[0] * dir[0] + dir[1] * dir[1] + dir[2] * dir[2];
 	b = 2.0f * (dir[0] * v1[0] + dir[1] * v1[1] + dir[2] * v1[2]);
 	c = v1[0] * v1[0] + v1[1] * v1[1] + v1[2] * v1[2] - (radius + RADIUS_EPSILON) * (radius + RADIUS_EPSILON);
 
@@ -1632,7 +1632,7 @@ the cylinder extends halfheight above and below the origin
 void CM_TraceThroughVerticalCylinder(traceWork_t * tw, vec3_t origin, float radius, float halfheight, vec3_t start, vec3_t end)
 {
 	float           length, scale, fraction, l1, l2;
-	float           a, b, c, d, sqrtd;
+	float           b, c, d, sqrtd;
 	vec3_t          v1, dir, start2d, end2d, org2d, intersection;
 
 	// 2d coordinates
@@ -1681,7 +1681,7 @@ void CM_TraceThroughVerticalCylinder(traceWork_t * tw, vec3_t origin, float radi
 	//
 	VectorSubtract(start, origin, v1);
 	// dir is normalized so we can use a = 1
-	a = 1.0f;					// * (dir[0] * dir[0] + dir[1] * dir[1]);
+	// * (dir[0] * dir[0] + dir[1] * dir[1]);
 	b = 2.0f * (v1[0] * dir[0] + v1[1] * dir[1]);
 	c = v1[0] * v1[0] + v1[1] * v1[1] - (radius + RADIUS_EPSILON) * (radius + RADIUS_EPSILON);
 

--- a/src/engine/qcommon/cm_trisoup.c
+++ b/src/engine/qcommon/cm_trisoup.c
@@ -894,7 +894,7 @@ static void CM_SurfaceCollideFromTriangleSoup(cTriangleSoup_t * triSoup, cSurfac
 {
 	int             i;
 	float          *p1, *p2, *p3;
-	int             i1, i2, i3;
+//	int             i1, i2, i3;
 
 	cFacet_t       *facet;
 
@@ -924,10 +924,6 @@ static void CM_SurfaceCollideFromTriangleSoup(cTriangleSoup_t * triSoup, cSurfac
 		facet = &facets[numFacets];
 		Com_Memset(facet, 0, sizeof(*facet));
 
-		i1 = triSoup->indexes[i * 3 + 0];
-		i2 = triSoup->indexes[i * 3 + 1];
-		i3 = triSoup->indexes[i * 3 + 2];
-
 		p1 = triSoup->points[i][0];
 		p2 = triSoup->points[i][1];
 		p3 = triSoup->points[i][2];
@@ -936,6 +932,10 @@ static void CM_SurfaceCollideFromTriangleSoup(cTriangleSoup_t * triSoup, cSurfac
 
 		// try and make a quad out of two triangles
 #if 0
+        i1 = triSoup->indexes[i * 3 + 0];
+		i2 = triSoup->indexes[i * 3 + 1];
+		i3 = triSoup->indexes[i * 3 + 2];
+
 		if(i != triSoup->numTriangles - 1)
 		{
 			i4 = triSoup->indexes[i * 3 + 3];

--- a/src/engine/qcommon/common.c
+++ b/src/engine/qcommon/common.c
@@ -2,9 +2,9 @@
 ===========================================================================
 
 Daemon GPL Source Code
-Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company. 
+Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).  
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
 
 Daemon Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -19,14 +19,14 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms. 
-You should have received a copy of these additional terms immediately following the 
-terms and conditions of the GNU General Public License which accompanied the Daemon 
-Source Code.  If not, please request a copy in writing from id Software at the address 
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
-If you have questions concerning this license or the applicable additional terms, you 
-may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, 
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
 Maryland 20850 USA.
 
 ===========================================================================
@@ -55,7 +55,7 @@ int demo_protocols[] = { 66, 67, 68, 0 };
 
 #define MIN_DEDICATED_COMHUNKMEGS 4
 #define MIN_COMHUNKMEGS 256				// JPW NERVE changed this to 42 for MP, was 56 for team arena and 75 for wolfSP
-#define DEF_COMHUNKMEGS 512				// RF, increased this, some maps are exceeding 56mb 
+#define DEF_COMHUNKMEGS 512				// RF, increased this, some maps are exceeding 56mb
 										// JPW NERVE changed this for multiplayer back to 42, 56 for depot/mp_cpdepot, 42 for everything else
 #define DEF_COMZONEMEGS 96				// RF, increased this from 16, to account for botlib/AAS
 #define DEF_COMHUNKMEGS_S	XSTRING(DEF_COMHUNKMEGS)
@@ -1099,7 +1099,7 @@ void           *Z_TagMallocDebug(int size, int tag, char *label, char *file, int
 void           *Z_TagMalloc(int size, int tag)
 {
 #endif
-	int             extra, allocSize;
+	int             extra;
 	memblock_t     *start, *rover, *new, *base;
 	memzone_t      *zone;
 
@@ -1117,8 +1117,6 @@ void           *Z_TagMalloc(int size, int tag)
 		zone = mainzone;
 	}
 
-	allocSize = size;
-	//
 	// scan through the block list looking for the first free block
 	// of sufficient size
 	//
@@ -1663,7 +1661,7 @@ static void Com_DetectSSE(void)
 {
 #if !idx64
 	cpuFeatures_t feat;
-	
+
 	feat = Sys_GetProcessorFeatures();
 
 	if(feat & CF_SSE)
@@ -2307,7 +2305,7 @@ Com_InitJournaling
 =================
 */
 void Com_InitJournaling( void ) {
-	
+
 	int i;
 
 	Com_StartupVariable( "journal" );
@@ -2853,12 +2851,12 @@ char            cl_cdkey[34] = "123456789";
 #endif
 
 void Com_SetRecommended() {
-	cvar_t         *r_highQualityVideo, *com_recommended;
+	cvar_t         *r_highQualityVideo;//, *com_recommended;
 	qboolean        goodVideo;
 
 	// will use this for recommended settings as well.. do i outside the lower check so it gets done even with command line stuff
 	r_highQualityVideo = Cvar_Get("r_highQualityVideo", "1", CVAR_ARCHIVE);
-	com_recommended = Cvar_Get("com_recommended", "-1", CVAR_ARCHIVE);
+	//com_recommended = Cvar_Get("com_recommended", "-1", CVAR_ARCHIVE);
 	goodVideo = (r_highQualityVideo && r_highQualityVideo->integer);
 
 	if(goodVideo)
@@ -3315,10 +3313,10 @@ void Com_Init(char *commandLine)
 	Hist_Load();
 
 	if (!Crypto_Init()) {
-		// Disable all crypto functions 
-		Cvar_Get("g_adminPubkeyID", "0", CVAR_ROM); 
+		// Disable all crypto functions
+		Cvar_Get("g_adminPubkeyID", "0", CVAR_ROM);
 #ifndef DEDICATED
-		Cvar_Get("cl_pubkeyID", "0", CVAR_ROM); 
+		Cvar_Get("cl_pubkeyID", "0", CVAR_ROM);
 #endif
 	}
 
@@ -3520,7 +3518,7 @@ void Com_Frame(void)
 
 	int             msec, minMsec;
 	static int      lastTime;
-	int             key;
+	//int             key;
 
 	int             timeBeforeFirstEvents;
 	int             timeBeforeServer;
@@ -3547,7 +3545,7 @@ void Com_Frame(void)
 	// Check to make sure we don't have any http data waiting
 	// comment this out until I get things going better under win32
 	// old net chan encryption key
-	key = 0x87243987;
+	//key = 0x87243987;
 
 	// write config file if anything changed
 	Com_WriteConfiguration();
@@ -3586,7 +3584,7 @@ void Com_Frame(void)
 		//give cycles back to the OS
 		Sys_Sleep( minMsec - msec );
 
-		com_frameTime = Com_EventLoop();	
+		com_frameTime = Com_EventLoop();
 		msec = com_frameTime - lastTime;
 	}
 
@@ -3734,7 +3732,7 @@ void Com_Frame(void)
 	}
 
 	// old net chan encryption key
-	key = lastTime * 0x87243987;
+	//key = lastTime * 0x87243987;
 
 	com_frameNumber++;
 }
@@ -3842,6 +3840,7 @@ static int      matchCount;
 static field_t *completionField;
 static const char *completionPrompt;
 
+
 /*
 ===============
 FindMatches
@@ -3879,11 +3878,13 @@ static void FindMatches(const char *s)
 PrintCmdMatches
 ===============
 */
+#if 0
 static void PrintCmdMatches( const char *s ) {
 	if(!Q_stricmpn(s, shortestMatch, strlen(shortestMatch))) {
 		Com_Printf( " %s\n", s );
 	}
 }
+#endif
 
 /*
 ===============
@@ -3908,6 +3909,7 @@ static void PrintCvarMatches( const char *s ) {
 	}
 }
 
+#if 0
 static void keyConcatArgs(void) {
 	int             i;
 	char           *arg;
@@ -3932,7 +3934,9 @@ static void keyConcatArgs(void) {
 		}
 	}
 }
+#endif
 
+#if 0
 static void ConcatRemaining(const char *src, const char *start)
 {
 	char           *str;
@@ -3947,6 +3951,7 @@ static void ConcatRemaining(const char *src, const char *start)
 	str += strlen(start);
 	Q_strcat(completionField->buffer, sizeof(completionField->buffer), str);
 }
+#endif
 
 /*
 ===============
@@ -4230,12 +4235,12 @@ qboolean Com_IsVoipTarget(uint8_t *voipTargets, int voipTargetsSize, int clientN
 			if(voipTargets[index])
 				return qtrue;
 		}
-		
+
 		return qfalse;
 	}
 
 	index = clientNum >> 3;
-	
+
 	if(index < voipTargetsSize)
 		return (voipTargets[index] & (1 << (clientNum & 0x07)));
 
@@ -4248,7 +4253,7 @@ qboolean Com_IsVoipTarget(uint8_t *voipTargets, int voipTargetsSize, int clientN
 #define CON_HISTORY_FILE "conhistory"
 static char history[CON_HISTORY][MAX_EDIT_LINE];
 static int hist_current, hist_next;
- 
+
 /*
 ==================
 Hist_Load

--- a/src/engine/qcommon/cvar.c
+++ b/src/engine/qcommon/cvar.c
@@ -2,9 +2,9 @@
 ===========================================================================
 
 Daemon GPL Source Code
-Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company. 
+Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).  
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
 
 Daemon Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -19,14 +19,14 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms. 
-You should have received a copy of these additional terms immediately following the 
-terms and conditions of the GNU General Public License which accompanied the Daemon 
-Source Code.  If not, please request a copy in writing from id Software at the address 
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
-If you have questions concerning this license or the applicable additional terms, you 
-may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, 
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
 Maryland 20850 USA.
 
 ===========================================================================
@@ -235,7 +235,7 @@ Cvar_Flags
 int Cvar_Flags(const char *var_name)
 {
 	cvar_t *var;
-	
+
 	if(! (var = Cvar_FindVar(var_name)) )
 		return CVAR_NONEXISTENT;
 	else
@@ -810,7 +810,7 @@ weren't declared in C code.
 */
 void Cvar_Set_f(void)
 {
-	int             i, c, l, len, unsafe = 0, q;
+	int             c, unsafe = 0;
 	char            *value;
 
 	c = Cmd_Argc();

--- a/src/engine/qcommon/files.c
+++ b/src/engine/qcommon/files.c
@@ -2,9 +2,9 @@
 ===========================================================================
 
 Daemon GPL Source Code
-Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company. 
+Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).  
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
 
 Daemon Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -19,14 +19,14 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms. 
-You should have received a copy of these additional terms immediately following the 
-terms and conditions of the GNU General Public License which accompanied the Daemon 
-Source Code.  If not, please request a copy in writing from id Software at the address 
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
-If you have questions concerning this license or the applicable additional terms, you 
-may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, 
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
 Maryland 20850 USA.
 
 ===========================================================================
@@ -519,7 +519,7 @@ FS_BuildOSHomePath
 */
 void FS_BuildOSHomePath( char * ospath, int size, const char *qpath ) {
 	Com_sprintf( ospath, size, "%s/%s/%s", fs_homepath->string, fs_gamedir, qpath );
-	FS_ReplaceSeparators( ospath );	
+	FS_ReplaceSeparators( ospath );
 }
 
 /*
@@ -1312,10 +1312,10 @@ int FS_FOpenFileRead( const char *filename, fileHandle_t *file, qboolean uniqueF
 					} else {
 						fsh[*file].handleFiles.file.z = pak->handle;
 					}
-					
+
 					Q_strncpyz( fsh[*file].name, filename, sizeof( fsh[*file].name ) );
 					fsh[*file].zipFile = qtrue;
-					
+
 					// set the file position in the zip file (also sets the current file info)
 					unzSetOffset(fsh[*file].handleFiles.file.z, pakFile->pos);
 
@@ -1400,8 +1400,8 @@ int FS_FOpenFileRead( const char *filename, fileHandle_t *file, qboolean uniqueF
 			}
 
 			if ( Q_stricmp( filename + l - 4, ".cfg" )       // for config files
-				 && Q_stricmp( filename + l - 4, ".ttf") != 0 
-				 && Q_stricmp( filename + l - 4, ".otf") != 0 
+				 && Q_stricmp( filename + l - 4, ".ttf") != 0
+				 && Q_stricmp( filename + l - 4, ".otf") != 0
 				 && Q_stricmp( filename + l - 5, ".menu" )  // menu files
 				 && Q_stricmp( filename + l - 5, ".game" )  // menu files
 				 && Q_stricmp( filename + l - strlen( demoExt ), demoExt ) // menu files
@@ -3024,15 +3024,15 @@ then loads the zip headers
 #define MAX_PAKFILES    1024
 void FS_AddGameDirectory( const char *path, const char *dir ) {
 	searchpath_t    *sp;
-	int i;
+//	int i;
 	searchpath_t    *search;
 	pack_t          *pak;
 	char            *pakfile;
 	int numfiles;
 	char            **pakfiles;
-	char            *sorted[MAX_PAKFILES];
+//	char            *sorted[MAX_PAKFILES];
 	int				pakfilesi=0;
-	char			**pakfilestmp;
+//	char			**pakfilestmp;
 	int				numdirs;
 	char			**pakdirs;
 	int				pakdirsi=0;
@@ -3082,7 +3082,7 @@ void FS_AddGameDirectory( const char *path, const char *dir ) {
 
 	qsort( pakfiles, numfiles, sizeof(char*), paksort );
 	qsort( pakdirs, numdirs, sizeof(char *), paksort );
-	
+
 	// Log may not be initialized at this point, but it will still show in the console.
 	Com_DPrintf("FS_AddGameDirectory(\"%s\", \"%s\") found %d .pk3 and %d .pk3dir\n", path, dir, numfiles, numdirs);
 #if 0
@@ -3153,7 +3153,7 @@ void FS_AddGameDirectory( const char *path, const char *dir ) {
 		}
 	}
 #endif
-	
+
 	while( pakfilesi < numfiles )
 	{
 	  // The next .pk3 file is before the next .pk3dir
@@ -3176,7 +3176,7 @@ void FS_AddGameDirectory( const char *path, const char *dir ) {
 
 	  pakfilesi++;
 	}
-	
+
 	while( pakdirsi < numdirs )
 	{
 	  // The next .pk3dir is before the next .pk3 file
@@ -3204,7 +3204,7 @@ void FS_AddGameDirectory( const char *path, const char *dir ) {
 	  pakdirsi++;
 	}
 
-	
+
 	// done
 	Sys_FreeFileList( pakfiles );
 	Sys_FreeFileList( pakdirs );
@@ -3333,7 +3333,7 @@ we are not interested in a download string format, we want something human-reada
 qboolean CL_WWWBadChecksum( const char *pakname );
 qboolean FS_ComparePaks( char *neededpaks, int len, qboolean dlstring ) {
 	searchpath_t    *sp;
-	qboolean havepak, badchecksum;
+	qboolean havepak;
 	int i;
 
 	if ( !fs_numServerReferencedPaks ) {
@@ -3343,8 +3343,7 @@ qboolean FS_ComparePaks( char *neededpaks, int len, qboolean dlstring ) {
 	*neededpaks = 0;
 
 	for ( i = 0 ; i < fs_numServerReferencedPaks ; i++ ) {
-		// Ok, see if we have this pak file
-		badchecksum = qfalse;
+
 		havepak = qfalse;
 
 		// never autodownload any of the id paks
@@ -3518,7 +3517,7 @@ static void FS_Startup( const char *gameName ) {
 	fs_buildpath = Cvar_Get( "fs_buildpath", "", CVAR_INIT );
 	fs_buildgame = Cvar_Get( "fs_buildgame", BASEGAME, CVAR_INIT );
 	fs_basegame = Cvar_Get( "fs_basegame", "", CVAR_INIT );
-#ifdef __FreeBSD__	
+#ifdef __FreeBSD__
 	fs_libpath = Cvar_Get ("fs_libpath", Sys_DefaultLibPath(), CVAR_INIT );
 #endif
 #ifdef MACOS_X
@@ -3545,7 +3544,7 @@ static void FS_Startup( const char *gameName ) {
 	if (fs_apppath->string[0])
 		FS_AddGameDirectory(fs_apppath->string, gameName);
 #endif
-	
+
 	// NOTE: same filtering below for mods and basegame
 	if ( fs_basepath->string[0] && Q_stricmp( fs_homepath->string,fs_basepath->string ) ) {
 		FS_AddGameDirectory( fs_homepath->string, gameName );
@@ -4454,7 +4453,7 @@ int     FS_FOpenFileByMode( const char *qpath, fileHandle_t *f, fsMode_t mode ) 
 			if (*f == 0) {
 				r = -1;
 			}
-			break;		
+			break;
 	default:
 		Com_Error( ERR_FATAL, "FSH_FOpenFile: bad mode" );
 		return -1;

--- a/src/engine/qcommon/net_chan.c
+++ b/src/engine/qcommon/net_chan.c
@@ -2,9 +2,9 @@
 ===========================================================================
 
 Daemon GPL Source Code
-Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company. 
+Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).  
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
 
 Daemon Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -19,14 +19,14 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms. 
-You should have received a copy of these additional terms immediately following the 
-terms and conditions of the GNU General Public License which accompanied the Daemon 
-Source Code.  If not, please request a copy in writing from id Software at the address 
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
-If you have questions concerning this license or the applicable additional terms, you 
-may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, 
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
 Maryland 20850 USA.
 
 ===========================================================================
@@ -97,7 +97,7 @@ called to open a channel to a remote system
 */
 void Netchan_Setup( netsrc_t sock, netchan_t *chan, netadr_t adr, int qport ) {
 	Com_Memset (chan, 0, sizeof(*chan));
-	
+
 	chan->sock = sock;
 	chan->remoteAddress = adr;
 	chan->qport = qport;
@@ -315,14 +315,14 @@ copied out.
 */
 qboolean Netchan_Process( netchan_t *chan, msg_t *msg ) {
 	int			sequence;
-	int			qport;
+//	int			qport;
 	int			fragmentStart, fragmentLength;
 	qboolean	fragmented;
 
 	// XOR unscramble all data in the packet after the header
 //	Netchan_UnScramblePacket( msg );
 
-	// get sequence numbers		
+	// get sequence numbers
 	MSG_BeginReadingOOB( msg );
 	sequence = MSG_ReadLong( msg );
 
@@ -336,7 +336,7 @@ qboolean Netchan_Process( netchan_t *chan, msg_t *msg ) {
 
 	// read the qport if we are a server
 	if ( chan->sock == NS_SERVER ) {
-		qport = MSG_ReadShort( msg );
+		/*qport = */MSG_ReadShort( msg );
 	}
 
 	// read the fragment information
@@ -388,11 +388,11 @@ qboolean Netchan_Process( netchan_t *chan, msg_t *msg ) {
 			, sequence );
 		}
 	}
-	
+
 
 	//
 	// if this is the final framgent of a reliable message,
-	// bump incoming_reliable_sequence 
+	// bump incoming_reliable_sequence
 	//
 	if ( fragmented ) {
 		// TTimo
@@ -426,7 +426,7 @@ qboolean Netchan_Process( netchan_t *chan, msg_t *msg ) {
 			return qfalse;
 		}
 
-		Com_Memcpy( chan->fragmentBuffer + chan->fragmentLength, 
+		Com_Memcpy( chan->fragmentBuffer + chan->fragmentLength,
 			msg->data + msg->readcount, fragmentLength );
 
 		chan->fragmentLength += fragmentLength;
@@ -457,7 +457,7 @@ qboolean Netchan_Process( netchan_t *chan, msg_t *msg ) {
 		// TTimo
 		// clients were not acking fragmented messages
 		chan->incomingSequence = sequence;
-		
+
 		return qtrue;
 	}
 
@@ -562,7 +562,7 @@ static void NET_QueuePacket( int length, const void *data, netadr_t to,
 	Com_Memcpy(new->data, data, length);
 	new->length = length;
 	new->to = to;
-	new->release = Sys_Milliseconds() + (int)((float)offset / com_timescale->value);	
+	new->release = Sys_Milliseconds() + (int)((float)offset / com_timescale->value);
 	new->next = NULL;
 
 	if(!packetQueue) {
@@ -701,7 +701,7 @@ int NET_StringToAdr( const char *s, netadr_t *a, netadrtype_t family )
 	}
 
 	Q_strncpyz( base, s, sizeof( base ) );
-	
+
 	if(*base == '[' || Q_CountChar(base, ':') > 1)
 	{
 		// This is an ipv6 address, handle it specially.
@@ -714,7 +714,7 @@ int NET_StringToAdr( const char *s, netadr_t *a, netadrtype_t family )
 			if(*search == ':')
 				port = search + 1;
 		}
-		
+
 		if(*base == '[')
 			search = base + 1;
 		else
@@ -724,12 +724,12 @@ int NET_StringToAdr( const char *s, netadr_t *a, netadrtype_t family )
 	{
 		// look for a port number
 		port = strchr( base, ':' );
-		
+
 		if ( port ) {
 			*port = '\0';
 			port++;
 		}
-		
+
 		search = base;
 	}
 

--- a/src/engine/qcommon/net_ip.c
+++ b/src/engine/qcommon/net_ip.c
@@ -2,9 +2,9 @@
 ===========================================================================
 
 Daemon GPL Source Code
-Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company. 
+Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).  
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
 
 Daemon Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -19,14 +19,14 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms. 
-You should have received a copy of these additional terms immediately following the 
-terms and conditions of the GNU General Public License which accompanied the Daemon 
-Source Code.  If not, please request a copy in writing from id Software at the address 
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
-If you have questions concerning this license or the applicable additional terms, you 
-may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, 
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
 Maryland 20850 USA.
 
 ===========================================================================
@@ -143,7 +143,7 @@ static struct sockaddr_in6 boundto;
 typedef struct
 {
 	char ifname[IF_NAMESIZE];
-	
+
 	netadrtype_t type;
 	sa_family_t family;
 	struct sockaddr_storage addr;
@@ -268,7 +268,7 @@ static struct addrinfo *SearchAddrInfo(struct addrinfo *hints, sa_family_t famil
 
 		hints = hints->ai_next;
 	}
-	
+
 	return NULL;
 }
 
@@ -284,14 +284,14 @@ static qboolean Sys_StringToSockaddr(const char *s, struct sockaddr *sadr, int s
 	struct addrinfo *search = NULL;
 	struct addrinfo *hintsp;
 	int retval;
-	
+
 	memset(sadr, '\0', sizeof(*sadr));
 	memset(&hints, '\0', sizeof(hints));
 
 	hintsp = &hints;
 	hintsp->ai_family = family;
 	hintsp->ai_socktype = SOCK_DGRAM;
-	
+
 	retval = getaddrinfo(s, NULL, hintsp, &res);
 
 	if(!retval)
@@ -303,7 +303,7 @@ static qboolean Sys_StringToSockaddr(const char *s, struct sockaddr *sadr, int s
 			{
 				if(net_enabled->integer & NET_ENABLEV6)
 					search = SearchAddrInfo(res, AF_INET6);
-				
+
 				if(!search && (net_enabled->integer & NET_ENABLEV4))
 					search = SearchAddrInfo(res, AF_INET);
 			}
@@ -311,7 +311,7 @@ static qboolean Sys_StringToSockaddr(const char *s, struct sockaddr *sadr, int s
 			{
 				if(net_enabled->integer & NET_ENABLEV4)
 					search = SearchAddrInfo(res, AF_INET);
-				
+
 				if(!search && (net_enabled->integer & NET_ENABLEV6))
 					search = SearchAddrInfo(res, AF_INET6);
 			}
@@ -323,10 +323,10 @@ static qboolean Sys_StringToSockaddr(const char *s, struct sockaddr *sadr, int s
 		{
 			if(res->ai_addrlen > sadr_len)
 				res->ai_addrlen = sadr_len;
-				
+
 			memcpy(sadr, res->ai_addr, res->ai_addrlen);
 			freeaddrinfo(res);
-			
+
 			return qtrue;
 		}
 		else
@@ -334,10 +334,10 @@ static qboolean Sys_StringToSockaddr(const char *s, struct sockaddr *sadr, int s
 	}
 	else
 		Com_Printf("Sys_StringToSockaddr: Error resolving %s: %s\n", s, gai_strerror(retval));
-	
+
 	if(res)
 		freeaddrinfo(res);
-	
+
 	return qfalse;
 }
 
@@ -367,7 +367,7 @@ Sys_StringToAdr
 qboolean Sys_StringToAdr( const char *s, netadr_t *a, netadrtype_t family ) {
 	struct sockaddr_storage sadr;
 	sa_family_t fam;
-	
+
 	switch(family)
 	{
 		case NA_IP:
@@ -383,7 +383,7 @@ qboolean Sys_StringToAdr( const char *s, netadr_t *a, netadrtype_t family ) {
 	if( !Sys_StringToSockaddr(s, (struct sockaddr *) &sadr, sizeof(sadr), fam ) ) {
 		return qfalse;
 	}
-	
+
 	SockadrToNetadr( (struct sockaddr *) &sadr, a );
 	return qtrue;
 }
@@ -400,7 +400,7 @@ qboolean NET_CompareBaseAdrMask(netadr_t a, netadr_t b, int netmask)
 	qboolean differed;
 	byte cmpmask, *addra, *addrb;
 	int curbyte;
-	
+
 	if (a.type != b.type)
 		return qfalse;
 
@@ -411,7 +411,7 @@ qboolean NET_CompareBaseAdrMask(netadr_t a, netadr_t b, int netmask)
 	{
 		addra = (byte *) &a.ip;
 		addrb = (byte *) &b.ip;
-		
+
 		if(netmask < 0 || netmask > 32)
 			netmask = 32;
 	}
@@ -419,7 +419,7 @@ qboolean NET_CompareBaseAdrMask(netadr_t a, netadr_t b, int netmask)
 	{
 		addra = (byte *) &a.ip6;
 		addrb = (byte *) &b.ip6;
-		
+
 		if(netmask < 0 || netmask > 128)
 			netmask = 128;
 	}
@@ -457,7 +457,7 @@ qboolean NET_CompareBaseAdrMask(netadr_t a, netadr_t b, int netmask)
 	}
 	else
 		return qtrue;
-	
+
 	return qfalse;
 }
 
@@ -485,7 +485,7 @@ const char	*NET_AdrToString (netadr_t a)
 	else if (a.type == NA_IP || a.type == NA_IP6)
 	{
 		struct sockaddr_storage sadr;
-	
+
 		memset(&sadr, 0, sizeof(sadr));
 		NetadrToSockadr(&a, (struct sockaddr *) &sadr);
 		Sys_SockaddrToString(s, sizeof(s), (struct sockaddr *) &sadr);
@@ -515,7 +515,7 @@ qboolean	NET_CompareAdr (netadr_t a, netadr_t b)
 {
 	if(!NET_CompareBaseAdr(a, b))
 		return qfalse;
-	
+
 	if (a.type == NA_IP || a.type == NA_IP6)
 	{
 		if (a.port == b.port)
@@ -523,7 +523,7 @@ qboolean	NET_CompareAdr (netadr_t a, netadr_t b)
 	}
 	else
 		return qtrue;
-		
+
 	return qfalse;
 }
 
@@ -554,12 +554,12 @@ qboolean Sys_GetPacket( netadr_t *net_from, msg_t *net_message ) {
 #ifdef _DEBUG
 	recvfromCount++;		// performance check
 #endif
-	
+
 	if(ip_socket != INVALID_SOCKET)
 	{
 		fromlen = sizeof(from);
 		ret = recvfrom( ip_socket, (void *)net_message->data, net_message->maxsize, 0, (struct sockaddr *) &from, &fromlen );
-		
+
 		if (ret == SOCKET_ERROR)
 		{
 			err = socketError;
@@ -571,7 +571,7 @@ qboolean Sys_GetPacket( netadr_t *net_from, msg_t *net_message ) {
 		{
 
 			memset( ((struct sockaddr_in *)&from)->sin_zero, 0, 8 );
-		
+
 			if ( usingSocks && memcmp( &from, &socksRelayAddr, fromlen ) == 0 ) {
 				if ( ret < 10 || net_message->data[0] != 0 || net_message->data[1] != 0 || net_message->data[2] != 0 || net_message->data[3] != 1 ) {
 					return qfalse;
@@ -588,22 +588,22 @@ qboolean Sys_GetPacket( netadr_t *net_from, msg_t *net_message ) {
 				SockadrToNetadr( (struct sockaddr *) &from, net_from );
 				net_message->readcount = 0;
 			}
-		
+
 			if( ret == net_message->maxsize ) {
 				Com_Printf( "Oversize packet from %s\n", NET_AdrToString (*net_from) );
 				return qfalse;
 			}
-			
+
 			net_message->cursize = ret;
 			return qtrue;
 		}
 	}
-	
+
 	if(ip6_socket != INVALID_SOCKET)
 	{
 		fromlen = sizeof(from);
 		ret = recvfrom(ip6_socket, (void *)net_message->data, net_message->maxsize, 0, (struct sockaddr *) &from, &fromlen);
-		
+
 		if (ret == SOCKET_ERROR)
 		{
 			err = socketError;
@@ -615,13 +615,13 @@ qboolean Sys_GetPacket( netadr_t *net_from, msg_t *net_message ) {
 		{
 			SockadrToNetadr((struct sockaddr *) &from, net_from);
 			net_message->readcount = 0;
-		
+
 			if(ret == net_message->maxsize)
 			{
 				Com_Printf( "Oversize packet from %s\n", NET_AdrToString (*net_from) );
 				return qfalse;
 			}
-			
+
 			net_message->cursize = ret;
 			return qtrue;
 		}
@@ -631,7 +631,7 @@ qboolean Sys_GetPacket( netadr_t *net_from, msg_t *net_message ) {
 	{
 		fromlen = sizeof(from);
 		ret = recvfrom(multicast6_socket, (void *)net_message->data, net_message->maxsize, 0, (struct sockaddr *) &from, &fromlen);
-		
+
 		if (ret == SOCKET_ERROR)
 		{
 			err = socketError;
@@ -643,19 +643,19 @@ qboolean Sys_GetPacket( netadr_t *net_from, msg_t *net_message ) {
 		{
 			SockadrToNetadr((struct sockaddr *) &from, net_from);
 			net_message->readcount = 0;
-		
+
 			if(ret == net_message->maxsize)
 			{
 				Com_Printf( "Oversize packet from %s\n", NET_AdrToString (*net_from) );
 				return qfalse;
 			}
-			
+
 			net_message->cursize = ret;
 			return qtrue;
 		}
 	}
-	
-	
+
+
 	return qfalse;
 }
 
@@ -764,7 +764,7 @@ qboolean Sys_IsLANAddress( netadr_t adr ) {
 		if((adr.ip6[0] & 0xfe) == 0xfc)
 			return qtrue;
 	}
-	
+
 	// Now compare against the networks this computer is member of.
 	for(index = 0; index < numIP; index++)
 	{
@@ -775,7 +775,7 @@ qboolean Sys_IsLANAddress( netadr_t adr ) {
 				compareip = (byte *) &((struct sockaddr_in *) &localIP[index].addr)->sin_addr.s_addr;
 				comparemask = (byte *) &((struct sockaddr_in *) &localIP[index].netmask)->sin_addr.s_addr;
 				compareadr = adr.ip;
-				
+
 				addrsize = sizeof(adr.ip);
 			}
 			else
@@ -785,7 +785,7 @@ qboolean Sys_IsLANAddress( netadr_t adr ) {
 				compareip = (byte *) &((struct sockaddr_in6 *) &localIP[index].addr)->sin6_addr;
 				comparemask = (byte *) &((struct sockaddr_in6 *) &localIP[index].netmask)->sin6_addr;
 				compareadr = adr.ip6;
-				
+
 				addrsize = sizeof(adr.ip6);
 			}
 
@@ -798,13 +798,13 @@ qboolean Sys_IsLANAddress( netadr_t adr ) {
 					break;
 				}
 			}
-			
+
 			if(!differed)
 				return qtrue;
 
 		}
 	}
-	
+
 	return qfalse;
 }
 
@@ -976,7 +976,7 @@ int NET_IP6Socket( char *net_interface, int port, struct sockaddr_in6 *bindto, i
 		closesocket( newsocket );
 		return INVALID_SOCKET;
 	}
-	
+
 	if(bindto)
 		*bindto = address;
 
@@ -997,12 +997,12 @@ void NET_SetMulticast6(void)
 	{
 		Com_Printf("WARNING: NET_JoinMulticast6: Incorrect multicast address given, "
 			   "please set cvar %s to a sane value.\n", net_mcast6addr->name);
-		
+
 		Cvar_SetValue(net_enabled->name, net_enabled->integer | NET_DISABLEMCAST);
-		
+
 		return;
 	}
-	
+
 	memcpy(&curgroup.ipv6mr_multiaddr, &addr.sin6_addr, sizeof(curgroup.ipv6mr_multiaddr));
 
 	if(*net_mcast6iface->string)
@@ -1026,10 +1026,10 @@ Join an ipv6 multicast group
 void NET_JoinMulticast6(void)
 {
 	int err;
-	
+
 	if(ip6_socket == INVALID_SOCKET || multicast6_socket != INVALID_SOCKET || (net_enabled->integer & NET_DISABLEMCAST))
 		return;
-	
+
 	if(IN6_IS_ADDR_MULTICAST(&boundto.sin6_addr) || IN6_IS_ADDR_UNSPECIFIED(&boundto.sin6_addr))
 	{
 		// The way the socket was bound does not prohibit receiving multi-cast packets. So we don't need to open a new one.
@@ -1043,7 +1043,7 @@ void NET_JoinMulticast6(void)
 			multicast6_socket = ip6_socket;
 		}
 	}
-	
+
 	if(curgroup.ipv6mr_interface)
 	{
 		if (setsockopt(multicast6_socket, IPPROTO_IPV6, IPV6_MULTICAST_IF,
@@ -1093,7 +1093,6 @@ NET_OpenSocks
 */
 void NET_OpenSocks( int port ) {
 	struct sockaddr_in	address;
-	int					err;
 	struct hostent		*h;
 	int					len;
 	qboolean			rfc1929;
@@ -1104,14 +1103,12 @@ void NET_OpenSocks( int port ) {
 	Com_Printf( "Opening connection to SOCKS server.\n" );
 
 	if ( ( socks_socket = socket( AF_INET, SOCK_STREAM, IPPROTO_TCP ) ) == INVALID_SOCKET ) {
-		err = socketError;
 		Com_Printf( "WARNING: NET_OpenSocks: socket: %s\n", NET_ErrorString() );
 		return;
 	}
 
 	h = gethostbyname( net_socksServer->string );
 	if ( h == NULL ) {
-		err = socketError;
 		Com_Printf( "WARNING: NET_OpenSocks: gethostbyname: %s\n", NET_ErrorString() );
 		return;
 	}
@@ -1124,7 +1121,6 @@ void NET_OpenSocks( int port ) {
 	address.sin_port = htons( (short)net_socksPort->integer );
 
 	if ( connect( socks_socket, (struct sockaddr *)&address, sizeof( address ) ) == SOCKET_ERROR ) {
-		err = socketError;
 		Com_Printf( "NET_OpenSocks: connect: %s\n", NET_ErrorString() );
 		return;
 	}
@@ -1152,7 +1148,6 @@ void NET_OpenSocks( int port ) {
 		buf[2] = 2;		// method #2 - method id #02: username/password
 	}
 	if ( send( socks_socket, (void *)buf, len, 0 ) == SOCKET_ERROR ) {
-		err = socketError;
 		Com_Printf( "NET_OpenSocks: send: %s\n", NET_ErrorString() );
 		return;
 	}
@@ -1160,7 +1155,6 @@ void NET_OpenSocks( int port ) {
 	// get the response
 	len = recv( socks_socket, (void *)buf, 64, 0 );
 	if ( len == SOCKET_ERROR ) {
-		err = socketError;
 		Com_Printf( "NET_OpenSocks: recv: %s\n", NET_ErrorString() );
 		return;
 	}
@@ -1199,7 +1193,6 @@ void NET_OpenSocks( int port ) {
 
 		// send it
 		if ( send( socks_socket, (void *)buf, 3 + ulen + plen, 0 ) == SOCKET_ERROR ) {
-			err = socketError;
 			Com_Printf( "NET_OpenSocks: send: %s\n", NET_ErrorString() );
 			return;
 		}
@@ -1207,7 +1200,6 @@ void NET_OpenSocks( int port ) {
 		// get the response
 		len = recv( socks_socket, (void *)buf, 64, 0 );
 		if ( len == SOCKET_ERROR ) {
-			err = socketError;
 			Com_Printf( "NET_OpenSocks: recv: %s\n", NET_ErrorString() );
 			return;
 		}
@@ -1229,7 +1221,6 @@ void NET_OpenSocks( int port ) {
 	*(int *)&buf[4] = INADDR_ANY;
 	*(short *)&buf[8] = htons( (short)port );		// port
 	if ( send( socks_socket, (void *)buf, 10, 0 ) == SOCKET_ERROR ) {
-		err = socketError;
 		Com_Printf( "NET_OpenSocks: send: %s\n", NET_ErrorString() );
 		return;
 	}
@@ -1237,7 +1228,6 @@ void NET_OpenSocks( int port ) {
 	// get the response
 	len = recv( socks_socket, (void *)buf, 64, 0 );
 	if( len == SOCKET_ERROR ) {
-		err = socketError;
 		Com_Printf( "NET_OpenSocks: recv: %s\n", NET_ErrorString() );
 		return;
 	}
@@ -1272,11 +1262,11 @@ static void NET_AddLocalAddress(char *ifname, struct sockaddr *addr, struct sock
 {
 	int addrlen;
 	sa_family_t family;
-	
+
 	// only add addresses that have all required info.
 	if(!addr || !netmask || !ifname)
 		return;
-	
+
 	family = addr->sa_family;
 
 	if(numIP < MAX_IPS)
@@ -1293,14 +1283,14 @@ static void NET_AddLocalAddress(char *ifname, struct sockaddr *addr, struct sock
 		}
 		else
 			return;
-		
+
 		Q_strncpyz(localIP[numIP].ifname, ifname, sizeof(localIP[numIP].ifname));
-	
+
 		localIP[numIP].family = family;
 
 		memcpy(&localIP[numIP].addr, addr, addrlen);
 		memcpy(&localIP[numIP].netmask, netmask, addrlen);
-		
+
 		numIP++;
 	}
 }
@@ -1322,9 +1312,9 @@ static void NET_GetLocalAddress(void)
 			if(ifap->ifa_flags & IFF_UP)
 				NET_AddLocalAddress(search->ifa_name, search->ifa_addr, search->ifa_netmask);
 		}
-	
+
 		freeifaddrs(ifap);
-		
+
 		Sys_ShowIP();
 	}
 }
@@ -1340,21 +1330,21 @@ static void NET_GetLocalAddress( void ) {
 		return;
 
 	Com_Printf( "Hostname: %s\n", hostname );
-	
+
 	memset(&hint, 0, sizeof(hint));
-	
+
 	hint.ai_family = AF_UNSPEC;
 	hint.ai_socktype = SOCK_DGRAM;
-	
+
 	if(!getaddrinfo(hostname, NULL, &hint, &res))
 	{
 		struct sockaddr_in mask4;
 		struct sockaddr_in6 mask6;
 		struct addrinfo *search;
-	
+
 		/* On operating systems where it's more difficult to find out the configured interfaces, we'll just assume a
 		 * netmask with all bits set. */
-	
+
 		memset(&mask4, 0, sizeof(mask4));
 		memset(&mask6, 0, sizeof(mask6));
 		mask4.sin_family = AF_INET;
@@ -1370,10 +1360,10 @@ static void NET_GetLocalAddress( void ) {
 			else if(search->ai_family == AF_INET6)
 				NET_AddLocalAddress("", search->ai_addr, (struct sockaddr *) &mask6);
 		}
-	
+
 		Sys_ShowIP();
 	}
-	
+
 	if(res)
 		freeaddrinfo(res);
 }
@@ -1437,7 +1427,7 @@ void NET_OpenIP( void ) {
 					break;
 			}
 		}
-		
+
 		if(ip_socket == INVALID_SOCKET)
 			Com_Printf( "WARNING: Couldn't bind to a v4 ip address.\n");
 	}
@@ -1469,15 +1459,15 @@ static qboolean NET_GetCvars( void ) {
 	net_ip = Cvar_Get( "net_ip", "0.0.0.0", CVAR_LATCH );
 	modified += net_ip->modified;
 	net_ip->modified = qfalse;
-	
+
 	net_ip6 = Cvar_Get( "net_ip6", "::", CVAR_LATCH );
 	modified += net_ip6->modified;
 	net_ip6->modified = qfalse;
-	
+
 	net_port = Cvar_Get( "net_port", va( "%i", PORT_SERVER ), CVAR_LATCH );
 	modified += net_port->modified;
 	net_port->modified = qfalse;
-	
+
 	net_port6 = Cvar_Get( "net_port6", va( "%i", PORT_SERVER ), CVAR_LATCH );
 	modified += net_port6->modified;
 	net_port6->modified = qfalse;
@@ -1573,7 +1563,7 @@ void NET_Config( qboolean enableNetworking ) {
 		{
 			if(multicast6_socket != ip6_socket)
 				closesocket(multicast6_socket);
-				
+
 			multicast6_socket = INVALID_SOCKET;
 		}
 
@@ -1586,7 +1576,7 @@ void NET_Config( qboolean enableNetworking ) {
 			closesocket( socks_socket );
 			socks_socket = INVALID_SOCKET;
 		}
-		
+
 	}
 
 	if( start )
@@ -1620,7 +1610,7 @@ void NET_Init( void ) {
 #endif
 
 	NET_Config( qtrue );
-	
+
 	Cmd_AddCommand ("net_restart", NET_Restart_f);
 }
 
@@ -1676,7 +1666,7 @@ void NET_Sleep( int msec ) {
 	if(ip6_socket != INVALID_SOCKET)
 	{
 		FD_SET(ip6_socket, &fdset);
-		
+
 		if(ip6_socket > highestfd)
 			highestfd = ip6_socket;
 	}

--- a/src/engine/qcommon/parse.c
+++ b/src/engine/qcommon/parse.c
@@ -156,7 +156,7 @@ typedef struct script_s
   char *end_p;                    //pointer to the end of the script
   char *lastscript_p;             //script pointer before reading token
   char *whitespace_p;             //begin of the white space
-  char *endwhitespace_p;         
+  char *endwhitespace_p;
   int length;                     //length of the script in bytes
   int line;                       //current line in script
   int lastline;                   //line before reading token
@@ -1927,7 +1927,7 @@ static int Parse_EvaluateTokens(source_t *source, token_t *tokens, signed long i
   int questmarkintvalue = 0;
   double questmarkfloatvalue = 0;
   int gotquestmarkvalue = qfalse;
-  int lastoperatortype = 0;
+//  int lastoperatortype = 0;
   //
   operator_t operator_heap[MAX_OPERATORS];
   int numoperators = 0;
@@ -2296,7 +2296,7 @@ static int Parse_EvaluateTokens(source_t *source, token_t *tokens, signed long i
       }
     }
     if (error) break;
-    lastoperatortype = o->operator;
+//    lastoperatortype = o->operator;
     //if not an operator with arity 1
     if (o->operator != P_LOGIC_NOT
         && o->operator != P_BIN_NOT)

--- a/src/engine/qcommon/vm.c
+++ b/src/engine/qcommon/vm.c
@@ -2,9 +2,9 @@
 ===========================================================================
 
 Daemon GPL Source Code
-Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company. 
+Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).  
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
 
 Daemon Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -19,14 +19,14 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms. 
-You should have received a copy of these additional terms immediately following the 
-terms and conditions of the GNU General Public License which accompanied the Daemon 
-Source Code.  If not, please request a copy in writing from id Software at the address 
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
-If you have questions concerning this license or the applicable additional terms, you 
-may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, 
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
 Maryland 20850 USA.
 
 ===========================================================================
@@ -89,7 +89,7 @@ void VM_Init( void ) {
 	// NOTE to myself
 	// vm_* 0 means .dll files are used (windows)
 	// vm_* 1 means .so files are used (mac, linux)
-	// vm_* 2 (default) means qvm files are used. 
+	// vm_* 2 (default) means qvm files are used.
 	Cvar_Get( "vm_cgame", "0", CVAR_ARCHIVE );
 	Cvar_Get( "vm_game", "0", CVAR_ARCHIVE );
 	Cvar_Get( "vm_ui", "0", CVAR_ARCHIVE );
@@ -237,7 +237,6 @@ VM_LoadSymbols
 ===============
 */
 void VM_LoadSymbols( vm_t *vm ) {
-	int	len;
 	union {
 		char	*c;
 		void	*v;
@@ -259,7 +258,7 @@ void VM_LoadSymbols( vm_t *vm ) {
 
 	COM_StripExtension3(vm->name, name, sizeof(name));
 	Com_sprintf( symbols, sizeof( symbols ), "vm/%s.map", name );
-	len = FS_ReadFile( symbols, &mapfile.v );
+	FS_ReadFile( symbols, &mapfile.v );
 	if ( !mapfile.c ) {
 		Com_Printf( "Couldn't load symbol file: %s\n", symbols );
 		return;
@@ -353,7 +352,7 @@ Dlls will call this directly
 
   For speed, we just grab 15 arguments, and don't worry about exactly
    how many the syscall actually needs; the extra is thrown away.
- 
+
 ============
 */
 intptr_t QDECL VM_DllSyscall( intptr_t arg, ... ) {
@@ -362,14 +361,14 @@ intptr_t QDECL VM_DllSyscall( intptr_t arg, ... ) {
   intptr_t args[16];
   int i;
   va_list ap;
-  
+
   args[0] = arg;
-  
+
   va_start(ap, arg);
   for (i = 1; i < ARRAY_LEN (args); i++)
     args[i] = va_arg(ap, intptr_t);
   va_end(ap);
-  
+
   return currentVM->systemCall( args );
 #else // original id code
 	return currentVM->systemCall( &arg );
@@ -384,7 +383,6 @@ Load a .qvm file
 =================
 */
 vmHeader_t *VM_LoadQVM( vm_t *vm, qboolean alloc ) {
-    int                 length;
     int                 dataLength;
     int                 i;
     char                filename[MAX_QPATH];
@@ -396,7 +394,7 @@ vmHeader_t *VM_LoadQVM( vm_t *vm, qboolean alloc ) {
     // load the image
     Com_sprintf( filename, sizeof(filename), "vm/%s.qvm", vm->name );
     Com_Printf( "Loading vm file %s...\n", filename );
-    length = FS_ReadFile( filename, &header.v );
+    FS_ReadFile( filename, &header.v );
     if ( !header.h ) {
         Com_Printf( "Failed.\n" );
         VM_Free( vm );

--- a/src/engine/qcommon/vm_x86.c
+++ b/src/engine/qcommon/vm_x86.c
@@ -2,9 +2,9 @@
 ===========================================================================
 
 Daemon GPL Source Code
-Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company. 
+Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).  
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
 
 Daemon Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -19,14 +19,14 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms. 
-You should have received a copy of these additional terms immediately following the 
-terms and conditions of the GNU General Public License which accompanied the Daemon 
-Source Code.  If not, please request a copy in writing from id Software at the address 
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
-If you have questions concerning this license or the applicable additional terms, you 
-may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville, 
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
 Maryland 20850 USA.
 
 ===========================================================================
@@ -87,7 +87,7 @@ static	int	lastConst = 0;
 static	int	oc0, oc1, pop0, pop1;
 static	int jlabel;
 
-typedef enum 
+typedef enum
 {
 	LAST_COMMAND_NONE	= 0,
 	LAST_COMMAND_MOV_STACK_EAX,
@@ -136,7 +136,7 @@ static int	Constant1( void ) {
 	return v;
 }
 
-static void Emit1( int v ) 
+static void Emit1( int v )
 {
 	buf[ compiledOfs ] = v;
 	compiledOfs++;
@@ -162,7 +162,7 @@ static void Emit4(int v)
 static void EmitPtr(void *ptr)
 {
 	intptr_t v = (intptr_t) ptr;
-	
+
 	Emit4(v);
 #if idx64
 	Emit1((v >> 32) & 0xFF);
@@ -278,7 +278,7 @@ static void EmitMovEAXStack(vm_t *vm, int andit)
 {
 	if(!jlabel)
 	{
-		if(LastCommand == LAST_COMMAND_MOV_STACK_EAX) 
+		if(LastCommand == LAST_COMMAND_MOV_STACK_EAX)
 		{	// mov [edi + ebx * 4], eax
 			compiledOfs -= 3;
 			vm->instructionPointers[instruction - 1] = compiledOfs;
@@ -293,12 +293,12 @@ static void EmitMovEAXStack(vm_t *vm, int andit)
 				Emit4(lastConst & andit);
 			else
 				Emit4(lastConst);
-			
+
 			return;
 		}
 		else if(pop1 != OP_DIVI && pop1 != OP_DIVU && pop1 != OP_MULI && pop1 != OP_MULU &&
 			pop1 != OP_STORE4 && pop1 != OP_STORE2 && pop1 != OP_STORE1)
-		{	
+		{
 			EmitString("8B 04 9F");	// mov eax, dword ptr [edi + ebx * 4]
 		}
 	}
@@ -324,8 +324,8 @@ void EmitMovECXStack(vm_t *vm)
 			return;
 		}
 		if(pop1 == OP_DIVI || pop1 == OP_DIVU || pop1 == OP_MULI || pop1 == OP_MULU ||
-			pop1 == OP_STORE4 || pop1 == OP_STORE2 || pop1 == OP_STORE1) 
-		{	
+			pop1 == OP_STORE4 || pop1 == OP_STORE2 || pop1 == OP_STORE1)
+		{
 			EmitString("89 C1");		// mov ecx, eax
 			return;
 		}
@@ -348,7 +348,7 @@ void EmitMovEDXStack(vm_t *vm, int andit)
 		}
 		else if(pop1 == OP_DIVI || pop1 == OP_DIVU || pop1 == OP_MULI || pop1 == OP_MULU ||
 			pop1 == OP_STORE4 || pop1 == OP_STORE2 || pop1 == OP_STORE1)
-		{	
+		{
 			EmitString("8B D0");	// mov edx, eax
 		}
 		else if(pop1 == OP_CONST && buf[compiledOfs-7] == 0xC7 && buf[compiledOfs-6] == 0x07 && buf[compiledOfs - 5] == 0x9F)
@@ -361,16 +361,16 @@ void EmitMovEDXStack(vm_t *vm, int andit)
 				Emit4(lastConst & andit);
 			else
 				Emit4(lastConst);
-			
+
 			return;
 		}
 		else
 			EmitString("8B 14 9F");	// mov edx, dword ptr [edi + ebx * 4]
-		
+
 	}
 	else
 		EmitString("8B 14 9F");		// mov edx, dword ptr [edi + ebx * 4]
-	
+
 	if(andit)
 		MASK_REG("E2", andit);		// and edx, 0x12345678
 }
@@ -396,7 +396,7 @@ Error handler for jump/call to invalid instruction number
 */
 
 static void ErrJump(void)
-{ 
+{
 	Com_Error(ERR_DROP, "program tried to execute code outside VM");
 	exit(1);
 }
@@ -459,14 +459,14 @@ static void DoSyscall(void)
 		int index;
 		intptr_t args[11];
 #endif
-		
+
 		data = (int *) (savedVM->dataBase + programStack + 4);
 
 #if idx64
 		args[0] = ~syscallNum;
 		for(index = 1; index < ARRAY_LEN(args); index++)
 			args[index] = data[index];
-			
+
 		opStackBase[opStackOfs + 1] = savedVM->systemCall(args);
 #else
 		data[0] = ~syscallNum;
@@ -480,10 +480,10 @@ static void DoSyscall(void)
 		case VM_JMP_VIOLATION:
 			ErrJump();
 		break;
-		case VM_BLOCK_COPY: 
+		case VM_BLOCK_COPY:
 			if(opStackOfs < 1)
 				Com_Error(ERR_DROP, "VM_BLOCK_COPY failed due to corrupted opStack");
-			
+
 			VM_BlockCopy(opStackBase[(opStackOfs - 1)], opStackBase[opStackOfs], arg);
 		break;
 		default:
@@ -540,7 +540,7 @@ int EmitCallDoSyscall(vm_t *vm)
 	EmitString("55");			// push ebp
 	EmitRexString(0x48, "89 E5");		// mov ebp, esp
 	EmitRexString(0x48, "83 E4 F0");	// and esp, 0xFFFFFFF0
-			
+
 	// call the syscall wrapper function DoSyscall()
 
 	EmitString("FF D2");			// call edx
@@ -596,12 +596,12 @@ int EmitCallProcedure(vm_t *vm, int sysCallOfs)
 	// Jump to syscall code, 1 byte offset should suffice
 	EmitString("7C");		// jl systemCall
 	jmpSystemCall = compiledOfs++;
-		
+
 	/************ Call inside VM ************/
-	
+
 	EmitString("81 F8");		// cmp eax, vm->instructionCount
 	Emit4(vm->instructionCount);
-		
+
 	// Error jump if invalid jump target
 	EmitString("73");		// jae badAddr
 	jmpBadAddr = compiledOfs++;
@@ -614,13 +614,13 @@ int EmitCallProcedure(vm_t *vm, int sysCallOfs)
 #endif
 	EmitString("8B 04 9F");			// mov eax, dword ptr [edi + ebx * 4]
 	EmitString("C3");			// ret
-		
+
 	// badAddr:
 	SET_JMPOFS(jmpBadAddr);
 	EmitCallErrJump(vm, sysCallOfs);
 
 	/************ System Call ************/
-	
+
 	// systemCall:
 	SET_JMPOFS(jmpSystemCall);
 	retval = compiledOfs;
@@ -751,7 +751,7 @@ qboolean ConstOptimize(vm_t *vm, int callProcOfsSyscall)
 	int v;
 	int op1;
 
-	// we can safely perform optimizations only in case if 
+	// we can safely perform optimizations only in case if
 	// we are 100% sure that next instruction is not a jump label
 	if (vm->jumpTableTargets && !jused[instruction])
 		op1 = code[pc+4];
@@ -934,7 +934,7 @@ qboolean ConstOptimize(vm_t *vm, int callProcOfsSyscall)
 		v = NextConstant4();
 		if(v < 0 || v > 31)
 			break;
-			
+
 		EmitMovEAXStack(vm, 0);
 		EmitString("C1 F8");				// sar eax, 0x12
 		Emit1(v);
@@ -948,7 +948,7 @@ qboolean ConstOptimize(vm_t *vm, int callProcOfsSyscall)
 		v = NextConstant4();
 		if(v < 0 || v > 31)
 			break;
-			
+
 		EmitMovEAXStack(vm, 0);
 		EmitString("C1 E8");				// shr eax, 0x12
 		Emit1(v);
@@ -957,7 +957,7 @@ qboolean ConstOptimize(vm_t *vm, int callProcOfsSyscall)
 		pc += 5;					// CONST + OP_RSHU
 		instruction += 1;
 		return qtrue;
-	
+
 	case OP_BAND:
 		v = Constant4();
 
@@ -973,7 +973,7 @@ qboolean ConstOptimize(vm_t *vm, int callProcOfsSyscall)
 			Emit4(v);
 		}
 		EmitCommand(LAST_COMMAND_MOV_STACK_EAX);
-		
+
 		pc += 1;					// OP_BAND
 		instruction += 1;
 		return qtrue;
@@ -993,14 +993,14 @@ qboolean ConstOptimize(vm_t *vm, int callProcOfsSyscall)
 			Emit4(v);
 		}
 		EmitCommand(LAST_COMMAND_MOV_STACK_EAX);
-		
+
 		pc += 1;				 	// OP_BOR
 		instruction += 1;
 		return qtrue;
 
 	case OP_BXOR:
 		v = Constant4();
-		
+
 		EmitMovEAXStack(vm, 0);
 		if(iss8(v))
 		{
@@ -1013,7 +1013,7 @@ qboolean ConstOptimize(vm_t *vm, int callProcOfsSyscall)
 			Emit4(v);
 		}
 		EmitCommand(LAST_COMMAND_MOV_STACK_EAX);
-		
+
 		pc += 1;					// OP_BXOR
 		instruction += 1;
 		return qtrue;
@@ -1054,7 +1054,7 @@ qboolean ConstOptimize(vm_t *vm, int callProcOfsSyscall)
 			EmitJumpIns(vm, "0F 84", Constant4());	// jz 0x12345678
 		else
 			EmitJumpIns(vm, "0F 85", Constant4());	// jnz 0x12345678
-		
+
 		instruction += 1;
 		return qtrue;
 
@@ -1101,7 +1101,7 @@ void VM_Compile(vm_t *vm, vmHeader_t *header)
 	buf = Z_Malloc(maxLength);
 	jused = Z_Malloc(jusedSize);
 	code = Z_Malloc(header->codeLength+32);
-	
+
 	Com_Memset(jused, 0, jusedSize);
 	Com_Memset(buf, 0, maxLength);
 
@@ -1151,7 +1151,7 @@ void VM_Compile(vm_t *vm, vmHeader_t *header)
 
 		if ( !vm->jumpTableTargets )
 			jlabel = 1;
-		else 
+		else
 			jlabel = jused[ instruction ];
 
 		instruction++;
@@ -1256,7 +1256,7 @@ void VM_Compile(vm_t *vm, vmHeader_t *header)
 #endif
 					EmitString("05");			// add eax, v
 					Emit4(v);
-					
+
 					if (oc0 == oc1 && pop0 == OP_LOCAL && pop1 == OP_LOCAL)
 					{
 #if idx64
@@ -1294,7 +1294,7 @@ void VM_Compile(vm_t *vm, vmHeader_t *header)
 					compiledOfs -= 12;
 					vm->instructionPointers[instruction - 1] = compiledOfs;
 				}
-				
+
 				pc++;					// OP_CONST
 				v = Constant4();
 
@@ -1318,7 +1318,7 @@ void VM_Compile(vm_t *vm, vmHeader_t *header)
 #endif
 					EmitString("2D");			// sub eax, v
 					Emit4(v);
-					
+
 					if(oc0 == oc1 && pop0 == OP_LOCAL && pop1 == OP_LOCAL)
 					{
 #if idx64
@@ -1362,7 +1362,7 @@ void VM_Compile(vm_t *vm, vmHeader_t *header)
 				EmitCommand(LAST_COMMAND_MOV_STACK_EAX);	// mov dword ptr [edi + ebx * 4], eax
 				break;
 			}
-			
+
 			EmitMovEAXStack(vm, vm->dataMask);
 #if idx64
 			EmitRexString(0x41, "8B 04 01");		// mov eax, dword ptr [r9 + eax]
@@ -1393,7 +1393,7 @@ void VM_Compile(vm_t *vm, vmHeader_t *header)
 			EmitCommand(LAST_COMMAND_MOV_STACK_EAX);	// mov dword ptr [edi + ebx * 4], eax
 			break;
 		case OP_STORE4:
-			EmitMovEAXStack(vm, 0);	
+			EmitMovEAXStack(vm, 0);
 			EmitString("8B 54 9F FC");			// mov edx, dword ptr -4[edi + ebx * 4]
 			MASK_REG("E2", vm->dataMask & ~3);		// and edx, 0x12345678
 #if idx64
@@ -1405,7 +1405,7 @@ void VM_Compile(vm_t *vm, vmHeader_t *header)
 			EmitCommand(LAST_COMMAND_SUB_BL_2);		// sub bl, 2
 			break;
 		case OP_STORE2:
-			EmitMovEAXStack(vm, 0);	
+			EmitMovEAXStack(vm, 0);
 			EmitString("8B 54 9F FC");			// mov edx, dword ptr -4[edi + ebx * 4]
 			MASK_REG("E2", vm->dataMask & ~1);		// and edx, 0x12345678
 #if idx64
@@ -1418,7 +1418,7 @@ void VM_Compile(vm_t *vm, vmHeader_t *header)
 			EmitCommand(LAST_COMMAND_SUB_BL_2);		// sub bl, 2
 			break;
 		case OP_STORE1:
-			EmitMovEAXStack(vm, 0);	
+			EmitMovEAXStack(vm, 0);
 			EmitString("8B 54 9F FC");			// mov edx, dword ptr -4[edi + ebx * 4]
 			MASK_REG("E2", vm->dataMask);			// and edx, 0x12345678
 #if idx64
@@ -1484,7 +1484,7 @@ void VM_Compile(vm_t *vm, vmHeader_t *header)
 				EmitJumpIns(vm, "0F 84", Constant4());	// je 0x12345678
 			break;
 			}
-		break;			
+		break;
 		case OP_NEGI:
 			EmitMovEAXStack(vm, 0);
 			EmitString("F7 D8");				// neg eax
@@ -1688,7 +1688,7 @@ void VM_Compile(vm_t *vm, vmHeader_t *header)
 #elif _WIN32
 	{
 		DWORD oldProtect = 0;
-		
+
 		// remove write permissions.
 		if(!VirtualProtect(vm->codeBase, compiledOfs, PAGE_EXECUTE_READ, &oldProtect))
 			Com_Error(ERR_FATAL, "VM_CompileX86: VirtualProtect failed");
@@ -1731,7 +1731,6 @@ int VM_CallCompiled(vm_t *vm, int *args)
 {
 	byte	stack[OPSTACK_SIZE + 15];
 	void	*entryPoint;
-	int		programCounter;
 	int		programStack, stackOnEntry;
 	byte	*image;
 	int	*opStack;
@@ -1745,10 +1744,8 @@ int VM_CallCompiled(vm_t *vm, int *args)
 	// we might be called recursively, so this might not be the very top
 	programStack = stackOnEntry = vm->programStack;
 
-	// set up the stack frame 
+	// set up the stack frame
 	image = vm->dataBase;
-
-	programCounter = 0;
 
 	programStack -= 48;
 
@@ -1788,10 +1785,10 @@ int VM_CallCompiled(vm_t *vm, int *args)
 		mov	dword ptr opStackOfs, ebx
 		mov	dword ptr opStack, edi
 		mov	dword ptr programStack, esi
-		
+
 		popad
 	}
-  #endif		
+  #endif
 #elif idx64
 	__asm__ volatile(
 		"movq %5, %%rax\n"


### PR DESCRIPTION
There are ton of unused variables in the codebase...
Also, please just breeze over the changes. A quick compile and test proves these seems to work fine but it could be reduced even more probably. Also, I apologize for the non-sense whitespace changes, I'm not sure what's causing that. 
Also, the branch name means nothing. 
