### PR TITLE
bugfix: environment loops not muted with dma backend

### DIFF
--- a/src/engine/client/snd_main.c
+++ b/src/engine/client/snd_main.c
@@ -126,8 +126,14 @@ void S_StartLocalSound( sfxHandle_t sfx, int channelNum )
 	}
 }
 
+/**
+ * start background track gets used for example for the menu-intro or other background music-tracks
+ */
 void S_StartBackgroundTrack( const char *intro, const char *loop )
 {
+	if( S_IsMuted())
+		return;
+
 	if( si.StartBackgroundTrack )
 	{
 		si.StartBackgroundTrack( intro, loop );
@@ -227,6 +233,7 @@ void S_Update( void )
 	if (S_IsMuted())
 	{
 		S_ClearLoopingSounds(qtrue);
+		S_StopBackgroundTrack();
 	}
 
 	if( si.Update )


### PR DESCRIPTION
Thanks to the player _foot on teh hill_, who reported this issue and helped with debugging and testing, the s_mute cvars now also work with the DMA backend, that gets autoselected, when openal is not avaialable.
The cvars now also extend to muting the start menu music with the same mechanism used to solve the dma backend-problem.
