### PR TITLE
Coins

### DIFF
--- a/src/engine/qcommon/cmd.c
+++ b/src/engine/qcommon/cmd.c
@@ -831,8 +831,7 @@ void Cmd_If_f( void )
 			break;
 
 		default:
-			Com_Printf(_( "if <number> <relation> <number> <cmdthen> (<cmdelse>) : compares the first two numbers and executes <cmdthen> if true, <cmdelse> if false\n"
-
+			Com_Printf(_( "if <number|string> <relation> <number|string> <cmdthen> (<cmdelse>) : compares the first two numbers or strings and executes <cmdthen> if true, <cmdelse> if false\n"
 			            "if <modifiers> <cmdthen> (<cmdelse>) : check if modifiers are (not) pressed\n"
 			            "-- modifiers are %s\n"
 			            "-- commands are cvar names unless prefixed with / or \\\n"),


### PR DESCRIPTION
besides adding support for using unicode relations and operators, /if now handles strings and integers completly transparent, simplifying syntax
also as a result /strcmp was removed due to now complete redundancy
