### PR TITLE
ignore .*.swp files created by vim editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ build-64/*
 *.vcxproj.user
 *.kdev4
 
+#ignore vim editor swap files
+.*.swp
+
 #ignore eclipse cdt project files
 .project
 .cproject


### PR DESCRIPTION
Hi, it could be usefull to ignore .*.swp files created by the [vim editor](http://www.vim.org/about.php), preventing to commit temporary files when vim is used !

Thanks in advance !
