### PR TITLE
Minor bug in Sys_LoadDll

### DIFF
--- a/src/engine/sys/sys_main.c
+++ b/src/engine/sys/sys_main.c
@@ -467,12 +467,6 @@ void *QDECL Sys_LoadDll( const char *name,
 
 	if ( !libHandle )
 	{
-		Com_DPrintf( "Sys_LoadDll(%s) could not find it\n", fname );
-		return NULL;
-	}
-
-	if ( !libHandle )
-	{
 		Com_Printf( "Sys_LoadDll(%s) failed:\n\"%s\"\n", name, Sys_LibraryError() );
 		return NULL;
 	}


### PR DESCRIPTION
The first check for libhandle will return and unless you're running developer 1 you'll never see the error message which caused the game not to load.
