### PR TITLE
Rotate and displace ckit properly

### DIFF
--- a/main/models/weapons/ckit/weapon.cfg
+++ b/main/models/weapons/ckit/weapon.cfg
@@ -2,6 +2,6 @@ weaponModel          models/weapons/ckit/ckit.md3
 weaponModel3rdPerson models/weapons/ckit/vwep.md3
 
 icon         icons/iconw_construct
-rotation     0.0 0.0 0.0
+rotation     10.85 0.0 -11.2
 rotationBone tag_weapon
-posOffs      -11.0 5.0 6.5
+posOffs      -11 5 6.5  //-11.0 8.9 6.5 for centered


### PR DESCRIPTION
Ckit rotation is very disturbing to the point I would want to use cg_drawgun 0 when building.

Displacement has been changed so it doesn't block the view.
Rotation makes it point forwards and also makes it in level with the horizon.

Commented in the displacement is just an optional setting for people who want their guns centered (which cannot happen for some models, as they are one-sided.
