### PR TITLE
fix: 'nix, don't make assumptions on display name

### DIFF
--- a/src/engine/sys/sys_unix.c
+++ b/src/engine/sys/sys_unix.c
@@ -1136,11 +1136,27 @@ Sys_IsNumLockDown
 qboolean Sys_IsNumLockDown( void )
 {
 #if !defined(MACOS_X) && !defined(DEDICATED) && !defined(BUILD_TTY_CLIENT)
-	Display        *dpy = XOpenDisplay(":0");
-	XKeyboardState x;
+  const char     *denv = getenv( "DISPLAY" );
+  Display        *dpy;
+  XKeyboardState x;
 
-	XGetKeyboardControl(dpy, &x);
-	XCloseDisplay(dpy);
+  if ( denv != NULL && strlen( denv ) > 0 )
+    dpy = XOpenDisplay(denv);
+  else
+    dpy = XOpenDisplay(":0");
+
+  if ( dpy == 0 )
+  {
+    Com_Printf( "ERROR: cannot determine numlock state as we couldn't \n   \
+                        grab your non-standard (e.g. not ':0') X display.\n   \
+                        ensure the 'DISPLAY' environment variable is set.\n" );
+    return qtrue;
+  }
+  else
+  {
+    XGetKeyboardControl(dpy, &x);
+    XCloseDisplay(dpy);
+  }
 
 	return (x.led_mask & 2) ? qtrue : qfalse;
 #else


### PR DESCRIPTION
tried binding my usual keypad-based layout but got a segfault. been hit by this type of thing before! the patch is overkill given the fact that if DISPLAY isn't set, the game won't initialise at all, but i certainly needed something as i don't run any xservers on :0
