### PR TITLE
Fix compile error with updated GL Spec

### DIFF
--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -967,7 +967,7 @@ static GLenum debugTypes[] =
 #define DEBUG_CALLBACK_CALL
 #endif
 static void DEBUG_CALLBACK_CALL GLimp_DebugCallback( GLenum source, GLenum type, GLuint id,
-                                       GLenum severity, GLsizei length, const GLchar *message, void *userParam )
+                                       GLenum severity, GLsizei length, const GLchar *message, const void *userParam )
 {
 	const char *debugTypeName;
 	const char *debugSeverity;


### PR DESCRIPTION
userParam is const in mesa, as per the spec
https://www.opengl.org/registry/specs/ARB/debug_output.txt
