### PR TITLE
func_bobbing now works

### DIFF
--- a/src/gamelogic/game/g_spawn_mover.c
+++ b/src/gamelogic/game/g_spawn_mover.c
@@ -1180,22 +1180,22 @@ void reset_moverspeed( gentity_t *self, float fallbackSpeed )
 
 	G_ResetFloatField(&self->speed, qtrue, self->config.speed, self->eclass->config.speed, fallbackSpeed);
 
-        // reset duration only for linear moving
-        // else func_bobbing will not move
-        if ( self->s.pos.trType != TR_SINE )
-        {
-            // calculate time to reach second position from speed
-            VectorSubtract( self->activatedPosition, self->restingPosition, move );
-            distance = VectorLength( move );
+	// reset duration only for linear moving
+	// else func_bobbing will not move
+	if ( self->s.pos.trType != TR_SINE )
+	{
+		// calculate time to reach second position from speed
+		VectorSubtract( self->activatedPosition, self->restingPosition, move );
+		distance = VectorLength( move );
 
-            VectorScale( move, self->speed, self->s.pos.trDelta );
-            self->s.pos.trDuration = distance * 1000 / self->speed;
+		VectorScale( move, self->speed, self->s.pos.trDelta );
+		self->s.pos.trDuration = distance * 1000 / self->speed;
 
-            if ( self->s.pos.trDuration <= 0 )
-            {
-                    self->s.pos.trDuration = 1;
-            }
-        }
+		if ( self->s.pos.trDuration <= 0 )
+		{
+			self->s.pos.trDuration = 1;
+		}
+	}
 }
 
 static void SP_ConstantLightField( gentity_t *self )


### PR DESCRIPTION
trDuration needs no reset for func_bobbing, it calculated in SP_func_bobbing. Since it doesn't use activatedPosition and restingPositions, distance becomes 0 causing trDuration set to 1.
Every int deltaTime divided by 1 results in integral num, multiplied by 2*pi gives us same angle and same sin(angle). That's the reason func_bobbing didn't move before.
