### PR TITLE
Add static_asserts to ensure that the assumptions hold.

### DIFF
--- a/src/engine/audio/OggCodec.cpp
+++ b/src/engine/audio/OggCodec.cpp
@@ -39,12 +39,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vorbis/vorbisfile.h>
 
 /*
- *The following assumptions made:
+ *The following assumptions are made:
  *-Each byte consists of 8bits
  *-sizeof(char) == 1
  *-sizeof(short) == 2
  *-sizeof(int) == 4
  */
+static_assert(sizeof(char)==1,"sizeof(char)!=1");
+static_assert(sizeof(short)==2,"sizeof(short)!=2");
+static_assert(sizeof(int)==4,"sizeof(int)!=4");
 
 namespace Audio{
 /*

--- a/src/engine/audio/OpusCodec.cpp
+++ b/src/engine/audio/OpusCodec.cpp
@@ -38,12 +38,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <opusfile.h>
 
 /*
- *The following assumptions made:
+ *The following assumptions are made:
  *-Each byte consists of 8bits
  *-sizeof(char) == 1
  *-sizeof(short) == 2
  *-sizeof(int) == 4
  */
+static_assert(sizeof(char)==1,"sizeof(char)!=1");
+static_assert(sizeof(short)==2,"sizeof(short)!=2");
+static_assert(sizeof(int)==4,"sizeof(int)!=4");
 
 namespace Audio{
 

--- a/src/engine/audio/WavCodec.cpp
+++ b/src/engine/audio/WavCodec.cpp
@@ -35,12 +35,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <algorithm>
 
 /*
- *The following assumptions made:
+ *The following assumptions are made:
  *-Each byte consists of 8bits
  *-sizeof(char) == 1
  *-sizeof(short) == 2
  *-sizeof(int) == 4
  */
+static_assert(sizeof(char)==1,"sizeof(char)!=1");
+static_assert(sizeof(short)==2,"sizeof(short)!=2");
+static_assert(sizeof(int)==4,"sizeof(int)!=4");
 
 namespace Audio {
 


### PR DESCRIPTION
Inside the *Codec code certain assumptions with regards to the size
of char, short and int are made. Previously, these assumptions were
only stated in comments. Now, they are also statically asserted.
