### PR TITLE
Allow name change to a name that is the same as the one stored by the client

### DIFF
--- a/src/engine/framework/CvarSystem.cpp
+++ b/src/engine/framework/CvarSystem.cpp
@@ -97,6 +97,12 @@ namespace Cvar {
                     modified = true;
                     Z_Free(var.string);
                     var.string = CopyString(cvar.value.c_str());
+                } else if (!Q_stricmp(var.name, "name"))
+                {
+                    /* Sometimes the previous attempt to set name may have been blocked by
+                      the gamelogic due to g_maxnamechanges, being muted, etc. This causes
+                      the name to always be sent to the server */
+                    modified = true;
                 }
             } else {
                 var.string = CopyString(cvar.value.c_str());


### PR DESCRIPTION
Workaround for 'Inconsistency 3' in #316.
That one annoyed me on many occasions. It would occur when my client crashed, I reconnected and had name set to unnamedplayer because my old dead connection still had my name, and then /name to the same thing as before would have no effect.
