### PR TITLE
Make /alias usable with multiple commands

### DIFF
--- a/src/engine/framework/BaseCommands.cpp
+++ b/src/engine/framework/BaseCommands.cpp
@@ -810,7 +810,7 @@ namespace Cmd {
                 }
 
                 //Modify or create an alias
-                const std::string& command = args.EscapedArgs(2);
+                const std::string& command = args.ConcatArgs(2);
 
                 auto iter = aliases.find(name);
                 if (iter != aliases.end()) {


### PR DESCRIPTION
Currently it escapes characters e.g. ";" is replaced with "\;" so it is not very useful - only a single command can be done with one alias.
