### PR TITLE
Fix mara zap dynamic light bug (?)

### DIFF
--- a/src/gamelogic/cgame/cg_ents.c
+++ b/src/gamelogic/cgame/cg_ents.c
@@ -282,7 +282,7 @@ static void CG_EntityEffects( centity_t *cent )
 	}
 
 	// constant light glow
-	if ( cent->currentState.constantLight )
+	if ( cent->currentState.constantLight && ( cent->currentState.eType == ET_MOVER || cent->currentState.eType == ET_MODELDOOR ) )
 	{
 		int cl;
 		int i, r, g, b;

--- a/src/gamelogic/cgame/cg_event.c
+++ b/src/gamelogic/cgame/cg_event.c
@@ -658,72 +658,6 @@ void CG_OnMapRestart( void )
 }
 
 /*
-=========================
-CG_Level2Zap
-=========================
-*/
-static void CG_Level2Zap( entityState_t *es )
-{
-	int       i;
-	centity_t *source = NULL, *target = NULL;
-
-	if ( es->misc < 0 || es->misc >= MAX_CLIENTS )
-	{
-		return;
-	}
-
-	source = &cg_entities[ es->misc ];
-
-	for ( i = 0; i <= 2; i++ )
-	{
-		switch ( i )
-		{
-			case 0:
-				if ( es->time <= 0 )
-				{
-					continue;
-				}
-
-				target = &cg_entities[ es->time ];
-				break;
-
-			case 1:
-				if ( es->time2 <= 0 )
-				{
-					continue;
-				}
-
-				target = &cg_entities[ es->time2 ];
-				break;
-
-			case 2:
-				if ( es->constantLight <= 0 )
-				{
-					continue;
-				}
-
-				target = &cg_entities[ es->constantLight ];
-				break;
-		}
-
-		if ( !CG_IsTrailSystemValid( &source->level2ZapTS[ i ] ) )
-		{
-			source->level2ZapTS[ i ] = CG_SpawnNewTrailSystem( cgs.media.level2ZapTS );
-		}
-
-		if ( CG_IsTrailSystemValid( &source->level2ZapTS[ i ] ) )
-		{
-			CG_SetAttachmentCent( &source->level2ZapTS[ i ]->frontAttachment, source );
-			CG_SetAttachmentCent( &source->level2ZapTS[ i ]->backAttachment, target );
-			CG_AttachToCent( &source->level2ZapTS[ i ]->frontAttachment );
-			CG_AttachToCent( &source->level2ZapTS[ i ]->backAttachment );
-		}
-	}
-
-	source->level2ZapTime = cg.time;
-}
-
-/*
 ==============
 CG_Momentum
 
@@ -1398,10 +1332,6 @@ void CG_EntityEvent( centity_t *cent, vec3_t position )
 				cg.spawnTime = cg.time;
 			}
 
-			break;
-
-		case EV_LEV2_ZAP:
-			CG_Level2Zap( es );
 			break;
 
 		case EV_HIT:

--- a/src/gamelogic/shared/bg_misc.c
+++ b/src/gamelogic/shared/bg_misc.c
@@ -1255,8 +1255,6 @@ static const char *const eventnames[] =
   "EV_CLIPS_REFILL",    // weapon clips have been refilled
   "EV_FUEL_REFILL",     // jetpack fuel has been refilled
 
-  "EV_LEV2_ZAP",
-
   "EV_HIT", // notify client of a hit
 
   "EV_MOMENTUM" // notify client of generated momentum

--- a/src/gamelogic/shared/bg_public.h
+++ b/src/gamelogic/shared/bg_public.h
@@ -624,8 +624,6 @@ typedef enum
   EV_CLIPS_REFILL,    // weapon clips have been refilled
   EV_FUEL_REFILL,     // jetpack fuel has been refilled
 
-  EV_LEV2_ZAP,
-
   EV_HIT, // notify client of a hit
 
   EV_MOMENTUM // notify client of generated momentum


### PR DESCRIPTION
Remove some old unused mara zap code. Ignore an entity's constantLight f.ield if it is not ET_MOVER or ET_MODELDOOR as these are the only types that the server-side code creates a constant light in. For the mara, constantLight is used to store entity nums which erroneously caused a dynamic light to be created on each zap.

I believe it is actually a bug that the mara created any dynamic light when zapping. The reason this happens is because 3 entitynums are packed into the constantLight field. Often they are all ENTITYNUM_NONE which just happens to result in a moderately bright white light which looks quite reasonable as if it might have been designed that way on purpose.

It looks like the constantlight field is only supposed to be used for a couple of map elements so I added a line that ignores it if it isn't one of these. Hopefully this will prevent any dretch lamps.
