### PR TITLE
Use physical keyboard layout for game controls

### DIFF
--- a/src/engine/sys/sdl_input.cpp
+++ b/src/engine/sys/sdl_input.cpp
@@ -295,8 +295,67 @@ static keyNum_t IN_TranslateSDLToQ3Key( SDL_Keysym *keysym, qboolean down )
 
 	if ( keysym->sym >= SDLK_SPACE && keysym->sym < SDLK_DELETE )
 	{
-		// These happen to match the ASCII chars
-		key = ( keyNum_t ) keysym->sym;
+		if ( keysym->scancode >= SDL_SCANCODE_A && keysym->scancode <= SDL_SCANCODE_Z )
+		{
+			key = (keyNum_t)(keysym->scancode - SDL_SCANCODE_A + 'a');
+		} 
+		else if ( keysym->scancode >= SDL_SCANCODE_1 && keysym->scancode <= SDL_SCANCODE_9 )
+		{
+			key = (keyNum_t)(keysym->scancode - SDL_SCANCODE_1 + '1');
+		} 
+		else switch ( keysym->scancode )
+		{
+			case SDL_SCANCODE_0:
+				key = (keyNum_t)'0';
+				break;
+
+			case SDL_SCANCODE_SEMICOLON:
+				key = (keyNum_t)';';
+				break;
+
+			case SDL_SCANCODE_MINUS:
+				key = (keyNum_t)'-';
+				break;
+
+			case SDL_SCANCODE_EQUALS:
+				key = (keyNum_t)'=';
+				break;
+
+			case SDL_SCANCODE_LEFTBRACKET:
+				key = (keyNum_t)'[';
+				break;
+
+			case SDL_SCANCODE_RIGHTBRACKET:
+				key = (keyNum_t)']';
+				break;
+
+			case SDL_SCANCODE_APOSTROPHE:
+				key = (keyNum_t)'\'';
+				break;
+
+			case SDL_SCANCODE_PERIOD:
+				key = (keyNum_t)'.';
+				break;
+
+			case SDL_SCANCODE_COMMA:
+				key = (keyNum_t)',';
+				break;
+
+			case SDL_SCANCODE_SLASH:
+				key = (keyNum_t)'/';
+				break;
+
+			case SDL_SCANCODE_GRAVE:
+				key = (keyNum_t)'`';
+				break;
+
+			case SDL_SCANCODE_BACKSLASH:
+				key = (keyNum_t)'\\';
+				break;
+
+			default:
+				key = (keyNum_t)keysym->sym;
+		}
 	}
 	else
 	{


### PR DESCRIPTION
If you are using a software keyboard remapping, it is better for the controls to correspond to the physical keys instead of the virtual layout. This fixes a regression caused by the introduction of SDL2.