### PR TITLE
Correct buffer size for formatted net address with port

### DIFF
--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -3079,7 +3079,7 @@ void CL_ServersResponsePacket( const netadr_t *from, msg_t *msg, qboolean extend
 				if ( addresses[ numservers ].port == cls.serverLinks[ j ].port4 && !memcmp( addresses[ numservers ].ip, cls.serverLinks[ j ].ip, 4 ) )
 				{
 					// found it, so look up the corresponding address
-					char s[ NET_ADDRSTRMAXLEN ];
+					char s[ NET_ADDR_W_PORT_STR_MAX_LEN ];
 
 					// hax to get the IP address & port as a string (memcmp etc. SHOULD work, but...)
 					cls.serverLinks[ j ].type = NA_IP6;
@@ -3131,7 +3131,7 @@ void CL_ServersResponsePacket( const netadr_t *from, msg_t *msg, qboolean extend
 				if ( addresses[ numservers ].port == cls.serverLinks[ j ].port6 && !memcmp( addresses[ numservers ].ip6, cls.serverLinks[ j ].ip6, 16 ) )
 				{
 					// found it, so look up the corresponding address
-					char s[ NET_ADDRSTRMAXLEN ];
+					char s[ NET_ADDR_W_PORT_STR_MAX_LEN ];
 
 					// hax to get the IP address & port as a string (memcmp etc. SHOULD work, but...)
 					cls.serverLinks[ j ].type = NA_IP;

--- a/src/engine/qcommon/net_ip.cpp
+++ b/src/engine/qcommon/net_ip.cpp
@@ -625,7 +625,7 @@ qboolean NET_CompareBaseAdr( netadr_t a, netadr_t b )
 
 const char      *NET_AdrToString( netadr_t a )
 {
-	static  char s[ NET_ADDRSTRMAXLEN ];
+	static  char s[ NET_ADDR_STR_MAX_LEN ];
 
 	if ( a.type == NA_LOOPBACK )
 	{
@@ -649,7 +649,7 @@ const char      *NET_AdrToString( netadr_t a )
 
 const char      *NET_AdrToStringwPort( netadr_t a )
 {
-	static  char s[ NET_ADDRSTRMAXLEN ];
+	static  char s[ NET_ADDR_W_PORT_STR_MAX_LEN ];
 
 	if ( a.type == NA_LOOPBACK )
 	{
@@ -661,11 +661,11 @@ const char      *NET_AdrToStringwPort( netadr_t a )
 	}
 	else if ( NET_IS_IPv4( a.type ) )
 	{
-		Com_sprintf( s, sizeof( s ), "%s:%lu", NET_AdrToString( a ), ( unsigned long ) ntohs( a.type == NA_IP_DUAL ? a.port4 : a.port ) );
+		Com_sprintf( s, sizeof( s ), "%s:%hu", NET_AdrToString( a ), ntohs( a.type == NA_IP_DUAL ? a.port4 : a.port ) );
 	}
 	else if ( NET_IS_IPv6( a.type ) )
 	{
-		Com_sprintf( s, sizeof( s ), "[%s]:%lu", NET_AdrToString( a ), ( unsigned long ) ntohs( a.type == NA_IP_DUAL ? a.port6 : a.port ) );
+		Com_sprintf( s, sizeof( s ), "[%s]:%hu", NET_AdrToString( a ), ntohs( a.type == NA_IP_DUAL ? a.port6 : a.port ) );
 	}
 	return s;
 }
@@ -1031,7 +1031,7 @@ Sys_ShowIP
 void Sys_ShowIP( void )
 {
 	int  i;
-	char addrbuf[ NET_ADDRSTRMAXLEN ];
+	char addrbuf[ NET_ADDR_STR_MAX_LEN ];
 
 	for ( i = 0; i < numIP; i++ )
 	{

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -174,7 +174,13 @@ typedef enum
   NS_SERVER
 } netsrc_t;
 
-#define NET_ADDRSTRMAXLEN 48 // maximum length of an IPv6 address string including trailing '\0'
+// maximum length of an IPv6 address string including trailing '\0'
+#define NET_ADDR_STR_MAX_LEN 48
+
+// maximum length of an formatted IPv6 address string including port and trailing '\0'
+// format [%s]:%hu - 48 for %s (address), 3 for []: and 5 for %hu (port number, max value 65535)
+#define NET_ADDR_W_PORT_STR_MAX_LEN ( NET_ADDR_STR_MAX_LEN + 3 + 5 )
+
 typedef struct
 {
     netadrtype_t   type;


### PR DESCRIPTION
Fixes "Com_sprintf: overflow of 48 bytes buffer" console spam on server listing

Feel free to come with better name than NET_ADDR_W_PORT_STR_MAX_LEN it was derived from NET_AdrToString - NET_AdrToString**wPort**