### PR TITLE
Respect master volume setting from first millisecond

### DIFF
--- a/src/engine/audio/Audio.cpp
+++ b/src/engine/audio/Audio.cpp
@@ -138,6 +138,8 @@ namespace Audio {
         InitSounds();
         InitEmitters();
 
+        UpdateListenerGain();
+
         for (int i = 0; i < MAX_GENTITIES; i++) {
             entityLoops[i] = {false, nullptr, -1, -1};
         }
@@ -203,11 +205,7 @@ namespace Audio {
             }
         }
 
-        if ((muteWhenMinimized.Get() and com_minimized->integer) or (muteWhenUnfocused.Get() and com_unfocused->integer)) {
-            AL::SetListenerGain(0.0f);
-        } else {
-            AL::SetListenerGain(SliderToAmplitude(masterVolume.Get()));
-        }
+        UpdateListenerGain();
 
         // Update the rest of the system
         CaptureTestUpdate();
@@ -383,6 +381,14 @@ namespace Audio {
         }
 
         UpdateListenerEntity(entityNum, orientation);
+    }
+
+    void UpdateListenerGain() {
+        if ((muteWhenMinimized.Get() and com_minimized->integer) or (muteWhenUnfocused.Get() and com_unfocused->integer)) {
+            AL::SetListenerGain(0.0f);
+        } else {
+            AL::SetListenerGain(SliderToAmplitude(masterVolume.Get()));
+        }
     }
 
     void UpdateEntityPosition(int entityNum, const vec3_t position) {

--- a/src/engine/audio/Audio.h
+++ b/src/engine/audio/Audio.h
@@ -60,6 +60,7 @@ namespace Audio {
     void StreamData(int streamNum, const void* data, int numSamples, int rate, int width, int channels, float volume, int entityNum);
 
     void UpdateListener(int entityNum, const vec3_t orientation[3]);
+    void UpdateListenerGain();
     void UpdateEntityPosition(int entityNum, const vec3_t position);
     void UpdateEntityVelocity(int entityNum, const vec3_t velocity);
 


### PR DESCRIPTION
Menu background music starts playing before first Audio::Update call which syncs the master volume, so set it also in Audio::Init