### PR TITLE
larger and scrollable map list with max-height, fix #667

### DIFF
--- a/main/ui/server_create.rml
+++ b/main/ui/server_create.rml
@@ -7,6 +7,14 @@
 			.levelshot {
 				width: 100%;
 			}
+			/* select and selectbox elements are implicit, but their styles must be explicitely written */
+			row#maplist dataselect, row#maplist select, input#hostname, input#password {
+				width: 25em;
+			}
+			row#maplist selectbox {
+				max-height: 25em;
+				overflow-y: auto;
+			}
 
 
 		</style>
@@ -14,17 +22,17 @@
 	<body template="window" id="createserver" onShow="buildDS mapList" style="width:40em; margin:10%;">
 		<h1> Start local/LAN game</h1>
 		<row>
-			<input type="text" cvar="sv_hostname" class="text" style="width:20em;"/>
+			<input type="text" cvar="sv_hostname" class="text" id="hostname"/>
 			<h3> Hostname </h3>
 		</row>
 		<row>
-			<input type="text" cvar="g_password" class="text" style="width:20em;"/>
+			<input type="text" cvar="g_password" class="text" id="password"/>
 			<input cvar="g_needpass" type="checkbox" style="margin-right:1em;"/>
 			<h3> Password </h3>
 		</row>
 
 		<form onsubmit='execForm "map $map$"'>
-			<row>
+			<row id="maplist">
 				<dataselect source="mapList.default" fields="mapName" valuefield="mapLoadName" name="map" cvar="ui_dialogCvar1"/>
 				<h3> Map </h3>
 			</row>


### PR DESCRIPTION
Hi, this is some ui changes to fix #667.

Before this changes, the map list could be longer than the screen, and the map names larger than the map list:

![map list](http://dl.illwieckz.net/u/thomas-debesse/bazar/unvanquished/bugs/unvanquished_2015-03-08_033321_001.png)

With this fix, the map selector is as large as other form entries (I have enlarged each since it was possible and it allows future needs), scrollable and have a max-height.

The max-height and the scroll bar only appears on long list.

Small list (adaptive height, no scrollbar):

![small list](http://dl.illwieckz.net/u/thomas-debesse/bazar/unvanquished/bugs/unvanquished_2015-03-08_031008_001.png)

Long list (max height, scrollbar):

![long list](http://dl.illwieckz.net/u/thomas-debesse/bazar/unvanquished/bugs/unvanquished_2015-03-08_030239_001.png)