### PR TITLE
sort maps by internal bsp name instead of color code, fix #670

### DIFF
--- a/src/gamelogic/cgame/cg_gameinfo.cpp
+++ b/src/gamelogic/cgame/cg_gameinfo.cpp
@@ -144,16 +144,16 @@ static void CG_LoadArenasFromFile( char *filename )
 }
 
 /*
-=================
-CG_MapNameCompare
-=================
+===============
+CG_MapLoadNameCompare
+===============
 */
-static int CG_MapNameCompare( const void *a, const void *b )
+static int CG_MapLoadNameCompare( const void *a, const void *b )
 {
 	mapInfo_t *A = ( mapInfo_t * ) a;
 	mapInfo_t *B = ( mapInfo_t * ) b;
 
-	return Q_stricmp( A->mapName, B->mapName );
+	return Q_stricmp( A->mapLoadName, B->mapLoadName );
 }
 
 /*
@@ -199,5 +199,5 @@ void CG_LoadArenas( void )
 		}
 	}
 
-	qsort( rocketInfo.data.mapList, rocketInfo.data.mapCount, sizeof( mapInfo_t ), CG_MapNameCompare );
+	qsort( rocketInfo.data.mapList, rocketInfo.data.mapCount, sizeof( mapInfo_t ), CG_MapLoadNameCompare );
 }


### PR DESCRIPTION
Hi, map names were sorted by display name, so maps were sorted by color codes!

To fix that, two options:

* filter map names before sorting them (slower, and needs a safe filter algorithm)
* filter by bsp name (quick and safe)

This change implements the sort by bsp name.

Before:

![sort by color code](http://dl.illwieckz.net/u/thomas-debesse/bazar/unvanquished/bugs/unvanquished_2015-03-08_045745_001.png)

After:

![sort by internal bsp map name](http://dl.illwieckz.net/u/thomas-debesse/bazar/unvanquished/bugs/unvanquished_2015-03-08_050431_004.png)

This change fixes issue #670.