### PR TITLE
fix sensor_player entity, ref #663

### DIFF
--- a/src/gamelogic/sgame/sg_spawn_sensor.cpp
+++ b/src/gamelogic/sgame/sg_spawn_sensor.cpp
@@ -489,7 +489,7 @@ void sensor_player_touch( gentity_t *self, gentity_t *activator, trace_t *trace 
 	}
 	else
 	{
-		shouldFire = qfalse;
+		shouldFire = qtrue;
 	}
 
 	if( shouldFire == !self->conditions.negated )


### PR DESCRIPTION
Without that, many entities are broken if we use new official keywords instead of old ones.