### PR TITLE
Vs2015

### DIFF
--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -165,9 +165,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define DLLIMPORT __declspec(dllimport)
 #define OVERRIDE override
 #define FINAL final
+// VS2015 supports this
+#if _MSC_VER >= 1900
+#define NOEXCEPT noexcept
+#define NOEXCEPT_IF(x) noexcept(x)
+#define NOEXCEPT_EXPR(x) false
+#else
 #define NOEXCEPT
 #define NOEXCEPT_IF(x)
 #define NOEXCEPT_EXPR(x) false
+#endif
 // Work around lack of C99 support
 #define __func__ __FUNCTION__
 // Work around lack of constexpr

--- a/src/common/Cvar.h
+++ b/src/common/Cvar.h
@@ -274,12 +274,12 @@ namespace Cvar {
         if (Parse(text, value)) {
             OnValueChangedResult validationResult = Validate(value);
             if (validationResult.success) {
-                return {true, GetDescription()};
+                return OnValueChangedResult{true, GetDescription()};
             } else {
                 return validationResult;
             }
         } else {
-            return {false, Str::Format("value \"%s\" is not of type '%s' as expected", text, GetCvarTypeName<T>())};
+            return OnValueChangedResult{false, Str::Format("value \"%s\" is not of type '%s' as expected", text, GetCvarTypeName<T>())};
         }
     }
 
@@ -290,7 +290,7 @@ namespace Cvar {
 
     template<typename T>
     OnValueChangedResult Cvar<T>::Validate(const T&) {
-        return {true, ""};
+        return OnValueChangedResult{true, ""};
     }
 
     template<typename T>
@@ -387,9 +387,9 @@ namespace Cvar {
     OnValueChangedResult Range<Base>::Validate(const value_type& value) {
         bool inBounds = value <= max and value >= min;
         if (inBounds) {
-            return {true, ""};
+            return OnValueChangedResult{true, ""};
         } else {
-            return {false, Str::Format("%s is not between %s and %s", SerializeCvarValue(value), SerializeCvarValue(min), SerializeCvarValue(max))};
+            return OnValueChangedResult{false, Str::Format("%s is not between %s and %s", SerializeCvarValue(value), SerializeCvarValue(min), SerializeCvarValue(max))};
         }
     }
 

--- a/src/gamelogic/shared/CommonProxies.cpp
+++ b/src/gamelogic/shared/CommonProxies.cpp
@@ -377,7 +377,7 @@ class VMCvarProxy : public Cvar::CvarProxy {
         virtual Cvar::OnValueChangedResult OnValueChanged(Str::StringRef newValue) OVERRIDE {
             value = newValue;
             modificationCount++;
-            return {true, ""};
+            return Cvar::OnValueChangedResult{true, ""};
         }
 
         void Update(vmCvar_t* cvar) {

--- a/src/libs/libRocket/Source/Core/PropertyParserNumber.cpp
+++ b/src/libs/libRocket/Source/Core/PropertyParserNumber.cpp
@@ -57,6 +57,7 @@ bool PropertyParserNumber::ParseValue(Property& property, const String& value, c
 	property.unit = Property::NUMBER;
 
 	// Check for a unit declaration at the end of the number.
+	size_t suffixLength = 0;
 	for (size_t i = 0; i < unit_suffixes.size(); i++)
 	{
 		const UnitSuffix& unit_suffix = unit_suffixes[i];
@@ -66,13 +67,17 @@ bool PropertyParserNumber::ParseValue(Property& property, const String& value, c
 
 		if (strcasecmp(value.CString() + (value.Length() - unit_suffix.second.Length()), unit_suffix.second.CString()) == 0)
 		{
+			// Found a suffix, remember the size.
+			suffixLength = unit_suffix.second.Length();
 			property.unit = unit_suffix.first;
 			break;
 		}
 	}
 
 	float float_value;
-	if (sscanf(value.CString(), "%f", &float_value) == 1)
+	// Remove the unit suffix if there was one so sscanf doesn't see it and get confused.
+	int matched = sscanf(suffixLength == 0 ? value.CString() : value.Substring(0, value.Length() - suffixLength).CString(), "%f", &float_value);
+	if (matched == 1)
 	{
 		property.value = Variant(float_value);
 		return true;


### PR DESCRIPTION
Enable Unvanquished to compile and run with VS2015.
Note SDL2 needs to be built with VS2015 before Unvanquished will link.
Requires change to librocket too to actually work as graphics/layout is a mess otherwise.
Will also submit librocket change upstream.