### PR TITLE
Fix file error handling

### DIFF
--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -307,6 +307,7 @@ static const minizip_category_impl& minizip_category()
 
 // Filesystem-specific error codes
 enum filesystem_error {
+	no_filesystem_error,
 	invalid_filename,
 	no_such_file,
 	no_such_directory,
@@ -1878,7 +1879,8 @@ DirectoryRange ListFiles(Str::StringRef path, std::error_code& err)
 		SetErrorCodeFilesystem(err, filesystem_error::invalid_filename);
 		return {};
 	}
-	return RawPath::ListFiles(Path::Build(homePath, path), err);
+	auto fpath = Path::Build(homePath, path);
+	return RawPath::ListFiles(fpath, err);
 #endif
 }
 

--- a/src/engine/qcommon/files.cpp
+++ b/src/engine/qcommon/files.cpp
@@ -86,7 +86,7 @@ int FS_FOpenFileRead(const char* path, fileHandle_t* handle, bool)
 		return FS_FileExists(path);
 
 	*handle = FS_AllocHandle();
-	int length;
+	int length = -1;
 	std::error_code err;
 	if (FS::PakPath::FileExists(path)) {
 		handleTable[*handle].fileData = FS::PakPath::ReadFile(path, err);
@@ -97,7 +97,7 @@ int FS_FOpenFileRead(const char* path, fileHandle_t* handle, bool)
 			length = handleTable[*handle].fileData.size();
 		}
 	} else {
-		handleTable[*handle].file = FS::HomePath::OpenRead(path);
+		handleTable[*handle].file = FS::HomePath::OpenRead(path,err);
 		if (!err) {
 			length = handleTable[*handle].file.Length();
 			handleTable[*handle].isPakFile = false;


### PR DESCRIPTION
This change fixes a bug in file error handling that is preventing the app working, at least on windows, possibly elsewhere too. An error code of 0 not considered an error at all, so moved the error codes up and hopefully made things a bit more robust. The Windows build appears to works better at least for it.