### PR TITLE
Audio

### DIFF
--- a/src/common/String.h
+++ b/src/common/String.h
@@ -132,7 +132,7 @@ namespace Str {
         }
         size_t rfind(T chr, size_t pos = npos)
         {
-            pos = std::min(pos + 1, len);
+            pos = (pos == npos) ? len : std::min(pos + 1, len);
             for (const T* p = ptr + pos; p != ptr;) {
                 if (*--p == chr)
                     return p - ptr;

--- a/src/engine/audio/OggCodec.cpp
+++ b/src/engine/audio/OggCodec.cpp
@@ -168,9 +168,13 @@ AudioData LoadOggCodec(Str::StringRef filename)
 			else
 				bufferCapacity *= 2;
 			bufferRemaining = bufferCapacity - bufferUsed;
+			char* oldBuffer = buffer;
 			buffer = (char*)realloc(buffer, bufferCapacity);
 			if (!buffer)
+			{
+				free(oldBuffer);
 				throw std::bad_alloc();
+			}
 		}
 		bytesRead = ov_read(vorbisFile.get(), &buffer[bufferUsed], bufferRemaining, 0, sampleWidth, 1, &bitStream);
 		if (bytesRead <= 0)

--- a/src/engine/audio/OggCodec.cpp
+++ b/src/engine/audio/OggCodec.cpp
@@ -121,11 +121,11 @@ AudioData LoadOggCodec(Str::StringRef filename)
 		audioLogs.Warn("Failed to open %s: %s", filename, err.what());
 		return AudioData();
 	}
-	OggDataSource dataSource = {&audioFile, 0};
+	OggDataSource dataSource = { &audioFile, 0 };
 	std::unique_ptr<OggVorbis_File> vorbisFile(new OggVorbis_File);
 
 	if (ov_open_callbacks(&dataSource, vorbisFile.get(), nullptr, 0, Ogg_Callbacks) != 0) {
-        audioLogs.Warn("Error while reading %s", filename);
+		audioLogs.Warn("Error while reading %s", filename);
 		ov_clear(vorbisFile.get());
 		return AudioData();
 	}
@@ -139,7 +139,7 @@ AudioData LoadOggCodec(Str::StringRef filename)
 	vorbis_info* oggInfo = ov_info(vorbisFile.get(), 0);
 
 	if (!oggInfo) {
-        audioLogs.Warn("Could not read vorbis_info in %s.", filename);
+		audioLogs.Warn("Could not read vorbis_info in %s.", filename);
 		ov_clear(vorbisFile.get());
 		return AudioData();
 	}
@@ -149,20 +149,41 @@ AudioData LoadOggCodec(Str::StringRef filename)
 	int sampleRate = oggInfo->rate;
 	int numberOfChannels = oggInfo->channels;
 
-	char buffer[4096];
 	int bytesRead = 0;
 	int bitStream = 0;
 
-	std::vector<char> samples;
+	char* buffer = nullptr;
+	const size_t bufferInitialCapacity = 4096;
+	const size_t bufferMinCapacity = 4096;
+	size_t bufferCapacity = 0;
+	size_t bufferUsed = 0;
 
-	while ((bytesRead = ov_read(vorbisFile.get(), buffer, 4096, 0, sampleWidth, 1, &bitStream)) > 0) {
-		std::copy_n(buffer, bytesRead, std::back_inserter(samples));
+	for (;;)
+	{
+		size_t bufferRemaining = bufferCapacity - bufferUsed;
+		if (bufferRemaining < bufferMinCapacity)
+		{
+			if (!bufferCapacity)
+				bufferCapacity = bufferInitialCapacity;
+			else
+				bufferCapacity *= 2;
+			bufferRemaining = bufferCapacity - bufferUsed;
+		}
+		buffer = (char*)realloc(buffer, bufferCapacity);
+		if (!buffer)
+			throw std::bad_alloc();
+		if (bytesRead <= 0)
+			break;
+		bytesRead = ov_read(vorbisFile.get(), &buffer[bufferUsed], bufferRemaining, 0, sampleWidth, 1, &bitStream);
+		bufferUsed += bytesRead;
 	}
 	ov_clear(vorbisFile.get());
 
-	char* rawSamples = new char[samples.size()];
-	std::copy_n(samples.data(), samples.size(), rawSamples);
-	return AudioData(sampleRate, sampleWidth, numberOfChannels, samples.size(), rawSamples);
+	char* rawSamples = new char[bufferUsed];
+	std::copy_n(buffer, bufferUsed, rawSamples);
+	free(buffer);
+
+	return AudioData(sampleRate, sampleWidth, numberOfChannels, bufferUsed, rawSamples);
 }
 
 } //namespace Audio

--- a/src/engine/audio/OggCodec.cpp
+++ b/src/engine/audio/OggCodec.cpp
@@ -168,13 +168,13 @@ AudioData LoadOggCodec(Str::StringRef filename)
 			else
 				bufferCapacity *= 2;
 			bufferRemaining = bufferCapacity - bufferUsed;
+			buffer = (char*)realloc(buffer, bufferCapacity);
+			if (!buffer)
+				throw std::bad_alloc();
 		}
-		buffer = (char*)realloc(buffer, bufferCapacity);
-		if (!buffer)
-			throw std::bad_alloc();
+		bytesRead = ov_read(vorbisFile.get(), &buffer[bufferUsed], bufferRemaining, 0, sampleWidth, 1, &bitStream);
 		if (bytesRead <= 0)
 			break;
-		bytesRead = ov_read(vorbisFile.get(), &buffer[bufferUsed], bufferRemaining, 0, sampleWidth, 1, &bitStream);
 		bufferUsed += bytesRead;
 	}
 	ov_clear(vorbisFile.get());

--- a/src/engine/audio/OggCodec.cpp
+++ b/src/engine/audio/OggCodec.cpp
@@ -109,7 +109,7 @@ size_t OggCallbackRead(void* ptr, size_t size, size_t count, void* datasource)
 
 const ov_callbacks Ogg_Callbacks = {&OggCallbackRead, nullptr, nullptr, nullptr};
 
-AudioData LoadOggCodec(std::string filename)
+AudioData LoadOggCodec(Str::StringRef filename)
 {
 	std::string audioFile;
 	try

--- a/src/engine/audio/OpusCodec.cpp
+++ b/src/engine/audio/OpusCodec.cpp
@@ -96,7 +96,7 @@ int OpusCallbackRead(void* dataSource, unsigned char* ptr, int nBytes)
 
 const OpusFileCallbacks Opus_Callbacks = {&OpusCallbackRead, nullptr, nullptr, nullptr};
 
-AudioData LoadOpusCodec(std::string filename)
+AudioData LoadOpusCodec(Str::StringRef filename)
 {
 	std::string audioFile;
 	try

--- a/src/engine/audio/SoundCodec.cpp
+++ b/src/engine/audio/SoundCodec.cpp
@@ -32,12 +32,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace Audio {
 
-AudioData LoadSoundCodec(std::string filename)
+AudioData LoadSoundCodec(Str::StringRef filename)
 {
+	size_t position_of_last_dot{filename.rfind('.')};
 
-	size_t position_of_last_dot{filename.find_last_of('.')};
-
-	if (position_of_last_dot == std::string::npos) {
+	if (position_of_last_dot == Str::StringRef::npos) {
 		audioLogs.Warn("Could not find the extension in %s", filename);
 		return AudioData();
 	}

--- a/src/engine/audio/SoundCodec.h
+++ b/src/engine/audio/SoundCodec.h
@@ -36,13 +36,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace Audio {
 
-    AudioData LoadSoundCodec(std::string filename);
+    AudioData LoadSoundCodec(Str::StringRef filename);
 
-    AudioData LoadWavCodec(std::string filename);
+    AudioData LoadWavCodec(Str::StringRef filename);
 
-    AudioData LoadOggCodec(std::string filename);
+    AudioData LoadOggCodec(Str::StringRef filename);
 
-    AudioData LoadOpusCodec(std::string filename);
+    AudioData LoadOpusCodec(Str::StringRef filename);
 
 } // namespace Audio
 #endif

--- a/src/engine/audio/WavCodec.cpp
+++ b/src/engine/audio/WavCodec.cpp
@@ -55,7 +55,7 @@ inline int PackChars(const std::string& input, int startingPosition, int numberO
 	return packed;
 }
 
-AudioData LoadWavCodec(std::string filename)
+AudioData LoadWavCodec(Str::StringRef filename)
 {
 	std::string audioFile;
 


### PR DESCRIPTION
Some string to stringref changes. A bug fix to rfind. A performance workaround for Windows debug builds.

Cuts a minute of loading times for debug builds caused by MS debug checks. Setting debug_debug_iterator_level differently would fix this bug that's kind of handy. It's just too much for this situation as audio loads some big files.