### PR TITLE
Fix potential bug in zip file reading. If there's an read error we ca…

### DIFF
--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -1146,7 +1146,8 @@ static void InternalLoadPak(const PakInfo& pak, Util::optional<uint32_t> expecte
 			if (err)
 				return;
 			depsData.resize(length);
-			zipFile.ReadFile(&depsData[0], length, err);
+			auto read = zipFile.ReadFile(&depsData[0], length, err);
+			depsData.resize(read);
 			if (err)
 				return;
 		}


### PR DESCRIPTION
…n still have valid data read. We want to return that and not random chunk to the caller.

I think cases of this issue exist such as CopyTo but have not looked into that.