### PR TITLE
allow extension independent soundfile path, fix #642

### DIFF
--- a/daemon/src/engine/audio/SoundCodec.cpp
+++ b/daemon/src/engine/audio/SoundCodec.cpp
@@ -32,26 +32,77 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace Audio {
 
+typedef struct
+{
+	const char *ext;
+	AudioData (*SoundLoader) (std::string);
+} soundExtToLoaderMap_t;
+
+// Note that the ordering indicates the order of preference used
+// when there are multiple sound files of different formats available
+static const soundExtToLoaderMap_t soundLoaders[] =
+{
+	{ ".wav",	LoadWavCodec },
+	{ ".opus",	LoadOpusCodec  },
+	{ ".ogg",	LoadOggCodec  },
+};
+
+static int numSoundLoaders = ARRAY_LEN(soundLoaders);
+
 AudioData LoadSoundCodec(std::string filename)
 {
 
-	size_t position_of_last_dot{filename.find_last_of('.')};
+	std::string ext = FS::Path::Extension(filename);
 
-	if (position_of_last_dot == std::string::npos) {
-		audioLogs.Warn("Could not find the extension in %s", filename);
+	// if filename has extension, try to load it
+	if (ext != "") {
+		// look for the correct loader and use it
+		for (int i = 0; i < numSoundLoaders; i++) {
+			if (ext == soundLoaders[i].ext) {
+				// if file exists, load it
+				if (FS::PakPath::FileExists(filename)) {
+					return soundLoaders[i].SoundLoader(filename);
+				}
+			}
+		}
+	}
+
+	// if filename does not have extension or there is no file with such extension
+	// or if there is no codec available for this file format,
+	// try and find a suitable match using all the sound file formats supported
+	// prioritize with the pak priority
+	int bestLoader = -1;
+	const FS::PakInfo* bestPak = nullptr;
+	std::string strippedname = FS::Path::StripExtension(filename);
+	
+	for (int i = 0; i < numSoundLoaders; i++)
+	{
+		std::string altName = Str::Format("%s%s", strippedname, soundLoaders[i].ext);
+		const FS::PakInfo* pak = FS::PakPath::LocateFile(altName);
+
+		// We found a file and its pak is better than the best pak we have
+		// this relies on how the filesystem works internally and should be moved
+		// to a more explicit interface once there is one. (FIXME)
+		if (pak != nullptr && (bestPak == nullptr || pak < bestPak ))
+		{
+			bestPak = pak;
+			bestLoader = i;
+		}
+	}
+
+	if (bestLoader >= 0)
+	{
+		std::string altName = Str::Format("%s%s", strippedname, soundLoaders[bestLoader].ext );
+		return soundLoaders[bestLoader].SoundLoader(altName);
+	}
+
+	if (FS::PakPath::FileExists(filename)) {
+		audioLogs.Warn("No codec available for opening %s.", filename);
 		return AudioData();
 	}
 
-	std::string ext{filename.substr(position_of_last_dot + 1)};
-
-	if (ext == "wav")
-		return LoadWavCodec(filename);
-	if (ext == "ogg")
-		return LoadOggCodec(filename);
-	if (ext == "opus")
-		return LoadOpusCodec(filename);
-
-	audioLogs.Warn("No codec available for opening %s.", filename);
+	audioLogs.Warn("Sound file %s not found.", filename);
 	return AudioData();
+
 }
 } // namespace Audio


### PR DESCRIPTION
Hi, this PR allows the engine to use extension independent sound path, so mappers can just write _elemusic_ to load _elemusic.wav_ or _elemusic.opus_, if one of them is available.

Also, the engine can load the _elemusic.opus_ path if the bsp was compiled with _elemusic.wav_ path. It allows asset managers to convert sound file without having to recompile the bsp.

It's the first time I'm writing some c++ lines in my life, so your comments are welcome, perhaps there is a better way to do it! :wink: 

This will also help out-of-tree map packaging, allowing mappers to compile their map against lossless assets and distribute them with lossy assets.

This PR fixes issue #642.