### PR TITLE
beacon: display “Here” if player <= 1m from entity

### DIFF
--- a/src/cgame/cg_beacon.cpp
+++ b/src/cgame/cg_beacon.cpp
@@ -613,8 +613,15 @@ static void HandHLBeaconToUI()
 		}
 
 		// distance
-		Com_sprintf( br->distance, sizeof( br->distance ), "%im from here",
-		             (int)round( beacon->dist * QU_TO_METER ) );
+		int distance = (int)floor( beacon->dist * QU_TO_METER );
+		if ( distance > 1 )
+		{
+			Com_sprintf( br->distance, sizeof( br->distance ), "%im from here", distance );
+		}
+		else
+		{
+			Com_sprintf( br->distance, sizeof( br->distance ), "Here" );
+		}
 		showDistance = true;
 
 		// age


### PR DESCRIPTION
Hi, this is a little patch that substract 1m to beacon distance since IRL, people don't say something is at 1m if it's less than 1m (so, people truncates, they do not rounds).

Currently is it weird to stand on a telenode and see _1m_, also, the only way to see less than _1m_ is to navigate with `noclip` in the center of the entity. So the current feel not natural at all. In fact, when Unvanquished says something is at 3m, it looks like it's at 2m.

Before:
![telenode 1m](http://dl.illwieckz.net/b/unvanquished/bugs/unvanquished_2015-07-25_224558_000.jpg)
![egg 1m](http://dl.illwieckz.net/b/unvanquished/bugs/unvanquished_2015-07-25_231428_000.jpg)

After:
![telenode 0m](http://dl.illwieckz.net/b/unvanquished/bugs/unvanquished_2015-07-25_231259_000.jpg)
![egg 0m](http://dl.illwieckz.net/b/unvanquished/bugs/unvanquished_2015-07-25_231317_000.jpg)

Since I subtract the distance, I added a check to not subtract 0 (only happens with `noclip`, you must fly inside the building to have a 0m distance).