### PR TITLE
Fix crash in daemonded when calling /systeminfo

### DIFF
--- a/daemon/src/engine/qcommon/common.cpp
+++ b/daemon/src/engine/qcommon/common.cpp
@@ -433,8 +433,8 @@ bool Com_AddStartupCommands()
 
 void Info_Print( const char *s )
 {
-	char key[ 512 ];
-	char value[ 512 ];
+	char key[ 8192 ];
+	char value[ 8192 ];
 	char *o;
 	int  l;
 


### PR DESCRIPTION
Run "make server", choose a map and call /systeminfo, it should not crash anymore. Info_Print(char *s) will not check any array boundaries, so I just increased the static buffer length, as it is done in ioquake3:

https://github.com/ariya/ioquake3/blob/master/code/qcommon/q_shared.h#L228
https://github.com/ariya/ioquake3/blob/master/code/qcommon/common.c#L521