### PR TITLE
Rewrite how the console history is handled

### DIFF
--- a/daemon/src/engine/framework/ConsoleField.cpp
+++ b/daemon/src/engine/framework/ConsoleField.cpp
@@ -34,18 +34,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace Console {
 
-    Field::Field(int size): LineEditData(size), hist(HISTORY_END) {
+    Field::Field(int size): LineEditData(size) {
     }
 
     void Field::HistoryPrev() {
         std::string current = Str::UTF32To8(GetText());
-        PrevLine(hist, current);
+        hist.PrevLine(current);
         SetText(Str::UTF8To32(current));
     }
 
     void Field::HistoryNext() {
         std::string current = Str::UTF32To8(GetText());
-        NextLine(hist, current);
+        hist.NextLine(current);
         SetText(Str::UTF8To32(current));
     }
 
@@ -62,7 +62,7 @@ namespace Console {
         } else {
             Cmd::BufferCommandText(defaultCommand + " " + Cmd::Escape(current), true);
         }
-        AddToHistory(hist, std::move(current));
+        hist.Add(std::move(current));
 
         Clear();
     }

--- a/daemon/src/engine/framework/ConsoleField.h
+++ b/daemon/src/engine/framework/ConsoleField.h
@@ -46,7 +46,7 @@ namespace Console {
             void AutoComplete();
 
         private:
-            HistoryHandle hist;
+            History hist;
     };
 
 }

--- a/daemon/src/engine/framework/ConsoleHistory.cpp
+++ b/daemon/src/engine/framework/ConsoleHistory.cpp
@@ -28,7 +28,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ===========================================================================
 */
 
-#include "qcommon/q_shared.h"
 #include "framework/Application.h"
 #include "ConsoleHistory.h"
 
@@ -98,6 +97,8 @@ void History::Add( const Line& text )
 
 	current_line = lines.size();
 	unfinished.clear();
+
+	Save();
 }
 
 void History::PrevLine( Line& text )

--- a/daemon/src/engine/framework/ConsoleHistory.cpp
+++ b/daemon/src/engine/framework/ConsoleHistory.cpp
@@ -29,10 +29,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "qcommon/q_shared.h"
-#include "qcommon/qcommon.h"
 #include "framework/Application.h"
 #include "ConsoleHistory.h"
-#include <limits>
 
 namespace Console {
 History::Container History::lines;

--- a/daemon/src/engine/framework/ConsoleHistory.cpp
+++ b/daemon/src/engine/framework/ConsoleHistory.cpp
@@ -32,98 +32,117 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "qcommon/qcommon.h"
 #include "framework/Application.h"
 #include "ConsoleHistory.h"
+#include <limits>
 
-//TODO: make it thread safe.
 namespace Console {
-    static const int SAVED_HISTORY_LINES = 512;
+History::Container History::lines;
+std::mutex History::lines_mutex;
 
-    static std::vector<std::string> lines;
+std::string History::GetFilename()
+{
+	return "conhistory" + Application::GetTraits().uniqueHomepathSuffix;
+}
 
-    static std::string GetHistoryFilename() {
-        return "conhistory" + Application::GetTraits().uniqueHomepathSuffix;
-    }
+void History::Save() {
+	try {
+		FS::File f = FS::HomePath::OpenWrite(GetFilename());
 
-    void SaveHistory() {
-        try {
-            FS::File f = FS::HomePath::OpenWrite(GetHistoryFilename());
+		auto lock = Lock();
+		Container::size_type i = 0;
+		if ( lines.size() > SAVED_HISTORY_LINES )
+			i = lines.size() - SAVED_HISTORY_LINES;
+		for (; i < lines.size(); i++)
+		{
+			f.Write(lines[i].data(), lines[i].size());
+			f.Write("\n", 1);
+		}
+	} catch (const std::system_error& error) {
+		Log::Warn("Couldn't write %s: %s", GetFilename(), error.what());
+	}
+}
 
-            for (unsigned i = std::max(0L, ((long)lines.size()) - SAVED_HISTORY_LINES); i < lines.size(); i++) {
-                f.Write(lines[i].data(), lines[i].size());
-                f.Write("\n", 1);
-            }
-        } catch (const std::system_error& error) {
-            Log::Warn("Couldn't write %s: %s", GetHistoryFilename(), error.what());
-        }
-    }
+void History::Load() {
+	std::string buffer;
 
-    void LoadHistory() {
-        std::string buffer;
+	try {
+		FS::File f = FS::HomePath::OpenRead(GetFilename());
+		buffer = f.ReadAll();
+	} catch (const std::system_error& error) {
+		Log::Warn("Couldn't read %s: %s", GetFilename(), error.what());
+	}
 
-        try {
-            FS::File f = FS::HomePath::OpenRead(GetHistoryFilename());
-            buffer = f.ReadAll();
-        } catch (const std::system_error& error) {
-            Log::Warn("Couldn't read %s: %s", GetHistoryFilename(), error.what());
-        }
+	auto lock = Lock();
+	lines.clear();
+	std::size_t currentPos = 0;
+	std::size_t nextPos = 0;
+	while (true)
+	{
+		nextPos = buffer.find('\n', currentPos);
+		if ( nextPos == std::string::npos )
+			break;
+		lines.emplace_back(buffer, currentPos, (nextPos - currentPos));
+		currentPos = nextPos + 1;
+	}
+}
 
-        size_t currentPos = 0;
-        size_t nextPos = 0;
-        while (nextPos != std::string::npos) {
-            nextPos = buffer.find('\n', currentPos);
-            lines.push_back(std::string(buffer, currentPos, (nextPos - currentPos)));
-            currentPos = nextPos + 1;
-        }
-    }
+History::History()
+	: current_line( std::numeric_limits<Container::size_type>::max() )
+{}
 
-    static const std::string& GetLine(HistoryHandle handle)
-    {
-        static std::string empty = "";
-        if (handle == HISTORY_END) {
-            return empty;
-        } else {
-            return lines[handle];
-        }
-    }
+void History::Add( const Line& text )
+{
+	auto lock = Lock();
 
-    void AddToHistory(HistoryHandle& handle, std::string current) {
-        if (lines.empty() || current != lines.back()) {
-            lines.push_back(std::move(current));
-        }
-        handle = HISTORY_END;
+	if ( lines.empty() || text != lines.back() )
+	{
+		lines.push_back(std::move( text ));
+	}
 
-        //TODO defer it more? when the programs exits?
-        SaveHistory();
-    }
+	current_line = lines.size();
+	unfinished.clear();
+}
 
-    void PrevLine(HistoryHandle& handle, std::string& current) {
-        if (!current.empty() && current != GetLine(handle)) {
-            lines.push_back(current);
-        }
+void History::PrevLine( Line& text )
+{
+	auto lock = Lock();
 
-        if (handle == 0 || (handle == HISTORY_END && lines.empty())) {
-            return;
-        } else if (handle == HISTORY_END) {
-            handle = lines.size() -1;
-        } else {
-            handle --;
-        }
-        current = GetLine(handle);
-    }
+	if ( lines.empty() )
+	{
+		return;
+	}
 
-    void NextLine(HistoryHandle& handle, std::string& current) {
-        if (!current.empty() && current != GetLine(handle)) {
-            lines.push_back(current);
-        }
+	if ( !text.empty() && ( current_line >= lines.size() || text != lines[current_line] ) )
+	{
+		unfinished = text;
+	}
 
-        if (handle == HISTORY_END) {
-            current.clear();
-        } else if (handle == lines.size() - 1) {
-            handle = HISTORY_END;
-            current.clear();
-        } else {
-            handle ++;
-            current = GetLine(handle);
-        }
-    }
+	if ( current_line >= lines.size() )
+	{
+		current_line = lines.size() - 1;
+	}
+	else if ( current_line > 0 )
+	{
+		current_line--;
+	}
+
+	text = lines[current_line];
+}
+
+void History::NextLine( Line& text )
+{
+	auto lock = Lock();
+
+	if ( lines.empty() || current_line >= lines.size() - 1 )
+	{
+		text = unfinished;
+		unfinished.clear();
+		current_line = lines.size();
+	}
+	else
+	{
+		current_line++;
+		text = lines[current_line];
+	}
+}
 
 }

--- a/daemon/src/engine/framework/ConsoleHistory.h
+++ b/daemon/src/engine/framework/ConsoleHistory.h
@@ -31,10 +31,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef FRAMEWORK_CONSOLE_HISTORY_H_
 #define FRAMEWORK_CONSOLE_HISTORY_H_
 
-#include <string>
-#include <vector>
-#include <mutex>
-
 namespace Console {
 
     class History

--- a/daemon/src/engine/framework/ConsoleHistory.h
+++ b/daemon/src/engine/framework/ConsoleHistory.h
@@ -31,18 +31,40 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef FRAMEWORK_CONSOLE_HISTORY_H_
 #define FRAMEWORK_CONSOLE_HISTORY_H_
 
+#include <string>
+#include <vector>
+#include <mutex>
+
 namespace Console {
 
-    typedef unsigned HistoryHandle;
-    static const HistoryHandle HISTORY_END = -1;
+    class History
+    {
+    public:
+        using Container = std::vector<std::string>;
+        using Line = Container::value_type;
 
-    void SaveHistory();
-    void LoadHistory();
+        History();
 
-    void AddToHistory(HistoryHandle& handle, std::string current);
-    void PrevLine(HistoryHandle& handle, std::string& current);
-    void NextLine(HistoryHandle& handle, std::string& current);
+        static void Save();
+        static void Load();
 
+        void Add(const Line& text);
+        void PrevLine(Line& text);
+        void NextLine(Line& text);
+
+    private:
+        static std::string GetFilename();
+        static const Container::size_type SAVED_HISTORY_LINES = 512;
+        static Container lines;
+        static std::mutex lines_mutex;
+        static std::unique_lock<std::mutex> Lock()
+        {
+            return std::unique_lock<std::mutex>{lines_mutex};
+        }
+
+        Container::size_type  current_line;
+        Container::value_type unfinished;
+    };
 }
 
 #endif // FRAMEWORK_CONSOLE_HISTORY_H_

--- a/daemon/src/engine/framework/System.cpp
+++ b/daemon/src/engine/framework/System.cpp
@@ -277,6 +277,9 @@ static void Shutdown(bool error, Str::StringRef message)
 	// Stop accepting commands from other instances
 	CloseSingletonSocket();
 
+	// Save the console history
+	Console::History::Save();
+
     Application::Shutdown(error, message);
 
 	// Always run CON_Shutdown, because it restores the terminal to a usable state.
@@ -625,7 +628,7 @@ static void Init(int argc, char** argv)
 		Cvar::SetValue(cvar.first, cvar.second);
 
 	// Load the console history
-	Console::LoadHistory();
+	Console::History::Load();
 
 	// Legacy initialization code, needs to be replaced
 	// TODO: eventually move all of Com_Init into here

--- a/daemon/src/engine/framework/System.cpp
+++ b/daemon/src/engine/framework/System.cpp
@@ -277,9 +277,6 @@ static void Shutdown(bool error, Str::StringRef message)
 	// Stop accepting commands from other instances
 	CloseSingletonSocket();
 
-	// Save the console history
-	Console::History::Save();
-
     Application::Shutdown(error, message);
 
 	// Always run CON_Shutdown, because it restores the terminal to a usable state.


### PR DESCRIPTION
This branch encapsulates the console history in a class.
In doing so, the overall code has been cleaned up a bit, fixing several minor bugs and making it thread-safe.

I'm not sure whether it would be worth merging this class with Console::Field since it's basically only used there.