### PR TITLE
Binary messages

### DIFF
--- a/daemon/src/engine/client/cg_msgdef.h
+++ b/daemon/src/engine/client/cg_msgdef.h
@@ -542,7 +542,7 @@ namespace Key {
 	> GetKeynumForBindsMsg;
 	// KeyNumToStringMsg
 	typedef IPC::SyncMessage<
-		IPC::Message<IPC::Id<VM::QVM, CG_KEY_KEYNUMTOSTRINGBUF>, int, int>,
+		IPC::Message<IPC::Id<VM::QVM, CG_KEY_KEYNUMTOSTRINGBUF>, int>,
 		IPC::Reply<std::string>
 	> KeyNumToStringMsg;
 	// SetBindingMsg

--- a/daemon/src/engine/client/cl_cgame.cpp
+++ b/daemon/src/engine/client/cl_cgame.cpp
@@ -295,24 +295,13 @@ bool CL_GetSnapshot( int snapshotNumber, snapshot_t *snapshot )
 		return false;
 	}
 
-	// if the entities in the frame have fallen out of their
-	// circular buffer, we can't return it
-	if ( cl.parseEntitiesNum - clSnap->parseEntitiesNum >= MAX_PARSE_ENTITIES )
-	{
-		return false;
-	}
-
 	// write the snapshot
 	snapshot->snapFlags = clSnap->snapFlags;
 	snapshot->ping = clSnap->ping;
 	snapshot->serverTime = clSnap->serverTime;
 	memcpy( snapshot->areamask, clSnap->areamask, sizeof( snapshot->areamask ) );
 	snapshot->ps = clSnap->ps;
-
-	snapshot->entities.reserve(clSnap->numEntities);
-	for (unsigned i = 0; i < clSnap->numEntities; i++) {
-		snapshot->entities.push_back(cl.parseEntities[( clSnap->parseEntitiesNum + i ) & ( MAX_PARSE_ENTITIES - 1 ) ]);
-	}
+	snapshot->entities = clSnap->entities;
 
 	CL_FillServerCommands(snapshot->serverCommands, clc.lastExecutedServerCommand + 1, clSnap->serverCommandNum);
 	clc.lastExecutedServerCommand = clSnap->serverCommandNum;

--- a/daemon/src/engine/client/cl_cgame.cpp
+++ b/daemon/src/engine/client/cl_cgame.cpp
@@ -1239,8 +1239,8 @@ void CGameVM::QVMSyscall(int index, Util::Reader& reader, IPC::Channel& channel)
 
 		case CG_GETCURRENTSNAPSHOTNUMBER:
 			IPC::HandleMsg<GetCurrentSnapshotNumberMsg>(channel, std::move(reader), [this] (int& number, int& serverTime) {
-	            number = cl.snap.messageNum;
-	            serverTime = cl.snap.serverTime;
+				number = cl.snap.messageNum;
+				serverTime = cl.snap.serverTime;
 			});
 			break;
 
@@ -1264,9 +1264,9 @@ void CGameVM::QVMSyscall(int index, Util::Reader& reader, IPC::Channel& channel)
 
 		case CG_SETUSERCMDVALUE:
 			IPC::HandleMsg<SetUserCmdValueMsg>(channel, std::move(reader), [this] (int stateValue, int flags, float scale) {
-                cl.cgameUserCmdValue = stateValue;
-                cl.cgameFlags = flags;
-                cl.cgameSensitivity = scale;
+				cl.cgameUserCmdValue = stateValue;
+				cl.cgameFlags = flags;
+				cl.cgameSensitivity = scale;
 			});
 			break;
 
@@ -1525,7 +1525,7 @@ void CGameVM::QVMSyscall(int index, Util::Reader& reader, IPC::Channel& channel)
 
 		case CG_KEY_KEYNUMTOSTRINGBUF:
 			IPC::HandleMsg<Key::KeyNumToStringMsg>(channel, std::move(reader), [this] (int keynum, std::string& result) {
-                result = Key_KeynumToString(keynum);
+				result = Key_KeynumToString(keynum);
 			});
 			break;
 
@@ -1606,7 +1606,7 @@ void CGameVM::QVMSyscall(int index, Util::Reader& reader, IPC::Channel& channel)
 
 		case CG_LAN_UPDATEVISIBLEPINGS:
 			IPC::HandleMsg<LAN::UpdateVisiblePingsMsg>(channel, std::move(reader), [this] (int source, bool& res) {
-	            res = CL_UpdateVisiblePings_f(source);
+				res = CL_UpdateVisiblePings_f(source);
 			});
 			break;
 
@@ -1619,14 +1619,14 @@ void CGameVM::QVMSyscall(int index, Util::Reader& reader, IPC::Channel& channel)
 		case CG_LAN_SERVERSTATUS:
 			IPC::HandleMsg<LAN::ServerStatusMsg>(channel, std::move(reader), [this] (const std::string& serverAddress, int len, std::string& status, int& res) {
 				std::unique_ptr<char[]> buffer(new char[len]);
-                res = CL_ServerStatus(serverAddress.c_str(), buffer.get(), len);
+				res = CL_ServerStatus(serverAddress.c_str(), buffer.get(), len);
 				status.assign(buffer.get(), len);
 			});
 			break;
 
 		case CG_LAN_RESETSERVERSTATUS:
 			IPC::HandleMsg<LAN::ResetServerStatusMsg>(channel, std::move(reader), [this] {
-                CL_ServerStatus(nullptr, nullptr, 0);
+				CL_ServerStatus(nullptr, nullptr, 0);
 			});
 			break;
 

--- a/daemon/src/engine/client/cl_input.cpp
+++ b/daemon/src/engine/client/cl_input.cpp
@@ -313,13 +313,9 @@ void CL_KeyMove( usercmd_t *cmd )
 	forward += movespeed * CL_KeyState( &kb[ KB_FORWARD ] );
 	forward -= movespeed * CL_KeyState( &kb[ KB_BACK ] );
 
-	// fretn - moved this to bg_pmove.c
-	//if (!(cl.snap.ps.persistant[PERS_HWEAPON_USE]))
-	//{
 	cmd->forwardmove = ClampChar( forward );
 	cmd->rightmove = ClampChar( side );
 	cmd->upmove = ClampChar( up );
-	//}
 
 	// Arnout: double tap
 	cmd->doubleTap = DT_NONE; // reset
@@ -596,16 +592,6 @@ void CL_MouseMove( usercmd_t *cmd )
 			mx = cl_sensitivity->value * ( mx + ( ( mx < 0 ) ? -power[ 0 ] : power[ 0 ] ) * cl_mouseAccelOffset->value );
 			my = cl_sensitivity->value * ( my + ( ( my < 0 ) ? -power[ 1 ] : power[ 1 ] ) * cl_mouseAccelOffset->value );
 
-			/*  NERVE - SMF - this has moved to CG_CalcFov to fix zoomed-in/out transition movement bug
-			        if ( cl.snap.ps.stats[STAT_ZOOMED_VIEW] ) {
-			                if(cl.snap.ps.weapon == WP_SNIPERRIFLE) {
-			                        accelSensitivity *= 0.1;
-			                }
-			                else if(cl.snap.ps.weapon == WP_SNOOPERSCOPE) {
-			                        accelSensitivity *= 0.2;
-			                }
-			        }
-			*/
 			if ( cl_showMouseRate->integer )
 			{
 				Com_Printf( "ratex: %f, ratey: %f, powx: %f, powy: %f", rate[ 0 ], rate[ 1 ], power[ 0 ], power[ 1 ] );

--- a/daemon/src/engine/client/cl_parse.cpp
+++ b/daemon/src/engine/client/cl_parse.cpp
@@ -114,12 +114,12 @@ void CL_ParsePacketEntities( msg_t *msg, const clSnapshot_t *oldSnapshot, clSnap
     while (true) {
         unsigned int newEntityNum = MSG_ReadBits(msg, GENTITYNUM_BITS);
 
-        if (newEntityNum == MAX_GENTITIES - 1) {
-            break;
+        if (msg->readcount > msg->cursize) {
+            Sys::Drop("CL_ParsePacketEntities: Unexpected end of message");
         }
 
-        if (msg->readcount > msg->cursize) {
-            Sys::Drop("CL_ParsePacketEntities: end of message");
+        if (newEntityNum == MAX_GENTITIES - 1) {
+            break;
         }
 
         // (1) all entities that weren't specified between the previous newEntityNum and

--- a/daemon/src/engine/client/cl_parse.cpp
+++ b/daemon/src/engine/client/cl_parse.cpp
@@ -39,7 +39,6 @@ Maryland 20850 USA.
 static const char *const svc_strings[ 256 ] =
 {
 	"svc_bad",
-
 	"svc_nop",
 	"svc_gamestate",
 	"svc_configstring",
@@ -48,7 +47,6 @@ static const char *const svc_strings[ 256 ] =
 	"svc_download",
 	"svc_snapshot",
 	"svc_voip",
-	"svc_extension",
 	"svc_EOF"
 };
 
@@ -1090,22 +1088,6 @@ void CL_ParseServerMessage( msg_t *msg )
 		}
 
 		cmd = MSG_ReadByte( msg );
-
-		// See if this is an extension command after the EOF, which means we
-		//  got data that a legacy client should ignore.
-		if ( ( cmd == svc_EOF ) && ( MSG_LookaheadByte( msg ) == svc_extension ) )
-		{
-			SHOWNET( msg, "EXTENSION" );
-			MSG_ReadByte( msg );  // throw the svc_extension byte away.
-			cmd = MSG_ReadByte( msg );  // something legacy clients can't do!
-
-			// sometimes you get a svc_extension at end of stream...dangling
-			//  bits in the huffman decoder giving a bogus value?
-			if ( cmd == -1 )
-			{
-				cmd = svc_EOF;
-			}
-		}
 
 		if ( cmd == svc_EOF )
 		{

--- a/daemon/src/engine/client/cl_parse.cpp
+++ b/daemon/src/engine/client/cl_parse.cpp
@@ -148,7 +148,7 @@ void CL_ParsePacketEntities( msg_t *msg, const clSnapshot_t *oldSnapshot, clSnap
         } else {
             // (3) the entry isn't in the old snapshot, so the entity will be specified
             // from the baseline
-            assert(oldEntityNum > newEnityNum);
+            assert(oldEntityNum > newEntityNum);
 
             CL_DeltaEntity(msg, newSnapshot, newEntityNum, cl.entityBaselines[newEntityNum]);
         }

--- a/daemon/src/engine/client/cl_parse.cpp
+++ b/daemon/src/engine/client/cl_parse.cpp
@@ -71,11 +71,11 @@ MESSAGE PARSING
 void CL_DeltaEntity( msg_t *msg, clSnapshot_t *snapshot, int entityNum, const entityState_t &oldEntity)
 {
     entityState_t entity;
-	MSG_ReadDeltaEntity(msg, &oldEntity, &entity, entityNum);
+    MSG_ReadDeltaEntity(msg, &oldEntity, &entity, entityNum);
 
-	if (entity.number != MAX_GENTITIES - 1) {
+    if (entity.number != MAX_GENTITIES - 1) {
         snapshot->entities.push_back(entity);
-	}
+    }
 }
 
 /*

--- a/daemon/src/engine/client/cl_parse.cpp
+++ b/daemon/src/engine/client/cl_parse.cpp
@@ -118,6 +118,7 @@ void CL_ParsePacketEntities( msg_t *msg, const clSnapshot_t *oldframe, clSnapsho
 	// delta from the entities present in oldframe
 	oldindex = 0;
 	oldstate = nullptr;
+    oldnum = MAX_GENTITIES;
 
 	if ( !oldframe )
 	{
@@ -125,20 +126,6 @@ void CL_ParsePacketEntities( msg_t *msg, const clSnapshot_t *oldframe, clSnapsho
         nullframe.valid = false;
 
 		oldframe = &nullframe;
-		oldnum = MAX_GENTITIES; // guaranteed out of range
-	}
-	else
-	{
-		if ( oldindex >= oldframe->numEntities )
-		{
-			oldnum = MAX_GENTITIES;
-		}
-		else
-		{
-			oldstate = &cl.parseEntities[
-			             ( oldframe->parseEntitiesNum + oldindex ) & ( MAX_PARSE_ENTITIES - 1 ) ];
-			oldnum = oldstate->number;
-		}
 	}
 
 	while ( 1 )

--- a/daemon/src/engine/client/client.h
+++ b/daemon/src/engine/client/client.h
@@ -77,7 +77,7 @@ typedef struct
 	int           serverCommandNum; // execute all commands up to this before
 	// making the snapshot current
 
-    std::vector<entityState_t> entities;
+	std::vector<entityState_t> entities;
 } clSnapshot_t;
 
 // Arnout: for double tapping

--- a/daemon/src/engine/client/client.h
+++ b/daemon/src/engine/client/client.h
@@ -110,11 +110,7 @@ typedef struct
 // entities, so that when a delta compressed message arives from the server
 // it can be un-deltad from the original
 
-#ifdef USE_INCREASED_ENTITIES
-#define MAX_PARSE_ENTITIES ( MAX_GENTITIES * 2 )
-#else
 #define MAX_PARSE_ENTITIES 2048
-#endif
 
 extern int g_console_field_width;
 

--- a/daemon/src/engine/client/client.h
+++ b/daemon/src/engine/client/client.h
@@ -74,11 +74,10 @@ typedef struct
 	int           cmdNum; // the next cmdNum the server is expecting
 	playerState_t ps; // complete information about the current player at this time
 
-	unsigned      numEntities; // all of the entities that need to be presented
-	int           parseEntitiesNum; // at the time of this snapshot
-
 	int           serverCommandNum; // execute all commands up to this before
 	// making the snapshot current
+
+    std::vector<entityState_t> entities;
 } clSnapshot_t;
 
 // Arnout: for double tapping
@@ -106,10 +105,6 @@ typedef struct
 	int p_realtime; // cls.realtime when packet was sent
 } outPacket_t;
 
-// the parseEntities array must be large enough to hold PACKET_BACKUP frames of
-// entities, so that when a delta compressed message arives from the server
-// it can be un-deltad from the original
-
 #define MAX_PARSE_ENTITIES 2048
 
 extern int g_console_field_width;
@@ -132,8 +127,6 @@ typedef struct
 	bool     newSnapshots; // set on parse of any valid packet
 
 	char         mapname[ MAX_QPATH ]; // extracted from CS_SERVERINFO
-
-	int          parseEntitiesNum; // index (not anded off) into cl_parse_entities[]
 
 	int          mouseDx[ 2 ], mouseDy[ 2 ]; // added to by mouse events
 	int          mouseIndex;
@@ -168,8 +161,6 @@ typedef struct
 	clSnapshot_t  snapshots[ PACKET_BACKUP ];
 
 	entityState_t entityBaselines[ MAX_GENTITIES ]; // for delta compression when not in previous frame
-
-	entityState_t parseEntities[ MAX_PARSE_ENTITIES ];
 } clientActive_t;
 
 extern clientActive_t cl;

--- a/daemon/src/engine/qcommon/huffman.cpp
+++ b/daemon/src/engine/qcommon/huffman.cpp
@@ -61,16 +61,6 @@ void Huff_putBit( int bit, byte *fout, int *offset )
 	*offset = bloc;
 }
 
-int     Huff_getBloc()
-{
-	return bloc;
-}
-
-void Huff_setBloc( int _bloc )
-{
-	bloc = _bloc;
-}
-
 //bani - optimized version
 //optimization works on gcc 3.x, but not 2.95 ? most curious.
 int Huff_getBit( byte *fin, int *offset )

--- a/daemon/src/engine/qcommon/msg.cpp
+++ b/daemon/src/engine/qcommon/msg.cpp
@@ -464,18 +464,6 @@ int MSG_ReadChar( msg_t *msg )
 	return c;
 }
 
-int MSG_LookaheadByte( msg_t *msg )
-{
-	const int bloc = Huff_getBloc();
-	const int readcount = msg->readcount;
-	const int bit = msg->bit;
-	int       c = MSG_ReadByte( msg );
-	Huff_setBloc( bloc );
-	msg->readcount = readcount;
-	msg->bit = bit;
-	return c;
-}
-
 int MSG_ReadByte( msg_t *msg )
 {
 	int c;

--- a/daemon/src/engine/qcommon/msg.cpp
+++ b/daemon/src/engine/qcommon/msg.cpp
@@ -913,7 +913,6 @@ typedef struct
 	int  used;
 } netField_t;
 
-// using the stringizing operator to save typing...
 #define NETF( x ) # x,int((size_t)&( (entityState_t*)0 )->x)
 
 static netField_t entityStateFields[] =

--- a/daemon/src/engine/qcommon/msg.cpp
+++ b/daemon/src/engine/qcommon/msg.cpp
@@ -1202,7 +1202,7 @@ Can go from either a baseline or a previous packet_entity
 */
 extern cvar_t *cl_shownet;
 
-void MSG_ReadDeltaEntity( msg_t *msg, entityState_t *from, entityState_t *to, int number )
+void MSG_ReadDeltaEntity( msg_t *msg, const entityState_t *from, entityState_t *to, int number )
 {
 	int        i, lc;
 	int        numFields;

--- a/daemon/src/engine/qcommon/qcommon.h
+++ b/daemon/src/engine/qcommon/qcommon.h
@@ -109,7 +109,7 @@ void  MSG_WriteDeltaUsercmd( msg_t *msg, usercmd_t *from, usercmd_t *to );
 void  MSG_ReadDeltaUsercmd( msg_t *msg, usercmd_t *from, usercmd_t *to );
 
 void  MSG_WriteDeltaEntity( msg_t *msg, struct entityState_s *from, struct entityState_s *to, bool force );
-void  MSG_ReadDeltaEntity( msg_t *msg, entityState_t *from, entityState_t *to, int number );
+void  MSG_ReadDeltaEntity( msg_t *msg, const entityState_t *from, entityState_t *to, int number );
 
 void  MSG_WriteDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct playerState_s *to );
 void  MSG_ReadDeltaPlayerstate( msg_t *msg, struct playerState_s *from, struct playerState_s *to );

--- a/daemon/src/engine/qcommon/qcommon.h
+++ b/daemon/src/engine/qcommon/qcommon.h
@@ -104,7 +104,6 @@ char  *MSG_ReadBigString( msg_t *sb );
 char  *MSG_ReadStringLine( msg_t *sb );
 float MSG_ReadAngle16( msg_t *sb );
 void  MSG_ReadData( msg_t *sb, void *buffer, int size );
-int   MSG_LookaheadByte( msg_t *msg );
 
 void  MSG_WriteDeltaUsercmd( msg_t *msg, usercmd_t *from, usercmd_t *to );
 void  MSG_ReadDeltaUsercmd( msg_t *msg, usercmd_t *from, usercmd_t *to );
@@ -952,10 +951,6 @@ void             Huff_offsetReceive( node_t *node, int *ch, byte *fin, int *offs
 void             Huff_offsetTransmit( huff_t *huff, int ch, byte *fout, int *offset );
 void             Huff_putBit( int bit, byte *fout, int *offset );
 int              Huff_getBit( byte *fout, int *offset );
-
-// don't use if you don't know what you're doing.
-int              Huff_getBloc();
-void             Huff_setBloc( int _bloc );
 
 extern huffman_t clientHuffTables;
 

--- a/daemon/src/engine/qcommon/qcommon.h
+++ b/daemon/src/engine/qcommon/qcommon.h
@@ -319,12 +319,8 @@ enum svc_ops_e
   svc_serverCommand, // [string] to be executed by client game module
   svc_download, // [short] size [size bytes]
   svc_snapshot,
-  svc_EOF,
-
-  // svc_extension follows a svc_EOF, followed by another svc_* ...
-  //  this keeps legacy clients compatible.
-  svc_extension,
   svc_voip, // not wrapped in USE_VOIP, so this value is reserved.
+  svc_EOF,
 };
 
 //

--- a/daemon/src/engine/qcommon/qcommon.h
+++ b/daemon/src/engine/qcommon/qcommon.h
@@ -332,8 +332,8 @@ enum clc_ops_e
   clc_move, // [usercmd_t]
   clc_moveNoDelta, // [usercmd_t]
   clc_clientCommand, // [string] message
-  clc_EOF,
   clc_voip, // not wrapped in USE_VOIP, so this value is reserved.
+  clc_EOF,
 };
 
 /*

--- a/daemon/src/engine/server/sv_snapshot.cpp
+++ b/daemon/src/engine/server/sv_snapshot.cpp
@@ -70,6 +70,8 @@ static void SV_EmitPacketEntities( const clientSnapshot_t *from, clientSnapshot_
 	int           oldnum, newnum;
 	int           from_num_entities;
 
+    MSG_WriteShort(msg, to->num_entities);
+
 	// generate the delta update
 	if ( !from )
 	{

--- a/src/cgame/cg_api.cpp
+++ b/src/cgame/cg_api.cpp
@@ -699,7 +699,7 @@ std::vector<std::vector<int>> trap_Key_GetKeynumForBinds(int team, std::vector<s
 void trap_Key_KeynumToStringBuf( int keynum, char *buf, int buflen )
 {
 	std::string result;
-	VM::SendMsg<Key::KeyNumToStringMsg>(keynum, buflen, result);
+	VM::SendMsg<Key::KeyNumToStringMsg>(keynum, result);
 	Q_strncpyz(buf, result.c_str(), buflen);
 }
 


### PR DESCRIPTION
I'd like to merge the binary message work little by little to avoid putting up a HUGE PR.

In here you'll find:
 - Some cleanup
 - The addition of the number of entities in the snapshot so that we can preallocate the entity vector
 - A rewrite (and potential bugfix) of the client side entity packet parsing in order to put entities in a vector owned by the snapshot (will make it easier to move that part of the netcode to the gamelogic)