### PR TITLE
g_emptyTeamsSkipMapTime

### DIFF
--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -2452,12 +2452,12 @@ void CheckExitRules()
 		LogExit( "Aliens win." );
 		G_MapLog_Result( 'a' );
 	}
-	else if( g_emptyTeamsSkipMapTime.integer &&
+	else if ( g_emptyTeamsSkipMapTime.integer &&
 		( level.time - level.startTime ) / 60000 >=
 		g_emptyTeamsSkipMapTime.integer &&
 		level.team[ TEAM_ALIENS ].numClients == 0 && level.team[ TEAM_HUMANS ].numClients == 0 )
 	{
-		//nobody wins because the teams are empty after x amount of game time
+		// nobody wins because the teams are empty after x amount of game time
 		level.lastWin = TEAM_NONE;
 		trap_SendServerCommand( -1, "print \"Empty teams skip map time exceeded.\n\"" );
 		trap_SetConfigstring( CS_WINNER, "Stalemate" );

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -195,6 +195,7 @@ vmCvar_t           g_debugEntities;
 
 vmCvar_t           g_instantBuilding;
 
+vmCvar_t           g_emptyTeamsSkipMapTime;
 
 // <bot stuff>
 
@@ -402,6 +403,8 @@ static cvarTable_t gameCvarTable[] =
 	{ &g_combatCooldown,              "g_combatCooldown",              "15",                               0,                                               0, false    , nullptr       },
 
 	{ &g_instantBuilding,             "g_instantBuilding",             "0",                                0,                                               0, true     , nullptr       },
+
+	{ &g_emptyTeamsSkipMapTime,       "g_emptyTeamsSkipMapTime",       "0",                                0,                                               0, true     , nullptr       },
 
 	// bots: buying
 	{ &g_bot_buy, "g_bot_buy", "1",  CVAR_NORESTART, 0, false, nullptr },
@@ -2448,6 +2451,18 @@ void CheckExitRules()
 		G_notify_sensor_end( TEAM_ALIENS );
 		LogExit( "Aliens win." );
 		G_MapLog_Result( 'a' );
+	}
+	else if( g_emptyTeamsSkipMapTime.integer &&
+		( level.time - level.startTime ) / 60000 >=
+		g_emptyTeamsSkipMapTime.integer &&
+		level.team[ TEAM_ALIENS ].numClients == 0 && level.team[ TEAM_HUMANS ].numClients == 0 )
+	{
+		//nobody wins because the teams are empty after x amount of game time
+		level.lastWin = TEAM_NONE;
+		trap_SendServerCommand( -1, "print \"Empty teams skip map time exceeded.\n\"" );
+		trap_SetConfigstring( CS_WINNER, "Stalemate" );
+		LogExit( "Timelimit hit." );
+		G_MapLog_Result( 't' );
 	}
 }
 

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -2455,7 +2455,7 @@ void CheckExitRules()
 	else if ( g_emptyTeamsSkipMapTime.integer &&
 		( level.time - level.startTime ) / 60000 >=
 		g_emptyTeamsSkipMapTime.integer &&
-		level.team[ TEAM_ALIENS ].numClients == 0 && level.team[ TEAM_HUMANS ].numClients == 0 )
+		level.team[ TEAM_ALIENS ].numPlayers == 0 && level.team[ TEAM_HUMANS ].numPlayers == 0 )
 	{
 		// nobody wins because the teams are empty after x amount of game time
 		level.lastWin = TEAM_NONE;


### PR DESCRIPTION
if the teams are empty after this amount of game time, the map is skipped (prevents players joining long-running empty games)

(original code by @mtiusane https://github.com/mtiusane/new-edge/blob/21c41b7b5584e35edea66f66832a980363a95443/src/game/g_main.c#L2482-L2493)