### PR TITLE
Replace all uses of <ctype.h> functions with locale-independent versions

### DIFF
--- a/daemon/src/common/Color.cpp
+++ b/daemon/src/common/Color.cpp
@@ -259,11 +259,11 @@ TokenIterator::value_type TokenIterator::NextToken(const char* input)
         {
             return value_type( input, input+2, parent->DefaultColor() );
         }
-        else if ( std::toupper( input[1] ) >= '0' && std::toupper( input[1] ) < 'P' )
+        else if ( Str::ctoupper( input[1] ) >= '0' && Str::ctoupper( input[1] ) < 'P' )
         {
             return value_type( input, input+2, detail::Indexed( input[1] - '0' ) );
         }
-        else if ( std::tolower( input[1] ) == 'x' && ishex( input[2] ) && ishex( input[3] ) && ishex( input[4] ) )
+        else if ( Str::ctolower( input[1] ) == 'x' && ishex( input[2] ) && ishex( input[3] ) && ishex( input[4] ) )
         {
             return value_type( input, input+5, Color(
                 gethex( input[2] ) / 15.f,

--- a/daemon/src/engine/client/cl_console.cpp
+++ b/daemon/src/engine/client/cl_console.cpp
@@ -515,7 +515,7 @@ bool CL_InternalConsolePrint( const char *text )
 				}
 				else if ( wordtoken.Type() == Color::Token::CHARACTER )
 				{
-					if ( std::isspace( *wordtoken.Begin() ) )
+					if ( Str::cisspace( *wordtoken.Begin() ) )
 					{
 						break;
 					}

--- a/daemon/src/engine/client/cl_keys.cpp
+++ b/daemon/src/engine/client/cl_keys.cpp
@@ -440,7 +440,7 @@ Key events are used for non-printable characters, others are gotten from char ev
 =================
 */
 void Field_KeyDownEvent(Util::LineEditData& edit, int key) {
-    key = tolower(key);
+    key = Str::ctolower(key);
 
     switch (key) {
         case K_DEL:
@@ -639,7 +639,7 @@ void Console_Key( int key )
 
 	//----(SA)  added some mousewheel functionality to the console
 	if ( ( key == K_MWHEELUP && keys[ K_SHIFT ].down ) || ( key == K_UPARROW ) || ( key == K_KP_UPARROW ) ||
-			( ( tolower( key ) == 'p' ) && keys[ K_CTRL ].down ) )
+			( ( Str::ctolower( key ) == 'p' ) && keys[ K_CTRL ].down ) )
 	{
 		g_consoleField.HistoryPrev();
 		return;
@@ -647,7 +647,7 @@ void Console_Key( int key )
 
 	//----(SA)  added some mousewheel functionality to the console
 	if ( ( key == K_MWHEELDOWN && keys[ K_SHIFT ].down ) || ( key == K_DOWNARROW ) || ( key == K_KP_DOWNARROW ) ||
-			( ( tolower( key ) == 'n' ) && keys[ K_CTRL ].down ) )
+			( ( Str::ctolower( key ) == 'n' ) && keys[ K_CTRL ].down ) )
 	{
 		g_consoleField.HistoryNext();
 		return;
@@ -860,7 +860,7 @@ int Key_GetTeam( const char *arg, const char *cmd )
 
 	for ( t = 0; arg[ t ]; ++t )
 	{
-		if ( !isdigit( arg[ t ] ) )
+		if ( !Str::cisdigit( arg[ t ] ) )
 		{
 			break;
 		}

--- a/daemon/src/engine/framework/BaseCommands.cpp
+++ b/daemon/src/engine/framework/BaseCommands.cpp
@@ -627,7 +627,7 @@ namespace Cmd {
                 }
 
                 //Get all the parameters!
-                bool isNamed = !isdigit(args.Argv(1)[0]);
+                bool isNamed = !Str::cisdigit(args.Argv(1)[0]);
                 const std::string& name = isNamed ? args.Argv(1) : "";
                 const std::string& command = args.EscapedArgs(2 + isNamed);
                 std::string delay = args.Argv(1 + isNamed);

--- a/daemon/src/engine/qcommon/print_translated.h
+++ b/daemon/src/engine/qcommon/print_translated.h
@@ -72,7 +72,7 @@ static const char *TranslateText_Internal( bool plural, int firstTextArg )
 
 			while( *in )
 			{
-				if( isdigit( *in ) )
+				if( Str::cisdigit( *in ) )
 				{
 					in++;
 

--- a/daemon/src/engine/qcommon/q_shared.cpp
+++ b/daemon/src/engine/qcommon/q_shared.cpp
@@ -1233,7 +1233,7 @@ int Com_HexStrToInt( const char *str )
 
 			n *= 16;
 
-			digit = tolower( str[ i ] );
+			digit = Str::ctolower( str[ i ] );
 
 			if ( digit >= '0' && digit <= '9' )
 			{
@@ -1624,7 +1624,7 @@ const char *Com_StringContains( const char *str1, const char *str2, int casesens
 			}
 			else
 			{
-				if ( toupper( str1[ j ] ) != toupper( str2[ j ] ) )
+				if ( Str::ctoupper( str1[ j ] ) != Str::ctoupper( str2[ j ] ) )
 				{
 					break;
 				}
@@ -1715,7 +1715,7 @@ int Com_Filter( const char *filter, const char *name, int casesensitive )
 					}
 					else
 					{
-						if ( toupper( *name ) >= toupper( *filter ) && toupper( *name ) <= toupper( * ( filter + 2 ) ) )
+						if ( Str::ctoupper( *name ) >= Str::ctoupper( *filter ) && Str::ctoupper( *name ) <= Str::ctoupper( * ( filter + 2 ) ) )
 						{
 							found = true;
 						}
@@ -1734,7 +1734,7 @@ int Com_Filter( const char *filter, const char *name, int casesensitive )
 					}
 					else
 					{
-						if ( toupper( *filter ) == toupper( *name ) )
+						if ( Str::ctoupper( *filter ) == Str::ctoupper( *name ) )
 						{
 							found = true;
 						}
@@ -1773,7 +1773,7 @@ int Com_Filter( const char *filter, const char *name, int casesensitive )
 			}
 			else
 			{
-				if ( toupper( *filter ) != toupper( *name ) )
+				if ( Str::ctoupper( *filter ) != Str::ctoupper( *name ) )
 				{
 					return false;
 				}

--- a/daemon/src/engine/qcommon/q_shared.h
+++ b/daemon/src/engine/qcommon/q_shared.h
@@ -88,7 +88,6 @@ void ignore_result(T) {}
 
 // C standard library headers
 #include <assert.h>
-#include <ctype.h>
 #include <errno.h>
 //#include <fenv.h>
 #include <float.h>

--- a/daemon/src/engine/renderer/tr_image.cpp
+++ b/daemon/src/engine/renderer/tr_image.cpp
@@ -65,7 +65,7 @@ long GenerateImageHashValue( const char *fname )
 
 	while ( fname[ i ] != '\0' )
 	{
-		letter = tolower( fname[ i ] );
+		letter = Str::ctolower( fname[ i ] );
 
 		if ( letter == '\\' )
 		{
@@ -1758,7 +1758,7 @@ static void R_ExportTexture( image_t *image )
 
 	// quick and dirty sanitize path name
 	for( i = strlen( path ) - 1; i >= 7; i-- ) {
-		if( !isalnum( path[ i ] ) && path[ i ] != '.' && path[ i ] != '-' ) {
+		if( !Str::cisalnum( path[ i ] ) && path[ i ] != '.' && path[ i ] != '-' ) {
 			path[ i ] = 'z';
 		}
 	}

--- a/daemon/src/engine/renderer/tr_shader.cpp
+++ b/daemon/src/engine/renderer/tr_shader.cpp
@@ -66,7 +66,7 @@ static long generateHashValue( const char *fname, const int size )
 
 	while ( fname[ i ] != '\0' )
 	{
-		letter = tolower( fname[ i ] );
+		letter = Str::ctolower( fname[ i ] );
 
 		if ( letter == '.' )
 		{

--- a/src/cgame/cg_rocket_dataformatter.cpp
+++ b/src/cgame/cg_rocket_dataformatter.cpp
@@ -83,7 +83,7 @@ static void CG_Rocket_DFResolution( int handle, const char *data )
 static void CG_Rocket_DFServerPing( int handle, const char *data )
 {
 	const char *str = Info_ValueForKey( data, "1" );
-	Rocket_DataFormatterFormattedData( handle, *str && std::isdigit( *str ) ? va( "%s ms", Info_ValueForKey( data, "1" ) ) : "", false );
+	Rocket_DataFormatterFormattedData( handle, *str && Str::cisdigit( *str ) ? va( "%s ms", Info_ValueForKey( data, "1" ) ) : "", false );
 }
 
 static void CG_Rocket_DFServerPlayers( int handle, const char *data )

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -787,7 +787,7 @@ static void CG_Say( const char *name, int clientNum, saymode_t mode, const char 
 		{
 			Com_sprintf( prefix, sizeof( prefix ), "[%s%c^*] ",
 			             Color::CString( tcolor ),
-			             toupper( * ( BG_TeamName( ci->team ) ) ) );
+			             Str::ctoupper( * ( BG_TeamName( ci->team ) ) ) );
 		}
 
 		if ( Com_ClientListContains( &cgs.ignoreList, clientNum ) )

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -641,7 +641,7 @@ bool G_admin_name_check( gentity_t *ent, const char *name, char *err, int len )
 
 	Color::StripColors( name, testName, sizeof( testName ) );
 
-	if ( isdigit( testName[ 0 ] ) )
+	if ( Str::cisdigit( testName[ 0 ] ) )
 	{
 		if ( err && len > 0 )
 		{
@@ -1255,7 +1255,7 @@ static int admin_find_admin( gentity_t *ent, char *name, const char *command,
 
 	for ( p = name; ( *p ); p++ )
 	{
-		if ( !isdigit( *p ) )
+		if ( !Str::cisdigit( *p ) )
 		{
 			numeric = false;
 			break;
@@ -2129,7 +2129,7 @@ bool G_admin_time( gentity_t *ent )
 
 		trap_Argv( 1, tstr, sizeof( tstr ) );
 
-		if ( isdigit( tstr[0] ) )
+		if ( Str::cisdigit( tstr[0] ) )
 		{
 			timelimit = atoi( tstr );
 
@@ -2411,12 +2411,12 @@ int G_admin_parse_time( const char *time )
 
 	while ( *time )
 	{
-		if ( !isdigit( *time ) )
+		if ( !Str::cisdigit( *time ) )
 		{
 			return -1;
 		}
 
-		while ( isdigit( *time ) )
+		while ( Str::cisdigit( *time ) )
 		{
 			num = num * 10 + *time++ - '0';
 		}
@@ -3453,7 +3453,7 @@ bool G_admin_listadmins( gentity_t *ent )
 		{
 			i = s[ 0 ] == '-';
 
-			for ( ; isdigit( s[ i ] ); i++ ) {; }
+			for ( ; Str::cisdigit( s[ i ] ); i++ ) { }
 		}
 
 		if ( i && !s[ i ] )
@@ -3678,7 +3678,7 @@ bool G_admin_listplayers( gentity_t *ent )
 		}
 		else
 		{
-			t = toupper( * ( BG_TeamName( p->pers.team ) ) );
+			t = Str::ctoupper( * ( BG_TeamName( p->pers.team ) ) );
 
 			if ( p->pers.team == TEAM_HUMANS )
 			{
@@ -3857,7 +3857,7 @@ bool G_admin_showbans( gentity_t *ent )
 
 		if ( trap_Argc() == 2 )
 		{
-			for ( i = filter[ 0 ] == '-'; isdigit( filter[ i ] ); i++ ) {; }
+			for ( i = filter[ 0 ] == '-'; Str::cisdigit( filter[ i ] ); i++ ) {; }
 		}
 
 		if ( !filter[ i ] )
@@ -4463,7 +4463,7 @@ bool G_admin_namelog( gentity_t *ent )
 
 		if ( trap_Argc() == 2 )
 		{
-			for ( i = search[ 0 ] == '-'; isdigit( search[ i ] ); i++ ) {; }
+			for ( i = search[ 0 ] == '-'; Str::cisdigit( search[ i ] ); i++ ) {; }
 		}
 
 		if ( !search[ i ] )
@@ -4504,7 +4504,7 @@ namelog_t *G_NamelogFromString( gentity_t *ent, char *s )
 	}
 
 	// if a number is provided, it is a clientnum or namelog id
-	for ( i = 0; s[ i ] && isdigit( s[ i ] ); i++ ) {; }
+	for ( i = 0; s[ i ] && Str::cisdigit( s[ i ] ); i++ ) {; }
 
 	if ( !s[ i ] )
 	{
@@ -4892,7 +4892,7 @@ bool G_admin_flag( gentity_t *ent )
 	// flag name must be alphanumeric
 	for ( i = 0; flag[ i ]; ++i )
 	{
-		if ( !isalnum( flag[ i ] ) )
+		if ( !Str::cisalnum( flag[ i ] ) )
 		{
 			break;
 		}
@@ -5152,7 +5152,7 @@ bool G_admin_buildlog( gentity_t *ent )
 	{
 		trap_Argv( 1, search, sizeof( search ) );
 
-		for ( i = search[ 0 ] == '-'; isdigit( search[ i ] ); i++ ) {; }
+		for ( i = search[ 0 ] == '-'; Str::cisdigit( search[ i ] ); i++ ) {; }
 
 		if ( i && !search[ i ] )
 		{

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -738,7 +738,8 @@ static void G_ClientCleanName( const char *in, char *out, int outSize, gclient_t
 			int cp = Q_UTF8_CodePoint(token.Begin());
 
 			// don't allow leading spaces
-			if ( !has_visible_characters && std::isspace( cp ) )
+			// TODO: use a Unicode-aware isspace
+			if ( !has_visible_characters && Str::cisspace( cp ) )
 			{
 				continue;
 			}
@@ -780,7 +781,8 @@ static void G_ClientCleanName( const char *in, char *out, int outSize, gclient_t
 			}
 
 		// don't allow too many consecutive spaces
-			if ( std::isspace( cp ) )
+			// TODO: use a Unicode-aware isspace
+			if ( Str::cisspace( cp ) )
 			{
 				spaces++;
 				if ( spaces > 3 )
@@ -823,11 +825,10 @@ static void G_ClientCleanName( const char *in, char *out, int outSize, gclient_t
 		invalid = true;
 	}
 	// don't allow names beginning with digits
-	else if ( std::isdigit( out_string[0] ) )
+	else if ( Str::cisdigit( out_string[0] ) )
 	{
 		out_string.erase( out_string.begin(),
-			std::find_if_not( out_string.begin(), out_string.end(),
-				(int (*)(int))std::isdigit ) );
+			std::find_if_not( out_string.begin(), out_string.end(), Str::cisdigit ) );
 	}
 
 	// if something made the name bad, put them back to UnnamedPlayer

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -155,7 +155,7 @@ int G_ClientNumberFromString( const char *s, char *err, int len )
 	}
 
 	// numeric values are just slot numbers
-	for ( i = 0; s[ i ] && isdigit( s[ i ] ); i++ ) {; }
+	for ( i = 0; s[ i ] && Str::cisdigit( s[ i ] ); i++ ) {; }
 
 	if ( !s[ i ] )
 	{
@@ -3830,7 +3830,7 @@ void Cmd_ListMaps_f( gentity_t *ent )
 	{
 		trap_Argv( 1, search, sizeof( search ) );
 
-		for ( p = search; ( *p ) && isdigit( *p ); p++ ) {; }
+		for ( p = search; ( *p ) && Str::cisdigit( *p ); p++ ) {; }
 
 		if ( !( *p ) )
 		{

--- a/src/sgame/sg_svcmds.cpp
+++ b/src/sgame/sg_svcmds.cpp
@@ -336,7 +336,7 @@ static void Svcmd_LayoutSave_f()
 
 	while ( *s && i < (int) sizeof( str2 ) - 1 )
 	{
-		if ( isalnum( *s ) || *s == '-' || *s == '_' )
+		if ( Str::cisalnum( *s ) || *s == '-' || *s == '_' )
 		{
 			str2[ i++ ] = *s;
 			str2[ i ] = '\0';

--- a/src/sgame/sg_team.cpp
+++ b/src/sgame/sg_team.cpp
@@ -33,7 +33,7 @@ Return the team referenced by a string
 */
 team_t G_TeamFromString( const char *str )
 {
-	switch ( tolower( *str ) )
+	switch ( Str::ctolower( *str ) )
 	{
 		case '0':
 		case 's':

--- a/src/sgame/sg_utils.cpp
+++ b/src/sgame/sg_utils.cpp
@@ -525,7 +525,7 @@ static const char *addr4parse( const char *str, addr_t *addr )
 
 	for ( i = 0; octet < 4; i++ )
 	{
-		if ( isdigit( str[ i ] ) )
+		if ( Str::cisdigit( str[ i ] ) )
 		{
 			num = num * 10 + str[ i ] - '0';
 		}
@@ -566,7 +566,7 @@ static const char *addr6parse( const char *str, addr_t *addr )
 	for ( i = 0; before + after <= 8; i++ )
 	{
 		//num = num << 4 | str[ i ] - '0';
-		if ( isdigit( str[ i ] ) )
+		if ( Str::cisdigit( str[ i ] ) )
 		{
 			num = num * 16 + str[ i ] - '0';
 		}


### PR DESCRIPTION
I was prompted to do this since I was getting some errors from `std::`-prefixed uses of these functions.

In one place (player name validation), I thought it would be better to use a Unicode-aware function to check for spaces, instead of `cisspace`. Is there any existing function for that?