### PR TITLE
Mark VM loading options as Cvar::CHEAT

### DIFF
--- a/daemon/src/engine/framework/VirtualMachine.cpp
+++ b/daemon/src/engine/framework/VirtualMachine.cpp
@@ -54,6 +54,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 namespace VM {
+// Map for each VM to its loading cvar flags.
+std::unordered_map<std::string, int> vmCvarFlagsMap = {
+	{ "cgame", Cvar::CHEAT },
+	{ "sgame", Cvar::NONE }
+};
 
 // Platform-specific code to load a module
 static std::pair<Sys::OSHandle, IPC::Socket> InternalLoadModule(std::pair<IPC::Socket, IPC::Socket> pair, const char* const* args, bool reserve_mem, FS::File stderrRedirect = FS::File())

--- a/daemon/src/engine/framework/VirtualMachine.h
+++ b/daemon/src/engine/framework/VirtualMachine.h
@@ -86,12 +86,14 @@ enum vmType_t {
 	TYPE_END
 };
 
+extern std::unordered_map<std::string, int> vmCvarFlagsMap;
+
 
 struct VMParams {
 	VMParams(std::string name)
 		: logSyscalls("vm." + name + ".logSyscalls", "dump all the syscalls in the " + name + ".syscallLog file", Cvar::NONE, false),
-		  vmType("vm." + name + ".type", "how the vm should be loaded for " + name, Cvar::NONE, TYPE_NACL, 0, TYPE_END - 1),
-		  debug("vm." + name + ".debug", "run a gdbserver on localhost:4014 to debug the VM", Cvar::NONE, false),
+		  vmType("vm." + name + ".type", "how the vm should be loaded for " + name, vmCvarFlagsMap[name], TYPE_NACL, 0, TYPE_END - 1),
+		  debug("vm." + name + ".debug", "run a gdbserver on localhost:4014 to debug the VM", vmCvarFlagsMap[name], false),
 		  debugLoader("vm." + name + ".debugLoader", "make nacl_loader dump information to " + name + "-nacl_loader.log", Cvar::NONE, 0, 0, 5) {
 	}
 


### PR DESCRIPTION
This forces you to use the VM in the pk3. This ensures
you never have a mismatch with the server you are
connecting to.