### PR TITLE
Cache constant strlen outside of cycles

### DIFF
--- a/daemon/src/engine/client/cl_main.cpp
+++ b/daemon/src/engine/client/cl_main.cpp
@@ -4058,6 +4058,7 @@ void CL_LocalServers_f()
 	// by the server.  We don't care about that here, but master servers
 	// can use that to prevent spoofed server responses from invalid IP addresses
 	message = "\377\377\377\377getinfo xxx";
+	int messageLen = strlen(message);
 
 	// send each message twice in case one is dropped
 	for ( i = 0; i < 2; i++ )
@@ -4070,10 +4071,10 @@ void CL_LocalServers_f()
 			to.port = BigShort( ( short )( PORT_SERVER + j ) );
 
 			to.type = netadrtype_t::NA_BROADCAST;
-			NET_SendPacket( netsrc_t::NS_CLIENT, strlen( message ), message, to );
+			NET_SendPacket( netsrc_t::NS_CLIENT, messageLen, message, to );
 
 			to.type = netadrtype_t::NA_MULTICAST6;
-			NET_SendPacket( netsrc_t::NS_CLIENT, strlen( message ), message, to );
+			NET_SendPacket( netsrc_t::NS_CLIENT, messageLen, message, to );
 		}
 	}
 }

--- a/daemon/src/engine/qcommon/q_shared.cpp
+++ b/daemon/src/engine/qcommon/q_shared.cpp
@@ -180,7 +180,9 @@ Com_CharIsOneOfCharset
 */
 static bool Com_CharIsOneOfCharset( char c, const char *set )
 {
-	for (unsigned i = 0; i < strlen( set ); i++ )
+	std::size_t len = strlen( set );
+
+	for ( std::size_t i = 0; i < len; i++ )
 	{
 		if ( set[ i ] == c )
 		{
@@ -1226,8 +1228,9 @@ int Com_HexStrToInt( const char *str )
 	if ( str[ 0 ] == '0' && str[ 1 ] == 'x' )
 	{
 		int n = 0;
+		std::size_t len = strlen( str );
 
-		for (unsigned i = 2; i < strlen( str ); i++ )
+		for ( std::size_t i = 2; i < len; i++ )
 		{
 			char digit;
 

--- a/src/cgame/cg_gameinfo.cpp
+++ b/src/cgame/cg_gameinfo.cpp
@@ -41,11 +41,11 @@ CG_ParseInfos
 int CG_ParseInfos( const char *buf, int max, char *infos[] )
 {
 	char *token;
-	int  count;
+	int  count = 0;
 	char key[ MAX_TOKEN_CHARS ];
 	char info[ MAX_INFO_STRING ];
 
-	count = 0;
+	auto infoPostfixLen = strlen( "\\num\\" ) + strlen( va( "%d", MAX_ARENAS ) );
 
 	while ( 1 )
 	{
@@ -98,7 +98,7 @@ int CG_ParseInfos( const char *buf, int max, char *infos[] )
 		}
 
 		//NOTE: extra space for arena number
-		infos[ count ] = (char*) BG_Alloc( strlen( info ) + strlen( "\\num\\" ) + strlen( va( "%d", MAX_ARENAS ) ) + 1 );
+		infos[ count ] = (char*) BG_Alloc( strlen( info ) + infoPostfixLen + 1 );
 
 		if ( infos[ count ] )
 		{

--- a/src/cgame/cg_rocket_datasource.cpp
+++ b/src/cgame/cg_rocket_datasource.cpp
@@ -888,7 +888,7 @@ void CG_Rocket_BuildDemoList( const char* )
 	char  demolist[ 4096 ];
 	char demoExt[ 32 ];
 	char  *demoname;
-	int   i, len;
+	int   i;
 
 	Com_sprintf( demoExt, sizeof( demoExt ), "dm_%d", ( int ) trap_Cvar_VariableIntegerValue( "protocol" ) );
 
@@ -904,14 +904,15 @@ void CG_Rocket_BuildDemoList( const char* )
 		}
 
 		demoname = demolist;
+		auto demoExtLen = strlen( demoExt );
 
 		for ( i = 0; i < rocketInfo.data.demoCount; i++ )
 		{
-			len = strlen( demoname );
+			auto len = strlen( demoname );
 
-			if ( !Q_stricmp( demoname +  len - strlen( demoExt ), demoExt ) )
+			if ( !Q_stricmp( demoname + len - demoExtLen, demoExt ) )
 			{
-				demoname[ len - strlen( demoExt ) ] = '\0';
+				demoname[ len - demoExtLen ] = '\0';
 			}
 
 			rocketInfo.data.demoList[ i ] = BG_strdup( demoname );

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -1797,7 +1797,7 @@ bool G_admin_readconfig( gentity_t *ent )
 	int               len;
 	char              *cnf1, *cnf2;
 	char              *t;
-	bool          level_open, admin_open, ban_open, command_open;
+	bool              level_open, admin_open, ban_open, command_open;
 	int               i;
 	char              ip[ 44 ];
 

--- a/src/sgame/sg_spawn.cpp
+++ b/src/sgame/sg_spawn.cpp
@@ -627,16 +627,14 @@ so message texts can be multi-line
 char *G_NewString( const char *string )
 {
 	char *newb, *new_p;
-	int  i, l;
+	size_t l = strlen( string ) + 1;
 
-	l = strlen( string ) + 1;
-
-	newb =(char*) BG_Alloc( l );
+	newb = (char*) BG_Alloc( l );
 
 	new_p = newb;
 
 	// turn \n into a real linefeed
-	for ( i = 0; i < l; i++ )
+	for ( size_t i = 0; i < l; i++ )
 	{
 		if ( string[ i ] == '\\' && i < l - 1 )
 		{
@@ -668,17 +666,16 @@ G_NewTarget
 gentityCallDefinition_t G_NewCallDefinition( const char *eventKey, const char *string )
 {
 	char *stringPointer;
-	int  i, stringLength;
 	gentityCallDefinition_t newCallDefinition = { nullptr, ON_DEFAULT, nullptr, nullptr, ECA_NOP };
 
-	stringLength = strlen( string ) + 1;
-	if(stringLength == 1)
+	size_t stringLength = strlen( string ) + 1;
+	if ( stringLength == 1 )
 		return newCallDefinition;
 
 	stringPointer = (char*) BG_Alloc( stringLength );
 	newCallDefinition.name = stringPointer;
 
-	for ( i = 0; i < stringLength; i++ )
+	for ( size_t i = 0; i < stringLength; i++ )
 	{
 		if ( string[ i ] == ':' && !newCallDefinition.action )
 		{

--- a/src/sgame/sg_utils.cpp
+++ b/src/sgame/sg_utils.cpp
@@ -256,7 +256,7 @@ G_CopyString
 char *G_CopyString( const char *str )
 {
 	size_t size = strlen( str ) + 1;
-	char *cp = (char*) BG_Alloc( size );
+	char *cp = (char*) malloc( size );
 	memcpy( cp, str, size );
 	return cp;
 }

--- a/src/shared/bg_alloc.cpp
+++ b/src/shared/bg_alloc.cpp
@@ -24,7 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "engine/qcommon/q_shared.h"
 #include "bg_public.h"
 
-void *BG_Alloc( int size )
+void *BG_Alloc( size_t size )
 {
 	void *ptr = malloc( size );
 
@@ -40,4 +40,3 @@ void BG_Free( void *ptr )
 {
 	free( ptr );
 }
-

--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -2832,8 +2832,6 @@ char *Substring( const char *in, int start, int count )
 	static char buffer[ MAX_STRING_CHARS ];
 	char        *buf = buffer;
 
-	memset( &buffer, 0, sizeof( buffer ) );
-
 	Q_strncpyz( buffer, in+start, count );
 
 	return buf;
@@ -2851,7 +2849,7 @@ char *BG_strdup( const char *string )
 	char *copy;
 
 	length = strlen(string) + 1;
-	copy = (char *)BG_Alloc(length);
+	copy = (char *)malloc(length);
 
 	if ( copy == nullptr )
 	{

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -1487,7 +1487,7 @@ void     UI_UpdateUnlockables();
 #define MASK_SHOT        ( CONTENTS_SOLID | CONTENTS_BODY )
 #define MASK_ENTITY      ( CONTENTS_MOVER )
 
-void     *BG_Alloc( int size );
+void     *BG_Alloc( size_t size );
 void     BG_InitMemory();
 void     BG_Free( void *ptr );
 void     BG_DefragmentMemory();

--- a/src/shared/bg_voice.cpp
+++ b/src/shared/bg_voice.cpp
@@ -269,7 +269,7 @@ static bool BG_VoiceParseTrack( int handle, voiceTrack_t *voiceTrack )
 				}
 				else if ( modelno < 0 )
 				{
-				        break; // possibly the next keyword
+					break; // possibly the next keyword
 				}
 
 				found = true;
@@ -300,16 +300,17 @@ static bool BG_VoiceParseTrack( int handle, voiceTrack_t *voiceTrack )
 			}
 
 			foundText = true;
+			auto tokenLen = strlen( token.string );
 
-			if ( strlen( token.string ) >= MAX_SAY_TEXT )
+			if ( tokenLen >= MAX_SAY_TEXT )
 			{
 				BG_VoiceParseError( handle, va( "BG_VoiceParseTrack(): "
 				                                "\"text\" value " "\"%s\" exceeds MAX_SAY_TEXT length",
 				                                token.string ) );
 			}
 
-			voiceTrack->text = ( char * ) BG_Alloc( strlen( token.string ) + 1 );
-			Q_strncpyz( voiceTrack->text, token.string, strlen( token.string ) + 1 );
+			voiceTrack->text = ( char * ) BG_Alloc( tokenLen + 1 );
+			Q_strncpyz( voiceTrack->text, token.string, tokenLen + 1 );
 			foundToken = trap_Parse_ReadToken( handle, &token );
 			continue;
 		}


### PR DESCRIPTION
Cache `strlen` value outside of cycles to improve performance.

Sometimes still need to use `int` instead of `std::size_t` because of old
code relying on passing int.