### PR TITLE
Use Str::ctolower instead of std::tolower

### DIFF
--- a/daemon/src/common/Color.cpp
+++ b/daemon/src/common/Color.cpp
@@ -228,7 +228,7 @@ TokenIterator::value_type TokenIterator::NextToken(const char* input)
         {
             return value_type( input, input+2, detail::Indexed( input[1] - '0' ) );
         }
-        else if ( std::tolower( input[1] ) == 'x' && Str::cisxdigit( input[2] ) &&
+        else if ( Str::ctolower( input[1] ) == 'x' && Str::cisxdigit( input[2] ) &&
                   Str::cisxdigit( input[3] ) && Str::cisxdigit( input[4] ) )
         {
             return value_type( input, input+5, Color(


### PR DESCRIPTION
A little buildfix

C:\projects\unvanquished\daemon\src\common\Color.cpp(231): error C2039: 'tolower': is not a member of 'std'
c:\projects\unvanquished\daemon\src\common\Optional.h(412): note: see declaration of 'std'