### PR TITLE
Fix compiler error

### DIFF
--- a/daemon/src/engine/renderer/tr_vbo.cpp
+++ b/daemon/src/engine/renderer/tr_vbo.cpp
@@ -300,7 +300,7 @@ static void R_SetVBOAttributeLayouts( VBO_t *vbo )
 	else
 	{
 		ri.Error(errorParm_t::ERR_DROP, "%sUnknown attribute layout for vbo: %s\n",
-			Color::ToString( Color::Yellow ),
+			Color::ToString( Color::Yellow ).c_str(),
 			vbo->name );
 	}
 }


### PR DESCRIPTION
I'm getting the following error because of this (g++ (Ubuntu 4.8.4-2ubuntu1~14.04.1) 4.8.4):

...Unvanquished/daemon/src/engine/renderer/tr_vbo.cpp:304:14: error: cannot pass objects of non-trivially-copyable type ‘std::string {aka class std::basic_string<char>}’ through ‘...’
    vbo->name );
              ^
...Unvanquished/daemon/src/engine/renderer/tr_vbo.cpp:304:14: warning: format ‘%s’ expects argument of type ‘char*’, but argument 3 has type ‘std::string {aka std::basic_string<char>}’ [-Wformat=]
