### PR TITLE
Support loading pak files which don't follow naming convention

### DIFF
--- a/daemon/src/common/Defs.h
+++ b/daemon/src/common/Defs.h
@@ -42,6 +42,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /** Default base package */
 #define DEFAULT_BASE_PAK    PRODUCT_NAME_LOWER
 
+#define DAEMON_FS_LEGACY_PAKS false
+
 /** URI scheme and server browser filter */
 #define GAMENAME_STRING     "unv"
 #define GAMENAME_FOR_MASTER PRODUCT_NAME_UPPER

--- a/daemon/src/common/Defs.h
+++ b/daemon/src/common/Defs.h
@@ -42,8 +42,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /** Default base package */
 #define DEFAULT_BASE_PAK    PRODUCT_NAME_LOWER
 
-#define DAEMON_FS_LEGACY_PAKS false
-
 /** URI scheme and server browser filter */
 #define GAMENAME_STRING     "unv"
 #define GAMENAME_FOR_MASTER PRODUCT_NAME_UPPER

--- a/daemon/src/common/FileSystem.cpp
+++ b/daemon/src/common/FileSystem.cpp
@@ -2161,10 +2161,11 @@ static void AddPak(pakType_t type, Str::StringRef filename, Str::StringRef baseP
 	std::string name, version;
 	Util::optional<uint32_t> checksum;
 	if (!ParsePakName(filename.begin(), filename.end() - suffixLen, name, version, checksum) || (type == pakType_t::PAK_DIR && checksum)) {
-		fsLogs.Warn("Invalid pak name: %s", fullPath);
 		if (!UseLegacyPaks()) {
+			fsLogs.Warn("Invalid pak name: %s", fullPath);
 			return;
 		} else {
+			fsLogs.Notice("Loading legacy pak: %s", fullPath);
 			name = filename.substr(0, filename.size() - suffixLen);
 			version = "1";
 		}

--- a/daemon/src/common/FileSystem.h
+++ b/daemon/src/common/FileSystem.h
@@ -39,6 +39,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace FS {
 
+bool UseLegacyPaks();
+
 // File offset type. Using 64bit to allow large files.
 using offset_t = int64_t;
 

--- a/daemon/src/engine/framework/System.cpp
+++ b/daemon/src/engine/framework/System.cpp
@@ -581,6 +581,7 @@ static void Init(int argc, char** argv)
 	// lowest priority, while the homepath is added last and has the highest.
 	cmdlineArgs.paths.insert(cmdlineArgs.paths.begin(), FS::Path::Build(FS::DefaultBasePath(), "pkg"));
 	cmdlineArgs.paths.push_back(FS::Path::Build(cmdlineArgs.homePath, "pkg"));
+	EarlyCvar("fs_legacypaks", cmdlineArgs);
 	FS::Initialize(cmdlineArgs.homePath, cmdlineArgs.libPath, cmdlineArgs.paths);
 
 	// Look for an existing instance of the engine running on the same homepath.

--- a/daemon/src/engine/server/server.h
+++ b/daemon/src/engine/server/server.h
@@ -379,7 +379,7 @@ void SV_GetPlayerPubkey( int clientNum, char *pubkey, int size );
 void SV_CreateBaseline();
 
 void SV_ChangeMaxClients();
-void SV_SpawnServer( const char *server );
+void SV_SpawnServer(const std::string pakname, const std::string server);
 
 //
 // sv_client.c

--- a/daemon/src/engine/server/sv_ccmds.cpp
+++ b/daemon/src/engine/server/sv_ccmds.cpp
@@ -59,7 +59,9 @@ class MapCmd: public Cmd::StaticCmd {
             const std::string& mapName = args.Argv(1);
 
             //Make sure the map exists to avoid typos that would kill the game
-            if (!FS::GetAvailableMaps().count(mapName)) {
+            FS::GetAvailableMaps();
+            const auto loadedPakInfo = FS::PakPath::LocateFile(Str::Format("maps/%s.bsp", mapName));
+            if (!loadedPakInfo) {
                 Print("Can't find map %s", mapName);
                 return;
             }
@@ -71,7 +73,7 @@ class MapCmd: public Cmd::StaticCmd {
             }
 
             Cvar::SetValueForce("sv_cheats", cheat ? "1" : "0");
-            SV_SpawnServer(mapName.c_str());
+            SV_SpawnServer(loadedPakInfo->name, mapName);
         }
 
         Cmd::CompletionResult Complete(int argNum, const Cmd::Args& args, Str::StringRef prefix) const OVERRIDE {
@@ -138,12 +140,14 @@ static void SV_MapRestart_f()
 	if ( sv_maxclients->modified )
 	{
 		char mapname[ MAX_QPATH ];
+		char pakname[ MAX_QPATH ];
 
 		Log::Notice( "sv_maxclients variable change — restarting.\n" );
 		// restart the map the slow way
 		Q_strncpyz( mapname, Cvar_VariableString( "mapname" ), sizeof( mapname ) );
+		Q_strncpyz( pakname, Cvar_VariableString( "pakname" ), sizeof( pakname ) );
 
-		SV_SpawnServer( mapname );
+		SV_SpawnServer(pakname, mapname);
 		return;
 	}
 

--- a/daemon/src/engine/server/sv_init.cpp
+++ b/daemon/src/engine/server/sv_init.cpp
@@ -447,7 +447,7 @@ clients along with it.
 This is NOT called for map_restart
 ================
 */
-void SV_SpawnServer( const char *server )
+void SV_SpawnServer(const std::string pakname, const std::string server)
 {
 	int        i;
 	bool   isBot;
@@ -513,13 +513,14 @@ void SV_SpawnServer( const char *server )
 
 	FS::PakPath::ClearPaks();
 	FS_LoadBasePak();
-	if (!FS_LoadPak(va("map-%s", server)))
+	if (!FS_LoadPak(pakname.c_str()))
 		Com_Error(errorParm_t::ERR_DROP, "Could not load map pak\n");
 
 	CM_LoadMap(server);
 
 	// set serverinfo visible name
-	Cvar_Set( "mapname", server );
+	Cvar_Set( "mapname", server.c_str() );
+	Cvar_Set( "pakname", pakname.c_str() );
 
 	// serverid should be different each time
 	sv.serverId = com_frameTime;
@@ -642,6 +643,7 @@ void SV_Init()
 
 	Cvar_Get( "protocol", va( "%i", PROTOCOL_VERSION ), CVAR_SERVERINFO  );
 	sv_mapname = Cvar_Get( "mapname", "nomap", CVAR_SERVERINFO | CVAR_ROM );
+	Cvar_Get( "pakname", "", CVAR_SERVERINFO | CVAR_ROM );
 	Cvar_Get( "layout", "", CVAR_SERVERINFO | CVAR_ROM );
 	Cvar_Get( "g_layouts", "", 0 ); // FIXME
 	sv_privateClients = Cvar_Get( "sv_privateClients", "0", CVAR_SERVERINFO );


### PR DESCRIPTION
Defines a flag for allowing the use of legacy pak naming, the primary use case being in xonotic