### PR TITLE
Precompiled headers fix for MSVC

### DIFF
--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -322,8 +322,10 @@ function(ADD_PRECOMPILED_HEADER Target)
             set_property(TARGET ${Target} APPEND PROPERTY COMPILE_OPTIONS "-include;${OBJ_DIR}/${Target}.h;-Winvalid-pch")
         endif()
     elseif (MSVC)
+        # /Fp sets the PCH path used by either of the /Yc and /Yu options.
+        # /Yc overrides /Yu.
         set_source_files_properties(${PCH_FILE} PROPERTIES COMPILE_FLAGS "/Yc${Header}")
-        set_property(TARGET ${Target} APPEND PROPERTY COMPILE_FLAGS "/Yu${Header} /Fp${OBJ_DIR}/${Target}.pch /FI${Header}")
+        target_compile_options(${Target} PRIVATE "/Yu${Header}" "/Fp${OBJ_DIR}/${Target}_$<CONFIG>.pch" "/FI${Header}")
     endif()
 endfunction()
 


### PR DESCRIPTION
Currently, if you build Project X in configuration A, then in configuration B, then in configuration A again, it will try to use an incompatible PCH and all the compiles fail. This creates separately persisting PCHes for each configuration (Debug, Release etc.)