### PR TITLE
Correct listmap cmd filtering & output

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -52,6 +52,7 @@ static void G_admin_notIntermission( gentity_t *ent )
 
 // big ugly global buffer for use with buffered printing of long outputs
 static std::string       g_bfb;
+#define MAX_MESSAGE_SIZE static_cast<size_t>(1022)
 
 static bool G_admin_maprestarted( gentity_t * );
 
@@ -5506,6 +5507,7 @@ void G_admin_print_plural( gentity_t *ent, Str::StringRef m, int number )
 void G_admin_buffer_begin()
 {
 	g_bfb.clear();
+	g_bfb.reserve(MAX_MESSAGE_SIZE);
 }
 
 void G_admin_buffer_end( gentity_t *ent )
@@ -5513,19 +5515,30 @@ void G_admin_buffer_end( gentity_t *ent )
 	G_admin_print( ent, Cmd::Escape( g_bfb ) );
 }
 
-void G_admin_buffer_print( gentity_t *ent, Str::StringRef m )
+static inline void G_admin_buffer_print_raw( gentity_t *ent, Str::StringRef m, bool appendNewLine )
 {
-	if ( !m.empty() )
+	// Ensure we don't overflow client buffers.
+	if ( g_bfb.size() + m.size() >= MAX_MESSAGE_SIZE )
 	{
-		// Ensure we don't overflow client buffers.
-		if ( g_bfb.size() + m.size() >= 1022 )
-		{
-			G_admin_buffer_end( ent );
-			g_bfb.clear();
-		}
-		g_bfb += m;
+		G_admin_buffer_end( ent );
+		G_admin_buffer_begin();
+	}
+	g_bfb += m;
+
+	if ( appendNewLine )
+	{
 		g_bfb += '\n';
 	}
+}
+
+void G_admin_buffer_print_raw( gentity_t *ent, Str::StringRef m )
+{
+	G_admin_buffer_print_raw( ent, m, false );
+}
+
+void G_admin_buffer_print( gentity_t *ent, Str::StringRef m )
+{
+	G_admin_buffer_print_raw( ent, m, true );
 }
 
 void G_admin_cleanup()

--- a/src/sgame/sg_admin.h
+++ b/src/sgame/sg_admin.h
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define CPx(x, y)     trap_SendServerCommand(x, y)
 #define ADMP(x)       G_admin_print(ent, x)
 #define ADMP_P(x,c)   G_admin_print_plural(ent, x, c)
+#define ADMBP_raw(x)  G_admin_buffer_print_raw(ent, x)
 #define ADMBP(x)      G_admin_buffer_print(ent, x)
 #define ADMBP_begin() G_admin_buffer_begin()
 #define ADMBP_end()   G_admin_buffer_end(ent)
@@ -236,6 +237,7 @@ bool        G_admin_bot( gentity_t *ent );
 
 void            G_admin_print( gentity_t *ent, Str::StringRef m );
 void            G_admin_print_plural( gentity_t *ent, Str::StringRef m, int number );
+void            G_admin_buffer_print_raw( gentity_t *ent, Str::StringRef m );
 void            G_admin_buffer_print( gentity_t *ent, Str::StringRef m );
 void            G_admin_buffer_begin();
 void            G_admin_buffer_end( gentity_t *ent );

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -3805,32 +3805,18 @@ List all maps on the server
 =================
 */
 
-static int SortMaps( const void *a, const void *b )
-{
-	return strcmp( * ( const char ** ) a, * ( const char ** ) b );
-}
-
 #define MAX_MAPLIST_MAPS 256
 #define MAX_MAPLIST_ROWS 9
 void Cmd_ListMaps_f( gentity_t *ent )
 {
 	char search[ 16 ] = { "" };
-	const char *fileSort[ MAX_MAPLIST_MAPS ] = { 0 };
-	char *p;
-	int  shown = 0;
-	int  count = 0;
 	int  page = 0;
-	int  pages;
-	int  row, rows;
-	int  start, i, j;
-	char mapName[ MAX_QPATH ];
-
-	trap_Cvar_VariableStringBuffer( "mapname", mapName, sizeof( mapName ) );
 
 	if ( trap_Argc() > 1 )
 	{
 		trap_Argv( 1, search, sizeof( search ) );
 
+		char *p;
 		for ( p = search; ( *p ) && Str::cisdigit( *p ); p++ ) {; }
 
 		if ( !( *p ) )
@@ -3855,62 +3841,80 @@ void Cmd_ListMaps_f( gentity_t *ent )
 		}
 	}
 
-	auto paks = FS::GetAvailablePaks();
+	const char *mapNames[ MAX_MAPLIST_MAPS ] = { 0 };
+	int         mapNamesCount = 0;
+	const auto paks = FS::GetAvailablePaks();
 
 	for ( size_t i = 0; i < paks.size(); ++i )
 	{
+		const char *pakName = paks[ i ].name.c_str();
+
 		// Filter out duplicates
-		if ( i && !strcmp( paks[ i ].name.c_str(), paks[ i - 1 ].name.c_str() ) )
+		if ( i && !strcmp( pakName, paks[ i - 1 ].name.c_str() ) )
 		{
 			continue;
 		}
 
-		if ( Q_strncmp( "map-", paks[ i ].name.c_str(), 4 ) || ( search[ 0 ] && !strstr( paks[ i ].name.c_str(), search ) ) )
+		if ( Q_strncmp( "map-", pakName, 4 ) ||
+			 ( search[ 0 ] && !strstr( pakName + 4, search ) ) )
 		{
 			continue;
 		}
 
-		fileSort[ count ] = paks[ i ].name.c_str() + 4;
-		count++;
+		mapNames[ mapNamesCount++ ] = pakName + 4;
 	}
 
-	qsort( fileSort, count, sizeof( fileSort[ 0 ] ), SortMaps );
+	std::sort( mapNames,
+			   mapNames + mapNamesCount,
+			   [] ( const char *mapNameFirst, const char *mapNameSecond )
+			   {
+			   		return strcmp( mapNameFirst, mapNameSecond ) < 0;
+			   }
+	);
 
-	rows = ( count + 2 ) / 3;
-	pages = std::max( 1, ( rows + MAX_MAPLIST_ROWS - 1 ) / MAX_MAPLIST_ROWS );
+	int rows = ( mapNamesCount + 2 ) / 3;
+	int pages = std::max( 1, ( rows + MAX_MAPLIST_ROWS - 1 ) / MAX_MAPLIST_ROWS );
 
 	if ( page >= pages )
 	{
 		page = pages - 1;
 	}
 
-	start = page * MAX_MAPLIST_ROWS * 3;
+	int start = page * MAX_MAPLIST_ROWS * 3;
 
-	if ( count < start + ( 3 * MAX_MAPLIST_ROWS ) )
+	if ( mapNamesCount < start + ( 3 * MAX_MAPLIST_ROWS ) )
 	{
-		rows = ( count - start + 2 ) / 3;
+		rows = ( mapNamesCount - start + 2 ) / 3;
 	}
 	else
 	{
 		rows = MAX_MAPLIST_ROWS;
 	}
 
+	char mapName[ MAX_QPATH ];
+
+	trap_Cvar_VariableStringBuffer( "mapname", mapName, sizeof( mapName ) );
+
 	ADMBP_begin();
 
-	for ( row = 0; row < rows; row++ )
+	int shownMapNamesCount = 0;
+
+	for ( int row = 0; row < rows; row++ )
 	{
-		for ( i = start + row, j = 0; i < count && j < 3; i += rows, j++ )
+		for ( int i = start + row, j = 0; i < mapNamesCount && j < 3; i += rows, j++ )
 		{
-			if ( !strcmp( fileSort[ i ], mapName ) )
+			const char *printedMapName = mapNames[ i ];
+
+			if ( !strcmp( printedMapName, mapName ) )
 			{
-				ADMBP( va( "^3 %-20s", fileSort[ i ] ) );
+				ADMBP( va( "^3 %-20s", printedMapName ) );
 			}
 			else
 			{
-				ADMBP( va( "^7 %-20s", fileSort[ i ] ) );
+				ADMBP( va( "^7 %-20s", printedMapName ) );
 			}
 
-			shown++;
+			shownMapNamesCount++;
 		}
 
 		ADMBP( "" );
@@ -3920,17 +3924,34 @@ void Cmd_ListMaps_f( gentity_t *ent )
 
 	if ( search[ 0 ] )
 	{
-		ADMP_P( va( "%s %d %s", Quote( P_("^3listmaps: ^7found $1$ map matching '$2$^7'", "^3listmaps: ^7found $1$ maps matching '$2$^7'", count) ), count, Quote( search ) ), count );
+		ADMP_P( va( "%s %d %s",
+					Quote( P_("^3listmaps: ^7found $1$ map matching '$2$^7'",
+							  "^3listmaps: ^7found $1$ maps matching '$2$^7'",
+							  mapNamesCount)
+					),
+					mapNamesCount,
+					Quote( search )
+			      ),
+				mapNamesCount );
 	}
 	else
 	{
-		ADMP_P( va( "%s %d %d", Quote( P_("^3listmaps: ^7listing $1$ of $2$ map", "^3listmaps: ^7listing $1$ of $2$ maps", count) ), shown, count ), count );
+		ADMP_P( va( "%s %d %d",
+					Quote( P_("^3listmaps: ^7listing $1$ of $2$ map",
+							  "^3listmaps: ^7listing $1$ of $2$ maps",
+							  mapNamesCount)
+					),
+					shownMapNamesCount,
+					mapNamesCount
+				  ),
+				mapNamesCount );
 	}
 
 	if ( pages > 1 && page + 1 < pages )
 	{
-		ADMP( va( "%s %d %d %s %s %d", QQ( N_("^3listmaps: ^7page $1$ of $2$; use 'listmaps $3$$4$$5$' to see more") ),
-		           page + 1, pages, Quote( search ), ( search[ 0 ] ) ? " " : "", page + 2 ) );
+		ADMP( va( "%s %d %d %s %s %d",
+				  QQ( N_("^3listmaps: ^7page $1$ of $2$; use 'listmaps $3$$4$$5$' to see more") ),
+		          page + 1, pages, Quote( search ), ( search[ 0 ] ) ? " " : "", page + 2 ) );
 	}
 	else if ( pages > 1 )
 	{

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -3907,11 +3907,11 @@ void Cmd_ListMaps_f( gentity_t *ent )
 
 			if ( !strcmp( printedMapName, mapName ) )
 			{
-				ADMBP( va( "^3 %-20s", printedMapName ) );
+				ADMBP_raw( va( "^3 %-20s", printedMapName ) );
 			}
 			else
 			{
-				ADMBP( va( "^7 %-20s", printedMapName ) );
+				ADMBP_raw( va( "^7 %-20s", printedMapName ) );
 			}
 
 			shownMapNamesCount++;


### PR DESCRIPTION
- Fix map filtering for filter containing 'map-' chars

When `listmaps` filter contains one of "map-" chars, filter returns all
map names. The reason is we take into account invisible "map-" prefix
for map when filter. Fixed by removing "map-" from map name before filter.
- Fix output maps names in columns & asc map names sorting. 

Before fix, maps names were unordered and not outputted in columns, as
it were before. Fixed by ensuring ADMBP( "" ) send newline instead of
do nothing. Was broken when forced end buffer with new line implicitly.
