### PR TITLE
do not abort shader parsing on unknown keyword warning, ref #799

### DIFF
--- a/daemon/src/engine/renderer/tr_shader.cpp
+++ b/daemon/src/engine/renderer/tr_shader.cpp
@@ -2424,7 +2424,7 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 		{
 			Log::Warn("unknown shader stage parameter '%s' in shader '%s'", token, shader.name );
 			SkipRestOfLine( text );
-			return false;
+			continue;
 		}
 	}
 


### PR DESCRIPTION
When an unknown keyword is found in a shader, the parser displays a warning, drops the current line but returns false, invalidating the whole shader, which is not a warning behavior. This change makes the shader parsing continue after the warning. If the shader must not continue, the parser must not raises a warning but an error. It was the behavior before the refactoring of this part. See #799.
