### PR TITLE
Bot fill

### DIFF
--- a/daemon/src/engine/renderer/gl_shader.cpp
+++ b/daemon/src/engine/renderer/gl_shader.cpp
@@ -1022,8 +1022,8 @@ GLuint GLShaderManager::CompileShader( Str::StringRef programName,
 				       GLenum shaderType ) const
 {
 	GLuint shader = glCreateShader( shaderType );
-	const GLchar *texts[headers.size() + 1];
-	GLint lengths[headers.size() + 1];
+	std::vector<const GLchar*> texts(headers.size() + 1);
+	std::vector<GLint> lengths(headers.size() + 1);
 	int i;
 
 	i = 0;
@@ -1040,7 +1040,7 @@ GLuint GLShaderManager::CompileShader( Str::StringRef programName,
 
 	GL_CheckErrors();
 
-	glShaderSource( shader, i, texts, lengths );
+	glShaderSource( shader, i, texts.data(), lengths.data() );
 
 	// compile shader
 	glCompileShader( shader );

--- a/daemon/src/engine/server/sv_client.cpp
+++ b/daemon/src/engine/server/sv_client.cpp
@@ -282,6 +282,8 @@ void SV_DropClient( client_t *drop, const char *reason )
 	{
 		return; // already dropped
 	}
+	bool isBot = SV_IsBot( drop );
+
 	Log::Debug( "Going to CS_ZOMBIE for %s", drop->name );
 	drop->state = clientState_t::CS_ZOMBIE; // become free in a few seconds
 
@@ -289,7 +291,7 @@ void SV_DropClient( client_t *drop, const char *reason )
 	// this will remove the body, among other things
 	gvm.GameClientDisconnect( drop - svs.clients );
 
-	if ( SV_IsBot(drop) )
+	if ( isBot )
 	{
 		SV_BotFreeClient( drop - svs.clients );
 	}

--- a/daemon/src/shared/CommonProxies.cpp
+++ b/daemon/src/shared/CommonProxies.cpp
@@ -240,6 +240,14 @@ void trap_Argv(int n, char *buffer, int bufferLength) {
     }
 }
 
+const Cmd::Args& trap_Args() {
+	static const Cmd::Args empty;
+	if (argStack.empty()) {
+		return empty;
+	}
+	return *argStack.back();
+}
+
 void trap_EscapedArgs( char *buffer, int bufferLength ) {
 	const Cmd::Args* args = argStack.back();
 	std::string res = args->EscapedArgs(0);

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -5579,135 +5579,128 @@ void G_admin_cleanup()
 	g_admin_commands = nullptr;
 }
 
-bool G_admin_bot( gentity_t *ent )
+static void BotUsage( gentity_t *ent )
 {
-	int min_args = 3;
-	char arg1[MAX_TOKEN_CHARS];
-	char name[MAX_TOKEN_CHARS];
-	char team[MAX_TOKEN_CHARS];
-	char skill[MAX_TOKEN_CHARS];
-	char err[MAX_STRING_CHARS];
-	char behavior[MAX_QPATH];
-	int skill_int;
-	int i;
-	int clientNum;
+	static const char bot_usage[] = QQ( N_( "^3bot: ^7usage: bot add (<name> | *) (aliens | humans) [<skill level> [<behavior>]]\n"
+	                                        "            bot del (<name> | all)\n"
+	                                        "            bot names (aliens | humans) <names>…\n"
+	                                        "            bot names (clear | list)" ) );
+	ADMP( bot_usage );
+}
 
-	static const char bot_usage[] = QQ( N_( "^3bot: ^7usage: bot add [^5name|*^7] [^5aliens|humans^7] (^5skill^7) (^5behavior^7)\n"
-	                                        "            bot del [^5name|all^7]\n"
-	                                        "            bot names [^5aliens|humans^7] [^5names…^7]\n"
-	                                        "            bot names [^5clear|list^7]" ) );
 
-	if ( trap_Argc() < min_args )
+static int BotSkillFromString( gentity_t* ent, const char* s )
+{
+	int skill0 = atoi( s );
+	int skill = Math::Clamp( atoi( s ), 1, 10 );
+	if (skill0 != skill) {
+		ADMP( QQ( N_( "Bot skill level should be from 1 to 10" ) ) );
+	}
+	return skill;
+}
+
+static bool BotAddCmd( gentity_t* ent, const Cmd::Args& args )
+{
+	if ( args.Argc() < 4 || args.Argc() > 6 )
 	{
-		ADMP( bot_usage );
+		BotUsage( ent );
 		return false;
 	}
-	trap_Argv( 1, arg1, sizeof( arg1 ) );
-	trap_Argv( 2, name, sizeof( name ) );
+
+	const char* name = args[2].data();
+	if ( !Q_stricmp( name, "all" ) )
+	{
+		ADMP( QQ( N_( "bots can't have that name" ) ) );
+		return false;
+	}
+
+	team_t team = BG_PlayableTeamFromString( args[3].data() );
+	if ( team == team_t::TEAM_NONE )
+	{
+		ADMP( QQ( N_( "Invalid team name" ) ) );
+		BotUsage( ent );
+		return false;
+	}
+
+	int skill;
+	if ( args.Argc() >= 5 )
+	{
+		skill = BotSkillFromString( ent, args[4].data() );
+	}
+	else
+	{
+		skill = 5;
+	}
+
+	const char* behavior = args.Argc() >= 6 ? args[5].data() : "default";
+
+	bool result = G_BotAdd( name, team, skill, behavior );
+	if ( !result )
+	{
+		ADMP( QQ( N_( "Can't add a bot" ) ) );
+	}
+	return result;
+}
+
+bool G_admin_bot( gentity_t *ent )
+{
+	auto args = trap_Args();
+	if ( args.Argc() < 2)
+	{
+		BotUsage( ent );
+		return false;
+	}
+	const char* arg1 = args[1].data();
 
 	if ( !Q_stricmp( arg1, "add" ) )
 	{
 		RETURN_IF_INTERMISSION;
-
-		min_args++; //now we also need a team name
-		if ( !Q_stricmp( name, "all" ) )
-		{
-			ADMP( QQ( N_( "bots can't have that name" ) ) );
-			return false;
-		}
-		if ( trap_Argc() < min_args )
-		{
-			ADMP( bot_usage );
-			return false;
-		}
-		trap_Argv( 3, team, sizeof( team ) );
-
-		//skill level checks
-		min_args++;
-		if ( trap_Argc() < min_args )
-		{
-			skill_int = 5; //no skill arg
-		}
-		else
-		{
-			trap_Argv( 4, skill, sizeof( skill ) );
-			skill_int = atoi( skill );
-			if ( skill_int < 1 )
-			{
-				skill_int = 1; //skill arg too small, reset to 1
-			}
-			else if ( skill_int > 10 )
-			{
-				skill_int = 10; //skill arg too bit, reset to 10
-			}
-		}
-
-		min_args++;
-		if ( trap_Argc() < min_args )
-		{
-			Q_strncpyz( behavior, "default", sizeof( behavior ) );
-		}
-		else
-		{
-			trap_Argv( 5, behavior, sizeof( behavior ) );
-		}
-		//choose team
-		if ( !Q_stricmp( team, "humans" ) || !Q_stricmp( team, "h" ) )
-		{
-			if ( !G_BotAdd( name, TEAM_HUMANS, skill_int, behavior ) )
-			{
-				ADMP( QQ( "Can't add a bot" ) );
-				return false;
-			}
-		}
-		else if ( !Q_stricmp( team, "aliens" ) || !Q_stricmp( team, "a" ) )
-		{
-			if ( !G_BotAdd( name, TEAM_ALIENS, skill_int, behavior ) )
-			{
-				ADMP( QQ( N_( "Can't add a bot" ) ) );
-				return false;
-			}
-		}
-		else
-		{
-			ADMP( QQ( N_( "Invalid team name" ) ) );
-			ADMP( bot_usage );
-			return false;
-		}
+		return BotAddCmd( ent, args );
 	}
-	else if ( !Q_stricmp( arg1, "del" ) )
+	else if ( !Q_stricmp( arg1, "del" ) && args.Argc() == 3 )
 	{
 		RETURN_IF_INTERMISSION;
 
-		clientNum = G_ClientNumberFromString( name, err, sizeof( err ) );
+		char err[MAX_STRING_CHARS];
+		const char *name = args[2].data();
+
 		if ( !Q_stricmp( name, "all" ) )
 		{
 			G_BotDelAllBots();
 		}
-		else if ( clientNum == -1 ) //something went wrong when finding the client Number
-		{
-			ADMP( va( "%s %s %s", QQ( "^3$1$: ^7$2t$" ), "bot", Quote( err ) ) );
-			return false;
-		}
 		else
 		{
+			int clientNum = G_ClientNumberFromString( name, err, sizeof( err ) );
+			if ( clientNum == -1 ) //something went wrong when finding the client Number
+			{
+				ADMP( va( "%s %s %s", QQ( "^3$1$: ^7$2t$" ), "bot", Quote( err ) ) );
+				return false;
+			}
 			G_BotDel( clientNum ); //delete the bot
 		}
 	}
-	else if ( !Q_stricmp( arg1, "names" ) )
+	else if ( !Q_stricmp( arg1, "names" ) && args.Argc() >= 3 )
 	{
-		if ( !Q_stricmp( name, "humans" ) || !Q_stricmp( name, "h" ) )
+		const char *name = args[2].data();
+		team_t team = BG_PlayableTeamFromString( name );
+
+		if ( team == team_t::TEAM_HUMANS )
 		{
-			i = G_BotAddNames( TEAM_HUMANS, 3, trap_Argc() );
+			int i = G_BotAddNames( team_t::TEAM_HUMANS, 3, trap_Argc() );
 			ADMP( va( "%s %d", Quote( P_( "added $1$ human bot name", "added $1$ human bot names", i ) ), i ) );
 		}
-		else if ( !Q_stricmp( name, "aliens" ) || !Q_stricmp( name, "a" ) )
+		else if ( team == team_t::TEAM_ALIENS )
 		{
-			i = G_BotAddNames( TEAM_ALIENS, 3, trap_Argc() );
+			int i = G_BotAddNames( team_t::TEAM_ALIENS, 3, trap_Argc() );
 			ADMP( va( "%s %d", Quote( P_( "added $1$ alien bot name", "added $1$ alien bot names", i ) ), i ) );
 		}
 		else if ( !Q_stricmp( name, "clear" ) || !Q_stricmp( name, "c" ) )
 		{
+			if ( args.Argc() > 3 )
+			{
+				BotUsage( ent );
+				return false;
+			}
 			if ( !G_BotClearNames() )
 			{
 				ADMP( QQ( N_( "some automatic bot names are in use – not clearing lists" ) ) );
@@ -5716,18 +5709,22 @@ bool G_admin_bot( gentity_t *ent )
 		}
 		else if ( !Q_stricmp( name, "list" ) || !Q_stricmp( name, "l" ) )
 		{
+			if ( args.Argc() > 3 )
+			{
+				BotUsage( ent );
+				return false;
+			}
 			G_BotListNames( ent );
 		}
 		else
 		{
-			goto usage;
+			BotUsage( ent );
+			return false;
 		}
 	}
 	else
 	{
-usage:
-		ADMP( QQ( N_( "Invalid command" ) ) );
-		ADMP( bot_usage );
+		BotUsage( ent );
 		return false;
 	}
 	return true;

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -5593,7 +5593,7 @@ bool G_admin_bot( gentity_t *ent )
 	int clientNum;
 
 	static const char bot_usage[] = QQ( N_( "^3bot: ^7usage: bot add [^5name|*^7] [^5aliens|humans^7] (^5skill^7) (^5behavior^7)\n"
-	                                        "            bot [^5del|spec|unspec^7] [^5name|all^7]\n"
+	                                        "            bot del [^5name|all^7]\n"
 	                                        "            bot names [^5aliens|humans^7] [^5names…^7]\n"
 	                                        "            bot names [^5clear|list^7]" ) );
 
@@ -5693,74 +5693,6 @@ bool G_admin_bot( gentity_t *ent )
 		{
 			G_BotDel( clientNum ); //delete the bot
 		}
-	}
-	else if ( !Q_stricmp( arg1, "spec" ) )
-	{
-		RETURN_IF_INTERMISSION;
-
-		clientNum = G_ClientNumberFromString( name, err, sizeof( err ) );
-		if ( !Q_stricmp( name, "all" ) )
-		{
-			for ( i = 0; i < MAX_CLIENTS; i++ )
-			{
-				if ( g_entities[i].r.svFlags & SVF_BOT )
-				{
-					G_ChangeTeam( &g_entities[i], TEAM_NONE );
-				}
-			}
-			return true;
-		}
-
-		if ( clientNum == -1 )
-		{
-			ADMP( va( "%s %s %s", QQ( "^3$1$: ^7$2t$" ), "bot", Quote( err ) ) );
-			return false;
-		}
-		if ( g_entities[clientNum].r.svFlags & SVF_BOT )
-		{
-			G_ChangeTeam( &g_entities[clientNum], TEAM_NONE );
-		}
-		else
-		{
-			ADMP( QQ( N_( "%s is not a bot" ) ) );
-		}
-	}
-	else if ( !Q_stricmp( arg1, "unspec" ) )
-	{
-		RETURN_IF_INTERMISSION;
-
-		clientNum = G_ClientNumberFromString( name, err, sizeof( err ) );
-		if ( !Q_stricmp( name, "all" ) )
-		{
-			for ( i = 0; i < MAX_CLIENTS; i++ )
-			{
-				if ( g_entities[i].r.svFlags & SVF_BOT && g_entities[i].client->pers.team == TEAM_NONE )
-				{
-					G_ChangeTeam( &g_entities[i], g_entities[i].botMind->botTeam );
-				}
-			}
-			return true;
-		}
-
-		if ( clientNum == -1 )
-		{
-			ADMP( va( "%s %s %s", QQ( "^3$1$: ^7$2t$" ), "bot", Quote( err ) ) );
-			return false;
-		}
-
-		if ( !( g_entities[clientNum].r.svFlags & SVF_BOT ) )
-		{
-			ADMP( QQ( N_( "%s is not a bot" ) ) );
-			return false;
-		}
-
-		if ( g_entities[clientNum].client->pers.team != TEAM_NONE )
-		{
-			ADMP( QQ( N_( "%s is not on spectators" ) ) );
-			return false;
-		}
-
-		G_ChangeTeam( &g_entities[clientNum], g_entities[clientNum].botMind->botTeam );
 	}
 	else if ( !Q_stricmp( arg1, "names" ) )
 	{

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -217,7 +217,7 @@ bool G_BotSetDefaults( int clientNum, team_t team, int skill, const char* behavi
 	return true;
 }
 
-bool G_BotAdd( char *name, team_t team, int skill, const char *behavior )
+bool G_BotAdd( const char *name, team_t team, int skill, const char *behavior )
 {
 	int clientNum;
 	char userinfo[MAX_INFO_STRING];

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -513,22 +513,18 @@ void G_BotInit()
 	}
 }
 
-void G_BotCleanup( int restart )
+void G_BotCleanup()
 {
-	if ( !restart )
+	for ( int i = 0; i < MAX_CLIENTS; ++i )
 	{
-		int i;
-
-		for ( i = 0; i < MAX_CLIENTS; ++i )
+		if ( g_entities[i].r.svFlags & SVF_BOT && level.clients[i].pers.connected != CON_DISCONNECTED )
 		{
-			if ( g_entities[i].r.svFlags & SVF_BOT && level.clients[i].pers.connected != CON_DISCONNECTED )
-			{
-				G_BotDel( i );
-			}
+			G_BotDel( i );
 		}
-
-		G_BotClearNames();
 	}
+
+	G_BotClearNames();
+
 	FreeTreeList( &treeList );
 	G_BotNavCleanup();
 }

--- a/src/sgame/sg_bot.h
+++ b/src/sgame/sg_bot.h
@@ -100,5 +100,5 @@ int      G_BotAddNames(team_t team, int arg, int last);
 void     G_BotDisableArea( vec3_t origin, vec3_t mins, vec3_t maxs );
 void     G_BotEnableArea( vec3_t origin, vec3_t mins, vec3_t maxs );
 void     G_BotInit();
-void     G_BotCleanup(int restart);
+void     G_BotCleanup();
 #endif

--- a/src/sgame/sg_bot.h
+++ b/src/sgame/sg_bot.h
@@ -87,7 +87,7 @@ typedef struct
 	botNavCmd_t nav;
 } botMemory_t;
 
-bool G_BotAdd( char *name, team_t team, int skill, const char* behavior );
+bool G_BotAdd( const char *name, team_t team, int skill, const char* behavior );
 bool G_BotSetDefaults( int clientNum, team_t team, int skill, const char* behavior );
 void     G_BotDel( int clientNum );
 void     G_BotDelAllBots();

--- a/src/sgame/sg_bot.h
+++ b/src/sgame/sg_bot.h
@@ -87,7 +87,11 @@ typedef struct
 	botNavCmd_t nav;
 } botMemory_t;
 
-bool G_BotAdd( const char *name, team_t team, int skill, const char* behavior );
+constexpr int BOT_DEFAULT_SKILL = 5;
+const char BOT_DEFAULT_BEHAVIOR[] = "default";
+const char BOT_NAME_FROM_LIST[] = "*";
+
+bool G_BotAdd( const char *name, team_t team, int skill, const char *behavior, bool filler = false );
 bool G_BotSetDefaults( int clientNum, team_t team, int skill, const char* behavior );
 void     G_BotDel( int clientNum );
 void     G_BotDelAllBots();
@@ -101,4 +105,5 @@ void     G_BotDisableArea( vec3_t origin, vec3_t mins, vec3_t maxs );
 void     G_BotEnableArea( vec3_t origin, vec3_t mins, vec3_t maxs );
 void     G_BotInit();
 void     G_BotCleanup();
+void G_BotFill( bool immediately );
 #endif

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -1341,18 +1341,6 @@ const char *ClientBotConnect( int clientNum, bool firstTime, team_t team )
 	// count current clients and rank for scoreboard
 	CalculateRanks();
 
-	// if this is after !restart keepteams or !restart switchteams, apply said selection
-	if ( client->sess.restartTeam != TEAM_NONE )
-	{
-//		G_ChangeTeam( ent, client->sess.restartTeam );
-//		client->sess.restartTeam = TEAM_NONE;
-	}
-	else if ( team != TEAM_NONE )
-	{
-//		G_ChangeTeam( ent, team );
-		client->sess.restartTeam = team;
-	}
-
 	return nullptr;
 }
 

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -1417,7 +1417,6 @@ static const struct {
 	{ "nextmap",      false, V_PUBLIC, T_OTHER,   false,  false,    qtrinary::qmaybe, &g_nextMapVotesPercent, VOTE_ALWAYS, nullptr, nullptr },
 	{ "poll",         false, V_ANY,    T_NONE,    false,  false,    qtrinary::qyes,   &g_pollVotesPercent,        VOTE_NO_AUTO, nullptr, nullptr },
 	{ "kickbots",     true,  V_PUBLIC, T_NONE,    false,  false,    qtrinary::qno,    &g_kickVotesPercent,        VOTE_ENABLE, &g_botKickVotesAllowedThisMap, nullptr },
-	{ "spectatebots", false, V_PUBLIC, T_NONE,    false,  false,    qtrinary::qno,    &g_kickVotesPercent,        VOTE_ENABLE, &g_botKickVotesAllowedThisMap, nullptr },
 	{ }
 	// note: map votes use the reason, if given, as the layout name
 };
@@ -1738,7 +1737,6 @@ vote_is_disabled:
 		break;
 
 	case VOTE_BOT_KICK:
-	case VOTE_BOT_SPECTATE:
 		for ( i = 0; i < MAX_CLIENTS; ++i )
 		{
 			if ( g_entities[i].r.svFlags & SVF_BOT &&
@@ -1755,16 +1753,9 @@ vote_is_disabled:
 			return;
 		}
 
-		if ( voteId == VOTE_BOT_KICK )
-		{
-			Com_sprintf( level.team[ team ].voteString, sizeof( level.team[ team ].voteString ), "bot del all" );
-			Com_sprintf( level.team[ team ].voteDisplayString, sizeof( level.team[ team ].voteDisplayString ), N_("Remove all bots") );
-		}
-		else
-		{
-			Com_sprintf( level.team[ team ].voteString, sizeof( level.team[ team ].voteString ), "bot spec all" );
-			Com_sprintf( level.team[ team ].voteDisplayString, sizeof( level.team[ team ].voteDisplayString ), N_("Move all bots to spectators") );
-		}
+		Com_sprintf( level.team[ team ].voteString, sizeof( level.team[ team ].voteString ), "bot del all" );
+		Com_sprintf( level.team[ team ].voteDisplayString, sizeof( level.team[ team ].voteDisplayString ), N_("Remove all bots") );
+
 		break;
 
 	case VOTE_MUTE:

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -2887,6 +2887,8 @@ void G_RunFrame( int levelTime )
 	// see if it is time to end the level
 	CheckExitRules();
 
+	G_BotFill( false );
+
 	// update to team status?
 	CheckTeamStatus();
 

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -924,7 +924,7 @@ static bool G_VotesRunning()
 G_ShutdownGame
 =================
 */
-void G_ShutdownGame( int restart )
+void G_ShutdownGame( int /* restart */ )
 {
 	// in case of a map_restart
 	G_ClearVotes( true );
@@ -953,7 +953,7 @@ void G_ShutdownGame( int restart )
 	G_WriteSessionData();
 
 	G_admin_cleanup();
-	G_BotCleanup( restart );
+	G_BotCleanup();
 	G_namelog_cleanup();
 
 	G_UnregisterCommands();

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -490,6 +490,8 @@ struct clientPersistant_s
 
 	// warnings in the ban log
 	bool            hasWarnings;
+
+	bool isFillerBot;
 };
 
 struct unlagged_s
@@ -754,6 +756,8 @@ struct level_locals_s
 		bool             locked;
 		float            momentum;
 		int              layoutBuildPoints;
+		int              botFillTeamSize;
+		int              botFillSkillLevel;
 	} team[ NUM_TEAMS ];
 
 	struct {

--- a/src/sgame/sg_trapcalls.h
+++ b/src/sgame/sg_trapcalls.h
@@ -33,6 +33,7 @@ int              trap_Cvar_VariableIntegerValue( const char *var_name );
 void             trap_Cvar_VariableStringBuffer( const char *var_name, char *buffer, int bufsize );
 int              trap_Argc();
 void             trap_Argv( int n, char *buffer, int bufferLength );
+const Cmd::Args& trap_Args();
 void             trap_SendConsoleCommand( const char *text );
 int              trap_FS_FOpenFile( const char *qpath, fileHandle_t *f, fsMode_t mode );
 int              trap_FS_Read( void *buffer, int len, fileHandle_t f );

--- a/src/sgame/sg_typedef.h
+++ b/src/sgame/sg_typedef.h
@@ -99,7 +99,6 @@ typedef enum {
 	VOTE_NEXT_MAP,
 	VOTE_POLL,
 	VOTE_BOT_KICK,
-	VOTE_BOT_SPECTATE
 } voteType_t;
 
 #endif // SG_TYPEDEF_H_

--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -2798,6 +2798,21 @@ const char *BG_TeamNamePlural( int team )
 	return "<team>";
 }
 
+// Matches a playable team i.e. humans or aliens
+// Return of TEAM_NONE means no match rather than spectator
+team_t BG_PlayableTeamFromString( const char* s )
+{
+	if ( !Q_stricmp( s, "a" ) || !Q_stricmp( s, "aliens" ) )
+	{
+		return team_t::TEAM_ALIENS;
+	}
+	if ( !Q_stricmp( s, "h" ) || !Q_stricmp( s, "humans" ) )
+	{
+		return team_t::TEAM_HUMANS;
+	}
+	return team_t::TEAM_NONE;
+}
+
 int cmdcmp( const void *a, const void *b )
 {
 	return b ? Q_stricmp( ( const char * ) a, ( ( dummyCmd_t * ) b )->name ) : 1;

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -1581,6 +1581,8 @@ int  BG_LoadEmoticons( emoticon_t *emoticons, int num );
 const char *BG_TeamName( int team );
 const char *BG_TeamNamePlural( int team );
 
+team_t BG_PlayableTeamFromString( const char* s );
+
 typedef struct
 {
 	const char *name;


### PR DESCRIPTION
This adds a `bot fill` command to automatically add bots to the team, addressing #522. If the number of players on the team is less than the specified threshold, bots will be added to meet it. If the number of players is higher than the threshold and there are bots which were automatically added, automatically added bots will be removed.

Other changes to bot handling:
 - Bots are always removed after a map restart, even if a keep teams option was selected.
 - Spectate bots vote removed.
 - `bot spec` and `bot unspec` commands removed.
