### PR TITLE
add g_neverEnd cvar to never end games on missing spawn

### DIFF
--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -56,7 +56,6 @@ extern  vmCvar_t g_minNameChangePeriod;
 extern  vmCvar_t g_maxNameChanges;
 
 extern  vmCvar_t g_showHelpOnConnection;
-extern  vmCvar_t g_neverEnd;
 extern  vmCvar_t g_timelimit;
 extern  vmCvar_t g_friendlyFire;
 extern  vmCvar_t g_friendlyBuildableFire;

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -56,6 +56,7 @@ extern  vmCvar_t g_minNameChangePeriod;
 extern  vmCvar_t g_maxNameChanges;
 
 extern  vmCvar_t g_showHelpOnConnection;
+extern  vmCvar_t g_neverEnd;
 extern  vmCvar_t g_timelimit;
 extern  vmCvar_t g_friendlyFire;
 extern  vmCvar_t g_friendlyBuildableFire;

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -190,6 +190,8 @@ vmCvar_t           g_instantBuilding;
 
 vmCvar_t           g_emptyTeamsSkipMapTime;
 
+vmCvar_t           g_neverEnd;
+
 // <bot stuff>
 
 // bot buy cvars
@@ -340,6 +342,7 @@ static cvarTable_t gameCvarTable[] =
 	{ &g_debugFire,                   "g_debugFire",                   "0",                                0,                                               0, false    , nullptr       },
 
 	// gameplay: basic
+	{ &g_neverEnd,                    "g_neverEnd",                    "0",                                CVAR_SERVERINFO,                                 0, true     , nullptr       },
 	{ &g_timelimit,                   "timelimit",                     "45",                               CVAR_SERVERINFO,                                 0, true     , nullptr       },
 	{ &g_friendlyFire,                "g_friendlyFire",                "1",                                CVAR_SERVERINFO,                                 0, true     , nullptr       },
 	{ &g_friendlyBuildableFire,       "g_friendlyBuildableFire",       "1",                                CVAR_SERVERINFO,                                 0, true     , nullptr       },
@@ -2273,6 +2276,10 @@ can see the last frag.
 */
 void CheckExitRules()
 {
+	if ( g_cheats.integer && g_neverEnd.integer ) {
+		return;
+	}
+
 	// if at the intermission, wait for all non-bots to
 	// signal ready, then go to next level
 	if ( level.intermissiontime )

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -190,7 +190,7 @@ vmCvar_t           g_instantBuilding;
 
 vmCvar_t           g_emptyTeamsSkipMapTime;
 
-vmCvar_t           g_neverEnd;
+Cvar::Cvar<bool>   g_neverEnd("g_neverEnd", "cheat to never end a game, helpful to load a map without spawn for testing purpose", Cvar::NONE, false);
 
 // <bot stuff>
 
@@ -342,7 +342,6 @@ static cvarTable_t gameCvarTable[] =
 	{ &g_debugFire,                   "g_debugFire",                   "0",                                0,                                               0, false    , nullptr       },
 
 	// gameplay: basic
-	{ &g_neverEnd,                    "g_neverEnd",                    "0",                                CVAR_SERVERINFO,                                 0, true     , nullptr       },
 	{ &g_timelimit,                   "timelimit",                     "45",                               CVAR_SERVERINFO,                                 0, true     , nullptr       },
 	{ &g_friendlyFire,                "g_friendlyFire",                "1",                                CVAR_SERVERINFO,                                 0, true     , nullptr       },
 	{ &g_friendlyBuildableFire,       "g_friendlyBuildableFire",       "1",                                CVAR_SERVERINFO,                                 0, true     , nullptr       },
@@ -2276,7 +2275,7 @@ can see the last frag.
 */
 void CheckExitRules()
 {
-	if ( g_cheats.integer && g_neverEnd.integer ) {
+	if ( g_cheats.integer && g_neverEnd.Get() ) {
 		return;
 	}
 


### PR DESCRIPTION
- allows to load maps that miss spawn entities,
  this can be helpful to:
  - load unported maps from third-party games to examine them
  - edit layout in-game without needing a default one
  - load test maps that are not meant to be played
- needs cheats to be enabled, so it only works on devmap games