### PR TITLE
[cmake] make DAEMON_DIR an option, fix #1000

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,22 +34,36 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
     message(FATAL_ERROR "Building in the source directory is not supported, try building in a 'build' directory. You may have to delete the CMakeCache.txt file and CMakeFiles directory that are next to the CMakeLists.txt.")
 endif()
 
-# Check if we need to initialize submodules
-file(GLOB DENG_RESULT ${CMAKE_CURRENT_SOURCE_DIR}/daemon)
-list(LENGTH ${DENG_RESULT} DENG_RES_LEN)
-if(DENG_RES_LEN EQUAL 0)
-  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
-    find_package(Git REQUIRED)
-    if(GIT_FOUND)
-      execute_process(
-        COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-    endif()
-  endif()
+set(SUBMODULE_LIST
+  "libs/libRocket"
+  "src/utils/cbse")
+
+set(DAEMON_DIR_STRING "Path to the Daemon Engine source.")
+if(NOT DAEMON_DIR)
+  set(DAEMON_DIR "${CMAKE_CURRENT_SOURCE_DIR}/daemon" CACHE STRING "${DAEMON_DIR_STRING}")
+  LIST(APPEND SUBMODULE_LIST "daemon")
+else()
+  set(DAEMON_DIR "${DAEMON_DIR}" CACHE STRING "${DAEMON_DIR_STRING}")
 endif()
 
+foreach(SUBMODULE_PATH ${SUBMODULE_LIST})
+  # Check if we need to initialize submodule
+  file(GLOB DENG_RESULT "${CMAKE_CURRENT_SOURCE_DIR}/${SUBMODULE_PATH}")
+  list(LENGTH ${DENG_RESULT} DENG_RES_LEN)
+  if(DENG_RES_LEN EQUAL 0)
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+      find_package(Git REQUIRED)
+      if(GIT_FOUND)
+        execute_process(
+         COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- "${SUBMODULE_PATH}"
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+      endif()
+    endif()
+  endif()
+endforeach()
+
 set(Daemon_OUT ${CMAKE_CURRENT_BINARY_DIR})
-add_subdirectory(daemon daemon_build)
+add_subdirectory("${DAEMON_DIR}" daemon_build)
 include(DaemonGame)
 
 set(LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libs)


### PR DESCRIPTION
As explained in #1000, this change makes user able to specify an arbitrary path for Dæmon directory.

On a game code point of view, the Dæmon source is just a kind of library. If this directory is not set, the `daemon/` submodule is used.

On an engine code point of view, the engine is standalone and being constrained by a game code tree is painful. Being constrained to make engine development in game vm source tree is painful.

The `daemon` submodule is handy for game vm developers who never touch the engine or for users who just want to build the game, but that submodule makes engine development very painful. So this option is proposed to make engine developers life easier, to allow developers to not caring about gamecode submodule everytime they hack on engine.

See [how I build](https://github.com/illwieckz/UnvBuildEnv/blob/master/Makefile#L36-L52) all unvanquished stuff (engine, gamevm, assets) with a single `make`, and [how I run](https://github.com/illwieckz/UnvBuildEnv/blob/master/Makefile#L60-L70) the game.

Basically I'm just building like that:

```
[user@box:src/Daemon]
$ cmake -H. -Bbuild && cmake --build build
[user@box:src/Unvanquished]
$ cmake -H. -Bbuild -DDAEMON_DIR=$(realpath ../Daemon) && cmake --build build
[user@box:src/UnvanquishedAssets]
$ make build
```

And I run the game like that:

```
[user@box:src]
$ Daemon/build/daemon -libpath Unvanquished/build -pakpath UnvanquishedAssets/build/test
```

That's very handy, especially when dealing with engine stuff everyday.

It would also make life easier to get hands on multiple Dæmon based games at the same time, but it was thought first for people hacking engine stuff on daily schedule, allowing engine developers to get rid of the _please develop engine stuff in game vm source tree_ requirement and annoyance.