### PR TITLE
Force 'loopFrames' to be equal to the number of frames in animation parsers

### DIFF
--- a/src/cgame/cg_animation.cpp
+++ b/src/cgame/cg_animation.cpp
@@ -65,7 +65,7 @@ void CG_RunLerpFrame( lerpFrame_t *lf, float scale )
 				bool looping = !!anim->loopFrames;
 				if (looping)
 				{
-					ASSERT(anim->loopFrames == numFrames);
+					ASSERT_EQ(anim->loopFrames, numFrames);
 					lf->animationTime += relativeFrame / numFrames * (numFrames * frameLength);
 					relativeFrame %= numFrames;
 					lf->frameTime = lf->animationTime + relativeFrame * frameLength;

--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -433,6 +433,11 @@ static bool CG_ParseBuildableAnimationFile( const char *filename, buildable_t bu
 		}
 
 		animations[ i ].loopFrames = atoi( token );
+		if ( animations[ i ].loopFrames && animations[ i ].loopFrames != animations[ i ].numFrames )
+		{
+			Log::Warn("CG_ParseBuildableAnimationFile: loopFrames != numFrames");
+			animations[ i ].loopFrames = animations[ i ].numFrames;
+		}
 
 		token = COM_Parse( &text_p );
 

--- a/src/cgame/cg_particles.cpp
+++ b/src/cgame/cg_particles.cpp
@@ -977,6 +977,11 @@ static bool CG_ParseParticle( baseParticle_t *bp, const char **text_p )
 			}
 
 			bp->modelAnimation.loopFrames = atoi( token );
+			if ( bp->modelAnimation.loopFrames && bp->modelAnimation.loopFrames != bp->modelAnimation.numFrames )
+			{
+				Log::Warn("CG_ParseParticle: loopFrames != numFrames");
+				bp->modelAnimation.loopFrames = bp->modelAnimation.numFrames;
+			}
 
 			token = COM_Parse( text_p );
 

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -581,6 +581,11 @@ static bool CG_ParseAnimationFile( const char *filename, clientInfo_t *ci )
 			}
 
 			animations[ i ].loopFrames = atoi( token );
+			if ( animations[ i ].loopFrames && animations[ i ].loopFrames != animations[ i ].numFrames )
+			{
+				Log::Warn("CG_ParseAnimationFile: loopFrames != numFrames");
+				animations[ i ].loopFrames = animations[ i ].numFrames;
+			}
 
 			token = COM_Parse2( &text_p );
 
@@ -674,6 +679,11 @@ static bool CG_ParseAnimationFile( const char *filename, clientInfo_t *ci )
 			}
 
 			animations[ i ].loopFrames = atoi( token );
+			if ( animations[ i ].loopFrames && animations[ i ].loopFrames != animations[ i ].numFrames )
+			{
+				Log::Warn("CG_ParseAnimationFile: loopFrames != numFrames");
+				animations[ i ].loopFrames = animations[ i ].numFrames;
+			}
 
 			token = COM_Parse2( &text_p );
 

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -277,6 +277,11 @@ static bool CG_ParseWeaponAnimationFile( const char *filename, weaponInfo_t *wi 
 
 		token = COM_Parse2( &text_p );
 		animations[ i ].loopFrames = atoi( token );
+		if ( animations[ i ].loopFrames && animations[ i ].loopFrames != animations[ i ].numFrames )
+		{
+			Log::Warn("CG_ParseWeaponAnimationFile: loopFrames != numFrames");
+			animations[ i ].loopFrames = animations[ i ].numFrames;
+		}
 
 		token = COM_Parse2( &text_p );
 		fps = atof( token );


### PR DESCRIPTION
It turns out there are a couple of animations with a nonzero `loopFrames != numFrames` in the deprecated models available with `cg_highPolyPlayerModels 0`, which could trigger the assert.  This condition is no longer supported, due to the unclear intended semantics.