### PR TITLE
Licensing fixes

### DIFF
--- a/COPYING.txt
+++ b/COPYING.txt
@@ -3,13 +3,12 @@ Unvanquished is licensed in two broadly separate sections: the code and the
 media.
 
 The code is licensed under the GNU GENERAL PUBLIC LICENSE. This license is
-contained in full in the file named GPL. Please be aware of the exceptions to
-this license as listed below.
+contained in full in the file named GPL.txt. Please be aware of the exceptions
+to this license as listed below.
 
 The media is licensed under the CREATIVE COMMONS ATTRIBUTION-SHAREALIKE 2.5
 LICENSE. Please read http://creativecommons.org/licenses/by-sa/2.5/ to learn
-more about this license. The full license text is contained in the file named
-CC. Please be aware of the exceptions to this license as listed below.
+more about this license.
 
 ---------------------------------------------------- Code License Exceptions ---
 The following files contain sections of code that are not licensed under the
@@ -17,20 +16,7 @@ GPL, but are nevertheless GPL compatible. The license text for these licenses
 is contained within the files as listed.
 
     src/cgame/cg_api.cpp                                         BSD license
-
---------------------------------------------------- Media License Exceptions ---
-All shaderlab (http://www.shaderlab.com/) textures (by Randy 'ydnar' Reddig)
-are subject to the following license:
-  Usage and redistribution policy: Textures may be freely downloaded, modified,
-  and used in free maps, mods or total conversions provided this copyright
-  notice is left intact and a link to Shaderlab is provided in the credits or
-  read-me file. Other non-commercial applications are considered on a
-  case-by-case basis via e-mail. All other usage requires written permission.
-  Bulk redistribution or archival of the textures in any medium, digital or
-  otherwise (except mapping packages for mods) is prohibited.
-
---------------------------------------------------------------------------------
-
+    src/sgame/sg_api.cpp                                         BSD license
 
 ------------------------------------------------------ ET-XreaL Code License ---
 The ET-XreaL code is licensed under the GNU GENERAL PUBLIC LICENSE. This
@@ -46,9 +32,3 @@ these additional terms immediately following the terms and conditions of the
 GNU GPL which accompanied the Wolf ET Source Code. If not, please request a
 copy in writing from id Software at id Software LLC, c/o ZeniMax Media Inc.,
 Suite 120, Rockville, Maryland 20850 USA.
-
-EXCLUDED CODE: The code described below and contained in the Wolfenstein:
-Enemy Territory GPL Source Code release is not part of the Program covered
-by the GPL and is expressly excluded from its terms. You are solely
-responsible for obtaining from the copyright holder a license for such code
-and complying with the applicable license terms.

--- a/src/cgame/Filter.h
+++ b/src/cgame/Filter.h
@@ -2,7 +2,7 @@
 ===========================================================================
 
 Unvanquished GPL Source Code
-Copyright 2015 Unvanquished Developers
+Copyright (C) 2015 Unvanquished Developers
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 

--- a/src/cgame/Filter.h
+++ b/src/cgame/Filter.h
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright 2015 Unvanquished Developers
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/cgame/Filter.h
+++ b/src/cgame/Filter.h
@@ -3,7 +3,7 @@
 
 Copyright 2015 Unvanquished Developers
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
 Unvanquished is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/cgame/cg_animation.cpp
+++ b/src/cgame/cg_animation.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_animation.cpp
+++ b/src/cgame/cg_animation.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_animdelta.cpp
+++ b/src/cgame/cg_animdelta.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_animdelta.cpp
+++ b/src/cgame/cg_animdelta.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_animdelta.h
+++ b/src/cgame/cg_animdelta.h
@@ -1,27 +1,31 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
+
 #ifndef CG_ANIMDELTA_H
 #define CG_ANIMDELTA_H
+
 #include <vector>
 #include <unordered_map>
 

--- a/src/cgame/cg_animdelta.h
+++ b/src/cgame/cg_animdelta.h
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_animmapobj.cpp
+++ b/src/cgame/cg_animmapobj.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_animmapobj.cpp
+++ b/src/cgame/cg_animmapobj.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_api.cpp
+++ b/src/cgame/cg_api.cpp
@@ -1,8 +1,11 @@
 /*
 ===========================================================================
-Daemon BSD Source Code
-Copyright (c) 2013-2016, Daemon Developers
+
+Unvanquished BSD Source Code
+Copyright (c) 2013-2016, Unvanquished Developers
 All rights reserved.
+
+This file is part of the Unvanquished BSD Source Code (Unvanquished Source Code).
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -11,7 +14,7 @@ modification, are permitted provided that the following conditions are met:
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-    * Neither the name of the Daemon developers nor the
+    * Neither the name of the Unvanquished developers nor the
       names of its contributors may be used to endorse or promote products
       derived from this software without specific prior written permission.
 
@@ -25,6 +28,7 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_attachment.cpp
+++ b/src/cgame/cg_attachment.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 2000-2009 Darklegion Development
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/cgame/cg_attachment.cpp
+++ b/src/cgame/cg_attachment.cpp
@@ -1,22 +1,24 @@
 /*
 ===========================================================================
+
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_beacon.cpp
+++ b/src/cgame/cg_beacon.cpp
@@ -2,7 +2,7 @@
 ===========================================================================
 
 Unvanquished GPL Source Code
-Copyright 2014 Unvanquished Developers
+Copyright (C) 2014 Unvanquished Developers
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 

--- a/src/cgame/cg_beacon.cpp
+++ b/src/cgame/cg_beacon.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright 2014 Unvanquished Developers
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/cgame/cg_beacon.cpp
+++ b/src/cgame/cg_beacon.cpp
@@ -3,20 +3,20 @@
 
 Copyright 2014 Unvanquished Developers
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software: you can redistribute it and/or modify
+Unvanquished is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon is distributed in the hope that it will be useful,
+Unvanquished is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished.  If not, see <http://www.gnu.org/licenses/>.
 
 ===========================================================================
 */

--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_gameinfo.cpp
+++ b/src/cgame/cg_gameinfo.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_gameinfo.cpp
+++ b/src/cgame/cg_gameinfo.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1,25 +1,28 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
+
 #ifndef CG_LOCAL_H
 #define CG_LOCAL_H
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_marks.cpp
+++ b/src/cgame/cg_marks.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_marks.cpp
+++ b/src/cgame/cg_marks.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_minimap.cpp
+++ b/src/cgame/cg_minimap.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 2000-2009 Darklegion Development
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/cgame/cg_minimap.cpp
+++ b/src/cgame/cg_minimap.cpp
@@ -1,22 +1,24 @@
 /*
 ===========================================================================
+
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_parseutils.cpp
+++ b/src/cgame/cg_parseutils.cpp
@@ -1,15 +1,15 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-Daemon is free software: you can redistribute it and/or modify
+Unvanquished is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 of the License, or
 (at your option) any later version.
 
-Daemon is distributed in the hope that it will be useful,
+Unvanquished is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.

--- a/src/cgame/cg_particles.cpp
+++ b/src/cgame/cg_particles.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 2000-2009 Darklegion Development
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/cgame/cg_particles.cpp
+++ b/src/cgame/cg_particles.cpp
@@ -1,22 +1,24 @@
 /*
 ===========================================================================
+
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_playerstate.cpp
+++ b/src/cgame/cg_playerstate.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_playerstate.cpp
+++ b/src/cgame/cg_playerstate.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_rocket.cpp
+++ b/src/cgame/cg_rocket.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/cg_rocket_dataformatter.cpp
+++ b/src/cgame/cg_rocket_dataformatter.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/cg_rocket_datasource.cpp
+++ b/src/cgame/cg_rocket_datasource.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/cg_rocket_events.cpp
+++ b/src/cgame/cg_rocket_events.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
@@ -34,7 +34,6 @@ Maryland 20850 USA.
 
 #include "cg_local.h"
 #include "shared/CommonProxies.h"
-
 
 static void CG_Rocket_EventOpen()
 {

--- a/src/cgame/cg_rocket_progressbar.cpp
+++ b/src/cgame/cg_rocket_progressbar.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/cg_segmented_skeleton.cpp
+++ b/src/cgame/cg_segmented_skeleton.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_segmented_skeleton.cpp
+++ b/src/cgame/cg_segmented_skeleton.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_segmented_skeleton.h
+++ b/src/cgame/cg_segmented_skeleton.h
@@ -1,25 +1,28 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
+
 #ifndef CG_SEGMENTED_SKELETON_H
 #define CG_SEGMENTED_SKELETON_H
 

--- a/src/cgame/cg_segmented_skeleton.h
+++ b/src/cgame/cg_segmented_skeleton.h
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_skeleton_modifier.h
+++ b/src/cgame/cg_skeleton_modifier.h
@@ -1,15 +1,15 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2016 Unvanquished Developers
 
-Daemon is free software: you can redistribute it and/or modify
+Unvanquished is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 of the License, or
 (at your option) any later version.
 
-Daemon is distributed in the hope that it will be useful,
+Unvanquished is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ===========================================================================
 */
+
 #ifndef CG_SKELETON_MODIFIER_H
 #define CG_SKELETON_MODIFIER_H
 

--- a/src/cgame/cg_snapshot.cpp
+++ b/src/cgame/cg_snapshot.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_snapshot.cpp
+++ b/src/cgame/cg_snapshot.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_trails.cpp
+++ b/src/cgame/cg_trails.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 2000-2009 Darklegion Development
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/cgame/cg_trails.cpp
+++ b/src/cgame/cg_trails.cpp
@@ -1,22 +1,24 @@
 /*
 ===========================================================================
+
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 2000-2009 Darklegion Development
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -1,22 +1,24 @@
 /*
 ===========================================================================
+
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_ui.h
+++ b/src/cgame/cg_ui.h
@@ -1,15 +1,15 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-Daemon is free software: you can redistribute it and/or modify
+Unvanquished is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 2 of the License, or
 (at your option) any later version.
 
-Daemon is distributed in the hope that it will be useful,
+Unvanquished is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.

--- a/src/cgame/cg_utils.cpp
+++ b/src/cgame/cg_utils.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_utils.cpp
+++ b/src/cgame/cg_utils.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/cgame/rocket/lua/Cmd.cpp
+++ b/src/cgame/rocket/lua/Cmd.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
@@ -31,6 +31,7 @@ Maryland 20850 USA.
 
 ===========================================================================
 */
+
 #include "Cmd.h"
 #include "../../cg_local.h"
 

--- a/src/cgame/rocket/lua/Cmd.h
+++ b/src/cgame/rocket/lua/Cmd.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
@@ -31,8 +31,10 @@ Maryland 20850 USA.
 
 ===========================================================================
 */
+
 #ifndef LUACMD_H
 #define LUACMD_H
+
 #include "../rocket.h"
 #include <Rocket/Core/Core.h>
 #include <Rocket/Core/Lua/lua.hpp>

--- a/src/cgame/rocket/lua/Cvar.cpp
+++ b/src/cgame/rocket/lua/Cvar.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
@@ -31,8 +31,10 @@ Maryland 20850 USA.
 
 ===========================================================================
 */
+
 #include "Cvar.h"
 #include "../../cg_local.h"
+
 namespace Rocket {
 namespace Core {
 namespace Lua {

--- a/src/cgame/rocket/lua/Cvar.h
+++ b/src/cgame/rocket/lua/Cvar.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
@@ -31,8 +31,10 @@ Maryland 20850 USA.
 
 ===========================================================================
 */
+
 #ifndef LUACVAR_H
 #define LUACVAR_H
+
 #include "../rocket.h"
 #include <Rocket/Core/Core.h>
 #include <Rocket/Core/Lua/lua.hpp>

--- a/src/cgame/rocket/lua/Events.cpp
+++ b/src/cgame/rocket/lua/Events.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
@@ -31,6 +31,7 @@ Maryland 20850 USA.
 
 ===========================================================================
 */
+
 #include "Events.h"
 
 namespace Rocket {

--- a/src/cgame/rocket/lua/Events.h
+++ b/src/cgame/rocket/lua/Events.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
@@ -31,8 +31,10 @@ Maryland 20850 USA.
 
 ===========================================================================
 */
+
 #ifndef LUAEVENTS_H
 #define LUAEVENTS_H
+
 #include "../rocket.h"
 #include <Rocket/Core/Core.h>
 #include <Rocket/Core/Lua/lua.hpp>

--- a/src/cgame/rocket/lua/Timer.cpp
+++ b/src/cgame/rocket/lua/Timer.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/lua/Timer.h
+++ b/src/cgame/rocket/lua/Timer.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
@@ -34,6 +34,7 @@ Maryland 20850 USA.
 
 #ifndef LUATIMER_H
 #define LUATIMER_H
+
 #include "../rocket.h"
 #include <Rocket/Core/Core.h>
 #include <Rocket/Core/Lua/lua.hpp>

--- a/src/cgame/rocket/rocket.cpp
+++ b/src/cgame/rocket/rocket.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocket.h
+++ b/src/cgame/rocket/rocket.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
@@ -31,6 +31,7 @@ Maryland 20850 USA.
 
 ===========================================================================
 */
+
 #ifndef ROCKET_H
 #define ROCKET_H
 #ifdef DotProduct

--- a/src/cgame/rocket/rocketChatField.h
+++ b/src/cgame/rocket/rocketChatField.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocketCircleMenu.h
+++ b/src/cgame/rocket/rocketCircleMenu.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocketColorInput.h
+++ b/src/cgame/rocket/rocketColorInput.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocketConditionalElement.h
+++ b/src/cgame/rocket/rocketConditionalElement.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
@@ -34,6 +34,7 @@ Maryland 20850 USA.
 
 #ifndef ROCKETCONDITIONALELEMENT_H
 #define ROCKETCONDITIONALELEMENT_H
+
 #include <Rocket/Core/Core.h>
 #include "../cg_local.h"
 

--- a/src/cgame/rocket/rocketConsoleTextElement.h
+++ b/src/cgame/rocket/rocketConsoleTextElement.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocketCvarInlineElement.h
+++ b/src/cgame/rocket/rocketCvarInlineElement.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocketDataFormatter.h
+++ b/src/cgame/rocket/rocketDataFormatter.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
@@ -34,6 +34,7 @@ Maryland 20850 USA.
 
 #ifndef ROCKETDATAFORMATTER_H
 #define ROCKETDATAFORMATTER_H
+
 #include "../cg_local.h"
 #include "rocket.h"
 

--- a/src/cgame/rocket/rocketDataGrid.h
+++ b/src/cgame/rocket/rocketDataGrid.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocketDataSelect.h
+++ b/src/cgame/rocket/rocketDataSelect.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocketDataSource.h
+++ b/src/cgame/rocket/rocketDataSource.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocketDataSourceSingle.h
+++ b/src/cgame/rocket/rocketDataSourceSingle.h
@@ -1,28 +1,28 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2011 Cervesato Andrea ("koochi")
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocketElement.h
+++ b/src/cgame/rocket/rocketElement.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocketElementDocument.h
+++ b/src/cgame/rocket/rocketElementDocument.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocketEventInstancer.h
+++ b/src/cgame/rocket/rocketEventInstancer.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
@@ -34,6 +34,7 @@ Maryland 20850 USA.
 
 #ifndef ROCKETEVENTINSTANCER_H
 #define ROCKETEVENTINSTANCER_H
+
 #include <Rocket/Core/EventListener.h>
 #include <Rocket/Core/EventListenerInstancer.h>
 #include "rocket.h"

--- a/src/cgame/rocket/rocketFocusManager.h
+++ b/src/cgame/rocket/rocketFocusManager.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocketFormControlInput.h
+++ b/src/cgame/rocket/rocketFormControlInput.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocketFormControlSelect.h
+++ b/src/cgame/rocket/rocketFormControlSelect.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocketIncludeElement.h
+++ b/src/cgame/rocket/rocketIncludeElement.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocketKeyBinder.h
+++ b/src/cgame/rocket/rocketKeyBinder.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocketProgressBar.h
+++ b/src/cgame/rocket/rocketProgressBar.h
@@ -1,36 +1,36 @@
 /*
- = =*=========================================================================
+===========================================================================
 
- Daemon GPL Source Code
- Copyright (C) 2013 Unvanquished Developers
+Unvanquished GPL Source Code
+Copyright (C) 2013 Unvanquished Developers
 
- This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
- Daemon Source Code is free software: you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
+Unvanquished Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
- Daemon Source Code is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
+Unvanquished Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
- You should have received a copy of the GNU General Public License
- along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
- In addition, the Daemon Source Code is also subject to certain additional terms.
- You should have received a copy of these additional terms immediately following the
- terms and conditions of the GNU General Public License which accompanied the Daemon
- Source Code.  If not, please request a copy in writing from id Software at the address
- below.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
 
- If you have questions concerning this license or the applicable additional terms, you
- may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
- Maryland 20850 USA.
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
 
- ===========================================================================
- */
+===========================================================================
+*/
 
 #ifndef ROCKETPROGRESSBAR_H
 #define ROCKETPROGRESSBAR_H

--- a/src/cgame/rocket/rocketSelectableDataGrid.h
+++ b/src/cgame/rocket/rocketSelectableDataGrid.h
@@ -1,28 +1,28 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2011 Cervesato Andrea ("koochi")
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 
 ===========================================================================
 */
+
 #ifndef ROCKETSELECTABLEDATAGRID_H
 #define ROCKETSELECTABLEDATAGRID_H
 #include "../cg_local.h"

--- a/src/cgame/rocket/rocket_dataformatter.cpp
+++ b/src/cgame/rocket/rocket_dataformatter.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocket_datagrid.cpp
+++ b/src/cgame/rocket/rocket_datagrid.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocket_documents.cpp
+++ b/src/cgame/rocket/rocket_documents.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocket_element.cpp
+++ b/src/cgame/rocket/rocket_element.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocket_events.cpp
+++ b/src/cgame/rocket/rocket_events.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocket_hud.cpp
+++ b/src/cgame/rocket/rocket_hud.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
@@ -34,7 +34,6 @@ Maryland 20850 USA.
 
 #include "rocket.h"
 #include "../cg_local.h"
-
 
 struct HudUnit
 {

--- a/src/cgame/rocket/rocket_keys.cpp
+++ b/src/cgame/rocket/rocket_keys.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 
@@ -31,6 +31,7 @@ Maryland 20850 USA.
 
 ===========================================================================
 */
+
 #include "rocket.h"
 #include "../cg_local.h"
 #include "engine/qcommon/q_unicode.h"

--- a/src/sgame/Beacon.cpp
+++ b/src/sgame/Beacon.cpp
@@ -2,7 +2,7 @@
 ===========================================================================
 
 Unvanquished GPL Source Code
-Copyright 2014 Unvanquished Developers
+Copyright (C) 2014 Unvanquished Developers
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 

--- a/src/sgame/Beacon.cpp
+++ b/src/sgame/Beacon.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright 2014 Unvanquished Developers
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/sgame/Beacon.cpp
+++ b/src/sgame/Beacon.cpp
@@ -3,14 +3,14 @@
 
 Copyright 2014 Unvanquished Developers
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
 Daemon is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon is distributed in the hope that it will be useful,
+Unvanquished is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.

--- a/src/sgame/Clustering.cpp
+++ b/src/sgame/Clustering.cpp
@@ -2,7 +2,7 @@
 ===========================================================================
 
 Unvanquished GPL Source Code
-Copyright 2014 Unvanquished Developers
+Copyright (C) 2014 Unvanquished Developers
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 

--- a/src/sgame/Clustering.cpp
+++ b/src/sgame/Clustering.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright 2014 Unvanquished Developers
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/sgame/Clustering.cpp
+++ b/src/sgame/Clustering.cpp
@@ -3,7 +3,7 @@
 
 Copyright 2014 Unvanquished Developers
 
-This file is part of Unvanquished.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
 Unvanquished is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/sgame/Utility.cpp
+++ b/src/sgame/Utility.cpp
@@ -2,7 +2,7 @@
 ===========================================================================
 
 Unvanquished GPL Source Code
-Copyright 2015 Unvanquished Developers
+Copyright (C) 2015 Unvanquished Developers
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 

--- a/src/sgame/Utility.cpp
+++ b/src/sgame/Utility.cpp
@@ -3,7 +3,7 @@
 
 Copyright 2015 Unvanquished Developers
 
-This file is part of Unvanquished.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
 Unvanquished is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/sgame/Utility.cpp
+++ b/src/sgame/Utility.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright 2015 Unvanquished Developers
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 2000-2009 Darklegion Development
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -1,8 +1,9 @@
 /*
 ===========================================================================
+
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
 This shrubbot implementation is the original work of Tony J. White.
 
@@ -14,19 +15,20 @@ inactive project shrubet (http://www.etstats.com/shrubet/index.php?ver=2)
 by Ryan Mannion.   However, shrubet was a closed-source project and
 none of its code has been copied, only its functionality.
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/sgame/sg_admin.h
+++ b/src/sgame/sg_admin.h
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 2000-2009 Darklegion Development
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/sgame/sg_admin.h
+++ b/src/sgame/sg_admin.h
@@ -1,22 +1,24 @@
 /*
 ===========================================================================
+
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/sgame/sg_api.cpp
+++ b/src/sgame/sg_api.cpp
@@ -1,8 +1,11 @@
 /*
 ===========================================================================
-Daemon BSD Source Code
-Copyright (c) 2013-2016, Daemon Developers
+
+Unvanquished BSD Source Code
+Copyright (c) 2013-2016, Unvanquished Developers
 All rights reserved.
+
+This file is part of the Unvanquished BSD Source Code (Unvanquished Source Code).
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -11,7 +14,7 @@ modification, are permitted provided that the following conditions are met:
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-    * Neither the name of the Daemon developers nor the
+    * Neither the name of the Unvanquished developers nor the
       names of its contributors may be used to endorse or promote products
       derived from this software without specific prior written permission.
 
@@ -25,6 +28,7 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 ===========================================================================
 */
 

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -1,24 +1,26 @@
 /*
- = *==========================================================================
- Copyright (C) 1999-2005 Id Software, Inc.
+===========================================================================
 
- This file is part of Daemon.
+Copyright (C) 1999-2005 Id Software, Inc.
 
- Daemon is free software; you can redistribute it
- and/or modify it under the terms of the GNU General Public License as
- published by the Free Software Foundation; either version 2 of the License,
- or (at your option) any later version.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
- Daemon is distributed in the hope that it will be
- useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
+Unvanquished is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
 
- You should have received a copy of the GNU General Public License
- along with Daemon; if not, write to the Free Software
- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- ===========================================================================
- */
+Unvanquished is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Unvanquished; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+===========================================================================
+*/
 
 #include "sg_bot_parse.h"
 #include "sg_bot_util.h"
@@ -28,10 +30,10 @@ static botMemory_t g_botMind[MAX_CLIENTS];
 static AITreeList_t treeList;
 
 /*
- = *======================
- Bot management functions
- =======================
- */
+=======================
+Bot management functions
+=======================
+*/
 static struct
 {
 	int count;
@@ -351,10 +353,10 @@ void G_BotDelAllBots()
 }
 
 /*
- = *======================
- Bot Thinks
- =======================
- */
+=======================
+Bot Thinks
+=======================
+*/
 
 void G_BotThink( gentity_t *self )
 {

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/sgame/sg_bot.h
+++ b/src/sgame/sg_bot.h
@@ -1,22 +1,24 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/sgame/sg_bot.h
+++ b/src/sgame/sg_bot.h
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1,24 +1,27 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
+
 #include "sg_bot_ai.h"
 #include "sg_bot_util.h"
 #include "CBSE.h"

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/sgame/sg_bot_ai.h
+++ b/src/sgame/sg_bot_ai.h
@@ -1,22 +1,24 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 #include "sg_local.h"

--- a/src/sgame/sg_bot_ai.h
+++ b/src/sgame/sg_bot_ai.h
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -1,24 +1,27 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
+
 #include "sg_bot_util.h"
 #include "engine/botlib/bot_types.h"
 
@@ -107,6 +110,7 @@ void BotSetNavmesh( gentity_t  *self, class_t newClass )
 Bot Navigation Querys
 ========================
 */
+
 float RadiusFromBounds2D( vec3_t mins, vec3_t maxs )
 {
 	float rad1s = Square( mins[0] ) + Square( mins[1] );

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -1,22 +1,24 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 
@@ -747,6 +749,7 @@ condition [expression]
 [expression] can be any valid set of boolean operations and values
 ======================
 */
+
 AIGenericNode_t *ReadConditionNode( pc_token_list **tokenlist )
 {
 	pc_token_list *current = *tokenlist;
@@ -951,6 +954,7 @@ action name( p1, p2, ... )
 Where name defines the action to execute, and the parameters are surrounded by parenthesis
 ======================
 */
+
 AIGenericNode_t *ReadActionNode( pc_token_list **tokenlist )
 {
 	pc_token_list *current = *tokenlist;
@@ -1068,6 +1072,7 @@ Parses and creates an AINodeList_t from a token list
 The token list pointer is modified to point to the beginning of the next node text block after reading
 ======================
 */
+
 AIGenericNode_t *ReadNodeList( pc_token_list **tokenlist )
 {
 	AINodeList_t *list;
@@ -1219,6 +1224,7 @@ ReadBehaviorTree
 Load a behavior tree of the given name from a file
 ======================
 */
+
 AIBehaviorTree_t *ReadBehaviorTree( const char *name, AITreeList_t *list )
 {
 	int i;

--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/sgame/sg_bot_parse.h
+++ b/src/sgame/sg_bot_parse.h
@@ -1,24 +1,27 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
+
 #ifndef __BOT_PARSE_HEADER
 #define __BOT_PARSE_HEADER
 

--- a/src/sgame/sg_bot_parse.h
+++ b/src/sgame/sg_bot_parse.h
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1,33 +1,37 @@
 /*
- = *==========================================================================
- Copyright (C) 1999-2005 Id Software, Inc.
+===========================================================================
 
- This file is part of Daemon.
+Copyright (C) 1999-2005 Id Software, Inc.
 
- Daemon is free software; you can redistribute it
- and/or modify it under the terms of the GNU General Public License as
- published by the Free Software Foundation; either version 2 of the License,
- or (at your option) any later version.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
- Daemon is distributed in the hope that it will be
- useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
+Unvanquished is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
 
- You should have received a copy of the GNU General Public License
- along with Daemon; if not, write to the Free Software
- Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- ===========================================================================
- */
+Unvanquished is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Unvanquished; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+===========================================================================
+*/
+
 #include "sg_bot_ai.h"
 #include "sg_bot_util.h"
 #include "CBSE.h"
 
 /*
- = *======================
- Scoring functions for logic
- =======================
- */
+=======================
+Scoring functions for logic
+=======================
+*/
+
 float BotGetBaseRushScore( gentity_t *ent )
 {
 
@@ -422,11 +426,13 @@ void BotGetDesiredBuy( gentity_t *self, weapon_t *weapon, upgrade_t *upgrades, i
 		}
 	}
 }
+
 /*
- = *======================
- Entity Querys
- =======================
- */
+=======================
+Entity Querys
+=======================
+*/
+
 gentity_t* BotFindBuilding( gentity_t *self, int buildingType, int range )
 {
 	float minDistance = -1;
@@ -761,11 +767,12 @@ botTarget_t BotGetRoamTarget( gentity_t *self )
 	BotSetTarget( &target, nullptr, targetPos );
 	return target;
 }
+
 /*
- = *=======================
- BotTarget Helpers
- ========================
- */
+========================
+BotTarget Helpers
+========================
+*/
 
 void BotSetTarget( botTarget_t *target, gentity_t *ent, vec3_t pos )
 {
@@ -1176,11 +1183,13 @@ bool BotTargetIsVisible( gentity_t *self, botTarget_t target, int mask )
 	}
 	return false;
 }
+
 /*
- = *=======================
- Bot Aiming
- ========================
- */
+========================
+Bot Aiming
+========================
+*/
+
 void BotGetIdealAimLocation( gentity_t *self, botTarget_t target, vec3_t aimLocation )
 {
 	//get the position of the target
@@ -1333,10 +1342,10 @@ float BotAimAngle( gentity_t *self, vec3_t pos )
 }
 
 /*
- = *=======================
- Bot Team Querys
- ========================
- */
+========================
+Bot Team Querys
+========================
+*/
 
 int FindBots( int *botEntityNumbers, int maxBots, team_t team )
 {
@@ -1443,10 +1452,11 @@ bool BotTeamateHasWeapon( gentity_t *self, int weapon )
 }
 
 /*
- = *=======================
- Misc Bot Stuff
- ========================
- */
+========================
+Misc Bot Stuff
+========================
+*/
+
 void BotFireWeapon( weaponMode_t mode, usercmd_t *botCmdBuffer )
 {
 	if ( mode == WPM_PRIMARY )

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/sgame/sg_bot_util.h
+++ b/src/sgame/sg_bot_util.h
@@ -1,22 +1,24 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/sgame/sg_bot_util.h
+++ b/src/sgame/sg_bot_util.h
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/sgame/sg_buildpoints.cpp
+++ b/src/sgame/sg_buildpoints.cpp
@@ -2,7 +2,7 @@
 ===========================================================================
 
 Unvanquished GPL Source Code
-Copyright 2014 Unvanquished Developers
+Copyright (C) 2014 Unvanquished Developers
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 

--- a/src/sgame/sg_buildpoints.cpp
+++ b/src/sgame/sg_buildpoints.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright 2014 Unvanquished Developers
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/sgame/sg_buildpoints.cpp
+++ b/src/sgame/sg_buildpoints.cpp
@@ -3,7 +3,7 @@
 
 Copyright 2014 Unvanquished Developers
 
-This file is part of Unvanquished.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
 Unvanquished is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/sgame/sg_cm_world.cpp
+++ b/src/sgame/sg_cm_world.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/sgame/sg_cm_world.h
+++ b/src/sgame/sg_cm_world.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/sgame/sg_definitions.h
+++ b/src/sgame/sg_definitions.h
@@ -1,23 +1,23 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012-2013 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
 ===========================================================================
 */

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/sgame/sg_entities.h
+++ b/src/sgame/sg_entities.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -1,23 +1,23 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012-2013 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
 ===========================================================================
 */

--- a/src/sgame/sg_local.h
+++ b/src/sgame/sg_local.h
@@ -1,23 +1,23 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012-2013 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
 ===========================================================================
 */

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/sgame/sg_maprotation.cpp
+++ b/src/sgame/sg_maprotation.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/sgame/sg_maprotation.cpp
+++ b/src/sgame/sg_maprotation.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/sgame/sg_missile.cpp
+++ b/src/sgame/sg_missile.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/sgame/sg_missile.cpp
+++ b/src/sgame/sg_missile.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/sgame/sg_momentum.cpp
+++ b/src/sgame/sg_momentum.cpp
@@ -2,7 +2,7 @@
 ===========================================================================
 
 Unvanquished GPL Source Code
-Copyright 2013 Unvanquished Developers
+Copyright (C) 2013 Unvanquished Developers
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 

--- a/src/sgame/sg_momentum.cpp
+++ b/src/sgame/sg_momentum.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright 2013 Unvanquished Developers
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/sgame/sg_momentum.cpp
+++ b/src/sgame/sg_momentum.cpp
@@ -3,14 +3,14 @@
 
 Copyright 2013 Unvanquished Developers
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
 Daemon is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon is distributed in the hope that it will be useful,
+Unvanquished is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.

--- a/src/sgame/sg_namelog.cpp
+++ b/src/sgame/sg_namelog.cpp
@@ -1,22 +1,24 @@
 /*
 ===========================================================================
+
 Copyright (C) 2010 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/sgame/sg_namelog.cpp
+++ b/src/sgame/sg_namelog.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 2010 Darklegion Development
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/sgame/sg_physics.cpp
+++ b/src/sgame/sg_physics.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/sgame/sg_physics.cpp
+++ b/src/sgame/sg_physics.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -1,23 +1,23 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012-2013 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
 ===========================================================================
 */

--- a/src/sgame/sg_session.cpp
+++ b/src/sgame/sg_session.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/sgame/sg_session.cpp
+++ b/src/sgame/sg_session.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/sgame/sg_spawn.cpp
+++ b/src/sgame/sg_spawn.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/sgame/sg_spawn.h
+++ b/src/sgame/sg_spawn.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/sgame/sg_spawn_afx.cpp
+++ b/src/sgame/sg_spawn_afx.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/sgame/sg_spawn_ctrl.cpp
+++ b/src/sgame/sg_spawn_ctrl.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/sgame/sg_spawn_fx.cpp
+++ b/src/sgame/sg_spawn_fx.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/sgame/sg_spawn_game.cpp
+++ b/src/sgame/sg_spawn_game.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/sgame/sg_spawn_generic.cpp
+++ b/src/sgame/sg_spawn_generic.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/sgame/sg_spawn_gfx.cpp
+++ b/src/sgame/sg_spawn_gfx.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/sgame/sg_spawn_position.cpp
+++ b/src/sgame/sg_spawn_position.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/sgame/sg_spawn_sensor.cpp
+++ b/src/sgame/sg_spawn_sensor.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/sgame/sg_spawn_shared.cpp
+++ b/src/sgame/sg_spawn_shared.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -1,23 +1,23 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012-2013 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
 ===========================================================================
 */

--- a/src/sgame/sg_svcmds.cpp
+++ b/src/sgame/sg_svcmds.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/sgame/sg_team.cpp
+++ b/src/sgame/sg_team.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 
@@ -200,6 +202,7 @@ void G_UpdateTeamConfigStrings()
 G_LeaveTeam
 ==================
 */
+
 void G_LeaveTeam( gentity_t *self )
 {
 	team_t    team = (team_t) self->client->pers.team;
@@ -264,6 +267,7 @@ void G_LeaveTeam( gentity_t *self )
 G_ChangeTeam
 =================
 */
+
 void G_ChangeTeam( gentity_t *ent, team_t newTeam )
 {
 	team_t oldTeam = (team_t) ent->client->pers.team;

--- a/src/sgame/sg_team.cpp
+++ b/src/sgame/sg_team.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/sgame/sg_trapcalls.h
+++ b/src/sgame/sg_trapcalls.h
@@ -1,23 +1,23 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012-2013 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
 ===========================================================================
 */

--- a/src/sgame/sg_typedef.h
+++ b/src/sgame/sg_typedef.h
@@ -1,23 +1,23 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012-2013 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
 ===========================================================================
 */

--- a/src/sgame/sg_utils.cpp
+++ b/src/sgame/sg_utils.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/sgame/sg_utils.cpp
+++ b/src/sgame/sg_utils.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/shared/bg_alloc.cpp
+++ b/src/shared/bg_alloc.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/shared/bg_alloc.cpp
+++ b/src/shared/bg_alloc.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/shared/bg_gameplay.h
+++ b/src/shared/bg_gameplay.h
@@ -1,23 +1,23 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
+Unvanquished GPL Source Code
 Copyright (C) 2012-2013 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
 ===========================================================================
 */

--- a/src/shared/bg_local.h
+++ b/src/shared/bg_local.h
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/shared/bg_local.h
+++ b/src/shared/bg_local.h
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/shared/bg_parse.cpp
+++ b/src/shared/bg_parse.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA	02110-1301	USA
+
 ===========================================================================
 */
 

--- a/src/shared/bg_parse.cpp
+++ b/src/shared/bg_parse.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/shared/bg_pmove.cpp
+++ b/src/shared/bg_pmove.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/shared/bg_pmove.cpp
+++ b/src/shared/bg_pmove.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/shared/bg_slidemove.cpp
+++ b/src/shared/bg_slidemove.cpp
@@ -1,23 +1,25 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/shared/bg_slidemove.cpp
+++ b/src/shared/bg_slidemove.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 

--- a/src/shared/bg_teamprogress.cpp
+++ b/src/shared/bg_teamprogress.cpp
@@ -2,7 +2,7 @@
 ===========================================================================
 
 Unvanquished GPL Source Code
-Copyright 2013 Unvanquished Developers
+Copyright (C) 2013 Unvanquished Developers
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 

--- a/src/shared/bg_teamprogress.cpp
+++ b/src/shared/bg_teamprogress.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright 2013 Unvanquished Developers
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/shared/bg_teamprogress.cpp
+++ b/src/shared/bg_teamprogress.cpp
@@ -3,14 +3,14 @@
 
 Copyright 2013 Unvanquished Developers
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
 Daemon is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon is distributed in the hope that it will be useful,
+Unvanquished is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.

--- a/src/shared/bg_utilities.cpp
+++ b/src/shared/bg_utilities.cpp
@@ -2,7 +2,7 @@
 ===========================================================================
 
 Unvanquished GPL Source Code
-Copyright 2014 Unvanquished Development
+Copyright (C) 2014 Unvanquished Development
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 

--- a/src/shared/bg_utilities.cpp
+++ b/src/shared/bg_utilities.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright 2014 Unvanquished Development
 
 This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).

--- a/src/shared/bg_utilities.cpp
+++ b/src/shared/bg_utilities.cpp
@@ -3,14 +3,14 @@
 
 Copyright 2014 Unvanquished Development
 
-This file is part of Daemon GPL Source.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
 Daemon GPL Source is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon is distributed in the hope that it will be useful,
+Unvanquished is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.

--- a/src/shared/bg_voice.cpp
+++ b/src/shared/bg_voice.cpp
@@ -1,24 +1,26 @@
 /*
 ===========================================================================
+
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 Copyright (C) 2008      Tony J. White
 
-This file is part of Daemon.
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon is free software; you can redistribute it
+Unvanquished is free software; you can redistribute it
 and/or modify it under the terms of the GNU General Public License as
 published by the Free Software Foundation; either version 2 of the License,
 or (at your option) any later version.
 
-Daemon is distributed in the hope that it will be
+Unvanquished is distributed in the hope that it will be
 useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon; if not, write to the Free Software
+along with Unvanquished; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
 ===========================================================================
 */
 

--- a/src/shared/bg_voice.cpp
+++ b/src/shared/bg_voice.cpp
@@ -1,6 +1,7 @@
 /*
 ===========================================================================
 
+Unvanquished GPL Source Code
 Copyright (C) 1999-2005 Id Software, Inc.
 Copyright (C) 2000-2009 Darklegion Development
 Copyright (C) 2008      Tony J. White


### PR DESCRIPTION
The very important changes are the ones in COPYING.txt:

- remove non-free shaderlab exception
  there is no shaderlab's file anymore
- remove non-GPL code from Wolf:ET source tree exception
  it was basically unzip, zlib, md4, jpeg, curl, ft2, and png
  they are now external.
- add sgame/sg_api.cpp as BSD licensed exception
- do not talk redirect to CC file, it's not there anymore
  keep the url

It fixes also some headers refering to Unvanquished or Daemon inconsistently, for example:

`src/sgame/sg_spawn_mover.cpp`
> **Daemon** GPL Source Code
> Copyright (C) 2012 **Unvanquished** Developers
> 
> This file is part of the **Daemon** GPL Source Code (**Daemon** Source Code).
> 
> **Daemon** Source Code is free software: you can redistribute it and/or modify

`src/cgame/Filter.h`
> Copyright 2015 **Unvanquished** Developers
> 
> This file is part of **Daemon**.
> 
> **Unvanquished** is free software: you can redistribute it and/or modify

Btw, all Daemon references in headers were replaced by Unvanquished ones.

It also unify some header spacing and line blanking.

It adds `Unvanquished GPL Source Code' mention to GPL headers when missing, so a simple recursive grep can find the related files.

There is still some files to be fixed because they don't have any header at all, you can find them this way:

```sh
find src -type f | sort > /tmp/srcfiles
grep -r 'Unvanquished .* Source Code' src | cut -f1 -d: | sort -u > /tmp/headfiles
comm -2 -3 /tmp/srcfiles /tmp/headfiles 
```

For example almost all files in `src/sgame/components` lack proper header, what to do with them?

Some look autogenerated, it would be nice to make the generator includes a license header too, and also check if all autogenerated files all contains a statement saying it's autogenerated (some have, I'm not sure all have).

Edit: See DaemonEngine/Daemon#48 for a similar PR on Daemon side.