### PR TITLE
do not hardcode bot names in ui rml, allow ui to reuse user defined botnames, fix #765

### DIFF
--- a/main/ui/menu_ingame.rml
+++ b/main/ui/menu_ingame.rml
@@ -67,8 +67,8 @@
 
 							<h2> Bots </h2>
 							<indent>
-								<blocklink onClick='Events.pushevent("exec bot add Lavishment aliens", event)'> Add an alien bot </blocklink>
-								<blocklink onClick='Events.pushevent("exec bot add Pulsifer humans", event)'> Add a human bot </blocklink>
+								<blocklink onClick='Events.pushevent("exec bot add * aliens", event)'> Add an alien bot </blocklink>
+								<blocklink onClick='Events.pushevent("exec bot add * humans", event)'> Add a human bot </blocklink>
 								<blocklink onClick='Events.pushevent("exec bot del all", event)'> Remove all bots </blocklink>
 							</indent>
 

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -707,7 +707,7 @@ static const char *G_UnnamedClientName( gclient_t *client )
 
 	client->pers.namelog->unnamedNumber = number;
 	Com_sprintf( name, sizeof( name ), "%.*s%d", (int)sizeof( name ) - 11,
-	             g_unnamedNamePrefix.string[ 0 ] ? g_unnamedNamePrefix.string : UNNAMED_PLAYER,
+	             g_unnamedNamePrefix.string[ 0 ] ? g_unnamedNamePrefix.string : UNNAMED_PLAYER"#",
 	             number );
 
 	return name;


### PR DESCRIPTION
- do not hardcode bot names in ui rml
- allow ui to reuse user defined botnames
- ~~set default bot names in G_BotInit()~~