### PR TITLE
sgame: Limit the number of visible characters in a name to 32.

### DIFF
--- a/main/ui/ingame_scoreboard.rml
+++ b/main/ui/ingame_scoreboard.rml
@@ -98,7 +98,8 @@
 		datagridcell:nth-child(2), datagridcolumn:nth-child(2) {
 			/* Name cell */
 			text-align: left;
-                        max-width: 56%;
+			max-width: 56%;
+			white-space: normal;
 		}
                 datagridcell:nth-child(n+3), datagridcolumn:nth-child(n+3) {
                         text-align: right;

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -928,6 +928,13 @@ const char *ClientUserinfoChanged( int clientNum, bool forceName )
 			trap_SendServerCommand( ent - g_entities, va( "print_tr %s %s %s", QQ( "$1t$ $2$" ), Quote( err ), Quote( newname ) ) );
 			revertName = true;
 		}
+		else if ( Q_UTF8_Strlen( newname ) > MAX_NAME_CHARACTERS )
+		{
+			trap_SendServerCommand( ent - g_entities,
+			                        va( "print_tr %s %d", QQ( N_("Name is too long! Must be less than $1$ characters.") ), MAX_NAME_CHARACTERS ) );
+			revertName = true;
+
+		}
 
 		if ( revertName )
 		{

--- a/src/sgame/sg_definitions.h
+++ b/src/sgame/sg_definitions.h
@@ -53,6 +53,8 @@ along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
 #define MAX_DAMAGE_REGIONS     16
 #define MAX_DAMAGE_REGION_TEXT 8192
 
+#define MAX_NAME_CHARACTERS 32
+
 #define FOFS(x) ((size_t)&(((gentity_t *)0 )->x ))
 
 #endif // SG_DEFINITIONS_H_


### PR DESCRIPTION
Note, that the since each character can be up to 4 bytes, we make
sure the underlying buffer can hold 128 chars. This ensures that
people can't have super long names in english, but shorter names in
other languages.