### PR TITLE
Remove cg_highPolicy*Models options.

### DIFF
--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -633,16 +633,14 @@ void CG_InitBuildables()
 		//Load models
 		//Prefer md5 models over md3
 
-		if ( cg_highPolyBuildableModels.integer &&
-		     CG_FileExists( va( "models/buildables/%s/%s.iqm", buildableName, buildableName ) ) &&
+		if ( CG_FileExists( va( "models/buildables/%s/%s.iqm", buildableName, buildableName ) ) &&
 		     ( bi->models[ 0 ] = trap_R_RegisterModel( va( "models/buildables/%s/%s.iqm",
 		                                                   buildableName, buildableName ) ) ) )
 		{
 			bi->md5 = true;
 			iqm     = true;
 		}
-		else if ( cg_highPolyBuildableModels.integer &&
-		          ( bi->models[ 0 ] = trap_R_RegisterModel( va( "models/buildables/%s/%s.md5mesh",
+		else if ( ( bi->models[ 0 ] = trap_R_RegisterModel( va( "models/buildables/%s/%s.md5mesh",
 		                                                        buildableName, buildableName ) ) ) )
 		{
 			bi->md5 = true;
@@ -1185,8 +1183,7 @@ void CG_GhostBuildable( int buildableInfo )
 	                                  mins, maxs, ent.axis, ent.origin );
 
 	//offset on the Z axis if required
-	VectorMA( ent.origin, cg_highPolyBuildableModels.integer ? bmc->zOffset : bmc->oldOffset,
-	          tr.plane.normal, ent.origin );
+	VectorMA( ent.origin, bmc->zOffset, tr.plane.normal, ent.origin );
 
 	VectorCopy( ent.origin, ent.lightingOrigin );
 	VectorCopy( ent.origin, ent.oldorigin );  // don't positionally lerp at all
@@ -1196,7 +1193,7 @@ void CG_GhostBuildable( int buildableInfo )
 	ent.customShader = ( SB_BUILDABLE_TO_IBE( buildableInfo ) == IBE_NONE )
 	                     ? cgs.media.greenBuildShader : cgs.media.redBuildShader;
 
-	scale = cg_highPolyBuildableModels.integer ? bmc->modelScale : bmc->oldScale;
+	scale = bmc->modelScale;
 	if ( !scale ) scale = 1.0f;
 
 	if ( cg_buildables[ buildable ].md5 )
@@ -2259,8 +2256,7 @@ void CG_Buildable( centity_t *cent )
 	}
 
 	//offset on the Z axis if required
-	VectorMA( ent.origin, cg_highPolyBuildableModels.integer ? bmc->zOffset : bmc->oldOffset,
-	          surfNormal, ent.origin );
+	VectorMA( ent.origin, bmc->zOffset, surfNormal, ent.origin );
 
 	VectorCopy( ent.origin, ent.oldorigin );  // don't positionally lerp at all
 	VectorCopy( ent.origin, ent.lightingOrigin );
@@ -2305,7 +2301,7 @@ void CG_Buildable( centity_t *cent )
 	}
 
 	// Apply scale from config.
-	scale = cg_highPolyBuildableModels.integer ? bmc->modelScale : bmc->oldScale;
+	scale = bmc->modelScale;
 
 	if ( scale != 1.0f )
 	{

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -173,7 +173,6 @@ vmCvar_t        cg_chatTeamPrefix;
 vmCvar_t        cg_animSpeed;
 vmCvar_t        cg_animBlend;
 
-vmCvar_t        cg_highPolyPlayerModels;
 vmCvar_t        cg_highPolyBuildableModels;
 vmCvar_t        cg_highPolyWeaponModels;
 vmCvar_t        cg_motionblur;
@@ -339,7 +338,6 @@ static const cvarTable_t cvarTable[] =
 	{ &cg_animBlend,                   "cg_animblend",                   "5.0",          0                            },
 
 	{ &cg_chatTeamPrefix,              "cg_chatTeamPrefix",              "1",            0                            },
-	{ &cg_highPolyPlayerModels,        "cg_highPolyPlayerModels",        "1",            CVAR_LATCH                   },
 	{ &cg_highPolyBuildableModels,     "cg_highPolyBuildableModels",     "1",            CVAR_LATCH                   },
 	{ &cg_highPolyWeaponModels,        "cg_highPolyWeaponModels",        "1",            CVAR_LATCH                   },
 	{ &cg_motionblur,                  "cg_motionblur",                  "0.05",         0                            },
@@ -1443,19 +1441,10 @@ static void CG_RegisterClients()
 		trap_UpdateScreen();
 	}
 
-	if ( !cg_highPolyPlayerModels.integer )
-	{
-		cgs.media.larmourHeadSkin = trap_R_RegisterSkin( "models/players/human_base/head_light.skin" );
-		cgs.media.larmourLegsSkin = trap_R_RegisterSkin( "models/players/human_base/lower_light.skin" );
-		cgs.media.larmourTorsoSkin = trap_R_RegisterSkin( "models/players/human_base/upper_light.skin" );
-	}
-	else
-	{
-		// Borrow these variables for MD5 models so we don't have to create new ones.
-		cgs.media.larmourHeadSkin = trap_R_RegisterSkin( "models/players/human_base/body_helmet.skin" );
-		cgs.media.larmourLegsSkin = trap_R_RegisterSkin( "models/players/human_base/body_larmour.skin" );
-		cgs.media.larmourTorsoSkin = trap_R_RegisterSkin( "models/players/human_base/body_helmetlarmour.skin" );
-	}
+	// Borrow these variables for MD5 models so we don't have to create new ones.
+	cgs.media.larmourHeadSkin = trap_R_RegisterSkin( "models/players/human_base/body_helmet.skin" );
+	cgs.media.larmourLegsSkin = trap_R_RegisterSkin( "models/players/human_base/body_larmour.skin" );
+	cgs.media.larmourTorsoSkin = trap_R_RegisterSkin( "models/players/human_base/body_helmetlarmour.skin" );
 
 	cgs.media.jetpackModel = trap_R_RegisterModel( "models/players/human_base/jetpack.iqm" );
 	cgs.media.jetpackFlashModel = trap_R_RegisterModel( "models/players/human_base/jetpack_flash.md3" );

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -173,7 +173,6 @@ vmCvar_t        cg_chatTeamPrefix;
 vmCvar_t        cg_animSpeed;
 vmCvar_t        cg_animBlend;
 
-vmCvar_t        cg_highPolyWeaponModels;
 vmCvar_t        cg_motionblur;
 vmCvar_t        cg_motionblurMinSpeed;
 vmCvar_t        cg_spawnEffects;
@@ -337,7 +336,6 @@ static const cvarTable_t cvarTable[] =
 	{ &cg_animBlend,                   "cg_animblend",                   "5.0",          0                            },
 
 	{ &cg_chatTeamPrefix,              "cg_chatTeamPrefix",              "1",            0                            },
-	{ &cg_highPolyWeaponModels,        "cg_highPolyWeaponModels",        "1",            CVAR_LATCH                   },
 	{ &cg_motionblur,                  "cg_motionblur",                  "0.05",         0                            },
 	{ &cg_motionblurMinSpeed,          "cg_motionblurMinSpeed",          "600",          0                            },
 	{ &cg_spawnEffects,                "cg_spawnEffects",                "1",            0                            },

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -173,7 +173,6 @@ vmCvar_t        cg_chatTeamPrefix;
 vmCvar_t        cg_animSpeed;
 vmCvar_t        cg_animBlend;
 
-vmCvar_t        cg_highPolyBuildableModels;
 vmCvar_t        cg_highPolyWeaponModels;
 vmCvar_t        cg_motionblur;
 vmCvar_t        cg_motionblurMinSpeed;
@@ -338,7 +337,6 @@ static const cvarTable_t cvarTable[] =
 	{ &cg_animBlend,                   "cg_animblend",                   "5.0",          0                            },
 
 	{ &cg_chatTeamPrefix,              "cg_chatTeamPrefix",              "1",            0                            },
-	{ &cg_highPolyBuildableModels,     "cg_highPolyBuildableModels",     "1",            CVAR_LATCH                   },
 	{ &cg_highPolyWeaponModels,        "cg_highPolyWeaponModels",        "1",            CVAR_LATCH                   },
 	{ &cg_motionblur,                  "cg_motionblur",                  "0.05",         0                            },
 	{ &cg_motionblurMinSpeed,          "cg_motionblurMinSpeed",          "600",          0                            },

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -807,35 +807,31 @@ static bool CG_RegisterClientModelname( clientInfo_t *ci, const char *modelName,
 {
 	char filename[ MAX_QPATH ];
 
-	if ( cg_highPolyPlayerModels.integer )
+	Com_sprintf( filename, sizeof( filename ), "models/players/%s/%s.iqm", modelName, modelName );
+	if ( CG_FileExists( filename ) )
 	{
-		Com_sprintf( filename, sizeof( filename ), "models/players/%s/%s.iqm",
-			     modelName, modelName );
-		if ( CG_FileExists( filename ) )
+		ci->bodyModel = trap_R_RegisterModel( filename );
+	}
+
+	if ( ! ci->bodyModel ) {
+		Com_sprintf( filename, sizeof( filename ), "models/players/%s/body.md5mesh", modelName );
+		if ( CG_FileExists(filename) )
 		{
 			ci->bodyModel = trap_R_RegisterModel( filename );
 		}
+	}
+	else
+	{
+		ci->iqm = true;
+	}
 
-		if ( ! ci->bodyModel ) {
-			Com_sprintf( filename, sizeof( filename ), "models/players/%s/body.md5mesh", modelName );
-			if ( CG_FileExists(filename) )
-			{
-				ci->bodyModel = trap_R_RegisterModel( filename );
-			}
-		}
-		else
-		{
-			ci->iqm = true;
-		}
-
-		if ( ci->bodyModel )
-		{
-			ci->skeletal = true;
-		}
-		else
-		{
-			ci->skeletal = false;
-		}
+	if ( ci->bodyModel )
+	{
+		ci->skeletal = true;
+	}
+	else
+	{
+		ci->skeletal = false;
 	}
 
 	if ( ci->skeletal )

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -731,8 +731,7 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 
 			COM_StripExtension( token, token2 );
 
-			if ( cg_highPolyWeaponModels.integer &&
-			     CG_FileExists( va( "%s_view.iqm", token2 ) ) &&
+			if ( CG_FileExists( va( "%s_view.iqm", token2 ) ) &&
 			     ( wi->weaponModel = trap_R_RegisterModel( va( "%s_view.iqm", token2 ) ) ) )
 			{
 				wi->md5 = true;
@@ -825,8 +824,7 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 													va( "%s_view.iqm:fire7", token2 ), false, false, false );
 				}
 			}
-			else if ( cg_highPolyWeaponModels.integer &&
-			          CG_FileExists( va( "%s_view.md5mesh", token2 ) ) &&
+			else if ( CG_FileExists( va( "%s_view.md5mesh", token2 ) ) &&
 			          ( wi->weaponModel = trap_R_RegisterModel( va( "%s_view.md5mesh", token2 ) ) ) )
 			{
 				wi->md5 = true;
@@ -1086,14 +1084,6 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 		}
 		else if ( !Q_stricmp( token, "rotation" ) )
 		{
-			if ( !cg_highPolyWeaponModels.integer )
-			{
-				for ( i = 0; i < 3; i++ )
-				{
-					token = COM_ParseExt2( &text_p, false );
-				}
-				continue;
-			}
 
 			for ( i = 0; i < 3; i++ )
 			{
@@ -1111,14 +1101,6 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 		}
 		else if ( !Q_stricmp( token, "posOffs" ) )
 		{
-			if ( !cg_highPolyWeaponModels.integer )
-			{
-				for ( i = 0; i < 3; i++ )
-				{
-					token = COM_ParseExt2( &text_p, false );
-				}
-				continue;
-			}
 			for ( i = 0; i < 3; i++ )
 			{
 				token = COM_ParseExt2( &text_p, false );
@@ -1135,24 +1117,12 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 		}
 		else if ( !Q_stricmp( token, "rotationBone" ) )
 		{
-			if ( !cg_highPolyWeaponModels.integer )
-			{
-				token = COM_Parse2( &text_p );
-				continue;
-			}
-
 			token = COM_Parse2( &text_p );
 			Q_strncpyz( wi->rotationBone, token, sizeof( wi->rotationBone ) );
 			continue;
 		}
 		else if ( !Q_stricmp( token, "modelScale" ) )
 		{
-			if ( !cg_highPolyWeaponModels.integer )
-			{
-				token = COM_ParseExt2( &text_p, false );
-				continue;
-			}
-
 			token = COM_ParseExt2( &text_p, false );
 
 			if ( token )

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -1337,42 +1337,18 @@ static int CG_MapTorsoToWeaponFrame( clientInfo_t *ci, int frame, int anim )
 {
 	if ( anim == -1 ) { return 0; }
 
-	if ( !cg_highPolyPlayerModels.integer )
+	// MD5 animations all start at 0, so there is no way to differentiate them with first frame alone
+
+	// change weapon
+	if ( anim == TORSO_DROP && frame < 9 )
 	{
-		// change weapon
-		if ( frame >= ci->animations[ TORSO_DROP ].firstFrame &&
-		     frame < ci->animations[ TORSO_DROP ].firstFrame + 9 )
-		{
-			return frame - ci->animations[ TORSO_DROP ].firstFrame + 6;
-		}
-
-		// stand attack
-		if ( frame >= ci->animations[ TORSO_ATTACK ].firstFrame &&
-		     frame < ci->animations[ TORSO_ATTACK ].firstFrame + 6 )
-		{
-			return 1 + frame - ci->animations[ TORSO_ATTACK ].firstFrame;
-		}
-
-		// stand attack 2
-		if ( frame >= ci->animations[ TORSO_ATTACK_BLASTER ].firstFrame &&
-		     frame < ci->animations[ TORSO_ATTACK_BLASTER ].firstFrame + 6 )
-		{
-			return 1 + frame - ci->animations[ TORSO_ATTACK_BLASTER ].firstFrame;
-		}
+		return frame - 6;
 	}
-	else // MD5 animations all start at 0, so there is no way to differentiate them with first frame alone
-	{
-		// change weapon
-		if ( anim == TORSO_DROP && frame < 9 )
-		{
-			return frame - 6;
-		}
 
-		// stand attack
-		else if ( ( anim == TORSO_ATTACK || anim == TORSO_ATTACK_BLASTER ) && frame < 6 )
-		{
-			return 1 + frame;
-		}
+	// stand attack
+	else if ( ( anim == TORSO_ATTACK || anim == TORSO_ATTACK_BLASTER ) && frame < 6 )
+	{
+		return 1 + frame;
 	}
 
 	return 0;


### PR DESCRIPTION
Remove these 3 cvars which allowed some old Tremulous models to be used. Also nuke code for md3 buildables since there are none remaining.