### PR TITLE
Buff and simplify the Spiker.

### DIFF
--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -768,7 +768,7 @@ bool CG_GetBuildableRangeMarkerProperties( buildable_t bType, rangeMarker_t *rmT
 			break;
 
 		case BA_A_SPIKER:
-			*range = SPIKER_SPIKE_RANGE;
+			*range = SPIKER_SENSE_RANGE;
 			shc = SHC_PINK;
 			break;
 

--- a/src/sgame/components/AlienBuildableComponent.cpp
+++ b/src/sgame/components/AlienBuildableComponent.cpp
@@ -17,7 +17,9 @@ void AlienBuildableComponent::HandleDamage(float amount, gentity_t* source, Util
 	if (GetBuildableComponent().GetState() != BuildableComponent::CONSTRUCTED) return;
 
 	// TODO: Move animation code to BuildableComponent.
-	G_SetBuildableAnim(entity.oldEnt, BANIM_PAIN1, false);
+	if (!GetBuildableComponent().AnimationProtected()) {
+		G_SetBuildableAnim(entity.oldEnt, BANIM_PAIN1, false);
+	}
 }
 
 void AlienBuildableComponent::Think(int timeDelta) {

--- a/src/sgame/components/BuildableComponent.h
+++ b/src/sgame/components/BuildableComponent.h
@@ -87,7 +87,7 @@ class BuildableComponent: public BuildableComponentBase {
 		 * Protect current animation from being disrupted by selected, less important animations.
 		 * A value of 0 protects for the rest of the frame only.
 		 */
-		void ProtectAnimation(int time) { protectAnimationUntil = level.time + time; }
+		void ProtectAnimation(int duration) { protectAnimationUntil = level.time + duration; }
 		void UnprotectAnimation() { protectAnimationUntil = -1; }
 
 		/**

--- a/src/sgame/components/BuildableComponent.h
+++ b/src/sgame/components/BuildableComponent.h
@@ -83,6 +83,18 @@ class BuildableComponent: public BuildableComponentBase {
 		void SetAimAngles(const Vec3 aimAngles) { this->aimAngles = aimAngles; }
 		Vec3 AimAngles() const { return this->aimAngles; }
 
+		/**
+		 * Protect current animation from being disrupted by selected, less important animations.
+		 * A value of 0 protects for the rest of the frame only.
+		 */
+		void ProtectAnimation(int time) { protectAnimationUntil = level.time + time; }
+		void UnprotectAnimation() { protectAnimationUntil = -1; }
+
+		/**
+		 * While the current animation is protected, less important animations should not be played.
+		 */
+		bool AnimationProtected() const { return (protectAnimationUntil > level.time); }
+
 	private:
 		lifecycle_t state;
 
@@ -92,6 +104,8 @@ class BuildableComponent: public BuildableComponentBase {
 		int  markTime;
 
 		Vec3 aimAngles; /**< Aim angles relative to world. */
+
+		int protectAnimationUntil;
 
 		// TODO: Move gentity_t.deconstruct and gentity_t.powered here.
 		//bool powered;

--- a/src/sgame/components/OvermindComponent.cpp
+++ b/src/sgame/components/OvermindComponent.cpp
@@ -42,6 +42,7 @@ void OvermindComponent::Think(int timeDelta) {
 		target->Damage(damage, entity.oldEnt, {}, {}, DAMAGE_NO_PROTECTION, MOD_OVERMIND);
 
 		G_SetBuildableAnim(entity.oldEnt, BANIM_ATTACK1, false);
+		GetBuildableComponent().ProtectAnimation(1000);
 	}
 }
 

--- a/src/sgame/components/SpikerComponent.cpp
+++ b/src/sgame/components/SpikerComponent.cpp
@@ -190,6 +190,7 @@ bool SpikerComponent::Fire() {
 
 	// Play shooting animation.
 	G_SetBuildableAnim(self, BANIM_ATTACK1, false);
+	GetBuildableComponent().ProtectAnimation(5000);
 
 	// TODO: Add a particle effect.
 	//G_AddEvent(self, EV_ALIEN_SPIKER, DirToByte(self->s.origin2));

--- a/src/sgame/components/SpikerComponent.h
+++ b/src/sgame/components/SpikerComponent.h
@@ -41,6 +41,15 @@ class SpikerComponent: public SpikerComponentBase {
 		} activeThinker_t;
 
 		void Think(int timeDelta);
+
+		/**
+		 * @return Whether it's somewhat safe to shoot in the given diection.
+		 * @note Does not consider the missile's trajectory, and thus even stationary friendly
+		 *       targets can still be hit. Reduces that risk by also tracing with a slightly larger
+		 *       bounding box than that of the missile.
+		 */
+		bool SafeToShoot(Vec3 direction);
+
 		bool Fire();
 		void RegisterFastThinker();
 		void RegisterSlowThinker();
@@ -48,7 +57,7 @@ class SpikerComponent: public SpikerComponentBase {
 		activeThinker_t activeThinker;
 
 		int   restUntil;
-		float lastScoring;
+		float lastExpectedDamage;
 		bool  lastSensing;
 };
 

--- a/src/sgame/components/SpikerComponent.h
+++ b/src/sgame/components/SpikerComponent.h
@@ -56,9 +56,14 @@ class SpikerComponent: public SpikerComponentBase {
 
 		activeThinker_t activeThinker;
 
-		int   restUntil;
+		/** Used for recovering after a shot. */
+		int restUntil;
+
+		/** The damage the spiker expected to do the last time it checked. */
 		float lastExpectedDamage;
-		bool  lastSensing;
+
+		/** Whether the spiker was actively sensing for an opportunity to shoot. */
+		bool lastSensing;
 };
 
 #endif // SPIKER_COMPONENT_H_

--- a/src/sgame/components/SpikerComponent.h
+++ b/src/sgame/components/SpikerComponent.h
@@ -40,6 +40,12 @@ class SpikerComponent: public SpikerComponentBase {
 			AT_FAST
 		} activeThinker_t;
 
+		/**
+		 * Instead of using exactly the upper hemisphere of the spiker as radius of damage, this
+		 * function computes a threshold used to compensate for the effect of gravity on spikes.
+		 */
+		void SetGravityCompensation();
+
 		void Think(int timeDelta);
 
 		/**
@@ -64,6 +70,12 @@ class SpikerComponent: public SpikerComponentBase {
 
 		/** Whether the spiker was actively sensing for an opportunity to shoot. */
 		bool lastSensing;
+
+		/**
+		 * The scalar product between the direction towards the target and the spiker's top needs
+		 * to be larger than this value in order to consider the target inside the radius of damage.
+		 */
+		float gravityCompensation;
 };
 
 #endif // SPIKER_COMPONENT_H_

--- a/src/shared/bg_gameplay.h
+++ b/src/shared/bg_gameplay.h
@@ -130,11 +130,6 @@ extern int   LEVEL4_CRUSH_REPEAT;
 #define ACIDTUBE_RANGE          300.0f
 
 #define SPIKER_SENSE_RANGE      250.0f // an enemy needs to be this close to consider an attack
-#define SPIKER_SPIKE_RANGE      500.0f // this is just an estimate used for predicting damage
-#define SPIKER_MISSILEROWS      4
-#define SPIKER_MISSILES         26   // actual value +/- SPIKER_MISSILEROWS
-#define SPIKER_ROWOFFSET        0.5f // 0.0: Spikes are shot upwards, 1.0: Spikes are shot sideways
-#define SPIKER_COOLDOWN         5000
 
 #define TRAPPER_RANGE           400
 

--- a/src/shared/bg_gameplay.h
+++ b/src/shared/bg_gameplay.h
@@ -129,8 +129,8 @@ extern int   LEVEL4_CRUSH_REPEAT;
 
 #define ACIDTUBE_RANGE          300.0f
 
-#define SPIKER_SPIKE_RANGE      400.0f // reach of spikes, also used for scoring
-#define SPIKER_SENSE_RANGE      200.0f // an enemy needs to be this close to consider an attack
+#define SPIKER_SENSE_RANGE      250.0f // an enemy needs to be this close to consider an attack
+#define SPIKER_SPIKE_RANGE      500.0f // this is just an estimate used for predicting damage
 #define SPIKER_MISSILEROWS      4
 #define SPIKER_MISSILES         26   // actual value +/- SPIKER_MISSILEROWS
 #define SPIKER_ROWOFFSET        0.5f // 0.0: Spikes are shot upwards, 1.0: Spikes are shot sideways


### PR DESCRIPTION
It will now always shoot but retain selected spikes to diminish the risk of
hitting friends. Sense range is increased slightly.

Note that without a proper trajectory trace, it still can and will occasionally hit friendly buildables.