### PR TITLE
allow custom soundstep in character file for bsuit

### DIFF
--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -213,6 +213,10 @@ static bool CG_ParseCharacterFile( const char *filename, clientInfo_t *ci )
 			{
 				ci->footsteps = FOOTSTEP_SPLASH;
 			}
+			else if ( !Q_stricmp( token, "custom" ) )
+			{
+				ci->footsteps = FOOTSTEP_CUSTOM;
+			}
 			else if( !Q_stricmp(token, "none") )
 			{
 				ci->footsteps = FOOTSTEP_NONE;


### PR DESCRIPTION
- this fixes new-bsuit soundsteps
- it requires bsuit character file to be updated (using 'custom' profile)
- for mysterious reason, the game code already plays bsuit jump sounds without it

bsuit jump sound worked without that but it was a bug, bsuit jump sound must be
dependent of this character file option too

See UnvanquishedAssets/res-players_src.dpkdir#4