### PR TITLE
Remove default-team binds when changing keys in the bind menu

### DIFF
--- a/src/cgame/rocket/rocket.cpp
+++ b/src/cgame/rocket/rocket.cpp
@@ -147,7 +147,7 @@ public:
 
 static polyVert_t *createVertexArray( Rocket::Core::Vertex *vertices, int count )
 {
-	polyVert_t *verts = new polyVert_t[ sizeof( polyVert_t ) * count ];
+	polyVert_t *verts = new polyVert_t[ count ];
 
 	for ( int i = 0; i < count; i++ )
 	{
@@ -180,7 +180,7 @@ public:
 	{
 		this->verts = createVertexArray( verticies, numVerticies );
 
-		this->indices = new int[ sizeof( int ) * _numIndicies ];
+		this->indices = new int[ _numIndicies ];
 		Com_Memcpy( indices, _indices, _numIndicies * sizeof( int ) );
 
 		this->shader = shader;

--- a/src/cgame/rocket/rocketKeyBinder.h
+++ b/src/cgame/rocket/rocketKeyBinder.h
@@ -168,13 +168,22 @@ protected:
 		{
 			return;
 		}
+		// For a team-specific bind, this returns keys that have the command set for the specific
+		// team as well as for the default team (when there is no team-specific bind overriding it.
 		auto previouslyBoundKeys = trap_Key_GetKeysForBinds(team, { cmd.CString() })[0];
 		for (Keyboard::Key key : previouslyBoundKeys)
 		{
-			// TODO(slipher): Make this work when the existing bind is for the "default" team?
 			trap_Key_SetBinding( key, team, "" );
 		}
-		trap_Key_SetBinding( newKey , team, cmd.CString() );
+		if (team != 0) {
+			// If the bind was set for the default team, then the previous attempt will have failed to remove it.
+			previouslyBoundKeys = trap_Key_GetKeysForBinds(team, { cmd.CString() })[0];
+			for (Keyboard::Key key : previouslyBoundKeys)
+			{
+				trap_Key_SetBinding( key, 0, "" );
+			}
+		}
+		trap_Key_SetBinding( newKey, team, cmd.CString() );
 
 		nextKeyUpdateTime = rocketInfo.realtime;
 		waitingForKeypress = false;

--- a/src/cgame/rocket/rocketKeyBinder.h
+++ b/src/cgame/rocket/rocketKeyBinder.h
@@ -95,7 +95,7 @@ public:
 
 	void OnUpdate()
 	{
-		if ( rocketInfo.realtime >= nextKeyUpdateTime && team >= 0 && !cmd.Empty() )
+		if ( rocketInfo.realtime >= nextKeyUpdateTime && team >= 0 && !cmd.Empty() && !waitingForKeypress )
 		{
 			nextKeyUpdateTime = rocketInfo.realtime + KEY_BINDING_REFRESH_INTERVAL_MS;
 			SetInnerRML( CG_KeyBinding( cmd.CString(), team ) );


### PR DESCRIPTION
When you change a bind using the menu, any old keys with the command are removed. But the removal does not succeed if the existing bind is for the "default" team (and the new bind is not). I hesitated to do this before since the existing bind might  be useful for a different team. But I see only two examples of commands used on multiple teams with separate menu items (crouch/wallwalk and armory/evolve) and the pairs are next to each other so it is easy to notice that the other one changes. The current behavior also looks very confusing in the menu, so it definitely makes more sense to purge old default team binds rather than leave them.