### PR TITLE
Fix rocket shutdown crash again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 foreach(SUBMODULE_PATH ${SUBMODULE_LIST})
   # Check if we need to initialize submodule
   file(GLOB DENG_RESULT "${CMAKE_CURRENT_SOURCE_DIR}/${SUBMODULE_PATH}")
-  list(LENGTH ${DENG_RESULT} DENG_RES_LEN)
+  list(LENGTH DENG_RESULT DENG_RES_LEN)
   if(DENG_RES_LEN EQUAL 0)
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
       find_package(Git REQUIRED)

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -1440,12 +1440,11 @@ CG_PrecacheClientInfo
 void CG_PrecacheClientInfo( class_t class_, const char *model, const char *skin )
 {
 	clientInfo_t *ci;
-	clientInfo_t newInfo;
 
 	ci = &cgs.corpseinfo[ class_ ];
 
 	// the old value
-	memset( &newInfo, 0, sizeof( newInfo ) );
+	clientInfo_t newInfo{};
 
 	// model
 	Q_strncpyz( newInfo.modelName, model, sizeof( newInfo.modelName ) );
@@ -1514,7 +1513,6 @@ CG_NewClientInfo
 void CG_NewClientInfo( int clientNum )
 {
 	clientInfo_t *ci;
-	clientInfo_t newInfo;
 	const char   *configstring;
 	const char   *v;
 	char         *slash;
@@ -1525,12 +1523,12 @@ void CG_NewClientInfo( int clientNum )
 
 	if ( !configstring[ 0 ] )
 	{
-		memset( ci, 0, sizeof( *ci ) );
+		*ci = {};
 		return; // player just left
 	}
 
 	// the old value
-	memset( &newInfo, 0, sizeof( newInfo ) );
+	clientInfo_t newInfo{};
 
 	// grab our own ignoreList
 	if ( clientNum == cg.predictedPlayerState.clientNum )


### PR DESCRIPTION
Here's a stack trace that nicely complements the one in https://github.com/DaemonEngine/Daemon/issues/103:

 	cgame-native-dll.dll!Rocket::Core::Geometry::Release(bool clear_buffers) Line 177
 	cgame-native-dll.dll!Rocket::Core::Geometry::~Geometry() Line 71
 	[External Code]	
 	cgame-native-dll.dll!Rocket::Core::ElementTextDefault::~ElementTextDefault() Line 61
 	[External Code]	
 	cgame-native-dll.dll!Rocket::Core::ElementInstancerGeneric<Rocket::Core::ElementTextDefault>::ReleaseElement(Rocket::Core::Element * element) Line 46
 	cgame-native-dll.dll!Rocket::Core::Element::OnReferenceDeactivate() Line 1688
 	cgame-native-dll.dll!Rocket::Core::ReferenceCountable::RemoveReference() Line 75
 	cgame-native-dll.dll!Rocket::Core::Element::ReleaseElements(std::vector<Rocket::Core::Element *,std::allocator<Rocket::Core::Element *> > & released_elements) Line 1809
 	cgame-native-dll.dll!Rocket::Core::Element::~Element() Line 137
 	[External Code]	
 	cgame-native-dll.dll!Rocket::Core::ElementInstancerGeneric<Rocket::Core::Element>::ReleaseElement(Rocket::Core::Element * element) Line 46
 	cgame-native-dll.dll!Rocket::Core::Element::OnReferenceDeactivate() Line 1688
 	cgame-native-dll.dll!Rocket::Core::ReferenceCountable::RemoveReference() Line 75
 	cgame-native-dll.dll!Rocket::Core::Element::ReleaseElements(std::vector<Rocket::Core::Element *,std::allocator<Rocket::Core::Element *> > & released_elements) Line 1809
 	cgame-native-dll.dll!Rocket::Core::Element::~Element() Line 137
 	[External Code]	
 	cgame-native-dll.dll!Rocket::Core::ElementInstancerGeneric<Rocket::Core::Element>::ReleaseElement(Rocket::Core::Element * element) Line 46
 	cgame-native-dll.dll!Rocket::Core::Element::OnReferenceDeactivate() Line 1688
 	cgame-native-dll.dll!Rocket::Core::ReferenceCountable::RemoveReference() Line 75
 	cgame-native-dll.dll!Rocket::Core::Element::ReleaseElements(std::vector<Rocket::Core::Element *,std::allocator<Rocket::Core::Element *> > & released_elements) Line 1809
 	cgame-native-dll.dll!Rocket::Core::Element::~Element() Line 137
 	[External Code]	
 	cgame-native-dll.dll!Rocket::Core::ElementInstancerGeneric<Rocket::Core::Element>::ReleaseElement(Rocket::Core::Element * element) Line 46
 	cgame-native-dll.dll!Rocket::Core::Element::OnReferenceDeactivate() Line 1688
 	cgame-native-dll.dll!Rocket::Core::ReferenceCountable::RemoveReference() Line 75
 	cgame-native-dll.dll!Rocket::Core::Element::ReleaseElements(std::vector<Rocket::Core::Element *,std::allocator<Rocket::Core::Element *> > & released_elements) Line 1809
 	cgame-native-dll.dll!Rocket::Core::Element::~Element() Line 137
 	[External Code]	
 	cgame-native-dll.dll!Rocket::Core::ElementInstancerGeneric<Rocket::Core::Element>::ReleaseElement(Rocket::Core::Element * element) Line 46
 	cgame-native-dll.dll!Rocket::Core::Element::OnReferenceDeactivate() Line 1688
 	cgame-native-dll.dll!Rocket::Core::ReferenceCountable::RemoveReference() Line 75
 	cgame-native-dll.dll!Rocket::Core::Element::ReleaseElements(std::vector<Rocket::Core::Element *,std::allocator<Rocket::Core::Element *> > & released_elements) Line 1809
 	cgame-native-dll.dll!Rocket::Core::Element::~Element() Line 137
 	cgame-native-dll.dll!Rocket::Core::ElementDocument::~ElementDocument() Line 63
 	[External Code]	
 	cgame-native-dll.dll!Rocket::Core::Lua::LuaDocumentElementInstancer::ReleaseElement(Rocket::Core::Element * element) Line 48
 	cgame-native-dll.dll!Rocket::Core::Element::OnReferenceDeactivate() Line 1688
 	cgame-native-dll.dll!Rocket::Core::ReferenceCountable::RemoveReference() Line 75
 	cgame-native-dll.dll!Rocket::Core::Lua::LuaType<Rocket::Core::Element>::gc_T(lua_State * L) Line 186
 	lua53.dll!0000000068d066af()	Unknown
 	lua53.dll!0000000068d06ab0()	Unknown
 	lua53.dll!0000000068d06061()	Unknown
 	lua53.dll!0000000068d06d73()	Unknown
 	lua53.dll!0000000068d07e72()	Unknown
 	lua53.dll!0000000068d094fa()	Unknown
 	lua53.dll!0000000068d0f0de()	Unknown
 	cgame-native-dll.dll!Rocket::Core::Lua::Interpreter::Shutdown() Line 238
 	cgame-native-dll.dll!Rocket_Shutdown() Line 415
 	cgame-native-dll.dll!CG_Shutdown() Line 1612
 	cgame-native-dll.dll!VM::VMHandleSyscall::__l7::<lambda>() Line 74
 	cgame-native-dll.dll!Util::apply_impl<void <lambda>(void),std::tuple<> >(VM::VMHandleSyscall::__l7::void <lambda>(void) && func, std::tuple<> && tuple, Util::seq<> __formal) Line 139
 	cgame-native-dll.dll!Util::apply<void <lambda>(void),std::tuple<> >(VM::VMHandleSyscall::__l7::void <lambda>(void) && func, std::tuple<> && tuple) Line 144
 	cgame-native-dll.dll!IPC::detail::HandleMsg<void <lambda>(void),IPC::Message<IPC::Id<0,2> >,IPC::Reply<> >(IPC::Channel & channel, IPC::SyncMessage<IPC::Message<IPC::Id<0,2> >,IPC::Reply<> > __formal, Util::Reader reader, VM::VMHandleSyscall::__l7::void <lambda>(void) && func) Line 218
 	cgame-native-dll.dll!IPC::HandleMsg<IPC::SyncMessage<IPC::Message<IPC::Id<0,2> >,IPC::Reply<> >,void <lambda>(void) >(IPC::Channel & channel, Util::Reader reader, VM::VMHandleSyscall::__l7::void <lambda>(void) && func) Line 241
 	cgame-native-dll.dll!VM::VMHandleSyscall(unsigned int id, Util::Reader reader) Line 75
 	cgame-native-dll.dll!CommonInit(void * rootSocket) Line 66
 	cgame-native-dll.dll!vmMain(void * rootSocket) Line 104
 	daemon.exe!VM::CreateInProcessNativeVM::__l7::<lambda>() Line 354
 	[External Code]	

The function at the top of the stack just dereferenced a `Context*` that apparently pointed to one of the destroyed contexts. So it fails to destroy the contexts before shutting down Lua, and it also fails in the reverse order.

My first attempt to fix this was to delete all of Rocket_Shutdown except the last two lines, but tricksy librocket foiled me again: If the VM is a DLL global destructors will be run. Rocket checks reference counts in global destructors and logs a message if they are not 0. The IPC message for logging does not go through at this point, which causes an exception to be thrown. Then this exception crashes the whole program because it is in a global destructor, not the main loop which has exception handlers.



