### PR TITLE
Replace ^7 colorcode usage with ^* where it was used as ending null-color

### DIFF
--- a/src/cgame/cg_animdelta.cpp
+++ b/src/cgame/cg_animdelta.cpp
@@ -51,7 +51,7 @@ bool AnimDelta::ParseConfiguration(clientInfo_t* ci, const char* token2, const c
 	char* token = COM_Parse2( data_p );
 	if ( !token || token[0] != '{' )
 	{
-		Log::Notice( "^1ERROR^7: Expected '{' but found '%s' in %s's character.cfg", token, ci->modelName );
+		Log::Notice( "^1ERROR^*: Expected '{' but found '%s' in %s's character.cfg", token, ci->modelName );
 		return true;
 	}
 	while ( 1 )

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -33,6 +33,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 CG_Obituary
 =============
 */
+// end on WHITE instead of ESC for player names following the tags
 static const char teamTag[][8] = { "^2●^7", "^1●^7", "^4●^7" };
 
 #define LONGFORM ">"
@@ -210,7 +211,7 @@ static void CG_Obituary( entityState_t *ent )
 			{
 				if ( meansOfDeath[ mod ].showAssist && assistantInfo )
 				{
-					Log::Notice( "%s (+ %s%s^7) %s %s%s", teamTag[ attackerTeam ], teamTag[ assistantTeam ], assistantName, meansOfDeath[ mod ].icon, teamTag[ ci->team ], targetName );
+					Log::Notice( "%s (+ %s%s^*) %s %s%s", teamTag[ attackerTeam ], teamTag[ assistantTeam ], assistantName, meansOfDeath[ mod ].icon, teamTag[ ci->team ], targetName );
 				}
 				else
 				{
@@ -225,17 +226,17 @@ static void CG_Obituary( entityState_t *ent )
 			{
 				if ( meansOfDeath[ mod ].showAssist && assistantInfo )
 				{
-					Log::Notice( "%s%s^7 (+ %s%s^7) %s %s%s", teamTag[ attackerTeam ], attackerName, teamTag[ assistantTeam ], assistantName, meansOfDeath[ mod ].icon, teamTag[ ci->team ], targetName );
+					Log::Notice( "%s%s^* (+ %s%s^*) %s %s%s", teamTag[ attackerTeam ], attackerName, teamTag[ assistantTeam ], assistantName, meansOfDeath[ mod ].icon, teamTag[ ci->team ], targetName );
 				}
 				else
 				{
-					Log::Notice( "%s%s^7 %s %s%s", teamTag[ attackerTeam ], attackerName, meansOfDeath[ mod ].icon, teamTag[ ci->team ], targetName );
+					Log::Notice( "%s%s^* %s %s%s", teamTag[ attackerTeam ], attackerName, meansOfDeath[ mod ].icon, teamTag[ ci->team ], targetName );
 				}
 
 				// nice big message for teamkills
 				if ( attackerTeam == ci->team && attacker == cg.clientNum )
 				{
-					CG_CenterPrint( va( _("You killed ^1TEAMMATE^7 %s"), targetName ),
+					CG_CenterPrint( va( _("You killed ^1TEAMMATE^* %s"), targetName ),
 							SCREEN_HEIGHT * 0.30, BIGCHAR_WIDTH );
 				}
 			}
@@ -251,86 +252,86 @@ static void CG_Obituary( entityState_t *ent )
 			// Environmental kills
 
 			case MOD_FALLING:
-				message = G_( "%s%s ^7fell to death" );
+				message = G_( "%s%s ^*fell to death" );
 				break;
 
 			case MOD_CRUSH:
-				message = G_( "%s%s ^7was crushed to death" );
+				message = G_( "%s%s ^*was crushed to death" );
 				break;
 
 			case MOD_WATER:
-				message = G_( "%s%s ^7drowned" );
+				message = G_( "%s%s ^*drowned" );
 				break;
 
 			case MOD_SLIME:
-				message = G_( "%s%s ^7melted" );
+				message = G_( "%s%s ^*melted" );
 				break;
 
 			case MOD_LAVA:
-				message = G_( "%s%s ^7took a dip in some lava" );
+				message = G_( "%s%s ^*took a dip in some lava" );
 				break;
 
 			case MOD_TRIGGER_HURT:
-				message = G_( "%s%s ^7was in the wrong place" );
+				message = G_( "%s%s ^*was in the wrong place" );
 				break;
 
 			// Building explosions
 
 			case MOD_HSPAWN:
-				message = G_( "%s%s ^7was caught in the explosion" );
+				message = G_( "%s%s ^*was caught in the explosion" );
 				break;
 
 			case MOD_ASPAWN:
-				message = G_( "%s%s ^7was caught in the acid" );
+				message = G_( "%s%s ^*was caught in the acid" );
 				break;
 
 			// Attacked by a building
 
 			case MOD_MGTURRET:
-				message = G_( "%s%s ^7was gunned down by a turret" );
-				messageAssisted = G_( "%s%s ^7was gunned down by a turret; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was gunned down by a turret" );
+				messageAssisted = G_( "%s%s ^*was gunned down by a turret; %s%s^* assisted" );
 				break;
 
 			case MOD_ROCKETPOD:
-				message = G_( "%s%s ^7caught a rocket" );
-				messageAssisted = G_( "%s%s ^7caught a rocket; %s%s^7 assisted" );
+				message = G_( "%s%s ^*caught a rocket" );
+				messageAssisted = G_( "%s%s ^*caught a rocket; %s%s^* assisted" );
 				break;
 
 			case MOD_ATUBE:
-				message = G_( "%s%s ^7was melted by an acid tube" );
-				messageAssisted = G_( "%s%s ^7was melted by an acid tube; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was melted by an acid tube" );
+				messageAssisted = G_( "%s%s ^*was melted by an acid tube; %s%s^* assisted" );
 				break;
 
 			case MOD_SPIKER:
-				message = G_( "%s%s ^7was flechetted by a spiker" );
-				messageAssisted = G_( "%s%s ^7was flechetted by a spiker; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was flechetted by a spiker" );
+				messageAssisted = G_( "%s%s ^*was flechetted by a spiker; %s%s^* assisted" );
 				break;
 
 			case MOD_OVERMIND:
-				message = G_( "%s%s ^7was whipped by the overmind" );
-				messageAssisted = G_( "%s%s ^7was whipped by the overmind; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was whipped by the overmind" );
+				messageAssisted = G_( "%s%s ^*was whipped by the overmind; %s%s^* assisted" );
 				break;
 
 			case MOD_REACTOR:
-				message = G_( "%s%s ^7was fried by the reactor" );
-				messageAssisted = G_( "%s%s ^7was fried by the reactor; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was fried by the reactor" );
+				messageAssisted = G_( "%s%s ^*was fried by the reactor; %s%s^* assisted" );
 				break;
 
 			case MOD_SLOWBLOB:
-				message = G_( "%s%s ^7couldn't avoid the granger" );
-				messageAssisted = G_( "%s%s ^7couldn't avoid the granger; %s%s^7 assisted" );
+				message = G_( "%s%s ^*couldn't avoid the granger" );
+				messageAssisted = G_( "%s%s ^*couldn't avoid the granger; %s%s^* assisted" );
 				break;
 
 			case MOD_SWARM:
-				message = G_( "%s%s ^7was consumed by the swarm" );
-				messageAssisted = G_( "%s%s ^7was consumed by the swarm; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was consumed by the swarm" );
+				messageAssisted = G_( "%s%s ^*was consumed by the swarm; %s%s^* assisted" );
 				break;
 
 			// Shouldn't happen
 
 			case MOD_TARGET_LASER:
-				message = G_( "%s%s ^7saw the light" );
-				messageAssisted = G_( "%s%s ^7saw the light; %s%s^7 assisted" );
+				message = G_( "%s%s ^*saw the light" );
+				messageAssisted = G_( "%s%s ^*saw the light; %s%s^* assisted" );
 				break;
 
 			default:
@@ -356,159 +357,159 @@ static void CG_Obituary( entityState_t *ent )
 		switch ( mod )
 		{
 			case MOD_PAINSAW:
-				message = G_( "%s%s ^7was sawn by %s%s" );
-				messageAssisted = G_( "%s%s ^7was sawn by %s%s^7; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was sawn by %s%s" );
+				messageAssisted = G_( "%s%s ^*was sawn by %s%s^*; %s%s^* assisted" );
 				break;
 
 			case MOD_BLASTER:
-				message = G_( "%s%s ^7was blasted by %s%s" );
-				messageAssisted = G_( "%s%s ^7was blasted by %s%s^7; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was blasted by %s%s" );
+				messageAssisted = G_( "%s%s ^*was blasted by %s%s^*; %s%s^* assisted" );
 				break;
 
 			case MOD_MACHINEGUN:
-				message = G_( "%s%s ^7was machinegunned by %s%s" );
-				messageAssisted = G_( "%s%s ^7was machinegunned by %s%s^7; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was machinegunned by %s%s" );
+				messageAssisted = G_( "%s%s ^*was machinegunned by %s%s^*; %s%s^* assisted" );
 				break;
 
 			case MOD_CHAINGUN:
-				message = G_( "%s%s ^7was mowed down by %s%s" );
-				messageAssisted = G_( "%s%s ^7was mowed down by %s%s^7; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was mowed down by %s%s" );
+				messageAssisted = G_( "%s%s ^*was mowed down by %s%s^*; %s%s^* assisted" );
 				break;
 
 			case MOD_SHOTGUN:
-				message = G_( "%s%s ^7was gunned down by %s%s" );
-				messageAssisted = G_( "%s%s ^7was gunned down by %s%s^7; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was gunned down by %s%s" );
+				messageAssisted = G_( "%s%s ^*was gunned down by %s%s^*; %s%s^* assisted" );
 				break;
 
 			case MOD_PRIFLE:
-				message = G_( "%s%s ^7was seared by %s%s^7's pulse blast" );
-				messageAssisted = G_( "%s%s ^7was seared by %s%s^7's pulse blast; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was seared by %s%s^*'s pulse blast" );
+				messageAssisted = G_( "%s%s ^*was seared by %s%s^*'s pulse blast; %s%s^* assisted" );
 				break;
 
 			case MOD_MDRIVER:
-				message = G_( "%s%s ^7was sniped by %s%s" );
-				messageAssisted = G_( "%s%s ^7was sniped by %s%s^7; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was sniped by %s%s" );
+				messageAssisted = G_( "%s%s ^*was sniped by %s%s^*; %s%s^* assisted" );
 				break;
 
 			case MOD_LASGUN:
-				message = G_( "%s%s ^7was lasered by %s%s" );
-				messageAssisted = G_( "%s%s ^7was lasered by %s%s^7; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was lasered by %s%s" );
+				messageAssisted = G_( "%s%s ^*was lasered by %s%s^*; %s%s^* assisted" );
 				break;
 
 			case MOD_FLAMER:
 			case MOD_FLAMER_SPLASH:
-				message = G_( "%s%s ^7was grilled by %s%s^7's flame" );
-				messageAssisted = G_( "%s%s ^7was grilled by %s%s^7's flame; %s%s^7 assisted" );
-				messageSuicide = G_( "%s%s ^7was charred to a crisp" );
+				message = G_( "%s%s ^*was grilled by %s%s^*'s flame" );
+				messageAssisted = G_( "%s%s ^*was grilled by %s%s^*'s flame; %s%s^* assisted" );
+				messageSuicide = G_( "%s%s ^*was charred to a crisp" );
 				break;
 
 			case MOD_BURN:
-				message = G_( "%s%s ^7was burned by %s%s^7's fire" );
-				messageAssisted = G_( "%s%s ^7was burned by %s%s^7's fire; %s%s^7 assisted" );
-				messageSuicide = G_( "%s%s ^7was burned to death" );
+				message = G_( "%s%s ^*was burned by %s%s^*'s fire" );
+				messageAssisted = G_( "%s%s ^*was burned by %s%s^*'s fire; %s%s^* assisted" );
+				messageSuicide = G_( "%s%s ^*was burned to death" );
 				break;
 
 			case MOD_LCANNON:
-				message = G_( "%s%s ^7was annihilated by %s%s^7's plasma blast" );
-				messageAssisted = G_( "%s%s ^7was annihilated by %s%s^7's plasma blast; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was annihilated by %s%s^*'s plasma blast" );
+				messageAssisted = G_( "%s%s ^*was annihilated by %s%s^*'s plasma blast; %s%s^* assisted" );
 				break;
 
 			case MOD_LCANNON_SPLASH:
-				message = G_( "%s%s ^7was irradiated by %s%s^7's plasma blast" );
-				messageAssisted = G_( "%s%s ^7was irradiated by %s%s^7's plasma blast; %s%s^7 assisted" );
-				messageSuicide = G_( "%s%s ^7was irradiated" );
+				message = G_( "%s%s ^*was irradiated by %s%s^*'s plasma blast" );
+				messageAssisted = G_( "%s%s ^*was irradiated by %s%s^*'s plasma blast; %s%s^* assisted" );
+				messageSuicide = G_( "%s%s ^*was irradiated" );
 				break;
 
 			case MOD_GRENADE:
-				message = G_( "%s%s ^7was blown up by %s%s^7's grenade" );
-				messageAssisted = G_( "%s%s ^7was blown up by %s%s^7's grenade; %s%s^7 assisted" );
-				messageSuicide = G_( "%s%s ^7was blown up" );
+				message = G_( "%s%s ^*was blown up by %s%s^*'s grenade" );
+				messageAssisted = G_( "%s%s ^*was blown up by %s%s^*'s grenade; %s%s^* assisted" );
+				messageSuicide = G_( "%s%s ^*was blown up" );
 				break;
 
 			case MOD_FIREBOMB:
-				message = G_( "%s%s ^7was incinerated by %s%s^7's firebomb" );
-				messageAssisted = G_( "%s%s ^7was incinerated by %s%s^7's firebomb; %s%s^7 assisted" );
-				messageSuicide = G_( "%s%s ^7was incinerated" );
+				message = G_( "%s%s ^*was incinerated by %s%s^*'s firebomb" );
+				messageAssisted = G_( "%s%s ^*was incinerated by %s%s^*'s firebomb; %s%s^* assisted" );
+				messageSuicide = G_( "%s%s ^*was incinerated" );
 				break;
 
 			case MOD_ABUILDER_CLAW:
-				message = G_( "%s%s ^7was gently nibbled by %s%s^7's granger" );
-				messageAssisted = G_( "%s%s ^7was gently nibbled by %s%s^7's granger; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was gently nibbled by %s%s^*'s granger" );
+				messageAssisted = G_( "%s%s ^*was gently nibbled by %s%s^*'s granger; %s%s^* assisted" );
 				break;
 
 			case MOD_LEVEL0_BITE:
-				message = G_( "%s%s ^7was bitten by %s%s" );
-				messageAssisted = G_( "%s%s ^7was bitten by %s%s^7; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was bitten by %s%s" );
+				messageAssisted = G_( "%s%s ^*was bitten by %s%s^*; %s%s^* assisted" );
 				break;
 
 			case MOD_LEVEL1_CLAW:
-				message = G_( "%s%s ^7was sliced by %s%s^7's %s" );
-				messageAssisted = G_( "%s%s ^7was sliced by %s%s^7's %s^7; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was sliced by %s%s^*'s %s" );
+				messageAssisted = G_( "%s%s ^*was sliced by %s%s^*'s %s^*; %s%s^* assisted" );
 				attackerClass = PCL_ALIEN_LEVEL1;
 				break;
 
 			case MOD_LEVEL2_CLAW:
-				message = G_( "%s%s ^7was shredded by %s%s^7's %s" );
-				messageAssisted = G_( "%s%s ^7was shredded by %s%s^7's %s^7; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was shredded by %s%s^*'s %s" );
+				messageAssisted = G_( "%s%s ^*was shredded by %s%s^*'s %s^*; %s%s^* assisted" );
 				attackerClass = PCL_ALIEN_LEVEL2;
 				break;
 
 			case MOD_LEVEL2_ZAP:
-				message = G_( "%s%s ^7was electrocuted by %s%s^7's %s" );
-				messageAssisted = G_( "%s%s ^7was electrocuted by %s%s^7's %s^7; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was electrocuted by %s%s^*'s %s" );
+				messageAssisted = G_( "%s%s ^*was electrocuted by %s%s^*'s %s^*; %s%s^* assisted" );
 				attackerClass = PCL_ALIEN_LEVEL2;
 				break;
 
 			case MOD_LEVEL3_CLAW:
-				message = G_( "%s%s ^7was eviscerated by %s%s^7's %s" );
-				messageAssisted = G_( "%s%s ^7was eviscerated by %s%s^7's %s^7; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was eviscerated by %s%s^*'s %s" );
+				messageAssisted = G_( "%s%s ^*was eviscerated by %s%s^*'s %s^*; %s%s^* assisted" );
 				attackerClass = PCL_ALIEN_LEVEL3;
 				break;
 
 			case MOD_LEVEL3_POUNCE:
-				message = G_( "%s%s ^7was pounced upon by %s%s^7's %s" );
-				messageAssisted = G_( "%s%s ^7was pounced upon by %s%s^7's %s^7; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was pounced upon by %s%s^*'s %s" );
+				messageAssisted = G_( "%s%s ^*was pounced upon by %s%s^*'s %s^*; %s%s^* assisted" );
 				attackerClass = PCL_ALIEN_LEVEL3;
 				break;
 
 			case MOD_LEVEL3_BOUNCEBALL:
-				message = G_( "%s%s ^7was barbed by %s%s^7's %s" );
-				messageAssisted = G_( "%s%s ^7was barbed by %s%s^7's %s^7; %s%s^7 assisted" );
-				messageSuicide = G_( "%s%s ^7was barbed" );
+				message = G_( "%s%s ^*was barbed by %s%s^*'s %s" );
+				messageAssisted = G_( "%s%s ^*was barbed by %s%s^*'s %s^*; %s%s^* assisted" );
+				messageSuicide = G_( "%s%s ^*was barbed" );
 				attackerClass = PCL_ALIEN_LEVEL3;
 				break;
 
 			case MOD_LEVEL4_CLAW:
-				message = G_( "%s%s ^7was mauled by %s%s^7's %s" );
-				messageAssisted = G_( "%s%s ^7was mauled by %s%s^7's %s^7; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was mauled by %s%s^*'s %s" );
+				messageAssisted = G_( "%s%s ^*was mauled by %s%s^*'s %s^*; %s%s^* assisted" );
 				attackerClass = PCL_ALIEN_LEVEL4;
 				break;
 
 			case MOD_LEVEL4_TRAMPLE:
-				message = G_( "%s%s ^7should have gotten out of the way of %s%s^7's %s" );
-				messageAssisted = G_( "%s%s ^7should have gotten out of the way of %s%s^7's %s^7; %s%s^7 assisted" );
+				message = G_( "%s%s ^*should have gotten out of the way of %s%s^*'s %s" );
+				messageAssisted = G_( "%s%s ^*should have gotten out of the way of %s%s^*'s %s^*; %s%s^* assisted" );
 				attackerClass = PCL_ALIEN_LEVEL4;
 				break;
 
 			case MOD_WEIGHT_H:
 			case MOD_WEIGHT_A:
-				message = G_( "%s%s ^7was crushed under %s%s^7's weight" );
-				messageAssisted = G_( "%s%s ^7was crushed under %s%s^7's weight; %s%s^7 assisted" );
+				message = G_( "%s%s ^*was crushed under %s%s^*'s weight" );
+				messageAssisted = G_( "%s%s ^*was crushed under %s%s^*'s weight; %s%s^* assisted" );
 				break;
 
 			case MOD_POISON:
-				message = G_( "%s%s ^7should have used a medkit against %s%s^7's poison" );
-				messageAssisted = G_( "%s%s ^7should have used a medkit against %s%s^7's poison; %s%s^7 assisted" );
+				message = G_( "%s%s ^*should have used a medkit against %s%s^*'s poison" );
+				messageAssisted = G_( "%s%s ^*should have used a medkit against %s%s^*'s poison; %s%s^* assisted" );
 				break;
 
 			case MOD_TELEFRAG:
-				message = G_( "%s%s ^7tried to invade %s%s^7's personal space" );
+				message = G_( "%s%s ^*tried to invade %s%s^*'s personal space" );
 				break;
 
 			default:
-				message = G_( "%s%s ^7was killed by %s%s" );
-				messageAssisted = G_( "%s%s ^7was killed by %s%s^7 and %s%s" );
-				messageSuicide = G_( "%s%s ^7committed suicide" );
+				message = G_( "%s%s ^*was killed by %s%s" );
+				messageAssisted = G_( "%s%s ^*was killed by %s%s^* and %s%s" );
+				messageSuicide = G_( "%s%s ^*committed suicide" );
 				break;
 		}
 
@@ -545,7 +546,7 @@ static void CG_Obituary( entityState_t *ent )
 
 			if ( attackerTeam == ci->team && attacker == cg.clientNum && attacker != target )
 			{
-				CG_CenterPrint( va( _("You killed ^1TEAMMATE^7 %s"), targetName ),
+				CG_CenterPrint( va( _("You killed ^1TEAMMATE^* %s"), targetName ),
 						SCREEN_HEIGHT * 0.30, BIGCHAR_WIDTH );
 			}
 
@@ -553,7 +554,7 @@ static void CG_Obituary( entityState_t *ent )
 		}
 
 		// we don't know what it was
-		Log::Notice( G_( "%s%s^7 died" ), teamTag[ ci->team ], targetName );
+		Log::Notice( G_( "%s%s^* died" ), teamTag[ ci->team ], targetName );
 	}
 }
 

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -161,7 +161,7 @@ static bool CG_ParseCharacterFile( const char *filename, clientInfo_t *ci )
 			char* token = COM_Parse2( &text_p );
 			if ( !token || *token != '{' )
 			{
-				Log::Notice( "^1ERROR^7: Expected '{' but found '%s' in %s's character.cfg", token, ci->modelName );
+				Log::Notice( "^1ERROR^*: Expected '{' but found '%s' in %s's character.cfg", token, ci->modelName );
 				continue;
 			}
 			while ( 1 )
@@ -1482,24 +1482,24 @@ static void CG_StatusMessages( clientInfo_t *new_, clientInfo_t *old )
 
 	if ( strcmp( new_->name, old->name ) )
 	{
-		Log::Notice(_( "%s^7 renamed to %s"), old->name, new_->name );
+		Log::Notice(_( "%s^* renamed to %s"), old->name, new_->name );
 	}
 
 	if ( old->team != new_->team )
 	{
 		if ( new_->team == TEAM_NONE )
 		{
-			Log::Notice(_( "%s^7 left the %s"), new_->name,
+			Log::Notice(_( "%s^* left the %s"), new_->name,
 			           BG_TeamNamePlural( old->team ) );
 		}
 		else if ( old->team == TEAM_NONE )
 		{
-			Log::Notice(_( "%s^7 joined the %s"), new_->name,
+			Log::Notice(_( "%s^* joined the %s"), new_->name,
 			           BG_TeamNamePlural( new_->team ) );
 		}
 		else
 		{
-			Log::Notice(_( "%s^7 left the %s and joined the %s"),
+			Log::Notice(_( "%s^* left the %s and joined the %s"),
 			           new_->name, BG_TeamNamePlural( old->team ), BG_TeamNamePlural( new_->team ) );
 		}
 	}

--- a/src/cgame/cg_segmented_skeleton.cpp
+++ b/src/cgame/cg_segmented_skeleton.cpp
@@ -137,7 +137,7 @@ bool SegmentedSkeletonCombiner::ParseConfiguration(clientInfo_t* ci, const char*
 	token = COM_Parse2(data_p);
 	if (!token || token[0] != '{')
 	{
-		Log::Notice("^1ERROR^7: Expected '{' but found '%s' in character.cfg\n", token);
+		Log::Notice("^1ERROR^*: Expected '{' but found '%s' in character.cfg\n", token);
 		return false;
 	}
 

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -858,18 +858,18 @@ static void CG_Say( const char *name, int clientNum, saymode_t mode, const char 
 			DAEMON_FALLTHROUGH;
 
 		case SAY_ALL_ADMIN:
-			Log::Notice(  "%s%s%s^7: %s%s",
+			Log::Notice(  "%s%s%s^*: %s%s",
 			           ignore, prefix, name, color, text );
 			break;
 
 		case SAY_TEAM:
-			Log::Notice( "%s%s(%s^7)%s: %s%s",
+			Log::Notice( "%s%s(%s^*)%s: %s%s",
 			           ignore, prefix, name, location, color, text );
 			break;
 
 		case SAY_ADMINS:
 		case SAY_ADMINS_PUBLIC:
-			Log::Notice( "%s%s%s%s^7: %s%s",
+			Log::Notice( "%s%s%s%s^*: %s%s",
 			           ignore, prefix,
 			           ( mode == SAY_ADMINS ) ? "[ADMIN]" : "[PLAYER]",
 			           name, color, text );
@@ -877,13 +877,13 @@ static void CG_Say( const char *name, int clientNum, saymode_t mode, const char 
 
 		case SAY_AREA:
 		case SAY_AREA_TEAM:
-			Log::Notice( "%s%s<%s^7>%s: %s%s",
+			Log::Notice( "%s%s<%s^*>%s: %s%s",
 			           ignore, prefix, name, location, color, text );
 			break;
 
 		case SAY_PRIVMSG:
 		case SAY_TPRIVMSG:
-			Log::Notice( "%s%s[%s^7 → %s^7]: %s%s",
+			Log::Notice( "%s%s[%s^* → %s^*]: %s%s",
 			           ignore, prefix, name, cgs.clientinfo[ cg.clientNum ].name,
 			           color, text );
 
@@ -903,12 +903,12 @@ static void CG_Say( const char *name, int clientNum, saymode_t mode, const char 
 			break;
 
 		case SAY_ALL_ME:
-			Log::Notice(  "%s* %s%s^7 %s%s",
+			Log::Notice(  "%s* %s%s^* %s%s",
 			           ignore, prefix, name, color, text );
 			break;
 
 		case SAY_TEAM_ME:
-			Log::Notice( "%s* %s(%s^7)%s %s%s",
+			Log::Notice( "%s* %s(%s^*)%s %s%s",
 			           ignore, prefix, name, location, color, text );
 			break;
 

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -701,7 +701,7 @@ bool ClientInactivityTimer( gentity_t *ent, bool active )
 			if( strchr( g_inactivity.string, 's' ) )
 			{
 				trap_SendServerCommand( -1,
-				                        va( "print_tr %s %s %s", QQ( N_("$1$^7 moved from $2$ to spectators due to inactivity\n") ),
+				                        va( "print_tr %s %s %s", QQ( N_("$1$^* moved from $2$ to spectators due to inactivity\n") ),
 				                            Quote( client->pers.netname ), Quote( BG_TeamName( client->pers.team ) ) ) );
 				G_LogPrintf( "Inactivity: %d\n", (int)( client - level.clients ) );
 				G_ChangeTeam( ent, TEAM_NONE );

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -41,7 +41,7 @@ static void G_admin_notIntermission( gentity_t *ent )
 	char command[ MAX_ADMIN_CMD_LEN ];
 	*command = 0;
 	trap_Argv( 0, command, sizeof( command ) );
-	ADMP( va( "%s %s", QQ( N_("^3$1$: ^7this command is not valid during intermission") ), command ) );
+	ADMP( va( "%s %s", QQ( N_("^3$1$:^* this command is not valid during intermission") ), command ) );
 }
 
 #define RETURN_IF_INTERMISSION \
@@ -1160,7 +1160,7 @@ static int admin_search( gentity_t *ent,
 
 	if ( limit > 0 )
 	{
-		ADMBP( va( "^3%s: ^7showing %d of %d %s %d-%d%s%s.",
+		ADMBP( va( "^3%s:^* showing %d of %d %s %d-%d%s%s.",
 		           cmd, count, found, noun, start + offset, end + offset,
 		           ( arglist && *arglist ) ? " matching " : "", arglist ) );
 
@@ -1211,7 +1211,7 @@ static int admin_out( void *admin, char *str )
 		trap_GetTimeString( lastSeen, sizeof( lastSeen ), "%Y-%m-%d", &a->lastSeen );
 	}
 
-	Com_sprintf( str, MAX_STRING_CHARS, "%-6d %*s^7 %s %s",
+	Com_sprintf( str, MAX_STRING_CHARS, "%-6d %*s %s %s",
 	             a->level, admin_level_maxname + lncol, l ? l->name : "(null)",
 	             lastSeen, a->name );
 
@@ -1276,7 +1276,7 @@ static int admin_find_admin( gentity_t *ent, char *name, const char *command,
 
 			if ( !vic || !vic->client || vic->client->pers.connected == CON_DISCONNECTED )
 			{
-				ADMP( va( "%s %s %d", QQ( N_("^3$1$: ^7no player connected in slot $2$") ), command, id ) );
+				ADMP( va( "%s %s %d", QQ( N_("^3$1$:^* no player connected in slot $2$") ), command, id ) );
 				return -1;
 			}
 
@@ -1311,7 +1311,7 @@ static int admin_find_admin( gentity_t *ent, char *name, const char *command,
 		{
 			for ( i = 0, a = g_admin_admins; a; i++, a = a->next ) {; }
 
-			ADMP( va( "%s %s %s %d %d %d", QQ( N_("^3$1$: ^7$2$ not in range 0–$3$ or $4$–$5$") ),
+			ADMP( va( "%s %s %s %d %d %d", QQ( N_("^3$1$:^* $2$ not in range 0–$3$ or $4$–$5$") ),
 			          Quote(command), Quote(name),
 			          level.maxclients - 1,
 			          MAX_CLIENTS, MAX_CLIENTS + i - 1 ) );
@@ -1363,7 +1363,7 @@ static int admin_find_admin( gentity_t *ent, char *name, const char *command,
 
 		if ( matches == 0 )
 		{
-			ADMP( va( "%s %s", QQ( N_("^3$1$:^7 no match, use listplayers or listadmins to "
+			ADMP( va( "%s %s", QQ( N_("^3$1$: no match, use listplayers or listadmins to "
 			          "find an appropriate number to use instead of name.") ),
 			          command ) );
 			return -1;
@@ -1371,7 +1371,7 @@ static int admin_find_admin( gentity_t *ent, char *name, const char *command,
 
 		if ( matches > 1 )
 		{
-			ADMP( va( "%s %s", QQ( N_("^3$1$:^7 more than one match, use the admin number instead:") ),
+			ADMP( va( "%s %s", QQ( N_("^3$1$: more than one match, use the admin number instead:") ),
 			          command ) );
 			admin_listadmins( ent, 0, cleanName );
 			return -1;
@@ -1612,7 +1612,7 @@ bool G_admin_cmd_check( gentity_t *ent )
 		}
 		else
 		{
-			ADMP( va( "%s %s", QQ( N_("^3$1$: ^7permission denied") ), c->command ) );
+			ADMP( va( "%s %s", QQ( N_("^3$1$:^* permission denied") ), c->command ) );
 		}
 
 		admin_log_end( success );
@@ -1645,7 +1645,7 @@ bool G_admin_cmd_check( gentity_t *ent )
 		}
 		else
 		{
-			ADMP( va( "%s %s", QQ( N_("^3$1$: ^7permission denied") ),admincmd->keyword ) );
+			ADMP( va( "%s %s", QQ( N_("^3$1$:^* permission denied") ),admincmd->keyword ) );
 			admin_log( ConcatArgsPrintable( 1 ) );
 		}
 
@@ -1818,7 +1818,7 @@ bool G_admin_readconfig( gentity_t *ent )
 
 	if ( len < 0 )
 	{
-		Log::Warn( "^3readconfig: ^7could not open admin config file %s",
+		Log::Warn( "^3readconfig:^* could not open admin config file %s",
 		          g_admin.string );
 		admin_default_levels();
 		return false;
@@ -2052,7 +2052,7 @@ bool G_admin_readconfig( gentity_t *ent )
 	}
 
 	BG_Free( cnf2 );
-	ADMP( va( "%s %d %d %d %d", QQ( N_("^3readconfig: ^7loaded $1$ levels, $2$ admins, $3$ bans, $4$ commands") ),
+	ADMP( va( "%s %d %d %d %d", QQ( N_("^3readconfig:^* loaded $1$ levels, $2$ admins, $3$ bans, $4$ commands") ),
 	          lc, ac, bc, cc ) );
 
 	if ( lc == 0 )
@@ -2112,12 +2112,12 @@ bool G_admin_time( gentity_t *ent )
 			remainingMinutes = (timelimit - level.matchTime)/1000 / 60;
 			remainingSeconds = (timelimit - level.matchTime)/1000 % 60 + 1;
 
-			ADMP( va( "%s %02i %02i %02i %02i %02i %i %02i", QQ( N_("^3time: ^7time is ^d$1$:$2$:$3$^7 UTC; game time is ^d$4$:$5$^7, reaching time limit in ^d$6$:$7$^7") ),
+			ADMP( va( "%s %02i %02i %02i %02i %02i %i %02i", QQ( N_("^3time: ^*time is ^d$1$:$2$:$3$^* UTC; game time is ^d$4$:$5$^*, reaching time limit in ^d$6$:$7$^*") ),
 			  qt.tm_hour, qt.tm_min, qt.tm_sec, gameMinutes, gameSeconds, remainingMinutes, remainingSeconds ) );
 		}
 		else // requesting time in intermission after the timelimit hit, or timelimit wasn't set
 		{
-			ADMP( va( "%s %02i %02i %02i %02i %02i", QQ( N_("^3time: ^7time is ^d$1$:$2$:$3$^7 UTC; game time is ^d$4$:$5$^7") ),
+			ADMP( va( "%s %02i %02i %02i %02i %02i", QQ( N_("^3time: ^*time is ^d$1$:$2$:$3$^* UTC; game time is ^d$4$:$5$^*") ),
 					  qt.tm_hour, qt.tm_min, qt.tm_sec, gameMinutes, gameSeconds) );
 		}
 		return true;
@@ -2127,7 +2127,7 @@ bool G_admin_time( gentity_t *ent )
 
 		if ( !G_admin_permission( ent, "gametimelimit" ) )
 		{
-			ADMP( va( "%s %s", QQ( N_("^3$1$: ^7permission denied") ), "time" ) );
+			ADMP( va( "%s %s", QQ( N_("^3$1$:^* permission denied") ), "time" ) );
 			return false;
 		}
 
@@ -2141,7 +2141,7 @@ bool G_admin_time( gentity_t *ent )
 			timelimit = std::min( 6 * 60, std::max( 0, timelimit ) );
 			if ( timelimit != level.timelimit )
 			{
-				AP( va( "print_tr %s %d %d %s", QQ( N_("^3time: ^7time limit set to $1$m from $2$m by $3$") ),
+				AP( va( "print_tr %s %d %d %s", QQ( N_("^3time:^* time limit set to $1$m from $2$m by $3$") ),
 				        timelimit, level.timelimit, G_quoted_admin_name( ent ) ) );
 				level.timelimit = timelimit;
 				// reset 'time remaining' warnings
@@ -2153,14 +2153,14 @@ bool G_admin_time( gentity_t *ent )
 			}
 			else
 			{
-				ADMP( QQ( N_("^3time: ^7time limit is unchanged") ) );
+				ADMP( QQ( N_("^3time:^* time limit is unchanged") ) );
 			}
 			return true;
 		}
 		// fallthrough
 
 	default:
-		ADMP( QQ( N_("^3time: ^7usage: time [minutes]") ) );
+		ADMP( QQ( N_("^3time:^* usage: time [minutes]") ) );
 		return false;
 	}
 }
@@ -2185,7 +2185,7 @@ bool G_admin_setlevel( gentity_t *ent )
 
 	if ( trap_Argc() < 3 )
 	{
-		ADMP( QQ( N_("^3setlevel: ^7usage: setlevel [name|slot#] [level]") ) );
+		ADMP( QQ( N_("^3setlevel:^* usage: setlevel [name|slot#] [level]") ) );
 		return false;
 	}
 
@@ -2194,14 +2194,14 @@ bool G_admin_setlevel( gentity_t *ent )
 
 	if ( !( l = G_admin_level( atoi( lstr ) ) ) )
 	{
-		ADMP( QQ( N_("^3setlevel: ^7level is not defined") ) );
+		ADMP( QQ( N_("^3setlevel:^* level is not defined") ) );
 		return false;
 	}
 
 	if ( ent && l->level >
 	     ( ent->client->pers.admin ? ent->client->pers.admin->level : 0 ) )
 	{
-		ADMP( QQ( N_("^3setlevel: ^7you may not use setlevel to set a level higher "
+		ADMP( QQ( N_("^3setlevel:^* you may not use setlevel to set a level higher "
 		      "than your current level") ) );
 		return false;
 	}
@@ -2213,13 +2213,13 @@ bool G_admin_setlevel( gentity_t *ent )
 
 	if ( l->level && vic && G_IsUnnamed( vic->client->pers.netname ) )
 	{
-		ADMP( QQ( N_("^3setlevel: ^7your intended victim has the default name") ) );
+		ADMP( QQ( N_("^3setlevel:^* your intended victim has the default name") ) );
 		return false;
 	}
 
 	if ( ent && !admin_higher_admin( ent->client->pers.admin, a ) )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3$1$: ^7sorry, but your intended victim has a higher admin"
+		ADMP( va( "%s %s", QQ( N_("^3$1$:^* sorry, but your intended victim has a higher admin"
 		          " level than you") ), "setlevel" ) );
 		return false;
 	}
@@ -2265,7 +2265,7 @@ bool G_admin_setlevel( gentity_t *ent )
 	               a->name ) );
 
 	AP( va(
-	      "print_tr %s %s %d %s", QQ( N_("^3setlevel: ^7$1$^7 was given level $2$ admin rights by $3$") ),
+	      "print_tr %s %s %d %s", QQ( N_("^3setlevel:^* $1$^* was given level $2$ admin rights by $3$") ),
 	      Quote( a->name ), a->level, G_quoted_admin_name( ent ) ) );
 
 	G_admin_writeconfig();
@@ -2513,7 +2513,7 @@ bool G_admin_kick( gentity_t *ent )
 
 	if ( trap_Argc() < minargc )
 	{
-		ADMP( QQ( N_("^3kick: ^7usage: kick [name] [reason]") ) );
+		ADMP( QQ( N_("^3kick:^* usage: kick [name] [reason]") ) );
 		return false;
 	}
 
@@ -2522,7 +2522,7 @@ bool G_admin_kick( gentity_t *ent )
 
 	if ( ( pid = G_ClientNumberFromString( name, err, sizeof( err ) ) ) == -1 )
 	{
-		ADMP( va( "%s %s %s", QQ( "^3$1$: ^7$2t$" ), "kick", Quote( err) ) );
+		ADMP( va( "%s %s %s", QQ( "^3$1$:^* $2t$" ), "kick", Quote( err) ) );
 		return false;
 	}
 
@@ -2530,14 +2530,14 @@ bool G_admin_kick( gentity_t *ent )
 
 	if ( !admin_higher( ent, vic ) )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3$1$: ^7sorry, but your intended victim has a higher admin"
+		ADMP( va( "%s %s", QQ( N_("^3$1$:^* sorry, but your intended victim has a higher admin"
 		          " level than you") ), "kick" ) );
 		return false;
 	}
 
 	if ( vic->client->pers.localClient )
 	{
-		ADMP( QQ( N_("^3kick: ^7disconnecting the host would end the game" ) ) );
+		ADMP( QQ( N_("^3kick:^* disconnecting the host would end the game" ) ) );
 		return false;
 	}
 
@@ -2573,7 +2573,7 @@ bool G_admin_ban( gentity_t *ent )
 
 	if ( trap_Argc() < 2 )
 	{
-		ADMP( QQ( N_("^3ban: ^7usage: ban [name|slot|address(/mask)] [duration] [reason]") ) );
+		ADMP( QQ( N_("^3ban:^* usage: ban [name|slot|address(/mask)] [duration] [reason]") ) );
 		return false;
 	}
 
@@ -2594,7 +2594,7 @@ bool G_admin_ban( gentity_t *ent )
 
 	if ( !*reason && !G_admin_permission( ent, ADMF_UNACCOUNTABLE ) )
 	{
-		ADMP( QQ( N_("^3ban: ^7you must specify a reason" ) ) );
+		ADMP( QQ( N_("^3ban:^* you must specify a reason" ) ) );
 		return false;
 	}
 
@@ -2604,7 +2604,7 @@ bool G_admin_ban( gentity_t *ent )
 
 		if ( seconds == 0 || seconds > std::max( 1, maximum ) )
 		{
-			ADMP( QQ( N_("^3ban: ^7you may not issue permanent bans") ) );
+			ADMP( QQ( N_("^3ban:^* you may not issue permanent bans") ) );
 			seconds = maximum;
 		}
 	}
@@ -2616,7 +2616,7 @@ bool G_admin_ban( gentity_t *ent )
 
 		if ( ip.mask < min || ip.mask > max )
 		{
-			ADMP( va( "%s %d %d %d", QQ( N_("^3ban: ^7invalid netmask ($1$ is not one of $2$–$3$)") ),
+			ADMP( va( "%s %d %d %d", QQ( N_("^3ban:^* invalid netmask ($1$ is not one of $2$–$3$)") ),
 			          ip.mask, min, max ) );
 			return false;
 		}
@@ -2647,33 +2647,33 @@ bool G_admin_ban( gentity_t *ent )
 
 		if ( !match )
 		{
-			ADMP( QQ( N_("^3ban: ^7no player found by that IP address" ) ) );
+			ADMP( QQ( N_("^3ban:^* no player found by that IP address" ) ) );
 			return false;
 		}
 	}
 	else if ( !( match = G_NamelogFromString( ent, search ) ) || match->banned )
 	{
-		ADMP( QQ( N_("^3ban: ^7no match") ) );
+		ADMP( QQ( N_("^3ban:^* no match") ) );
 		return false;
 	}
 
 	if ( ent && !admin_higher_guid( ent->client->pers.guid, match->guid ) )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3$1$: ^7sorry, but your intended victim has a higher admin"
+		ADMP( va( "%s %s", QQ( N_("^3$1$:^* sorry, but your intended victim has a higher admin"
 		          " level than you") ), "ban" ) );
 		return false;
 	}
 
 	if ( match->slot > -1 && level.clients[ match->slot ].pers.localClient )
 	{
-		ADMP( QQ( N_("^3ban: ^7disconnecting the host would end the game") ) );
+		ADMP( QQ( N_("^3ban:^* disconnecting the host would end the game") ) );
 		return false;
 	}
 
 	G_admin_duration( ( seconds ) ? seconds : -1, time, sizeof( time ),
 	                  duration, sizeof( duration ) );
 
-	AP( va( "print_tr %s %s %s %s %s %s", QQ( N_("^3ban:^7 $1$^7 has been banned by $2$^7; "
+	AP( va( "print_tr %s %s %s %s %s %s", QQ( N_("^3ban:^* $1$^* has been banned by $2$^*; "
 	        "duration: $3$$4t$, reason: $5t$") ),
 	        Quote( match->name[ match->nameOffset ] ),
 	        G_quoted_admin_name( ent ),
@@ -2714,7 +2714,7 @@ bool G_admin_ban( gentity_t *ent )
 
 	if ( !g_admin.string[ 0 ] )
 	{
-		ADMP( QQ( N_("^3ban: ^7WARNING g_admin not set, not saving ban to a file" ) ) );
+		ADMP( QQ( N_("^3ban:^* WARNING g_admin not set, not saving ban to a file" ) ) );
 	}
 	else
 	{
@@ -2735,7 +2735,7 @@ bool G_admin_unban( gentity_t *ent )
 
 	if ( trap_Argc() < 2 )
 	{
-		ADMP( QQ( N_("^3unban: ^7usage: unban [ban#]") ) );
+		ADMP( QQ( N_("^3unban:^* usage: unban [ban#]") ) );
 		return false;
 	}
 
@@ -2749,7 +2749,7 @@ bool G_admin_unban( gentity_t *ent )
 
 	if ( !ban )
 	{
-		ADMP( QQ( N_("^3unban: ^7invalid ban#" ) ) );
+		ADMP( QQ( N_("^3unban:^* invalid ban#" ) ) );
 		return false;
 	}
 
@@ -2759,14 +2759,14 @@ bool G_admin_unban( gentity_t *ent )
 		if ( ban->expires == 0 ||
 		     ( maximum = G_admin_parse_time( g_adminMaxBan.string ), ban->expires - time > std::max( 1, maximum ) ) )
 		{
-			ADMP( QQ( N_("^3unban: ^7you cannot remove permanent bans") ) );
+			ADMP( QQ( N_("^3unban:^* you cannot remove permanent bans") ) );
 			return false;
 		}
 	}
 
 	if ( expireOnly && G_ADMIN_BAN_EXPIRED( ban, time ) )
 	{
-		ADMP( va( "%s %d", QQ( N_("^3unban: ^7ban #$1$ has already expired") ), bnum ) );
+		ADMP( va( "%s %d", QQ( N_("^3unban:^* ban #$1$ has already expired") ), bnum ) );
 		return false;
 	}
 
@@ -2778,14 +2778,14 @@ bool G_admin_unban( gentity_t *ent )
 
 	if ( expireOnly )
 	{
-		AP( va( "print_tr %s %d %s %s", QQ( N_("^3unban: ^7ban #$1$ for $2$^7 has been expired by $3$") ),
+		AP( va( "print_tr %s %d %s %s", QQ( N_("^3unban:^* ban #$1$ for $2$^* has been expired by $3$") ),
 		        bnum, Quote( ban->name ), G_quoted_admin_name( ent ) ) );
 
 		ban->expires = time;
 	}
 	else
 	{
-		AP( va( "print_tr %s %d %s %s", QQ( N_("^3unban: ^7ban #$1$ for $2$^7 has been removed by $3$") ),
+		AP( va( "print_tr %s %d %s %s", QQ( N_("^3unban:^* ban #$1$ for $2$^* has been removed by $3$") ),
 		        bnum, Quote( ban->name ), G_quoted_admin_name( ent ) ) );
 
 		if ( p == ban )
@@ -2827,7 +2827,7 @@ bool G_admin_adjustban( gentity_t *ent )
 
 	if ( trap_Argc() < 3 )
 	{
-		ADMP( QQ( N_("^3adjustban: ^7usage: adjustban [ban#] [/mask] [duration] [reason]"
+		ADMP( QQ( N_("^3adjustban:^* usage: adjustban [ban#] [/mask] [duration] [reason]"
 		      "") ) );
 		return false;
 	}
@@ -2839,7 +2839,7 @@ bool G_admin_adjustban( gentity_t *ent )
 
 	if ( !ban )
 	{
-		ADMP( QQ( N_("^3adjustban: ^7invalid ban#") ) );
+		ADMP( QQ( N_("^3adjustban:^* invalid ban#") ) );
 		return false;
 	}
 
@@ -2849,7 +2849,7 @@ bool G_admin_adjustban( gentity_t *ent )
 	if ( !G_admin_permission( ent, ADMF_CAN_PERM_BAN ) &&
 	     ( ban->expires == 0 || ban->expires - time > maximum ) )
 	{
-		ADMP( QQ( N_("^3adjustban: ^7you cannot modify permanent bans") ) );
+		ADMP( QQ( N_("^3adjustban:^* you cannot modify permanent bans") ) );
 		return false;
 	}
 
@@ -2863,7 +2863,7 @@ bool G_admin_adjustban( gentity_t *ent )
 
 		if ( mask < min || mask > max )
 		{
-			ADMP( va( "%s %d %d %d", QQ( N_("^3adjustban: ^7invalid netmask ($1$ is not one of $2$–$3$)") ),
+			ADMP( va( "%s %d %d %d", QQ( N_("^3adjustban:^* invalid netmask ($1$ is not one of $2$–$3$)") ),
 			          mask, min, max ) );
 			return false;
 		}
@@ -2888,7 +2888,7 @@ bool G_admin_adjustban( gentity_t *ent )
 		{
 			if ( ban->expires == 0 && mode )
 			{
-				ADMP( QQ( N_("^3adjustban: ^7new duration must be explicit" ) ) );
+				ADMP( QQ( N_("^3adjustban:^* new duration must be explicit" ) ) );
 				return false;
 			}
 
@@ -2907,7 +2907,7 @@ bool G_admin_adjustban( gentity_t *ent )
 
 			if ( expires <= time )
 			{
-				ADMP( QQ( N_("^3adjustban: ^7ban duration must be positive" ) ) );
+				ADMP( QQ( N_("^3adjustban:^* ban duration must be positive" ) ) );
 				return false;
 			}
 		}
@@ -2919,7 +2919,7 @@ bool G_admin_adjustban( gentity_t *ent )
 		if ( !G_admin_permission( ent, ADMF_CAN_PERM_BAN ) &&
 		     ( length == 0 || length > maximum ) )
 		{
-			ADMP( QQ( N_("^3adjustban: ^7you may not issue permanent bans") ) );
+			ADMP( QQ( N_("^3adjustban:^* you may not issue permanent bans") ) );
 			expires = time + maximum;
 		}
 
@@ -2959,7 +2959,7 @@ bool G_admin_adjustban( gentity_t *ent )
 	admin_log( va( "%d (%s) \"%s^*\": \"%s^*\": [%s]",
 	               ban->expires ? ban->expires - time : 0, ban->guid, ban->name, ban->reason,
 	               ban->ip.str ) );
-	AP( va( "print_tr %s %d %s %s %s %s %s %s %s %s %s", QQ( N_("^3adjustban: ^7ban #$1$ for $2$^7 has been updated by $3$^7 "
+	AP( va( "print_tr %s %d %s %s %s %s %s %s %s %s %s", QQ( N_("^3adjustban:^* ban #$1$ for $2$^* has been updated by $3$^* "
 	        "$4t$$5$$6$$7t$$8$$9t$$10$") ),
 	        bnum,
 	        Quote( ban->name ),
@@ -3000,13 +3000,13 @@ bool G_admin_putteam( gentity_t *ent )
 
 	if ( trap_Argc() < 3 )
 	{
-		ADMP( QQ( N_("^3putteam: ^7usage: putteam [name] [h|a|s]") ) );
+		ADMP( QQ( N_("^3putteam:^* usage: putteam [name] [h|a|s]") ) );
 		return false;
 	}
 
 	if ( ( pid = G_ClientNumberFromString( name, err, sizeof( err ) ) ) == -1 )
 	{
-		ADMP( va( "%s %s %s", QQ( "^3$1$:^7 $2t$" ), "rename", Quote( err ) ) );
+		ADMP( va( "%s %s %s", QQ( "^3$1$:^* $2t$" ), "rename", Quote( err ) ) );
 		return false;
 	}
 
@@ -3014,7 +3014,7 @@ bool G_admin_putteam( gentity_t *ent )
 
 	if ( !admin_higher( ent, vic ) )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3$1$: ^7sorry, but your intended victim has a higher admin"
+		ADMP( va( "%s %s", QQ( N_("^3$1$:^* sorry, but your intended victim has a higher admin"
 		          " level than you") ), "putteam" ) );
 		return false;
 	}
@@ -3023,7 +3023,7 @@ bool G_admin_putteam( gentity_t *ent )
 
 	if ( teamnum == NUM_TEAMS )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3putteam: ^7unknown team $1$") ), team ) );
+		ADMP( va( "%s %s", QQ( N_("^3putteam:^* unknown team $1$") ), team ) );
 		return false;
 	}
 
@@ -3036,7 +3036,7 @@ bool G_admin_putteam( gentity_t *ent )
 	               vic->client->pers.netname ) );
 	G_ChangeTeam( vic, teamnum );
 
-	AP( va( "print_tr %s %s %s %s", QQ( N_("^3putteam: ^7$1$^7 put $2$^7 on to the $3$ team") ),
+	AP( va( "print_tr %s %s %s %s", QQ( N_("^3putteam:^* $1$^* put $2$^* on to the $3$ team") ),
 	        G_quoted_admin_name( ent ),
 	        Quote( vic->client->pers.netname ), BG_TeamName( teamnum ) ) );
 	return true;
@@ -3056,7 +3056,7 @@ bool G_admin_speclock( gentity_t *ent )
 
 	if ( trap_Argc() < 3 )
 	{
-		ADMP( QQ( N_("^3speclock: ^7usage: speclock [name] [duration]") ) );
+		ADMP( QQ( N_("^3speclock:^* usage: speclock [name] [duration]") ) );
 		return false;
 	}
 
@@ -3065,7 +3065,7 @@ bool G_admin_speclock( gentity_t *ent )
 
 	if ( ( pid = G_ClientNumberFromString( name, err, sizeof( err ) ) ) == -1 )
 	{
-		ADMP( va( "%s %s %s", QQ( "^3$1$: ^7$2t$" ), "speclock", Quote( err ) ) );
+		ADMP( va( "%s %s %s", QQ( "^3$1$:^* $2t$" ), "speclock", Quote( err ) ) );
 		return false;
 	}
 
@@ -3073,7 +3073,7 @@ bool G_admin_speclock( gentity_t *ent )
 
 	if ( !admin_higher( ent, vic ) )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3$1$: ^7sorry, but your intended victim has a higher admin"
+		ADMP( va( "%s %s", QQ( N_("^3$1$:^* sorry, but your intended victim has a higher admin"
 		          " level than you") ), "speclock" ) );
 		return false;
 	}
@@ -3118,13 +3118,13 @@ bool G_admin_speclock( gentity_t *ent )
 	if ( vic->client->pers.team != TEAM_NONE )
 	{
 		G_ChangeTeam( vic, TEAM_NONE );
-		AP( va( "print_tr %s %s %s %s %s", QQ( N_("^3speclock: ^7$1$^7 put $2$^7 on to the spectators team and blocked team-change for $3$$4t$") ),
+		AP( va( "print_tr %s %s %s %s %s", QQ( N_("^3speclock:^* $1$^* put $2$^* on to the spectators team and blocked team-change for $3$$4t$") ),
 		        G_quoted_admin_name( ent ),
 		        Quote( vic->client->pers.netname ), Quote( time ), duration ) );
 	}
 	else
 	{
-		AP( va( "print_tr %s %s %s %s %s", QQ( N_("^3speclock: ^7$1$^7 blocked team-change for $2$^7 for $3$$4t$") ),
+		AP( va( "print_tr %s %s %s %s %s", QQ( N_("^3speclock:^* $1$^* blocked team-change for $2$^* for $3$$4t$") ),
 		        G_quoted_admin_name( ent ),
 		        Quote( vic->client->pers.netname ), Quote( time ), duration ) );
 	}
@@ -3143,7 +3143,7 @@ bool G_admin_specunlock( gentity_t *ent )
 
 	if ( trap_Argc() < 2 )
 	{
-		ADMP( QQ( N_("^3specunlock: ^7usage: specunlock [name]") ) );
+		ADMP( QQ( N_("^3specunlock:^* usage: specunlock [name]") ) );
 		return false;
 	}
 
@@ -3151,7 +3151,7 @@ bool G_admin_specunlock( gentity_t *ent )
 
 	if ( ( pid = G_ClientNumberFromString( name, err, sizeof( err ) ) ) == -1 )
 	{
-		ADMP( va( "%s %s %s", QQ( "^3$1$: ^7$2t$" ), "specunlock", Quote( err ) ) );
+		ADMP( va( "%s %s %s", QQ( "^3$1$:^* $2t$" ), "specunlock", Quote( err ) ) );
 		return false;
 	}
 
@@ -3159,7 +3159,7 @@ bool G_admin_specunlock( gentity_t *ent )
 
 	if ( !admin_higher( ent, vic ) )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3$1$: ^7sorry, but your intended victim has a higher admin"
+		ADMP( va( "%s %s", QQ( N_("^3$1$:^* sorry, but your intended victim has a higher admin"
 		          " level than you") ), "specunlock" ) );
 		return false;
 	}
@@ -3171,7 +3171,7 @@ bool G_admin_specunlock( gentity_t *ent )
 		spec->expires = 0;
 		admin_log( va( "%d (%s) \"%s^*\" SPECTATE -", pid, vic->client->pers.guid,
 			               vic->client->pers.netname ) );
-			AP( va( "print_tr %s %s %s", QQ( N_("^3specunlock: ^7$1$^7 unblocked team-change for $2$") ),
+			AP( va( "print_tr %s %s %s", QQ( N_("^3specunlock:^* $1$^* unblocked team-change for $2$") ),
 			        G_quoted_admin_name( ent ),
 			        Quote( vic->client->pers.netname ) ) );
 	}
@@ -3186,7 +3186,7 @@ bool G_admin_changemap( gentity_t *ent )
 
 	if ( trap_Argc() < 2 )
 	{
-		ADMP( QQ( N_("^3changemap: ^7usage: changemap [map] (layout)") ) );
+		ADMP( QQ( N_("^3changemap:^* usage: changemap [map] (layout)") ) );
 		return false;
 	}
 
@@ -3194,7 +3194,7 @@ bool G_admin_changemap( gentity_t *ent )
 
 	if ( !G_MapExists( map ) )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3changemap: ^7invalid map name '$1$'") ), map ) );
+		ADMP( va( "%s %s", QQ( N_("^3changemap:^* invalid map name '$1$'") ), map ) );
 		return false;
 	}
 
@@ -3210,7 +3210,7 @@ bool G_admin_changemap( gentity_t *ent )
 		}
 		else
 		{
-			ADMP( va( "%s %s", QQ( N_("^3changemap: ^7invalid layout name '$1$'") ), layout ) );
+			ADMP( va( "%s %s", QQ( N_("^3changemap:^* invalid layout name '$1$'") ), layout ) );
 			return false;
 		}
 	}
@@ -3222,7 +3222,7 @@ bool G_admin_changemap( gentity_t *ent )
 
 	level.restarted = true;
 	G_MapLog_Result( 'M' );
-	AP( va( "print_tr %s %s %s %s %s %s", QQ( N_("^3changemap: ^7map '$1$' started by $2$^7 $3t$$4$$5$") ),
+	AP( va( "print_tr %s %s %s %s %s %s", QQ( N_("^3changemap:^* map '$1$' started by $2$^* $3t$$4$$5$") ),
 		Quote( map ),
 	        G_quoted_admin_name( ent ),
 	        ( layout[ 0 ] ) ? QQ( "(forcing layout '") : "" ,
@@ -3240,7 +3240,7 @@ bool G_admin_warn( gentity_t *ent )
 
 	if( trap_Argc() < 3 )
 	{
-		ADMP( QQ( N_("^3warn: ^7usage: warn [name|slot#] [reason]") ) );
+		ADMP( QQ( N_("^3warn:^* usage: warn [name|slot#] [reason]") ) );
 		return false;
 	}
 
@@ -3250,7 +3250,7 @@ bool G_admin_warn( gentity_t *ent )
 	{
 		count = G_MatchOnePlayer( pids, found, err, sizeof( err ) );
 		ADMP( va( "%s %s %s",
-				  QQ( "^3$1$: ^7$2t$" ),
+				  QQ( "^3$1$:^* $2t$" ),
 				  "warn",
 				  ( count > 0 ) ? Quote( Substring( err, 0, count ) ) : Quote( err ) ) );
 		return false;
@@ -3258,7 +3258,7 @@ bool G_admin_warn( gentity_t *ent )
 
 	if( !admin_higher( ent, &g_entities[ pids[ 0 ] ] ) )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3$1$: ^7sorry, but your intended victim has a higher admin"
+		ADMP( va( "%s %s", QQ( N_("^3$1$:^* sorry, but your intended victim has a higher admin"
 		          " level than you") ), "warn" ) );
 		return false;
 	}
@@ -3277,7 +3277,7 @@ bool G_admin_warn( gentity_t *ent )
 
 	CPx( pids[ 0 ], va( "cp_tr " QQ(N_("^1You have been warned by an administrator:\n^3$1$")) " %s",
 	                    Quote( reason ) ) );
-	AP( va( "print_tr %s %s %s %s", QQ( N_("^3warn: ^7$1$^7 has been warned: '$2$' by $3$") ),
+	AP( va( "print_tr %s %s %s %s", QQ( N_("^3warn:^* $1$^* has been warned: '$2$' by $3$") ),
 	        Quote( vic->client->pers.netname ),
 	        Quote( reason ),
 	        G_quoted_admin_name( ent ) ) );
@@ -3295,7 +3295,7 @@ bool G_admin_mute( gentity_t *ent )
 
 	if ( trap_Argc() < 2 )
 	{
-		ADMP( va( "%s %s %s", QQ( N_("^3$1$: ^7usage: $2$ [name|slot#]") ),command, command ) );
+		ADMP( va( "%s %s %s", QQ( N_("^3$1$:^* usage: $2$ [name|slot#]") ),command, command ) );
 		return false;
 	}
 
@@ -3303,14 +3303,14 @@ bool G_admin_mute( gentity_t *ent )
 
 	if ( !( vic = G_NamelogFromString( ent, name ) ) )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3$1$: ^7no match") ), command ) );
+		ADMP( va( "%s %s", QQ( N_("^3$1$:^* no match") ), command ) );
 		return false;
 	}
 
 	if ( ent && !admin_higher_admin( ent->client->pers.admin,
 	                                 G_admin_admin( vic->guid ) ) )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3$1$: ^7sorry, but your intended victim has a higher admin"
+		ADMP( va( "%s %s", QQ( N_("^3$1$:^* sorry, but your intended victim has a higher admin"
 		          " level than you") ), command ) );
 		return false;
 	}
@@ -3319,7 +3319,7 @@ bool G_admin_mute( gentity_t *ent )
 	{
 		if ( !Q_stricmp( command, "mute" ) )
 		{
-			ADMP( QQ( N_("^3mute: ^7player is already muted") ) );
+			ADMP( QQ( N_("^3mute:^* player is already muted") ) );
 			return false;
 		}
 
@@ -3330,7 +3330,7 @@ bool G_admin_mute( gentity_t *ent )
 			CPx( vic->slot, "cp_tr " QQ(N_("^1You have been unmuted")) );
 		}
 
-		AP( va( "print_tr %s %s %s", QQ( N_("^3unmute: ^7$1$^7 has been unmuted by $2$") ),
+		AP( va( "print_tr %s %s %s", QQ( N_("^3unmute:^* $1$^* has been unmuted by $2$") ),
 		        Quote( vic->name[ vic->nameOffset ] ),
 		        G_quoted_admin_name( ent ) ) );
 	}
@@ -3338,7 +3338,7 @@ bool G_admin_mute( gentity_t *ent )
 	{
 		if ( !Q_stricmp( command, "unmute" ) )
 		{
-			ADMP( QQ( N_("^3unmute: ^7player is not currently muted") ) );
+			ADMP( QQ( N_("^3unmute:^* player is not currently muted") ) );
 			return false;
 		}
 
@@ -3349,7 +3349,7 @@ bool G_admin_mute( gentity_t *ent )
 			CPx( vic->slot, "cp_tr " QQ(N_("^1You've been muted")) );
 		}
 
-		AP( va( "print_tr %s %s %s", QQ( N_("^3mute: ^7$1$^7 has been muted by $2$") ),
+		AP( va( "print_tr %s %s %s", QQ( N_("^3mute:^* $1$^* has been muted by $2$") ),
 		        Quote( vic->name[ vic->nameOffset ] ),
 		        G_quoted_admin_name( ent ) ) );
 	}
@@ -3371,7 +3371,7 @@ bool G_admin_denybuild( gentity_t *ent )
 
 	if ( trap_Argc() < 2 )
 	{
-		ADMP( va( "%s %s %s", QQ( N_("^3$1$: ^7usage: $2$ [name|slot#]") ), command, command ) );
+		ADMP( va( "%s %s %s", QQ( N_("^3$1$:^* usage: $2$ [name|slot#]") ), command, command ) );
 		return false;
 	}
 
@@ -3379,14 +3379,14 @@ bool G_admin_denybuild( gentity_t *ent )
 
 	if ( !( vic = G_NamelogFromString( ent, name ) ) )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3$1$: ^7no match") ), command ) );
+		ADMP( va( "%s %s", QQ( N_("^3$1$:^* no match") ), command ) );
 		return false;
 	}
 
 	if ( ent && !admin_higher_admin( ent->client->pers.admin,
 	                                 G_admin_admin( vic->guid ) ) )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3$1$: ^7sorry, but your intended victim has a higher admin"
+		ADMP( va( "%s %s", QQ( N_("^3$1$:^* sorry, but your intended victim has a higher admin"
 		          " level than you") ), command ) );
 		return false;
 	}
@@ -3395,7 +3395,7 @@ bool G_admin_denybuild( gentity_t *ent )
 	{
 		if ( !Q_stricmp( command, "denybuild" ) )
 		{
-			ADMP( QQ( N_("^3denybuild: ^7player already has no building rights" ) ) );
+			ADMP( QQ( N_("^3denybuild:^* player already has no building rights" ) ) );
 			return false;
 		}
 
@@ -3406,7 +3406,7 @@ bool G_admin_denybuild( gentity_t *ent )
 			CPx( vic->slot, "cp_tr " QQ(N_("^1You've regained your building rights")) );
 		}
 
-		AP( va( "print_tr %s %s %s", QQ( N_("^3allowbuild: ^7building rights for ^7$1$^7 restored by $2$") ),
+		AP( va( "print_tr %s %s %s", QQ( N_("^3allowbuild:^* building rights for ^7$1$^* restored by $2$") ),
 		        Quote( vic->name[ vic->nameOffset ] ),
 		        G_quoted_admin_name( ent ) ) );
 	}
@@ -3414,7 +3414,7 @@ bool G_admin_denybuild( gentity_t *ent )
 	{
 		if ( !Q_stricmp( command, "allowbuild" ) )
 		{
-			ADMP( QQ( N_("^3allowbuild: ^7player already has building rights" ) ) );
+			ADMP( QQ( N_("^3allowbuild:^* player already has building rights" ) ) );
 			return false;
 		}
 
@@ -3426,7 +3426,7 @@ bool G_admin_denybuild( gentity_t *ent )
 			CPx( vic->slot, "cp_tr " QQ(N_("^1You've lost your building rights")) );
 		}
 
-		AP( va( "print_tr %s %s %s", QQ( N_("^3denybuild: ^7building rights for ^7$1$^7 revoked by $2$") ),
+		AP( va( "print_tr %s %s %s", QQ( N_("^3denybuild:^* building rights for ^7$1$^* revoked by $2$") ),
 		        Quote( vic->name[ vic->nameOffset ] ),
 		        G_quoted_admin_name( ent ) ) );
 	}
@@ -3495,7 +3495,7 @@ bool G_admin_listinactive( gentity_t *ent )
 	i = trap_Argc();
 	if ( i > 3 )
 	{
-		ADMP( QQ( N_("^3listinactive: ^7usage: listinactive [^5months^7] (^5start admin#^7)") ) );
+		ADMP( QQ( N_("^3listinactive:^* usage: listinactive [^5months^7] (^5start admin#^7)") ) );
 		return false;
 	}
 
@@ -3556,7 +3556,7 @@ bool G_admin_listlayouts( gentity_t *ent )
 	}
 
 	count = G_LayoutList( map, list, sizeof( list ) );
-	ADMP( va( "%s %d %s", QQ( N_("^3listlayouts:^7 $1$ layouts found for '$2$':") ), count, map ) );
+	ADMP( va( "%s %d %s", QQ( N_("^3listlayouts:^* $1$ layouts found for '$2$':") ), count, map ) );
 	ADMBP_begin();
 	s = &list[ 0 ];
 
@@ -3638,7 +3638,7 @@ bool G_admin_listgeoip( gentity_t *ent )
 			continue;
 		}
 
-		ADMBP( va( "%2i %*s %s^7", clients[ i ], countryLength, p->pers.country[0] ? p->pers.country : "?", p->pers.netname ) );
+		ADMBP( va( "%2i %*s %s^*", clients[ i ], countryLength, p->pers.country[0] ? p->pers.country : "?", p->pers.netname ) );
 	}
 
 	ADMBP_end();
@@ -3663,7 +3663,7 @@ bool G_admin_listplayers( gentity_t *ent )
 	bool        canset = G_admin_permission( ent, "setlevel" );
 	bool	canseeWarn = G_admin_permission( ent, "warn" ) || G_admin_permission( ent, "ban" );
 
-	ADMP( va( "%s %d", QQ( N_("^3listplayers: ^7$1$ players connected:") ),
+	ADMP( va( "%s %d", QQ( N_("^3listplayers:^* $1$ players connected:") ),
 	           level.numConnectedClients ) );
 	ADMBP_begin();
 
@@ -3742,7 +3742,7 @@ bool G_admin_listplayers( gentity_t *ent )
 
 		int colorlen = Color::StrlenNocolor( lname );
 
-		ADMBP( va( "%2i %s%c^7 %-2i^2%c^7 %*s^7 ^5%c^1%c%c%s^7 %s^7 %s%s%s %s",
+		ADMBP( va( "%2i %s%c^7 %-2i^2%c^7 %*s^* ^5%c^1%c%c%s^7 %s^* %s%s%s %s",
 		           i,
 		           Color::ToString( color ).c_str(),
 		           t,
@@ -3757,7 +3757,7 @@ bool G_admin_listplayers( gentity_t *ent )
 		           p->pers.netname,
 		           ( registeredname ) ? "(a.k.a. " : "",
 		           ( registeredname ) ? registeredname : "",
-		           ( registeredname ) ? "^7)" : "",
+		           ( registeredname ) ? "^*)" : "",
 		           ( !authed ) ? "^1NOT AUTHED" : "" ) );
 	}
 
@@ -3822,7 +3822,7 @@ static int ban_out( void *ban, char *str )
 
 	Com_sprintf( str, MAX_STRING_CHARS, "%s"
 	             "         %s\\__ %s%s%-*s %s%-15s ^7%-8s %s"
-	             "          %s\\__ %s: ^7%s",
+	             "          %s\\__ %s:^* %s",
 	             b->name,
 	             Color::ToString( G_ADMIN_BAN_IS_WARNING( b ) ? Color::Yellow : Color::Red ).c_str(),
 	             Color::ToString( d_color ).c_str(),
@@ -3950,7 +3950,7 @@ bool G_admin_adminhelp( gentity_t *ent )
 		out += "\n";
 
 		ADMP( Cmd::Escape( out ) );
-		ADMP( va( "%s %d", QQ( N_("^3adminhelp: ^7$1$ available commands"
+		ADMP( va( "%s %d", QQ( N_("^3adminhelp:^* $1$ available commands"
 		"run adminhelp [^3command^7] for adminhelp with a specific command.") ),count ) );
 
 		return true;
@@ -3968,15 +3968,15 @@ bool G_admin_adminhelp( gentity_t *ent )
 		{
 			if ( G_admin_permission( ent, c->flag ) )
 			{
-				ADMP( va( "%s %s", QQ( N_("^3adminhelp: ^7help for '$1$':") ), c->command ) );
+				ADMP( va( "%s %s", QQ( N_("^3adminhelp:^* help for '$1$':") ), c->command ) );
 
 				if ( c->desc[ 0 ] )
 				{
-					ADMP( va( "%s %s", QQ( N_(" ^3Description: ^7$1t$") ), Quote( c->desc ) ) );
+					ADMP( va( "%s %s", QQ( N_(" ^3Description:^* $1t$") ), Quote( c->desc ) ) );
 				}
 
-				ADMP( va( "%s %s", QQ( N_(" ^3Syntax: ^7$1$") ), c->command ) );
-				ADMP( va( "%s %s", QQ( N_(" ^3Flag: ^7'$1$'") ), c->flag ) );
+				ADMP( va( "%s %s", QQ( N_(" ^3Syntax:^* $1$") ), c->command ) );
+				ADMP( va( "%s %s", QQ( N_(" ^3Flag:^* '$1$'") ), c->flag ) );
 
 				return true;
 			}
@@ -3988,18 +3988,18 @@ bool G_admin_adminhelp( gentity_t *ent )
 		{
 			if ( G_admin_permission( ent, admincmd->flag ) )
 			{
-				ADMP( va( "%s %s", QQ( N_("^3adminhelp: ^7help for '$1$':") ), admincmd->keyword ) );
+				ADMP( va( "%s %s", QQ( N_("^3adminhelp:^* help for '$1$':") ), admincmd->keyword ) );
 
 				if ( admincmd->function )
 				{
-					ADMP( va( "%s %s", QQ( N_(" ^3Description: ^7$1t$") ), admincmd->function ) );
+					ADMP( va( "%s %s", QQ( N_(" ^3Description:^* $1t$") ), admincmd->function ) );
 				}
 
-				ADMP( va( "%s %s %s", QQ( N_(" ^3Syntax: ^7$1$ $2t$") ), admincmd->keyword, admincmd->syntax ? Quote( admincmd->syntax ) : "" ) );
+				ADMP( va( "%s %s %s", QQ( N_(" ^3Syntax:^* $1$ $2t$") ), admincmd->keyword, admincmd->syntax ? Quote( admincmd->syntax ) : "" ) );
 
 				if ( admincmd->flag )
 				{
-					ADMP( va( "%s %s", QQ( N_(" ^3Flag: ^7'$1$'") ), admincmd->flag ) );
+					ADMP( va( "%s %s", QQ( N_(" ^3Flag:^* '$1$'") ), admincmd->flag ) );
 				}
 
 				return true;
@@ -4008,8 +4008,8 @@ bool G_admin_adminhelp( gentity_t *ent )
 			denied = true;
 		}
 
-		ADMP( va( "%s %s", denied ? QQ( N_("^3adminhelp: ^7you do not have permission to use '$1$'") )
-		                          : QQ( N_("^3adminhelp: ^7no help found for '$1$'") ), param ) );
+		ADMP( va( "%s %s", denied ? QQ( N_("^3adminhelp:^* you do not have permission to use '$1$'") )
+		                          : QQ( N_("^3adminhelp:^* no help found for '$1$'") ), param ) );
 		return false;
 	}
 }
@@ -4020,13 +4020,13 @@ bool G_admin_admintest( gentity_t *ent )
 
 	if ( !ent )
 	{
-		ADMP( QQ( N_("^3admintest: ^7you are on the console.") ) );
+		ADMP( QQ( N_("^3admintest:^* you are on the console.") ) );
 		return true;
 	}
 
 	l = G_admin_level( ent->client->pers.admin ? ent->client->pers.admin->level : 0 );
 
-	AP( va( "print_tr %s %s %d %s %s %s", QQ( N_("^3admintest: ^7$1$^7 is a level $2$ admin $3$$4$^7$5$") ),
+	AP( va( "print_tr %s %s %d %s %s %s", QQ( N_("^3admintest:^* $1$^* is a level $2$ admin $3$$4$^7$5$") ),
 	        Quote( ent->client->pers.netname ),
 	        l ? l->level : 0,
 	        l ? "(" : "",
@@ -4042,7 +4042,7 @@ bool G_admin_allready( gentity_t *ent )
 
 	if ( !level.intermissiontime )
 	{
-		ADMP( QQ( N_("^3allready: ^7this command is only valid during intermission") ));
+		ADMP( QQ( N_("^3allready:^* this command is only valid during intermission") ));
 		return false;
 	}
 
@@ -4063,7 +4063,7 @@ bool G_admin_allready( gentity_t *ent )
 		cl->readyToExit = true;
 	}
 
-	AP( va( "print_tr %s %s", QQ( N_("^3allready:^7 $1$^7 says everyone is READY now") ),
+	AP( va( "print_tr %s %s", QQ( N_("^3allready:^* $1$^* says everyone is READY now") ),
 	        G_quoted_admin_name( ent ) ) );
 	return true;
 }
@@ -4088,17 +4088,17 @@ bool G_admin_endvote( gentity_t *ent )
 
 	if ( team == NUM_TEAMS )
 	{
-		ADMP( va( "%s %s %s", QQ( N_( "^3$1$: ^7invalid team '$2$'" ) ), command, teamName ) );
+		ADMP( va( "%s %s %s", QQ( N_( "^3$1$:^* invalid team '$2$'" ) ), command, teamName ) );
 		return false;
 	}
 
-	msg = va( "print_tr %s %s %s", cancel ? QQ( N_("^3$1$: ^7$2$^7 decided that everyone voted No") ) :
-		QQ( N_("^3$1$: ^7$2$^7 decided that everyone voted Yes") ),
+	msg = va( "print_tr %s %s %s", cancel ? QQ( N_("^3$1$:^* $2$^* decided that everyone voted No") ) :
+		QQ( N_("^3$1$:^* $2$^* decided that everyone voted Yes") ),
 			  command, G_quoted_admin_name( ent ) );
 
 	if ( !level.team[ team ].voteTime )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3$1$: ^7no vote in progress") ), command ) );
+		ADMP( va( "%s %s", QQ( N_("^3$1$:^* no vote in progress") ), command ) );
 		return false;
 	}
 
@@ -4149,7 +4149,7 @@ bool G_admin_spec999( gentity_t *ent )
 		if ( vic->client->ps.ping == 999 )
 		{
 			G_ChangeTeam( vic, TEAM_NONE );
-			AP( va( "print_tr %s %s %s", QQ( N_("^3spec999: ^7$1$^7 moved $2$^7 to spectators") ),
+			AP( va( "print_tr %s %s %s", QQ( N_("^3spec999:^* $1$^* moved $2$^* to spectators") ),
 			        G_quoted_admin_name( ent ),
 			        Quote( vic->client->pers.netname ) ) );
 		}
@@ -4169,7 +4169,7 @@ bool G_admin_rename( gentity_t *ent )
 
 	if ( trap_Argc() < 3 )
 	{
-		ADMP( QQ( N_("^3rename: ^7usage: rename [name] [newname]") ) );
+		ADMP( QQ( N_("^3rename:^* usage: rename [name] [newname]") ) );
 		return false;
 	}
 
@@ -4186,20 +4186,20 @@ bool G_admin_rename( gentity_t *ent )
 
 	if ( !admin_higher( ent, victim ) )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3$1$: ^7sorry, but your intended victim has a higher admin"
+		ADMP( va( "%s %s", QQ( N_("^3$1$:^* sorry, but your intended victim has a higher admin"
 		          " level than you") ), "rename" ) );
 		return false;
 	}
 
 	if ( !G_admin_name_check( victim, newname, err, sizeof( err ) ) )
 	{
-		ADMP( va( "%s %s %s %s", QQ( "^3$1$: ^7$2t$ $3$" ), "rename", Quote( err ), Quote( name ) ) );
+		ADMP( va( "%s %s %s %s", QQ( "^3$1$:^* $2t$ $3$" ), "rename", Quote( err ), Quote( name ) ) );
 		return false;
 	}
 
 	if ( victim->client->pers.connected != CON_CONNECTED )
 	{
-		ADMP( QQ( N_("^3rename: ^7sorry, but your intended victim is still connecting") ) );
+		ADMP( QQ( N_("^3rename:^* sorry, but your intended victim is still connecting") ) );
 		return false;
 	}
 
@@ -4207,7 +4207,7 @@ bool G_admin_rename( gentity_t *ent )
 	               victim->client->pers.guid, victim->client->pers.netname ) );
 	admin_log( newname );
 	trap_GetUserinfo( pid, userinfo, sizeof( userinfo ) );
-	AP( va( "print_tr %s %s %s %s", QQ( N_("^3rename: ^7$1$^7 has been renamed to $2$^7 by $3$") ),
+	AP( va( "print_tr %s %s %s %s", QQ( N_("^3rename:^* $1$^* has been renamed to $2$^* by $3$") ),
 	        Quote( victim->client->pers.netname ),
 	        Quote( newname ),
 	        G_quoted_admin_name( ent ) ) );
@@ -4260,7 +4260,7 @@ bool G_admin_restart( gentity_t *ent )
 
 	if ( !builtin && !trap_FS_FOpenFile( va( "layouts/%s/%s.dat", map, layout ), nullptr, fsMode_t::FS_READ ) )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3restart: ^7layout '$1$' does not exist") ), layout ) );
+		ADMP( va( "%s %s", QQ( N_("^3restart:^* layout '$1$' does not exist") ), layout ) );
 		return false;
 	}
 
@@ -4319,7 +4319,7 @@ bool G_admin_restart( gentity_t *ent )
 	}
 	else if ( *teampref )
 	{
-		ADMP( va( "%s %s", QQ( N_( "^3restart: ^7unrecognised option '$1$'") ), Quote( teampref ) ) );
+		ADMP( va( "%s %s", QQ( N_( "^3restart:^* unrecognised option '$1$'") ), Quote( teampref ) ) );
 		return false;
 	}
 	else
@@ -4337,7 +4337,7 @@ bool G_admin_restart( gentity_t *ent )
 	trap_SendConsoleCommand( "map_restart" );
 	G_MapLog_Result( 'R' );
 
-	AP( va( "print_tr %s %s %s %s %s %s %s %s", QQ( N_("^3restart: ^7map restarted by $1$ $2$$3t$$4$$5$$6t$$7$") ),
+	AP( va( "print_tr %s %s %s %s %s %s %s %s", QQ( N_("^3restart:^* map restarted by $1$ $2$$3t$$4$$5$$6t$$7$") ),
 	        G_quoted_admin_name( ent ),
 	        ( layout[ 0 ] ) ? QQ( N_( "^7(forcing layout '" ) ) : "",
 			( layout[ 0 ] ) ? Quote( layout ) : "",
@@ -4352,7 +4352,7 @@ bool G_admin_nextmap( gentity_t *ent )
 {
 	RETURN_IF_INTERMISSION;
 
-	AP( va( "print_tr %s %s", QQ( N_("^3nextmap: ^7$1$^7 decided to load the next map") ),
+	AP( va( "print_tr %s %s", QQ( N_("^3nextmap:^* $1$^* decided to load the next map") ),
 	        G_quoted_admin_name( ent ) ) );
 	level.lastWin = TEAM_NONE;
 	trap_SetConfigstring( CS_WINNER, "Evacuation" );
@@ -4592,7 +4592,7 @@ bool G_admin_lock( gentity_t *ent )
 
 	if ( trap_Argc() < 2 )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3$1$: ^7usage: $1$ [a|h]") ), command ) );
+		ADMP( va( "%s %s", QQ( N_("^3$1$:^* usage: $1$ [a|h]") ), command ) );
 		return false;
 	}
 
@@ -4613,27 +4613,27 @@ bool G_admin_lock( gentity_t *ent )
 	}
 	else
 	{
-		ADMP( va( "%s %s %s", QQ( N_("^3$1$: ^7invalid team: '$2$'") ), command, teamName ) );
+		ADMP( va( "%s %s %s", QQ( N_("^3$1$:^* invalid team: '$2$'") ), command, teamName ) );
 		return false;
 	}
 
 	if ( fail )
 	{
-		ADMP( va( "%s %s %s", lock ? QQ( N_("^3$1$: ^7the $2$ team is already locked") ) :
-			QQ( N_("^3$1$: ^7the $2$ team is not currently locked") ), command, BG_TeamName( team ) ) );
+		ADMP( va( "%s %s %s", lock ? QQ( N_("^3$1$:^* the $2$ team is already locked") ) :
+			QQ( N_("^3$1$:^* the $2$ team is not currently locked") ), command, BG_TeamName( team ) ) );
 		return false;
 	}
 
 	admin_log( BG_TeamName( team ) );
 	if ( lock )
 	{
-		AP( va( "print_tr %s %s %s %s", QQ( N_("^3$1$: ^7the $2$ team has been locked by $3$") ),
+		AP( va( "print_tr %s %s %s %s", QQ( N_("^3$1$:^* the $2$ team has been locked by $3$") ),
 		        command, BG_TeamName( team ),
 		        G_quoted_admin_name( ent ) ) );
 	}
 	else
 	{
-		AP( va( "print_tr %s %s %s %s", QQ( N_("^3$1$: ^7the $2$ team has been unlocked by $3$") ),
+		AP( va( "print_tr %s %s %s %s", QQ( N_("^3$1$:^* the $2$ team has been unlocked by $3$") ),
 		        command, BG_TeamName( team ),
 		        G_quoted_admin_name( ent ) ) );
 	}
@@ -4787,7 +4787,7 @@ bool G_admin_flaglist( gentity_t *ent )
 	}
 
 	ADMBP_end();
-	ADMP( va( "%s %d %d", QQ( N_("^3flaglist: ^7listed $1$ ability and $2$ command flags") ), (int) adminNumFlags, count ) );
+	ADMP( va( "%s %d %d", QQ( N_("^3flaglist:^* listed $1$ ability and $2$ command flags") ), (int) adminNumFlags, count ) );
 
 	return true;
 }
@@ -4815,7 +4815,7 @@ bool G_admin_flag( gentity_t *ent )
 
 	if ( trap_Argc() < 2 )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3$1$: ^7usage: $1$ [^3name|slot#|admin#|*level#^7] (^5+^7|^5-^7)[^3flag^7]") ), command ) );
+		ADMP( va( "%s %s", QQ( N_("^3$1$:^* usage: $1$ [^3name|slot#|admin#|*level#^7] (^5+^7|^5-^7)[^3flag^7]") ), command ) );
 		return false;
 	}
 
@@ -4849,13 +4849,13 @@ bool G_admin_flag( gentity_t *ent )
 
 		if ( !admin || admin->level == 0 )
 		{
-			ADMP( va( "%s %s", QQ( N_("^3$1$:^7 your intended victim is not an admin") ), command ) );
+			ADMP( va( "%s %s", QQ( N_("^3$1$:^* your intended victim is not an admin") ), command ) );
 			return false;
 		}
 
 		if ( ent && !admin_higher_admin( ent->client->pers.admin, admin ) )
 		{
-			ADMP( va( "%s %s", QQ( N_("^3$1$:^7 your intended victim has a higher admin level than you") ), command ) );
+			ADMP( va( "%s %s", QQ( N_("^3$1$:^* your intended victim has a higher admin level than you") ), command ) );
 			return false;
 		}
 
@@ -4867,13 +4867,13 @@ bool G_admin_flag( gentity_t *ent )
 		if ( !level )
 		{
 			level = G_admin_level( admin->level );
-			ADMP( va( "%s %s %s %s", QQ( N_("^3$1$:^7 flags for $2$^7 are '^3$3$^7'") ),
+			ADMP( va( "%s %s %s %s", QQ( N_("^3$1$:^* flags for $2$^* are '^3$3$^*'") ),
 			          command, Quote( admin->name ), Quote( admin->flags ) ) );
 		}
 
 		if ( level )
 		{
-			ADMP( va( "%s %s %d %s", QQ( N_("^3$1$:^7 admin level $2$ flags are '$3$'") ),
+			ADMP( va( "%s %s %d %s", QQ( N_("^3$1$:^* admin level $2$ flags are '$3$'") ),
 			          command, level->level, Quote( level->flags ) ) );
 		}
 
@@ -4905,7 +4905,7 @@ bool G_admin_flag( gentity_t *ent )
 
 	if ( !i || flag[ i ] )
 	{
-		ADMP( va( "%s %s %s", QQ( N_("^3$1$:^7 bad flag name '$2$^7'") ), command, Quote( flag ) ) );
+		ADMP( va( "%s %s %s", QQ( N_("^3$1$:^* bad flag name '$2$^*'") ), command, Quote( flag ) ) );
 		return false;
 	}
 
@@ -4917,13 +4917,13 @@ bool G_admin_flag( gentity_t *ent )
 
 	if ( ent && ent->client->pers.admin == admin )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3$1$:^7 you may not change your own flags (use rcon)") ), command ) );
+		ADMP( va( "%s %s", QQ( N_("^3$1$:^* you may not change your own flags (use rcon)") ), command ) );
 		return false;
 	}
 
 	if ( !G_admin_permission( ent, flag ) )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3$1$:^7 you may only change flags that you also have") ), command ) );
+		ADMP( va( "%s %s", QQ( N_("^3$1$:^* you may only change flags that you also have") ), command ) );
 		return false;
 	}
 
@@ -4943,8 +4943,8 @@ bool G_admin_flag( gentity_t *ent )
 	if ( result )
 	{
 		const char *msg = add
-		                ? QQ( N_("^3$1$: ^7an error occurred when setting flag '^3$2$^7' for $3$^7, $4t$") )
-		                : QQ( N_("^3$1$: ^7an error occurred when clearing flag '^3$2$^7' for $3$^7, $4t$") );
+		                ? QQ( N_("^3$1$:^* an error occurred when setting flag '^3$2$^*' for $3$^*, $4t$") )
+		                : QQ( N_("^3$1$:^* an error occurred when clearing flag '^3$2$^*' for $3$^*, $4t$") );
 		ADMP( va( "%s %s %s %s %s", msg, command, Quote( flag ), Quote( adminname ), Quote( result ) ) );
 		return false;
 	}
@@ -4952,9 +4952,9 @@ bool G_admin_flag( gentity_t *ent )
 	if ( !G_admin_permission( ent, ADMF_ADMINCHAT ) )
 	{
 		const char *msg[] = {
-			QQ( N_("^3$1$: ^7flag '$2$' allowed for $3$") ),
-			QQ( N_("^3$1$: ^7flag '$2$' cleared for $3$") ),
-			QQ( N_("^3$1$: ^7flag '$2$' denied for $3$") )
+			QQ( N_("^3$1$:^* flag '$2$' allowed for $3$") ),
+			QQ( N_("^3$1$:^* flag '$2$' cleared for $3$") ),
+			QQ( N_("^3$1$:^* flag '$2$' denied for $3$") )
 		};
 		ADMP( va( "%s %s %s %s", msg[ action ], command, Quote( flag ), Quote( adminname ) ) );
 	}
@@ -4992,7 +4992,7 @@ bool G_admin_builder( gentity_t *ent )
 
 	if ( !ent )
 	{
-		ADMP( QQ( N_("^3builder: ^7console can't aim.") ) );
+		ADMP( QQ( N_("^3builder:^* console can't aim.") ) );
 		return false;
 	}
 
@@ -5023,7 +5023,7 @@ bool G_admin_builder( gentity_t *ent )
 		     ent->client->pers.team != TEAM_NONE &&
 		     ent->client->pers.team != traceEnt->buildableTeam )
 		{
-			ADMP( QQ( N_("^3builder: ^7structure not owned by your team" ) ) );
+			ADMP( QQ( N_("^3builder:^* structure not owned by your team" ) ) );
 			return false;
 		}
 
@@ -5056,23 +5056,23 @@ bool G_admin_builder( gentity_t *ent )
 
 		if ( buildlog && traceEnt->builtBy && i < level.numBuildLogs )
 		{
-			ADMP( va( "%s %s %s %d", QQ( N_("^3builder: ^7$1$ built by $2$^7, buildlog #$3$") ),
+			ADMP( va( "%s %s %s %d", QQ( N_("^3builder:^* $1$ built by $2$^*, buildlog #$3$") ),
 				  Quote( buildingName ), Quote( builder ), MAX_CLIENTS + level.buildId - i - 1 ) );
 		}
 		else if ( traceEnt->builtBy )
 		{
-			ADMP( va( "%s %s %s", QQ( N_("^3builder: ^7$1$ built by $2$^7") ),
+			ADMP( va( "%s %s %s", QQ( N_("^3builder:^* $1$ built by $2$^*") ),
 				  Quote( buildingName ), Quote( builder ) ) );
 		}
 		else
 		{
-			ADMP( va( "%s %s", QQ( N_("^3builder: ^7$1$ appears to be a layout item") ),
+			ADMP( va( "%s %s", QQ( N_("^3builder:^* $1$ appears to be a layout item") ),
 				  Quote( buildingName ) ) );
 		}
 	}
 	else
 	{
-		ADMP( QQ( N_("^3builder: ^7no structure found under crosshair") ) );
+		ADMP( QQ( N_("^3builder:^* no structure found under crosshair") ) );
 	}
 
 	return true;
@@ -5082,7 +5082,7 @@ bool G_admin_pause( gentity_t *ent )
 {
 	if ( !level.pausedTime )
 	{
-		AP( va( "print_tr %s %s", QQ( N_("^3pause: ^7$1$^7 paused the game.") ),
+		AP( va( "print_tr %s %s", QQ( N_("^3pause:^* $1$^* paused the game.") ),
 		        G_quoted_admin_name( ent ) ) );
 		level.pausedTime = 1;
 		trap_SendServerCommand( -1, "cp \"The game has been paused. Please wait.\"" );
@@ -5092,11 +5092,11 @@ bool G_admin_pause( gentity_t *ent )
 		// Prevent accidental pause->unpause race conditions by two admins
 		if ( level.pausedTime < 1000 )
 		{
-			ADMP( QQ( N_("^3pause: ^7Unpausing so soon assumed accidental and ignored.") ) );
+			ADMP( QQ( N_("^3pause:^* Unpausing so soon assumed accidental and ignored.") ) );
 			return false;
 		}
 
-		AP( va( "print_tr %s %s %d", QQ( N_("^3pause: ^7$1$^7 unpaused the game (paused for $2$ sec)") ),
+		AP( va( "print_tr %s %s %d", QQ( N_("^3pause:^* $1$^* unpaused the game (paused for $2$ sec)") ),
 		        G_quoted_admin_name( ent ),
 		        ( int )( ( float ) level.pausedTime / 1000.0f ) ) );
 		trap_SendServerCommand( -1, "cp \"The game has been unpaused!\"" );
@@ -5109,12 +5109,12 @@ bool G_admin_pause( gentity_t *ent )
 
 static const char *const fates[] =
 {
-	N_("^2built^7"),
-	N_("^3deconstructed^7"),
-	N_("^7replaced^7"),
-	N_("^5destroyed^7"),
-	N_("^1TEAMKILLED^7"),
-	N_("^7unpowered^7"),
+	N_("^2built^*"),
+	N_("^3deconstructed^*"),
+	N_("^7replaced^*"),
+	N_("^5destroyed^*"),
+	N_("^1TEAMKILLED^*"),
+	N_("^7unpowered^*"),
 	N_("removed")
 };
 bool G_admin_buildlog( gentity_t *ent )
@@ -5137,13 +5137,13 @@ bool G_admin_buildlog( gentity_t *ent )
 
 	if ( !admin && team == TEAM_NONE )
 	{
-		ADMP( QQ( N_("^3buildlog: ^7spectators have no buildings") ) );
+		ADMP( QQ( N_("^3buildlog:^* spectators have no buildings") ) );
 		return false;
 	}
 
 	if ( !level.buildId )
 	{
-		ADMP( QQ( N_("^3buildlog: ^7log is empty") ) );
+		ADMP( QQ( N_("^3buildlog:^* log is empty") ) );
 		return true;
 	}
 
@@ -5171,7 +5171,7 @@ bool G_admin_buildlog( gentity_t *ent )
 			else if ( id < 0 || id >= MAX_CLIENTS ||
 			          level.clients[ id ].pers.connected != CON_CONNECTED )
 			{
-				ADMP( QQ( N_("^3buildlog: ^7invalid client id") ) );
+				ADMP( QQ( N_("^3buildlog:^* invalid client id") ) );
 				return false;
 			}
 		}
@@ -5196,7 +5196,7 @@ bool G_admin_buildlog( gentity_t *ent )
 
 	if ( start < level.buildId - level.numBuildLogs || start >= level.buildId )
 	{
-		ADMP( QQ( N_("^3buildlog: ^7invalid build ID") ) );
+		ADMP( QQ( N_("^3buildlog:^* invalid build ID") ) );
 		return false;
 	}
 
@@ -5205,14 +5205,14 @@ bool G_admin_buildlog( gentity_t *ent )
 		if ( team == TEAM_NONE )
 		{
 			trap_SendServerCommand( -1,
-			                        va( "print_tr %s %s", QQ( N_("^3buildlog: ^7$1$^7 requested a log of recent building activity") ),
+			                        va( "print_tr %s %s", QQ( N_("^3buildlog:^* $1$^* requested a log of recent building activity") ),
 			                            Quote( ent->client->pers.netname ) ) );
 		}
 		else
 		{
 			// FIXME? Send only to team-mates
 			trap_SendServerCommand( -1,
-			                        va( "print_tr %s %s %s", QQ( N_("^3buildlog: ^7$1$^7 requested a log of recent $2$ building activity") ),
+			                        va( "print_tr %s %s %s", QQ( N_("^3buildlog:^* $1$^* requested a log of recent $2$ building activity") ),
 			                            Quote( ent->client->pers.netname ), Quote( BG_TeamName( team ) ) ) );
 		}
 	}
@@ -5279,7 +5279,7 @@ bool G_admin_buildlog( gentity_t *ent )
 
 	ADMBP_end();
 
-	ADMP( va( "%s %d %d %d %d %d %s", QQ( N_("^3buildlog: ^7showing $1$ build logs $2$–$3$ of $4$–$5$.  $6$") ),
+	ADMP( va( "%s %d %d %d %d %d %s", QQ( N_("^3buildlog:^* showing $1$ build logs $2$–$3$ of $4$–$5$.  $6$") ),
 	           printed, start + MAX_CLIENTS, i + MAX_CLIENTS - 1,
 	           level.buildId + MAX_CLIENTS - level.numBuildLogs,
 	           level.buildId + MAX_CLIENTS - 1,
@@ -5300,7 +5300,7 @@ bool G_admin_revert( gentity_t *ent )
 
 	if ( trap_Argc() != 2 )
 	{
-		ADMP( QQ( N_("^3revert: ^7usage: revert [id]") ) );
+		ADMP( QQ( N_("^3revert:^* usage: revert [id]") ) );
 		return false;
 	}
 
@@ -5309,7 +5309,7 @@ bool G_admin_revert( gentity_t *ent )
 
 	if ( id < level.buildId - level.numBuildLogs || id >= level.buildId )
 	{
-		ADMP( QQ( N_("^3revert: ^7invalid id") ) );
+		ADMP( QQ( N_("^3revert:^* invalid id") ) );
 		return false;
 	}
 
@@ -5318,7 +5318,7 @@ bool G_admin_revert( gentity_t *ent )
 	if ( !log->actor || log->fate == BF_REPLACE || log->fate == BF_UNPOWER )
 	{
 		// fixme: then why list them with an id # in build log ? - rez
-		ADMP( QQ( N_("^3revert: ^7you can only revert direct player actions, "
+		ADMP( QQ( N_("^3revert:^* you can only revert direct player actions, "
 		      "indicated by ^2* ^7in buildlog") ) );
 		return false;
 	}
@@ -5327,8 +5327,8 @@ bool G_admin_revert( gentity_t *ent )
 	                  sizeof( time ), duration, sizeof( duration ) );
 	admin_log( arg );
 	AP( va( "print_tr %s %s %d %s %s", ( level.buildId - id ) > 1 ?
-		QQ( N_("^3revert: ^7$1$^7 reverted $2$ changes over the past $3$ $4t$") ) :
-		QQ( N_("^3revert: ^7$1$^7 reverted $2$ change over the past $3$ $4t$") ),
+		QQ( N_("^3revert:^* $1$^* reverted $2$ changes over the past $3$ $4t$") ) :
+		QQ( N_("^3revert:^* $1$^* reverted $2$ change over the past $3$ $4t$") ),
 		G_quoted_admin_name( ent ),
 	    level.buildId - id,
 	    time, duration ) );
@@ -5345,7 +5345,7 @@ bool G_admin_l0( gentity_t *ent )
 
 	if ( trap_Argc() < 2 )
 	{
-		ADMP( QQ( N_("^3l0: ^7usage: l0 [name|slot#|admin#]") ) );
+		ADMP( QQ( N_("^3l0:^* usage: l0 [name|slot#|admin#]") ) );
 		return false;
 	}
 
@@ -5359,13 +5359,13 @@ bool G_admin_l0( gentity_t *ent )
 
 	if ( !a || a->level != 1 )
 	{
-		ADMP( QQ( N_("^3l0: ^7your intended victim is not level 1") ) );
+		ADMP( QQ( N_("^3l0:^* your intended victim is not level 1") ) );
 		return false;
 	}
 
 	trap_SendConsoleCommand( va( "setlevel %d 0;", id ) );
 
-	AP( va( "print_tr %s %s %s", QQ( N_("^3l0: ^7name protection for $1$^7 removed by $2$") ),
+	AP( va( "print_tr %s %s %s", QQ( N_("^3l0:^* name protection for $1$^* removed by $2$") ),
 	        G_quoted_user_name( vic, a->name ),
 	        G_quoted_admin_name( ent ) ) );
 	return true;
@@ -5380,7 +5380,7 @@ bool G_admin_l1( gentity_t *ent )
 
 	if ( trap_Argc() < 2 )
 	{
-		ADMP( QQ( N_("^3l1: ^7usage: l1 [name|slot#|admin#]") ) );
+		ADMP( QQ( N_("^3l1:^* usage: l1 [name|slot#|admin#]") ) );
 		return false;
 	}
 
@@ -5395,19 +5395,19 @@ bool G_admin_l1( gentity_t *ent )
 
 	if ( a && a->level != 0 )
 	{
-		ADMP( QQ( N_("^3l1: ^7your intended victim is not level 0") ) );
+		ADMP( QQ( N_("^3l1:^* your intended victim is not level 0") ) );
 		return false;
 	}
 
 	if ( vic && G_IsUnnamed( vic->client->pers.netname ) )
 	{
-		ADMP( QQ( N_("^3l1: ^7your intended victim has the default name") ) );
+		ADMP( QQ( N_("^3l1:^* your intended victim has the default name") ) );
 		return false;
 	}
 
 	trap_SendConsoleCommand( va( "setlevel %d 1;", id ) );
 
-	AP( va( "print_tr %s %s %s", QQ( N_("^3l1: ^7name protection for $1$^7 enabled by $2$") ),
+	AP( va( "print_tr %s %s %s", QQ( N_("^3l1:^* name protection for $1$^* enabled by $2$") ),
 	        G_quoted_user_name( vic, a->name ),
 	        G_quoted_admin_name( ent ) ) );
 	return true;
@@ -5429,7 +5429,7 @@ bool G_admin_register( gentity_t *ent )
 
 	if ( G_IsUnnamed( ent->client->pers.netname ) )
 	{
-		ADMP( QQ( N_("^3register: ^7you must first change your name" ) ) );
+		ADMP( QQ( N_("^3register:^* you must first change your name" ) ) );
 		return false;
 	}
 
@@ -5437,7 +5437,7 @@ bool G_admin_register( gentity_t *ent )
 	                         ( int )( ent - g_entities ),
 	                         level ) );
 
-	AP( va( "print_tr %s %s", QQ( N_("^3register: ^7$1$^7 is now a protected name") ),
+	AP( va( "print_tr %s %s", QQ( N_("^3register:^* $1$^* is now a protected name") ),
 	        Quote( ent->client->pers.netname ) ) );
 
 	return true;
@@ -5452,14 +5452,14 @@ bool G_admin_unregister( gentity_t *ent )
 
 	if ( !ent->client->pers.admin || ent->client->pers.admin->level == 0 )
 	{
-		ADMP( QQ( N_("^3unregister: ^7you do not have a protected name" ) ) );
+		ADMP( QQ( N_("^3unregister:^* you do not have a protected name" ) ) );
 		return false;
 	}
 
 	trap_SendConsoleCommand( va( "setlevel %d 0;",
 	                         ( int )( ent - g_entities ) ) );
 
-	AP( va( "print_tr %s %s", QQ( N_("^3unregister: ^7$1$^7 is now an unprotected name") ),
+	AP( va( "print_tr %s %s", QQ( N_("^3unregister:^* $1$^* is now an unprotected name") ),
 	        Quote( ent->client->pers.admin->name ) ) );
 
 	return true;
@@ -5598,7 +5598,7 @@ void G_admin_cleanup()
 
 static void BotUsage( gentity_t *ent )
 {
-	static const char bot_usage[] = QQ( N_( "^3bot: ^7usage: bot add (<name> | *) (aliens | humans) [<skill level> [<behavior>]]\n"
+	static const char bot_usage[] = QQ( N_( "^3bot:^* usage: bot add (<name> | *) (aliens | humans) [<skill level> [<behavior>]]\n"
 	                                        "            bot fill <count> [<team> [<skill level>]]\n"
 	                                        "            bot del (<name> | all)\n"
 	                                        "            bot names (aliens | humans) <names>…\n"
@@ -5731,7 +5731,7 @@ bool G_admin_bot( gentity_t *ent )
 			int clientNum = G_ClientNumberFromString( name, err, sizeof( err ) );
 			if ( clientNum == -1 ) //something went wrong when finding the client Number
 			{
-				ADMP( va( "%s %s %s", QQ( "^3$1$: ^7$2t$" ), "bot", Quote( err ) ) );
+				ADMP( va( "%s %s %s", QQ( "^3$1$:^* $2t$" ), "bot", Quote( err ) ) );
 				return false;
 			}
 			G_BotDel( clientNum ); //delete the bot

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -56,7 +56,7 @@ static void G_BotListTeamNames( gentity_t *ent, const char *heading, team_t team
 
 		for ( i = 0; i < botNames[team].count; ++i )
 		{
-			ADMBP( va( "  %s^7 %s", botNames[team].name[i].inUse ? marker : " ", botNames[team].name[i].name ) );
+			ADMBP( va( "  %s^* %s", botNames[team].name[i].inUse ? marker : " ", botNames[team].name[i].name ) );
 		}
 
 		ADMBP_end();
@@ -308,7 +308,7 @@ void G_BotDel( int clientNum )
 
 	if ( !( bot->r.svFlags & SVF_BOT ) || !bot->botMind )
 	{
-		Log::Warn( "'^7%s^7' is not a bot", bot->client->pers.netname );
+		Log::Warn( "'^7%s^*' is not a bot", bot->client->pers.netname );
 		return;
 	}
 
@@ -320,7 +320,7 @@ void G_BotDel( int clientNum )
 		G_BotNameUsed( BotGetEntityTeam( bot ), autoname, false );
 	}
 
-	trap_SendServerCommand( -1, va( "print_tr %s %s", QQ( N_( "$1$^7 disconnected" ) ),
+	trap_SendServerCommand( -1, va( "print_tr %s %s", QQ( N_( "$1$^* disconnected" ) ),
 					Quote( bot->client->pers.netname ) ) );
 	trap_DropClient( clientNum, "disconnected" );
 }

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -1942,12 +1942,12 @@ static gentity_t *SpawnBuildable( gentity_t *builder, buildable_t buildable, con
 	        // readable and the model name shouldn't need quoting
 		G_TeamCommand( (team_t) builder->client->pers.team,
 		               va( "print_tr %s %s %s %s", ( readable[ 0 ] ) ?
-						QQ( N_("$1$ ^2built^7 by $2$^7, ^3replacing^7 $3$\n") ) :
-						QQ( N_("$1$ ^2built^7 by $2$$3$\n") ),
+						QQ( N_("$1$ ^2built^* by $2$^*, ^3replacing^* $3$\n") ) :
+						QQ( N_("$1$ ^2built^* by $2$$3$\n") ),
 		                   Quote( BG_Buildable( built->s.modelindex )->humanName ),
 		                   Quote( builder->client->pers.netname ),
 		                   Quote( readable ) ) );
-		G_LogPrintf( "Construct: %d %d %s%s: %s^7 is building "
+		G_LogPrintf( "Construct: %d %d %s%s: %s^* is building "
 		             "%s%s%s\n",
 		             ( int )( builder - g_entities ),
 		             ( int )( built - g_entities ),

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -963,7 +963,7 @@ const char *ClientUserinfoChanged( int clientNum, bool forceName )
 
 			if ( *oldname )
 			{
-				G_LogPrintf( "ClientRename: %i [%s] (%s) \"%s^7\" -> \"%s^7\" \"%s^7\"",
+				G_LogPrintf( "ClientRename: %i [%s] (%s) \"%s^*\" -> \"%s^*\" \"%s^*\"",
 				             clientNum, client->pers.ip.str, client->pers.guid,
 				             oldname, client->pers.netname,
 				             client->pers.netname );
@@ -1242,7 +1242,7 @@ const char *ClientConnect( int clientNum, bool firstTime )
 		return userInfoError;
 	}
 
-	G_LogPrintf( "ClientConnect: %i [%s] (%s) \"%s^7\" \"%s^7\"",
+	G_LogPrintf( "ClientConnect: %i [%s] (%s) \"%s^*\" \"%s^*\"",
 	             clientNum, client->pers.ip.str[0] ? client->pers.ip.str : "127.0.0.1", client->pers.guid,
 	             client->pers.netname,
 	             client->pers.netname );
@@ -1257,12 +1257,12 @@ const char *ClientConnect( int clientNum, bool firstTime )
 	{
 		if ( g_geoip.integer && country && *country )
 		{
-			trap_SendServerCommand( -1, va( "print_tr %s %s %s", QQ( N_("$1$^7 connected from $2$") ),
+			trap_SendServerCommand( -1, va( "print_tr %s %s %s", QQ( N_("$1$^* connected from $2$") ),
 			                                Quote( client->pers.netname ), Quote( country ) ) );
 		}
 		else
 		{
-			trap_SendServerCommand( -1, va( "print_tr %s %s", QQ( N_("$1$^7 connected") ),
+			trap_SendServerCommand( -1, va( "print_tr %s %s", QQ( N_("$1$^* connected") ),
 			                                Quote( client->pers.netname ) ) );
 		}
 	}
@@ -1336,7 +1336,7 @@ const char *ClientBotConnect( int clientNum, bool firstTime, team_t team )
 		G_BotSetDefaults( clientNum, team, client->sess.botSkill, client->sess.botTree );
 	}
 
-	G_LogPrintf( "ClientConnect: %i [%s] (%s) \"%s^7\" \"%s^7\" [BOT]",
+	G_LogPrintf( "ClientConnect: %i [%s] (%s) \"%s^*\" \"%s^*\" [BOT]",
 	             clientNum, client->pers.ip.str[0] ? client->pers.ip.str : "127.0.0.1", client->pers.guid,
 	             client->pers.netname,
 	             client->pers.netname );
@@ -1344,7 +1344,7 @@ const char *ClientBotConnect( int clientNum, bool firstTime, team_t team )
 	// don't do the "xxx connected" messages if they were caried over from previous level
 	if ( firstTime )
 	{
-		trap_SendServerCommand( -1, va( "print_tr %s %s", QQ( N_("$1$^7 connected") ),
+		trap_SendServerCommand( -1, va( "print_tr %s %s", QQ( N_("$1$^* connected") ),
 		                                Quote( client->pers.netname ) ) );
 	}
 
@@ -1431,7 +1431,7 @@ void ClientBegin( int clientNum )
 	// locate ent at a spawn point
 	ClientSpawn( ent, nullptr, nullptr, nullptr );
 
-	trap_SendServerCommand( -1, va( "print_tr %s %s", QQ( N_("$1$^7 entered the game") ), Quote( client->pers.netname ) ) );
+	trap_SendServerCommand( -1, va( "print_tr %s %s", QQ( N_("$1$^* entered the game") ), Quote( client->pers.netname ) ) );
 
 	trap_Cvar_VariableStringBuffer( "g_mapStartupMessage", startMsg, sizeof( startMsg ) );
 
@@ -1977,7 +1977,7 @@ void ClientDisconnect( int clientNum )
 		tent->s.clientNum = ent->s.clientNum;
 	}
 
-	G_LogPrintf( "ClientDisconnect: %i [%s] (%s) \"%s^7\"", clientNum,
+	G_LogPrintf( "ClientDisconnect: %i [%s] (%s) \"%s^*\"", clientNum,
 	             ent->client->pers.ip.str, ent->client->pers.guid, ent->client->pers.netname );
 
 	ent->client->pers.connected = CON_DISCONNECTED;

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -111,7 +111,7 @@ int G_MatchOnePlayer( const int *plist, int found, char *err, int len )
 
 			if ( cl->pers.connected == CON_CONNECTED )
 			{
-				Com_sprintf( line, sizeof( line ), "%2i — %s^7",
+				Com_sprintf( line, sizeof( line ), "%2i — %s^*",
 				             plist[p], cl->pers.netname );
 
 				if ( strlen( err ) + strlen( line ) > (size_t) len )
@@ -228,7 +228,7 @@ int G_ClientNumberFromString( const char *s, char *err, int len )
 		{
 			if ( p )
 			{
-				l = Q_snprintf( p, l2, "%-2d — %s^7", i, cl->pers.netname );
+				l = Q_snprintf( p, l2, "%-2d — %s^*", i, cl->pers.netname );
 				p += l;
 				l2 -= l;
 			}
@@ -1001,13 +1001,13 @@ void G_Say( gentity_t *ent, saymode_t mode, const char *chatText )
 	switch ( mode )
 	{
 		case SAY_ALL:
-			G_LogPrintf( "Say: %d \"%s^7\": ^2%s",
+			G_LogPrintf( "Say: %d \"%s^*\": ^2%s",
 			             ( ent ) ? ( int )( ent - g_entities ) : -1,
 			             ( ent ) ? ent->client->pers.netname : "console", chatText );
 			break;
 
 		case SAY_ALL_ADMIN:
-			G_LogPrintf( "Say: %d \"%s^7\": ^6%s",
+			G_LogPrintf( "Say: %d \"%s^*\": ^6%s",
 			             ( ent ) ? ( int )( ent - g_entities ) : -1,
 			             ( ent ) ? ent->client->pers.netname : "console", chatText );
 			break;
@@ -1020,7 +1020,7 @@ void G_Say( gentity_t *ent, saymode_t mode, const char *chatText )
 				Com_Error( errorParm_t::ERR_FATAL, "SAY_TEAM by non-client entity" );
 			}
 
-			G_LogPrintf( "SayTeam: %d \"%s^7\": ^5%s",
+			G_LogPrintf( "SayTeam: %d \"%s^*\": ^5%s",
 			             ( int )( ent - g_entities ), ent->client->pers.netname, chatText );
 			break;
 
@@ -1070,7 +1070,7 @@ static void Cmd_SayArea_f( gentity_t *ent )
 		range[ i ] = g_sayAreaRange.value;
 	}
 
-	G_LogPrintf( "SayArea: %d \"%s^7\": ^4%s",
+	G_LogPrintf( "SayArea: %d \"%s^*\": ^4%s",
 	             ( int )( ent - g_entities ), ent->client->pers.netname, msg );
 
 	VectorAdd( ent->s.origin, range, maxs );
@@ -1115,7 +1115,7 @@ static void Cmd_SayAreaTeam_f( gentity_t *ent )
 		range[ i ] = g_sayAreaRange.value;
 	}
 
-	G_LogPrintf( "SayAreaTeam: %d \"%s^7\": ^4%s",
+	G_LogPrintf( "SayAreaTeam: %d \"%s^*\": ^4%s",
 	             ( int )( ent - g_entities ), ent->client->pers.netname, msg );
 
 	VectorAdd( ent->s.origin, range, maxs );
@@ -1170,7 +1170,7 @@ static void Cmd_Say_f( gentity_t *ent )
 	{
 		if ( !G_admin_permission( ent, ADMF_ADMINCHAT ) )
 		{
-			ADMP( va( "%s %s", QQ( N_("^3$1$: ^7permission denied") ), "asay" ) );
+			ADMP( va( "%s %s", QQ( N_("^3$1$: ^*permission denied") ), "asay" ) );
 			return;
 		}
 
@@ -1730,7 +1730,7 @@ vote_is_disabled:
 	{
 	case VOTE_KICK:
 		Com_sprintf( level.team[ team ].voteString, sizeof( level.team[ team ].voteString ),
-		             "ban %s 1s%s %s ^7called vote kick (%s^7)", level.clients[ clientNum ].pers.ip.str,
+		             "ban %s 1s%s %s^* called vote kick (%s^*)", level.clients[ clientNum ].pers.ip.str,
 		             Quote( g_adminTempBan.string ), Quote( ent->client->pers.netname ), Quote( reason ) );
 		Com_sprintf( level.team[ team ].voteDisplayString,
 		             sizeof( level.team[ team ].voteDisplayString ), N_("Kick player '%s'"), name );
@@ -1959,13 +1959,13 @@ vote_is_disabled:
 		          sizeof( level.team[ team ].voteDisplayString ), va( " for '%s'", reason ) );
 	}
 
-	G_LogPrintf( "%s: %d \"%s^7\": %s",
+	G_LogPrintf( "%s: %d \"%s^*\": %s",
 	             team == TEAM_NONE ? "CallVote" : "CallTeamVote",
 	             ( int )( ent - g_entities ), ent->client->pers.netname, level.team[ team ].voteString );
 
 	if ( team == TEAM_NONE )
 	{
-		trap_SendServerCommand( -1, va( "print_tr %s %s %s", QQ( N_("$1$^7 called a vote: $2$") ),
+		trap_SendServerCommand( -1, va( "print_tr %s %s %s", QQ( N_("$1$^* called a vote: $2$") ),
 		                                Quote( ent->client->pers.netname ), Quote( level.team[ team ].voteDisplayString ) ) );
 	}
 	else
@@ -1980,7 +1980,7 @@ vote_is_disabled:
 				     ( level.clients[ i ].pers.team == TEAM_NONE &&
 				       G_admin_permission( &g_entities[ i ], ADMF_SPEC_ALLCHAT ) ) )
 				{
-					trap_SendServerCommand( i, va( "print_tr %s %s %s", QQ( N_("$1$^7 called a team vote: $2t$") ),
+					trap_SendServerCommand( i, va( "print_tr %s %s %s", QQ( N_("$1$^* called a team vote: $2t$") ),
 					                               Quote( ent->client->pers.netname ), Quote( level.team[ team ].voteDisplayString ) ) );
 				}
 				else if ( G_admin_permission( &g_entities[ i ], ADMF_ADMINCHAT ) )
@@ -3751,13 +3751,13 @@ static void Cmd_Ignore_f( gentity_t *ent )
 				Com_ClientListAdd( &ent->client->sess.ignoreList, pids[ i ] );
 				ClientUserinfoChanged( ent->client->ps.clientNum, false );
 				trap_SendServerCommand( ent - g_entities, va( "print_tr \"" S_SKIPNOTIFY
-				                        "%s\" %s", N_("ignore: added $1$^7 to your ignore list"),
+				                        "%s\" %s", N_("ignore: added $1$^* to your ignore list"),
 				                        Quote( level.clients[ pids[ i ] ].pers.netname ) ) );
 			}
 			else
 			{
 				trap_SendServerCommand( ent - g_entities, va( "print_tr \"" S_SKIPNOTIFY
-				                        "%s\" %s", N_("ignore: $1$^7 is already on your ignore list"),
+				                        "%s\" %s", N_("ignore: $1$^* is already on your ignore list"),
 				                        Quote( level.clients[ pids[ i ] ].pers.netname ) ) );
 			}
 		}
@@ -3768,13 +3768,13 @@ static void Cmd_Ignore_f( gentity_t *ent )
 				Com_ClientListRemove( &ent->client->sess.ignoreList, pids[ i ] );
 				ClientUserinfoChanged( ent->client->ps.clientNum, false );
 				trap_SendServerCommand( ent - g_entities, va( "print_tr \"" S_SKIPNOTIFY
-				                        "%s\" %s", N_("unignore: removed $1$^7 from your ignore list"),
+				                        "%s\" %s", N_("unignore: removed $1$^* from your ignore list"),
 				                        Quote( level.clients[ pids[ i ] ].pers.netname ) ) );
 			}
 			else
 			{
 				trap_SendServerCommand( ent - g_entities, va( "print_tr \"" S_SKIPNOTIFY
-				                        "%s\" %s", N_("unignore: $1$^7 is not on your ignore list"),
+				                        "%s\" %s", N_("unignore: $1$^* is not on your ignore list"),
 				                        Quote( level.clients[ pids[ i ] ].pers.netname ) )  );
 			}
 		}
@@ -3946,8 +3946,8 @@ void Cmd_ListMaps_f( gentity_t *ent )
 	if ( search[ 0 ] )
 	{
 		ADMP_P( va( "%s %d %s",
-					Quote( P_("^3listmaps: ^7found $1$ map matching '$2$^7'",
-							  "^3listmaps: ^7found $1$ maps matching '$2$^7'",
+					Quote( P_("^3listmaps:^* found $1$ map matching '$2$^*'",
+							  "^3listmaps:^* found $1$ maps matching '$2$^*'",
 							  mapNamesCount)
 					),
 					mapNamesCount,
@@ -3958,8 +3958,8 @@ void Cmd_ListMaps_f( gentity_t *ent )
 	else
 	{
 		ADMP_P( va( "%s %d %d",
-					Quote( P_("^3listmaps: ^7listing $1$ of $2$ map",
-							  "^3listmaps: ^7listing $1$ of $2$ maps",
+					Quote( P_("^3listmaps:^* listing $1$ of $2$ map",
+							  "^3listmaps:^* listing $1$ of $2$ maps",
 							  mapNamesCount)
 					),
 					shownMapNamesCount,
@@ -3971,12 +3971,12 @@ void Cmd_ListMaps_f( gentity_t *ent )
 	if ( pages > 1 && page + 1 < pages )
 	{
 		ADMP( va( "%s %d %d %s %s %d",
-				  QQ( N_("^3listmaps: ^7page $1$ of $2$; use 'listmaps $3$$4$$5$' to see more") ),
+				  QQ( N_("^3listmaps:^* page $1$ of $2$; use 'listmaps $3$$4$$5$' to see more") ),
 		          page + 1, pages, Quote( search ), ( search[ 0 ] ) ? " " : "", page + 2 ) );
 	}
 	else if ( pages > 1 )
 	{
-		ADMP( va( "%s %d %d", QQ( N_("^3listmaps: ^7page $1$ of $2$") ),  page + 1, pages ) );
+		ADMP( va( "%s %d %d", QQ( N_("^3listmaps:^* page $1$ of $2$") ),  page + 1, pages ) );
 	}
 }
 
@@ -3990,9 +3990,9 @@ typedef struct {
 static const mapLogResult_t maplog_table[] = {
 	{ 't', "^7tie"                                  },
 	{ 'a', "^1Alien win"                            },
-	{ 'A', "^1Alien win ^7/ Humans admitted defeat" },
+	{ 'A', "^1Alien win^* / Humans admitted defeat" },
 	{ 'h', "^5Human win"                            },
-	{ 'H', "^5Human win ^7/ Aliens admitted defeat" },
+	{ 'H', "^5Human win^* / Aliens admitted defeat" },
 	{ 'd', "^2draw vote"                            },
 	{ 'm', "^2map vote"                             },
 	{ 'r', "^2restart vote"                         },
@@ -4090,7 +4090,7 @@ void Cmd_MapLog_f( gentity_t *ent )
 	Q_strncpyz( maplog, g_mapLog.string, sizeof( maplog ) );
 	ptr = maplog;
 
-	ADMP( "\"" N_("^3maplog: ^7recent map results, newest first") "\"" );
+	ADMP( "\"" N_("^3maplog:^* recent map results, newest first") "\"" );
 	ADMBP_begin();
 
 	while( *ptr )
@@ -4136,7 +4136,7 @@ void Cmd_MapLog_f( gentity_t *ent )
 			result = "^7current map";
 		}
 
-		ADMBP( va( "  ^%s%-20s %6s %s^7",
+		ADMBP( va( "  ^%s%-20s %6s %s^*",
 		           ptr == maplog ? "2" : "7",
 		           ptr, clock, result ) );
 		ptr = end;
@@ -4532,7 +4532,7 @@ void Cmd_PrivateMessage_f( gentity_t *ent )
 		              teamonly ? SAY_TPRIVMSG : SAY_PRIVMSG, msg ) )
 		{
 			count++;
-			Q_strcat( recipients, sizeof( recipients ), va( "%s^7, ",
+			Q_strcat( recipients, sizeof( recipients ), va( "%s^*, ",
 			          level.clients[ pids[ i ] ].pers.netname ) );
 		}
 	}
@@ -4542,7 +4542,7 @@ void Cmd_PrivateMessage_f( gentity_t *ent )
 
 	if ( !count )
 	{
-		ADMP( va( "%s %s", QQ( N_("^3No player matching ^7 '$1$^7' ^3to send message to.") ),
+		ADMP( va( "%s %s", QQ( N_("^3No player matching ^7 '$1$^*' ^3to send message to.") ),
 		          Quote( name ) ) );
 	}
 	else
@@ -4556,7 +4556,7 @@ void Cmd_PrivateMessage_f( gentity_t *ent )
 		                     "$1$sent to $2$ players: ^7$3$", count ) ),
 		          color.c_str(), count, Quote( recipients ) ) );
 
-		G_LogPrintf( "%s: %d \"%s^7\" \"%s\": %s%s",
+		G_LogPrintf( "%s: %d \"%s^*\" \"%s\": %s%s",
 		             ( teamonly ) ? "TPrivMsg" : "PrivMsg",
 		             ( ent ) ? ( int )( ent - g_entities ) : -1,
 		             ( ent ) ? ent->client->pers.netname : "console",

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -434,7 +434,7 @@ void G_PlayerDie( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, in
 		}
 		else if ( g_showKillerHP.integer )
 		{
-			trap_SendServerCommand( self - g_entities, va( "print_tr %s %s %3i", QQ( N_("Your killer, $1$^7, had $2$ HP.\n") ),
+			trap_SendServerCommand( self - g_entities, va( "print_tr %s %s %3i", QQ( N_("Your killer, $1$^*, had $2$ HP.\n") ),
 			                        Quote( killerName ),
 			                        (int)std::ceil(attacker->entity->Get<HealthComponent>()->Health()) ) );
 		}
@@ -1081,8 +1081,8 @@ void G_LogDestruction( gentity_t *self, gentity_t *actor, int mod )
 	     BG_Buildable( self->s.modelindex )->team )
 	{
 		G_TeamCommand( (team_t) actor->client->pers.team,
-		               va( "print_tr %s %s %s", mod == MOD_DECONSTRUCT ? QQ( N_("$1$ ^3DECONSTRUCTED^7 by $2$\n") ) :
-						   QQ( N_("$1$ ^3DESTROYED^7 by $2$\n") ),
+		               va( "print_tr %s %s %s", mod == MOD_DECONSTRUCT ? QQ( N_("$1$ ^3DECONSTRUCTED^* by $2$\n") ) :
+						   QQ( N_("$1$ ^3DESTROYED^* by $2$\n") ),
 		                   Quote( BG_Buildable( self->s.modelindex )->humanName ),
 		                   Quote( actor->client->pers.netname ) ) );
 	}

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -247,7 +247,7 @@ const char *etos( const gentity_t *entity )
 	index = ( index + 1 ) & 3;
 
 	Com_sprintf( resultString, MAX_ETOS_LENGTH,
-			"%s%s^7(^5%s^7|^5#%i^7)",
+			"%s%s^7(^5%s^*|^5#%i^*)",
 			entity->names[0] ? entity->names[0] : "", entity->names[0] ? " " : "", entity->classname, entity->s.number
 			);
 
@@ -461,7 +461,7 @@ gentity_t *G_PickRandomEntity( const char *classname, size_t fieldofs, const cha
 	{
 
 		if ( g_debugEntities.integer > -1 )
-			Log::Warn( "Could not find any entity matching \"^5%s%s%s^7\"",
+			Log::Warn( "Could not find any entity matching \"^5%s%s%s^*\"",
 					classname ? classname : "",
 					classname && match ? "^7 and ^5" :  "",
 					match ? match : ""

--- a/src/sgame/sg_maprotation.cpp
+++ b/src/sgame/sg_maprotation.cpp
@@ -779,13 +779,13 @@ void G_PrintCurrentRotation( gentity_t *ent )
 
 	if ( mapRotation == nullptr )
 	{
-		trap_SendServerCommand( ent - g_entities, "print_tr \"" N_("^3listrotation: ^7there is no active map rotation on this server\n") "\"" );
+		trap_SendServerCommand( ent - g_entities, "print_tr \"" N_("^3listrotation:^* there is no active map rotation on this server\n") "\"" );
 		return;
 	}
 
 	if ( mapRotation->numNodes == 0 )
 	{
-		trap_SendServerCommand( ent - g_entities, "print_tr \"" N_("^3listrotation: ^7there are no maps in the active map rotation\n") "\"" );
+		trap_SendServerCommand( ent - g_entities, "print_tr \"" N_("^3listrotation:^* there are no maps in the active map rotation\n") "\"" );
 		return;
 	}
 

--- a/src/sgame/sg_spawn.cpp
+++ b/src/sgame/sg_spawn.cpp
@@ -605,7 +605,7 @@ bool G_CallSpawnFunction( gentity_t *spawnedEntity )
 	{
 		if (!Q_stricmp(S_WORLDSPAWN, spawnedEntity->classname))
 		{
-			Log::Warn("a ^5" S_WORLDSPAWN "^7 class was misplaced into position ^5#%i^* of the spawn string – Ignoring", spawnedEntity->s.number );
+			Log::Warn("a ^5" S_WORLDSPAWN "^* class was misplaced into position ^5#%i^* of the spawn string – Ignoring", spawnedEntity->s.number );
 		}
 		else
 		{

--- a/src/sgame/sg_spawn_position.cpp
+++ b/src/sgame/sg_spawn_position.cpp
@@ -93,7 +93,7 @@ void SP_pos_location( gentity_t *self )
 			self->customNumber = 7;
 		}
 
-		message = va( "%c%c%s^7", Color::Constants::ESCAPE, self->customNumber + '0',
+		message = va( "%c%c%s^*", Color::Constants::ESCAPE, self->customNumber + '0',
 		              self->message );
 	}
 	else


### PR DESCRIPTION
Addresses #909 for the sgame/cgame

Also adds a few additional ^* where playernames were involved, to avoid playercolors leaking into text.
Leaves ^7 in front of names and where it might have been intentional.