### PR TITLE
Fix cbse-entity memory leak and mandatory component segfault

### DIFF
--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -36,8 +36,6 @@ Maryland 20850 USA.
 #include "sg_entities.h"
 #include "CBSE.h"
 
-static EmptyEntity emptyEntity(EmptyEntity::Params{nullptr});
-
 /*
 =================================================================================
 
@@ -51,7 +49,7 @@ basic gentity lifecycle handling
  */
 void G_InitGentityMinimal( gentity_t *entity )
 {
-	entity->entity = &emptyEntity;
+	entity->entity = level.emptyEntity;
 }
 
 void G_InitGentity( gentity_t *entity )
@@ -172,13 +170,13 @@ void G_FreeEntity( gentity_t *entity )
 		BaseClustering::Remove(entity);
 	}
 
-	if (entity->entity != &emptyEntity)
+	if (entity->entity != level.emptyEntity)
 	{
 		delete entity->entity;
 	}
 
 	memset( entity, 0, sizeof( *entity ) );
-	entity->entity = &emptyEntity;
+	entity->entity = level.emptyEntity;
 	entity->classname = "freent";
 	entity->freetime = level.time;
 	entity->inuse = false;

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -972,6 +972,17 @@ void G_ShutdownGame( int /* restart */ )
 	level.surrenderTeam = TEAM_NONE;
 	trap_SetConfigstring( CS_WINNER, "" );
 
+	/*
+	 * delete cbse entities attached to gentities
+	 * note, that this does not deal with several gentities having the same Entity attached
+	 * (except for the EmptyEntity) as we'd otherwise be trying to delete dangling pointers
+	 */
+	for (int i = 0; i < level.num_entities; i++) {
+		Entity* entity = level.gentities[i].entity;
+		if (entity != level.emptyEntity)
+			delete entity;
+	}
+
 	delete level.emptyEntity;
 }
 

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -777,6 +777,9 @@ void G_InitGame( int levelTime, int randomSeed, bool inClient )
 	memset( g_entities, 0, MAX_GENTITIES * sizeof( g_entities[ 0 ] ) );
 	level.gentities = g_entities;
 
+	// entity used as drop-in for unmigrated entities
+	level.emptyEntity = new EmptyEntity({ nullptr });
+
 	// initilize special entities so they don't need to be special cased in the CBSE code later on
 	G_InitGentityMinimal( g_entities + ENTITYNUM_NONE );
 	G_InitGentityMinimal( g_entities + ENTITYNUM_WORLD );
@@ -968,6 +971,8 @@ void G_ShutdownGame( int /* restart */ )
 	level.restarted = false;
 	level.surrenderTeam = TEAM_NONE;
 	trap_SetConfigstring( CS_WINNER, "" );
+
+	delete level.emptyEntity;
 }
 
 //===================================================================

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -658,6 +658,12 @@ struct level_locals_s
 	vec3_t           intermission_origin; // also used for spectator spawns
 	vec3_t           intermission_angle;
 
+	/**
+	 *  drop-in for yet unmigrated entities
+	 */
+	Entity* emptyEntity;
+
+
 	gentity_t        *locationHead; // head of the location list
 	gentity_t        *fakeLocation; // fake location for anything which might need one
 


### PR DESCRIPTION
CBSE Entities and all of their components were only being deleted in `G_FreeEntity`, which isn't used on game shutdowns like map restarts, map changes or actual shutdowns.

To simplify the fix, i also moved the `EmptyEntity` initialization, which also fixes DaemonEngine/CBSE-Toolchain#29

A quick look on the process memory shows that despite the fix we still seem to be leaking some memory somewhere across restarts (although i can't tell if that is cgame or sgame); but this should fix one bigger source.