### PR TITLE
responsive: compute font size from screen size

### DIFF
--- a/src/cgame/cg_rocket.cpp
+++ b/src/cgame/cg_rocket.cpp
@@ -105,6 +105,10 @@ void CG_Rocket_Init( glconfig_t gl )
 	// Register elements
 	CG_Rocket_RegisterElements();
 
+	// This gets 12px on 1920×1080 screen, which is libRocket default for 1em
+	int fontSize = std::min(cgs.glconfig.vidWidth, cgs.glconfig.vidHeight) / 90;
+	Rocket_RegisterProperty( "font-size", std::to_string(fontSize).c_str(), true, true, "number" );
+
 	Rocket_RegisterProperty( "cell-color", "white", false, false, "color" );
 	Rocket_RegisterProperty( "border-width", "0.5", false, false, "number" );
 	Rocket_RegisterProperty( "unlocked-marker-color", "green", false, false, "color" );

--- a/src/cgame/rocket/rocketCircleMenu.h
+++ b/src/cgame/rocket/rocketCircleMenu.h
@@ -370,9 +370,12 @@ protected:
 			float y = sin( angle * ( i - 1 ) * ( M_PI / 180.0f ) ) * radius;
 			float x = cos( angle * ( i - 1 ) * ( M_PI / 180.0f ) ) * radius;
 
+			// This gets 12px on 1920×1080 screen, which is libRocket default for 1em
+			int fontSize = std::min(cgs.glconfig.vidWidth, cgs.glconfig.vidHeight) / 90;
+
 			child->SetProperty( "position", "absolute" );
-			child->SetProperty( "left", va( "%fpx", ( dimensions.x / 2 ) - ( width / 2 ) + offset.x + x ) );
-			child->SetProperty( "top", va( "%fpx", ( dimensions.y / 2 ) - ( height / 2 ) + offset.y + y ) );
+			child->SetProperty( "left", va( "%fpx", ( dimensions.x / 2 ) - ( width / 2 ) + offset.x + x * fontSize ) );
+			child->SetProperty( "top", va( "%fpx", ( dimensions.y / 2 ) - ( height / 2 ) + offset.y + y * fontSize ) );
 		}
 	}
 

--- a/src/cgame/rocket/rocket_documents.cpp
+++ b/src/cgame/rocket/rocket_documents.cpp
@@ -60,8 +60,16 @@ void Rocket_LoadDocument( const char *path )
 void Rocket_LoadCursor( const char *path )
 {
 	Rocket::Core::ElementDocument* document = menuContext->LoadMouseCursor( path );
+
 	if( document )
 	{
+		// This gets 12px on 1920×1080 screen, which is libRocket default for 1em
+		int fontSize = std::min(cgs.glconfig.vidWidth, cgs.glconfig.vidHeight) / 90;
+
+		// 1.6×2.3em ≈ 20×28px on 1920×1080 screen
+		document->SetProperty( "width", va( "%fpx", 1.6 * fontSize ) );
+		document->SetProperty( "height", va( "%fpx", 2.3 * fontSize ) );
+
 		document->RemoveReference();
 	}
 }


### PR DESCRIPTION
This is an attempt to set default size relative to screen size.

Default libRocket font size is `12px`, see [StyleSheetSpecification.cpp:246](https://github.com/Unvanquished/libRocket/blob/7f7c34e67dee17bf2c1cb3e61fe6d847698267a3/Source/Core/StyleSheetSpecification.cpp#L246):

```c++
	RegisterProperty(FONT_SIZE, "12", true, true).AddParser("number");
```

Since FullHD is the most common screen resolution today the game was designed against that resolution, so we must compute a default font size that is 12px on FullHD screen.

That is the compute:

```
font_size = min(width, height)/90
```

This PR is considered WIP because it relies on `r_customWidth/Height` cvars, it would be better to read the screen size directly, especially since that's possible those values are not correctly set if not custom size is set (does it exists anymore, though?). So I need a way to get a proper screen size at this place of the code, other wise it's ok.

Use this branch https://github.com/UnvanquishedAssets/unvanquished_src.dpkdir/pull/6 on asset side (required to render it properly).

See also https://github.com/DaemonEngine/Daemon/pull/161 for similar change on engine side (not required).