### PR TITLE
always show evolve menu

### DIFF
--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -2199,16 +2199,7 @@ void ClientThink_real( gentity_t *self )
 
 			if ( !ent && client->pers.team == TEAM_ALIENS )
 			{
-				if ( BG_AlienCanEvolve( client->ps.stats[ STAT_CLASS ], client->pers.credit ) )
-				{
-					// no nearby objects and alien - show class menu
-					G_TriggerMenu( client->ps.clientNum, MN_A_INFEST );
-				}
-				else
-				{
-					// flash frags
-					G_AddEvent( self, EV_ALIEN_EVOLVE_FAILED, 0 );
-				}
+				G_TriggerMenu( client->ps.clientNum, MN_A_INFEST );
 			}
 		}
 	}


### PR DESCRIPTION
show evolve menu even when not enough morph points are available 
Fix #439 