### PR TITLE
Fix Entities::HasFullHealth

### DIFF
--- a/src/sgame/Entities.cpp
+++ b/src/sgame/Entities.cpp
@@ -96,7 +96,7 @@ float Entities::HealthOf(gentity_t* ent) {
 bool Entities::HasFullHealth(Entity& entity) {
 	HealthComponent *healthComponent = entity.Get<HealthComponent>();
 	ASSERT_NQ(healthComponent, nullptr);
-	return healthComponent->Health();
+	return healthComponent->FullHealth();
 }
 
 bool Entities::HasFullHealth(gentity_t* ent) {


### PR DESCRIPTION
This fixes health related bot actions like humans repair and aliens heal.