### PR TITLE
make travis use git-checkout-modules for branch names ending with /sync, <3 @slipher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ install:
       export PATH="/usr/local/opt/ccache/libexec:$PATH"
     fi
   - pip2 install --user -r src/utils/cbse/requirements.txt
+  - curl https://gitlab.com/illwieckz/git-checkout-modules/raw/master/git-checkout-modules -o ~/git-checkout-modules
+  - chmod +x ~/git-checkout-modules
 
 before_script:
   - ccache --zero-stats
@@ -65,6 +67,10 @@ before_script:
   # This issue is fixed in version 5 of gcc, so if we get a newer version on Travis the warning can be re-enabled.
   - if [ "$CC" == "gcc" ]; then export CXXFLAGS="$CXXFLAGS -Wno-missing-field-initializers"; fi
   - export CXXFLAGS="$CXXFLAGS -D__extern_always_inline=inline"
+  - ~/git-checkout-modules
+    --only-sub="${TRAVIS_BRANCH}":has='/sync$'
+    --only-sub="${TRAVIS_PULL_REQUEST_BRANCH}":has='/sync$'
+    --print
 
 script:
   - cmake -DUSE_PRECOMPILED_HEADER=0


### PR DESCRIPTION
This is the result of a talk I had with @slipher on IRC yesterday, he was expressing the need for CI tools like travis to be able to checkout a work-in-progress branch across submodules without having to commit temporary references. This is thought to avoid the risk to merge dead references while merging the PR, it would also make testing such branch possible.

I wrote a git helper named `git-checkout-modules` you can find there:
https://gitlab.com/illwieckz/git-checkout-modules

This PR attempts to configure Travis CI to leverage it.

To use this feature, people would have to name his branch with a `/sync` suffix across repositories, and to push it on our own repository (not on a personal fork).

For example, if I work on a branch to add emoji support to the game and this branch spans across the engine, the game code, and the assets, I would push branches named `illwieckz/emoji/sync` to those repositories:
- [DaemonEngine/Daemon](https://github.com/DaemonEngine/Daemon)
- [Unvanquished/Unvanquished](https://github.com/Unvanquished/Unvanquished)
- [UnvanquishedAssets/unvanquished_src.dpkdir](https://github.com/UnvanquishedAssets/unvanquished_src.dpkdir)