### PR TITLE
Make grangerspit act as trapper

### DIFF
--- a/src/sgame/sg_missile.cpp
+++ b/src/sgame/sg_missile.cpp
@@ -235,10 +235,12 @@ static int ImpactLockblock( gentity_t*, trace_t*, gentity_t *hitEnt )
 	return MIB_IMPACT;
 }
 
-static int ImpactSlowblob( gentity_t*, trace_t *trace, gentity_t *hitEnt )
+static int ImpactSlowblob( gentity_t *ent, trace_t *trace, gentity_t *hitEnt )
 {
 	gentity_t *neighbor;
 	int       impactFlags = MIB_IMPACT;
+	gentity_t *attacker = &g_entities[ ent->r.ownerNum ];
+	vec3_t dir;
 
 	// put out fires on direct hit
 	hitEnt->entity->Extinguish( ABUILDER_BLOB_FIRE_IMMUNITY );
@@ -257,8 +259,19 @@ static int ImpactSlowblob( gentity_t*, trace_t *trace, gentity_t *hitEnt )
 
 	if ( hitEnt->client && hitEnt->client->pers.team == TEAM_HUMANS )
 	{
-		hitEnt->client->ps.stats[ STAT_STATE ] |= SS_SLOWLOCKED;
-		hitEnt->client->lastSlowTime = level.time;
+		if( !ABUILDER_BLOB_LOCK_TIME || hitEnt->client->pers.classSelection == PCL_HUMAN_BSUIT )
+		{
+			hitEnt->client->ps.stats[ STAT_STATE ] |= SS_SLOWLOCKED;
+			hitEnt->client->lastSlowTime = level.time;
+		}
+		else if ( attacker->client->pers.classSelection == PCL_ALIEN_BUILDER0_UPG )
+		{
+			hitEnt->client->ps.stats[ STAT_STATE ] |= SS_BLOBLOCKED;
+			hitEnt->client->lastLockTime = level.time - LOCKBLOB_LOCKTIME + ABUILDER_BLOB_LOCK_TIME;
+			AngleVectors( hitEnt->client->ps.viewangles, dir, nullptr, nullptr );
+			hitEnt->client->ps.stats[ STAT_VIEWLOCK ] = DirToByte( dir );
+		}
+
 	}
 	else if ( hitEnt->s.eType == entityType_t::ET_BUILDABLE && hitEnt->buildableTeam == TEAM_ALIENS )
 	{

--- a/src/shared/bg_gameplay.h
+++ b/src/shared/bg_gameplay.h
@@ -35,6 +35,7 @@ extern float ABUILDER_CLAW_WIDTH;
 extern int   ABUILDER_BLOB_DMG;
 extern float ABUILDER_BLOB_SPEED;
 extern float ABUILDER_BLOB_SPEED_MOD;
+extern int   ABUILDER_BLOB_LOCK_TIME;
 extern int   ABUILDER_BLOB_TIME;
 #define ABUILDER_BLOB_FIRE_IMMUNITY   3000   // in ms, friendly buildables gain immunity for fire on hit
 #define ABUILDER_BLOB_FIRE_STOP_RANGE 20     // granger spit that hits a surface kills environmental fire in this range

--- a/src/shared/bg_parse.cpp
+++ b/src/shared/bg_parse.cpp
@@ -71,6 +71,7 @@ int   ABUILDER_BLOB_DMG;
 float ABUILDER_BLOB_SPEED;
 float ABUILDER_BLOB_SPEED_MOD;
 int   ABUILDER_BLOB_TIME;
+int		ABUILDER_BLOB_LOCK_TIME;
 
 int   LEVEL0_BITE_DMG;
 float LEVEL0_BITE_RANGE;
@@ -196,6 +197,7 @@ static configVar_t bg_configVars[] =
 	{"u_medkit_startupTime", INTEGER, false, &MEDKIT_STARTUP_TIME},
 
 	{"w_abuild_blobDmg", INTEGER, false, &ABUILDER_BLOB_DMG},
+	{"w_abuild_blobLockTime", INTEGER, false, &ABUILDER_BLOB_LOCK_TIME},
 	{"w_abuild_blobSlowTime", INTEGER, false, &ABUILDER_BLOB_TIME},
 	{"w_abuild_blobSpeed", FLOAT, false, &ABUILDER_BLOB_SPEED},
 	{"w_abuild_blobSpeedMod", FLOAT, false, &ABUILDER_BLOB_SPEED_MOD},


### PR DESCRIPTION
Traps humans for a short time. Two seconds seems to be a good start. It gives skilled grangers a way to escape or even kill a single human while leaves humans the possibility to free them self.
Battlesuits are only slowed as before.
config changes in /configs/weapon/abuild.attr.cfg are required for this change to work