### PR TITLE
travis: attempt to make brew more resilient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,10 @@ install:
     fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
       brew update;
-      brew install ccache ninja;
+      touch BrewFile;
+      echo 'brew "ccache"' >> BrewFile;
+      echo 'brew "ninja"' >> BrewFile;
+      brew bundle;
     fi
   - |
     # workarounds to make ccache work


### PR DESCRIPTION
attempt to make brew more resilient

by using `BrewFile` mechanism, `brew` does not fail if package is already installed