### PR TITLE
cg_view: pretend spectator is alive to avoid death animation to be applied, noclip does not care about walls, fix #1072

### DIFF
--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -292,6 +292,7 @@ void CG_OffsetThirdPersonView()
 	// Set the focus point where the camera will look (at the player's vieworg)
 	VectorCopy( cg.refdef.vieworg, focusPoint );
 
+	bool noclip = cg.predictedPlayerState.pm_type == PM_NOCLIP;
 	bool alive = cg.predictedPlayerState.stats[ STAT_HEALTH ] > 0;
 	bool spectate = cg.predictedPlayerState.persistant[ PERS_SPECSTATE ] != SPECTATOR_NOT;
 	// pretend the spectator is alive
@@ -421,20 +422,21 @@ void CG_OffsetThirdPersonView()
 	// Ensure that the current camera position isn't out of bounds and that there
 	// is nothing between the camera and the player.
 
-	// Trace a ray from the origin to the viewpoint to make sure the view isn't
-	// in a solid block.  Use an 8 by 8 block to prevent the view from near clipping anything
-	CG_Trace( &trace, cg.refdef.vieworg, mins, maxs, view, cg.predictedPlayerState.clientNum,
-	          MASK_SOLID, 0 );
-
-	if ( trace.fraction != 1.0f )
+	if ( !noclip )
 	{
-		VectorCopy( trace.endpos, view );
-		view[ 2 ] += ( 1.0f - trace.fraction ) * 32;
-		// Try another trace to this position, because a tunnel may have the ceiling
-		// close enough that this is poking out.
-		CG_Trace( &trace, cg.refdef.vieworg, mins, maxs, view, cg.predictedPlayerState.clientNum,
-		          MASK_SOLID, 0 );
-		VectorCopy( trace.endpos, view );
+		// Trace a ray from the origin to the viewpoint to make sure the view isn't
+		// in a solid block.  Use an 8 by 8 block to prevent the view from near clipping anything
+		CG_Trace( &trace, cg.refdef.vieworg, mins, maxs, view, cg.predictedPlayerState.clientNum, MASK_SOLID, 0 );
+
+		if ( trace.fraction != 1.0f )
+		{
+			VectorCopy( trace.endpos, view );
+			view[ 2 ] += ( 1.0f - trace.fraction ) * 32;
+			// Try another trace to this position, because a tunnel may have the ceiling
+			// close enough that this is poking out.
+			CG_Trace( &trace, cg.refdef.vieworg, mins, maxs, view, cg.predictedPlayerState.clientNum, MASK_SOLID, 0 );
+			VectorCopy( trace.endpos, view );
+		}
 	}
 
 	// Set the camera position to what we calculated.

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -292,9 +292,14 @@ void CG_OffsetThirdPersonView()
 	// Set the focus point where the camera will look (at the player's vieworg)
 	VectorCopy( cg.refdef.vieworg, focusPoint );
 
+	bool alive = cg.predictedPlayerState.stats[ STAT_HEALTH ] > 0;
+	bool spectate = cg.predictedPlayerState.persistant[ PERS_SPECSTATE ] != SPECTATOR_NOT;
+	// pretend the spectator is alive
+	alive |= spectate;
+
 	// If player is dead, we want the player to be between us and the killer
 	// so pretend that the player was looking at the killer, then place cam behind them.
-	if ( cg.predictedPlayerState.stats[ STAT_HEALTH ] <= 0 )
+	if ( !alive )
 	{
 		int killerEntNum = cg.predictedPlayerState.stats[ STAT_VIEWLOCK ];
 
@@ -320,9 +325,7 @@ void CG_OffsetThirdPersonView()
 	// Calculate the angle of the camera's position around the player.
 	// Unless in demo, PLAYING in third person, or in dead-third-person cam, allow the player
 	// to control camera position offsets using the mouse position.
-	if ( cg.demoPlayback ||
-	     ( ( cg.snap->ps.pm_flags & PMF_FOLLOW ) &&
-	       ( cg.predictedPlayerState.stats[ STAT_HEALTH ] > 0 ) ) )
+	if ( cg.demoPlayback || ( ( cg.snap->ps.pm_flags & PMF_FOLLOW ) && alive ) )
 	{
 		// Collect our input values from the mouse.
 		cmdNum = trap_GetCurrentCmdNumber();
@@ -392,7 +395,7 @@ void CG_OffsetThirdPersonView()
 	}
 	else
 	{
-		if ( cg.predictedPlayerState.stats[ STAT_HEALTH ] > 0 )
+		if ( alive )
 		{
 			// If we're playing the game in third person, the viewangles already
 			// take care of our mouselook, so just use them.
@@ -440,7 +443,7 @@ void CG_OffsetThirdPersonView()
 	// The above checks may have moved the camera such that the existing viewangles
 	// may not still face the player. Recalculate them to do so.
 	// but if we're dead, don't bother because we'd rather see what killed us
-	if ( cg.predictedPlayerState.stats[ STAT_HEALTH ] > 0 )
+	if ( alive )
 	{
 		VectorSubtract( focusPoint, cg.refdef.vieworg, focusPoint );
 		vectoangles( focusPoint, cg.refdefViewAngles );
@@ -593,8 +596,13 @@ void CG_OffsetFirstPersonView()
 
 	VectorCopy( origin, baseOrigin );
 
+	bool alive = ps->stats[ STAT_HEALTH ] > 0;
+	bool spectate = ps->persistant[ PERS_SPECSTATE ] != SPECTATOR_NOT;
+	// pretend the spectator is alive
+	alive |= spectate;
+
 	// if dead, fix the angle and don't add any kick
-	if ( cg.snap->ps.stats[ STAT_HEALTH ] <= 0 )
+	if ( !alive )
 	{
 		angles[ ROLL ] = 40;
 		angles[ PITCH ] = -15;
@@ -1900,9 +1908,14 @@ void CG_DrawActiveFrame( int serverTime, bool demoPlayback )
 	// update cvars (needs valid unlockables data)
 	CG_UpdateCvars();
 
+	bool alive = cg.snap->ps.stats[ STAT_HEALTH ] > 0;
+	bool spectate = cg.snap->ps.persistant[ PERS_SPECSTATE ] != SPECTATOR_NOT;
+	// pretend the spectator is alive
+	alive |= spectate;
+
 	// decide on third person view
-	cg.renderingThirdPerson = ( cg_thirdPerson.integer || ( cg.snap->ps.stats[ STAT_HEALTH ] <= 0 ) ||
-	                            ( cg.chaseFollow && cg.snap->ps.pm_flags & PMF_FOLLOW ) );
+	cg.renderingThirdPerson = ( cg_thirdPerson.integer || !alive
+		|| ( cg.chaseFollow && cg.snap->ps.pm_flags & PMF_FOLLOW ) );
 
 	// update speedometer
 	CG_AddSpeed();


### PR DESCRIPTION
## pretend spectator is alive to avoid death animation to be applied

The death animation was applied on spectator because the spectator is not alive, that's why the noclip spectator was crawling the map with third-person view while `cg_thirdPerson` is false.

I don't know why the clip spectator was not affected by the bug and is still using first-person view while `cg_thirdPerson` is true. This looks to be unintended (If we want this feature, the code must ask for it).

## noclip third-person spectator is not affected by walls, fix #1072

Previously, the third-person view range was affected by walls even if `noclip` was used.
