### PR TITLE
Allow devolving around Overmind

### DIFF
--- a/src/cgame/cg_rocket_dataformatter.cpp
+++ b/src/cgame/cg_rocket_dataformatter.cpp
@@ -409,7 +409,7 @@ static void CG_Rocket_DFCMAlienEvolve( int handle, const char *data )
 		//Padlock icon. UTF-8 encoding of \uf023
 		Icon = "<icon>\xEF\x80\xA3</icon>";
 	}
-	else if ( cost == -1 )
+	else if ( cost == CANT_EVOLVE )
 	{
 
 		Class = "expensive";

--- a/src/cgame/cg_rocket_datasource.cpp
+++ b/src/cgame/cg_rocket_datasource.cpp
@@ -1639,6 +1639,7 @@ void CG_Rocket_BuildAlienEvolveList( const char *table )
 	if ( !Q_stricmp( table, "default" ) )
 	{
 		int i;
+		float price;
 
 		Rocket_DSClearTable( "alienEvolveList", "default" );
 		CG_Rocket_CleanUpAlienEvolveList( "default" );
@@ -1648,11 +1649,17 @@ void CG_Rocket_BuildAlienEvolveList( const char *table )
 			if ( BG_Class( i )->team == TEAM_ALIENS )
 			{
 				buf[ 0 ] = '\0';
-
+				price = BG_CostToEvolve( cg.predictedPlayerState.stats[ STAT_CLASS ], i );
+				if( price == CANT_EVOLVE){
+					price = 0;
+				}
+				if( price < 0 ){
+					price *= (( float ) cg.predictedPlayerState.stats[ STAT_HEALTH ] / ( float ) BG_Class( cg.predictedPlayerState.stats[ STAT_CLASS ] )->health ) * DEVOLVE_RETURN_RATE;
+				}
 				Info_SetValueForKey( buf, "num", va( "%d", i ), false );
 				Info_SetValueForKey( buf, "name", BG_ClassModelConfig( i )->humanName, false );
 				Info_SetValueForKey( buf, "description", BG_Class( i )->info, false );
-				Info_SetValueForKey( buf, "price", va( "%d", BG_CostToEvolve( cg.predictedPlayerState.stats[ STAT_CLASS ], i ) / CREDITS_PER_EVO ), false );
+				Info_SetValueForKey( buf, "price", va( "%.1f", price / CREDITS_PER_EVO ), false );
 
 				Rocket_DSAddRow( "alienEvolveList", "default", buf );
 

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -683,6 +683,11 @@ void CG_Menu( int menuType, int arg )
 			shortMsg = _("This location is too close to the enemy to evolve");
 			break;
 
+		case MN_A_NOTINBASE:
+			longMsg = _("The Overmind is too far away to devolve.");
+			shortMsg = _("The Overmind is too far away to devolve.");
+			break;
+
 		case MN_A_NOOVMND_EVOLVE:
 			longMsg = _("There is no Overmind. An Overmind must be built to allow "
 			          "you to upgrade.");

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -242,7 +242,7 @@ float BotGetEnemyPriority( gentity_t *self, gentity_t *ent )
 bool BotCanEvolveToClass( gentity_t *self, class_t newClass )
 {
 	return ( BG_ClassCanEvolveFromTo( ( class_t )self->client->ps.stats[STAT_CLASS], newClass,
-	                                  self->client->ps.persistant[PERS_CREDIT] ) >= 0 );
+	                                  self->client->ps.persistant[PERS_CREDIT] ) >= 1 );
 }
 
 bool WeaponIsEmpty( weapon_t weapon, playerState_t *ps )
@@ -1751,7 +1751,7 @@ bool BotEvolveToClass( gentity_t *ent, class_t newClass )
 		if ( G_RoomForClassChange( ent, newClass, infestOrigin ) )
 		{
 			//...check we can evolve to that class
-			if ( numLevels >= 0 && BG_ClassUnlocked( newClass ) && !BG_ClassDisabled( newClass ) )
+			if ( numLevels >= 1 && BG_ClassUnlocked( newClass ) && !BG_ClassDisabled( newClass ) )
 			{
 				ent->client->pers.evolveHealthFraction = Entities::HealthFraction(ent);
 

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -1779,6 +1779,10 @@ void ClientSpawn( gentity_t *ent, gentity_t *spawn, const vec3_t origin, const v
 	maxClips = BG_Weapon( weapon )->maxClips;
 	client->ps.stats[ STAT_WEAPON ] = weapon;
 	client->ps.ammo = maxAmmo;
+	if( ent->client->pers.classSelection == PCL_ALIEN_LEVEL3_UPG )
+	{
+		client->ps.ammo = 1;
+	}
 	client->ps.clips = maxClips;
 
 	// We just spawned, not changing weapons

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -2404,8 +2404,17 @@ static bool Cmd_Class_internal( gentity_t *ent, const char *s, bool report )
 
 			if ( G_RoomForClassChange( ent, newClass, infestOrigin ) )
 			{
-				if ( cost >= 0 )
+				if ( cost != CANT_EVOLVE )
 				{
+
+					if ( ( cost < 0 || ( cost == 0 && currentClass == PCL_ALIEN_LEVEL0 ) )	&& ( G_DistanceToBase( ent ) >= g_devolveMaxBaseDistance.Get() ) ) {
+						if ( report )
+						{
+							G_TriggerMenu( clientNum, MN_A_NOTINBASE );
+						}
+						return false;
+					}
+
 					ent->client->pers.evolveHealthFraction = ent->entity->Get<HealthComponent>()->HealthFraction();
 
 					if ( ent->client->pers.evolveHealthFraction < 0.0f )
@@ -2417,6 +2426,9 @@ static bool Cmd_Class_internal( gentity_t *ent, const char *s, bool report )
 						ent->client->pers.evolveHealthFraction = 1.0f;
 					}
 
+					if ( cost < 0 ){
+						 cost = cost * ent->client->pers.evolveHealthFraction * DEVOLVE_RETURN_RATE;
+					}
 					//remove credit
 					G_AddCreditToClient( ent->client, -cost, true );
 					ent->client->pers.classSelection = newClass;

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -170,6 +170,7 @@ extern  vmCvar_t g_debugEntities;
 extern  vmCvar_t g_instantBuilding;
 
 extern  Cvar::Cvar<float> g_evolveAroundHumans;
+extern  Cvar::Cvar<float> g_devolveMaxBaseDistance;
 
 // bot buy cvars
 extern vmCvar_t g_bot_buy;

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -208,6 +208,7 @@ vmCvar_t           g_emptyTeamsSkipMapTime;
 Cvar::Cvar<bool>   g_neverEnd("g_neverEnd", "cheat to never end a game, helpful to load a map without spawn for testing purpose", Cvar::NONE, false);
 
 Cvar::Cvar<float>  g_evolveAroundHumans("g_evolveAroundHumans", "Ratio of alien buildings to human entities that always allow evolution", Cvar::NONE, 1.5f);
+Cvar::Cvar<float>  g_devolveMaxBaseDistance("g_devolveMaxBaseDistance", "Max Overmind distance to allow devolving", Cvar::NONE, 1000.0f);
 
 // <bot stuff>
 

--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -423,30 +423,12 @@ int BG_CostToEvolve( int from, int to )
 			 from <= PCL_NONE || from >= PCL_NUM_CLASSES ||
 			 to <= PCL_NONE || to >= PCL_NUM_CLASSES )
 	{
-		return -1;
+		return CANT_EVOLVE;
 	}
 
 	fromCost = BG_Class( from )->cost;
 	toCost = BG_Class( to )->cost;
 
-	// classes w/o a cost are for spawning only
-	if ( toCost == 0 )
-	{
-		// (adv.) granger may evolve into adv. granger or dretch at no cost
-		if ( ( from == PCL_ALIEN_BUILDER0 || from == PCL_ALIEN_BUILDER0_UPG ) &&
-		     ( to == PCL_ALIEN_BUILDER0_UPG || to == PCL_ALIEN_LEVEL0 ) )
-		{
-			return 0;
-		}
-
-		return -1;
-	}
-
-	// don't allow devolving
-	if ( toCost <= fromCost )
-	{
-		return -1;
-	}
 
 	return toCost - fromCost;
 }
@@ -462,14 +444,14 @@ int BG_ClassCanEvolveFromTo( int from, int to, int credits )
 
 	if ( !BG_ClassUnlocked( to ) || BG_ClassDisabled( to ) )
 	{
-		return -1;
+		return CANT_EVOLVE;
 	}
 
 	evolveCost = BG_CostToEvolve( from, to );
 
 	if ( credits < evolveCost )
 	{
-		return -1;
+		return CANT_EVOLVE;
 	}
 
 	return evolveCost;
@@ -486,7 +468,7 @@ bool BG_AlienCanEvolve( int from, int credits )
 
 	for ( to = PCL_NONE + 1; to < PCL_NUM_CLASSES; to++ )
 	{
-		if ( BG_ClassCanEvolveFromTo( from, to, credits ) >= 0 )
+		if ( BG_ClassCanEvolveFromTo( from, to, credits ) != CANT_EVOLVE )
 		{
 			return true;
 		}

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -667,6 +667,7 @@ enum dynMenu_t
   MN_A_INFEST,
   MN_A_NOEROOM,
   MN_A_TOOCLOSE,
+  MN_A_NOTINBASE,
   MN_A_NOOVMND_EVOLVE,
   MN_A_EVOLVEBUILDTIMER,
   MN_A_CANTEVOLVE,
@@ -1025,6 +1026,9 @@ enum meansOfDeath_t
   MOD_DECONSTRUCT,
   MOD_REPLACE
 };
+
+#define DEVOLVE_RETURN_RATE 0.9f
+#define CANT_EVOLVE -999
 
 //---------------------------------------------------------
 


### PR DESCRIPTION
Allow devolving around the Overmind and return morph points relative to the percent of health left * 0.9.

AdvDragoons spawn only with 1 barb since it could be abused to evolve back and forth for a quick way to ammo.
