### PR TITLE
macos: attempt to fix partial rendering issue on macOS Catalina, ref #1166

### DIFF
--- a/macosx/Info.plist
+++ b/macosx/Info.plist
@@ -31,5 +31,7 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>0.51</string>
+	<key>NSHighResolutionCapable</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
Note that it would only works when started with .app launcher.

Note that if the `NSHighResolutionCapable` is set to `false`,
it does not mean Unvanquished does not handles high resolution.

Unvanquished has responsive UI which scales UI elements whatever
the resolution, see:

- https://github.com/Unvanquished/Unvanquished/pull/1106
- https://github.com/UnvanquishedAssets/unvanquished_src.dpkdir/pull/6
- https://github.com/DaemonEngine/Daemon/pull/161

Unvanquished does not need to use any macOS-specific option to handle
high resolution screens, the way things are done accross all platforms
is done the “one ring to rule them all” way.