### PR TITLE
rename CG_NextWeapon_f to CG_SelectNextInventoryItem_f and other things, fix #1179, ref #544

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2062,6 +2062,7 @@ void CG_TransformSkeleton( refSkeleton_t *skel, const vec_t scale );
 void CG_NextWeapon_f();
 void CG_PrevWeapon_f();
 void CG_Weapon_f();
+void CG_SelectNextInventoryItem_f();
 
 void CG_InitUpgrades();
 void CG_RegisterUpgrade( int upgradeNum );

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -54,8 +54,8 @@ static bind_t bindings[] =
 	{ "+activate",      N_( "Use Structure/Evolve" ),                  {} },
 	{ "modcase alt \"/deconstruct marked\" /deconstruct",
 	                    N_( "Deconstruct Structure" ),                 {} },
-	{ "weapprev",       N_( "Previous Upgrade" ),                      {} },
-	{ "weapnext",       N_( "Next Upgrade" ),                          {} },
+	{ "weapprev",       N_( "Previous Weapon" ),                       {} },
+	{ "weapnext",       N_( "Next Weapon" ),                           {} },
 	{ OPEN_CONSOLE_CMD, N_( "Toggle Console" ),                        {} },
 	{ "itemact grenade", N_( "Throw a grenade" ),                      {} }
 };
@@ -444,13 +444,22 @@ static void CG_HumanText( char *text, playerState_t *ps )
 		}
 	}
 
-	if ( upgrade == UP_NONE ||
-	     ( upgrade > UP_NONE && BG_Upgrade( upgrade )->usable ) )
+	// This would have to be reimplemented the day it will be possible
+	// to cycle more than two weapons, like grenade or a buyable side firearm.
+	switch ( ps->weapon )
 	{
-		Q_strcat( text, MAX_TUTORIAL_TEXT,
-		          va( _( "Press %s to use the %s\n" ),
-		              CG_KeyNameForCommand( "+useitem" ),
-		              name ) );
+		case WP_BLASTER:
+			// FIXME: Properly name the next weapon.
+			Q_strcat( text, MAX_TUTORIAL_TEXT,
+			          va( _( "Press %s to use the primary weapon\n" ),
+			              CG_KeyNameForCommand( "weapprev" ) ) );
+			break;
+		default:
+			Q_strcat( text, MAX_TUTORIAL_TEXT,
+			          va( _( "Press %s to use the %s\n" ),
+			              CG_KeyNameForCommand( "weapnext" ),
+			              _( BG_Weapon( WP_BLASTER )->humanName ) ) );
+			break;
 	}
 
 	if ( ps->stats[ STAT_HEALTH ] <= 35 &&

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -2036,14 +2036,14 @@ void CG_DrawHumanInventory()
 		{
 			if ( !CG_WeaponSelectable( (weapon_t) cg.weaponSelect ) )
 			{
-				CG_NextWeapon_f();
+				CG_SelectNextInventoryItem_f();
 			}
 		}
 		else
 		{
 			if ( !CG_UpgradeSelectable( (upgrade_t) ( cg.weaponSelect - 32 ) ) )
 			{
-				CG_NextWeapon_f();
+				CG_SelectNextInventoryItem_f();
 			}
 		}
 	}
@@ -2196,9 +2196,6 @@ CG_NextWeapon_f
 */
 void CG_NextWeapon_f()
 {
-	int i;
-	int original;
-
 	if ( !cg.snap )
 	{
 		return;
@@ -2207,6 +2204,26 @@ void CG_NextWeapon_f()
 	if ( cg.snap->ps.pm_flags & PMF_FOLLOW )
 	{
 		trap_SendClientCommand( "followprev\n" );
+		return;
+	}
+
+	// HACK: This only works with two weapons.
+	// See: https://github.com/Unvanquished/Unvanquished/issues/544#issuecomment-619299752
+	trap_SendClientCommand( "itemtoggle blaster\n" );
+}
+
+/*
+===============
+CG_SelectNextInventoryItem_f
+===============
+*/
+void CG_SelectNextInventoryItem_f()
+{
+	int i;
+	int original;
+
+	if ( !cg.snap )
+	{
 		return;
 	}
 
@@ -2251,9 +2268,6 @@ CG_PrevWeapon_f
 */
 void CG_PrevWeapon_f()
 {
-	int i;
-	int original;
-
 	if ( !cg.snap )
 	{
 		return;
@@ -2262,6 +2276,26 @@ void CG_PrevWeapon_f()
 	if ( cg.snap->ps.pm_flags & PMF_FOLLOW )
 	{
 		trap_SendClientCommand( "follownext\n" );
+		return;
+	}
+
+	// HACK: This only works with two weapons.
+	// See: https://github.com/Unvanquished/Unvanquished/issues/544#issuecomment-619299752
+	trap_SendClientCommand( "itemtoggle blaster\n" );
+}
+
+/*
+===============
+CG_SelectPrevInventoryItem_f
+===============
+*/
+void CG_SelectPrevInventoryItem_f()
+{
+	int i;
+	int original;
+
+	if ( !cg.snap )
+	{
 		return;
 	}
 


### PR DESCRIPTION
- rename `CG_NextWeapon_f` to `CG_SelectNextInventoryItem_f` and `CG_PrevWeapon_f` to `CG_SelectPrevInventoryItem_f`, fix #1179.
- make `weapprev`/`weapnext` alias of `itemtoggle blaster` to emulate weapon cycling on mouse roll, ref #544.

See this comment: https://github.com/Unvanquished/Unvanquished/issues/544#issuecomment-619299752

The `weapprev`/`weapnext` thing is done the hacky way to be ready for 0.52 release. A clean implementation is welcome. It is less hacky than storing `itemtoggle blaster` in `default.cfg`, at least the public interface is correct from the start.



