### PR TITLE
Fix and use attack3 for barb/spit, mark and deconstruct with mouse, cycle weapons, rework binds and tutorial, fix #1179, #1180, #1181, #1183, ref #544

### DIFF
--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -581,8 +581,8 @@ void CG_InitConsoleCommands()
 
 	// Defined in src/engine/qcommon/q_shared.h, see BUTTON_ATTACK etc.
 	trap_RegisterButtonCommands(
-	    // 0      1       2       3     45      6        7       89ABCD           E      <- bit nos.
-	      "attack,attack2,attack3,taunt,,sprint,activate,useitem,,,,,,deconstruct,rally"
+	    // 0      1       2       3     45      6        789ABCD           E      <- bit nos.
+	      "attack,attack2,attack3,taunt,,sprint,activate,,,,,,,deconstruct,rally"
 	    );
 }
 

--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -581,8 +581,8 @@ void CG_InitConsoleCommands()
 
 	// Defined in src/engine/qcommon/q_shared.h, see BUTTON_ATTACK etc.
 	trap_RegisterButtonCommands(
-	    // 0      1       2       3     45      6        789ABCD           E      <- bit nos.
-	      "attack,attack2,attack3,taunt,,sprint,activate,,,,,,,deconstruct,rally"
+	    // 0      1       2       3     45      6        789ABCD           E    F  <- bit nos.
+	      "attack,attack2,attack3,taunt,,sprint,activate,,,,,,,deconstruct,rally,"
 	    );
 }
 

--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -579,9 +579,10 @@ void CG_InitConsoleCommands()
 		trap_AddCommand( commands[ i ].cmd );
 	}
 
+	// Defined in src/engine/qcommon/q_shared.h, see BUTTON_ATTACK etc.
 	trap_RegisterButtonCommands(
-	    // 0      12       3     45      6        78       9ABCD           E      <- bit nos.
-	      "attack,,useitem,taunt,,sprint,activate,,attack2,,,,,deconstruct,rally"
+	    // 0      1       2       3     45      6        7       89ABCD           E      <- bit nos.
+	      "attack,attack2,attack3,taunt,,sprint,activate,useitem,,,,,,deconstruct,rally"
 	    );
 }
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2059,6 +2059,7 @@ void CG_TransformSkeleton( refSkeleton_t *skel, const vec_t scale );
 //
 // cg_weapons.c
 //
+weapon_t CG_FindNextWeapon( playerState_t *ps );
 void CG_NextWeapon_f();
 void CG_PrevWeapon_f();
 void CG_Weapon_f();

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1206,7 +1206,7 @@ struct cg_t
 	int                     spawnTime; // fovwarp
 	int                     weapon1Time; // time when BUTTON_ATTACK went t->f f->t
 	int                     weapon2Time; // time when BUTTON_ATTACK2 went t->f f->t
-	int                     weapon3Time; // time when BUTTON_USE_HOLDABLE went t->f f->t
+	int                     weapon3Time; // time when BUTTON_ATTACK3 went t->f f->t
 	bool                weapon1Firing;
 	bool                weapon2Firing;
 	bool                weapon3Firing;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2062,6 +2062,7 @@ void CG_TransformSkeleton( refSkeleton_t *skel, const vec_t scale );
 void CG_NextWeapon_f();
 void CG_PrevWeapon_f();
 void CG_Weapon_f();
+void CG_SelectNextInventoryItem_f();
 
 void CG_InitUpgrades();
 void CG_RegisterUpgrade( int upgradeNum );

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -449,7 +449,7 @@ static void CG_HumanText( char *text, playerState_t *ps )
 	if ( upgrade != UP_NONE )
 	{
 		Q_strcat( text, MAX_TUTORIAL_TEXT, va( _( "Press %s to throw the %s\n" ),
-			CG_KeyNameForCommand( "+itemact grenade" ),
+			CG_KeyNameForCommand( "itemact grenade" ),
 			_( BG_Upgrade( upgrade )->humanName ) ));
 	}
 

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -102,7 +102,7 @@ static const char *CG_KeyNameForCommand( const char *command )
 			if ( binding.command == OPEN_CONSOLE_CMD )
 			{
 				// Hard-coded console toggle key binding
-				keyNames = "Shift-Escape";
+				keyNames = "SHIFT-ESCAPE";
 				// cl_consoleKeys is yet another source of keys for toggling the console,
 				// but it is omitted out of laziness.
 			}

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -504,6 +504,10 @@ static void CG_HumanText( char *text, playerState_t *ps )
 	Q_strcat( text, MAX_TUTORIAL_TEXT,
 	          va( _( "Press %s and any direction to sprint\n" ),
 	              CG_KeyNameForCommand( "+sprint" ) ) );
+
+	Q_strcat( text, MAX_TUTORIAL_TEXT,
+	          va( _( "Press %s to crouch\n" ),
+	              CG_KeyNameForCommand( "+movedown" ) ) );
 }
 
 /*

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -664,6 +664,8 @@ const char *CG_TutorialText()
 
 	if ( !cg.demoPlayback )
 	{
+		Q_strcat( text, MAX_TUTORIAL_TEXT, "\n" );
+
 		if ( cgs.clientinfo[ cg.clientNum ].team == TEAM_NONE )
 		{
 			Q_strcat( text, MAX_TUTORIAL_TEXT, va( _( "Press %s to chat\n" ), CG_KeyNameForCommand( "message_public" ) ) );
@@ -672,6 +674,9 @@ const char *CG_TutorialText()
 		{
 			Q_strcat( text, MAX_TUTORIAL_TEXT, va( _( "Press %s to chat or %s to chat to your team\n" ), CG_KeyNameForCommand( "message_public" ),  CG_KeyNameForCommand( "message_team" ) ) );
 		}
+
+		Q_strcat( text, MAX_TUTORIAL_TEXT, "\n" );
+
 		Q_strcat( text, MAX_TUTORIAL_TEXT, va( _( "Press %s to open the console\n" ), CG_KeyNameForCommand( "toggleconsole" ) ) );
 		Q_strcat( text, MAX_TUTORIAL_TEXT, _( "Press ESCAPE for the menu" ) );
 	}

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -52,8 +52,7 @@ static bind_t bindings[] =
 	{ "buy ammo",       N_( "Buy Ammo" ),                              {} },
 	{ "itemact medkit", N_( "Use Medkit" ),                            {} },
 	{ "+activate",      N_( "Use Structure/Evolve" ),                  {} },
-	{ "modcase alt \"/deconstruct marked\" /deconstruct",
-	                    N_( "Deconstruct Structure" ),                 {} },
+	{ "+deconstruct",   N_( "Deconstruct Structure" ),                 {} },
 	{ "weapprev",       N_( "Previous Weapon" ),                       {} },
 	{ "weapnext",       N_( "Next Weapon" ),                           {} },
 	{ "message_public", N_( "Global chat" ),                           {} },
@@ -195,7 +194,7 @@ static void CG_BuilderText( char *text, playerState_t *ps )
 
 	if ( ( es = CG_BuildableInRange( ps, nullptr ) ) )
 	{
-		const char *key = CG_KeyNameForCommand( "modcase alt \"/deconstruct marked\" /deconstruct" );
+		const char *key = CG_KeyNameForCommand( "+deconstruct" );
 
 		if ( es->eFlags & EF_B_MARKED )
 		{
@@ -207,6 +206,9 @@ static void CG_BuilderText( char *text, playerState_t *ps )
 			Q_strcat( text, MAX_TUTORIAL_TEXT,
 					  va( _( "Press %s to mark this structure for replacement\n" ), key ) );
 		}
+
+		Q_strcat( text, MAX_TUTORIAL_TEXT,
+				  va( _( "Hold %s to deconstruct this structure\n" ), key ) );
 	}
 }
 

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -41,13 +41,13 @@ static const char* const OPEN_CONSOLE_CMD = "toggleconsole";
 
 static bind_t bindings[] =
 {
-	{ "+useitem",       N_( "Activate Upgrade" ),                      {} },
 	{ "+speed",         N_( "Run/Walk" ),                              {} },
 	{ "+sprint",        N_( "Sprint" ),                                {} },
 	{ "+moveup",        N_( "Jump" ),                                  {} },
 	{ "+movedown",      N_( "Crouch" ),                                {} },
 	{ "+attack",        N_( "Primary Attack" ),                        {} },
 	{ "+attack2",       N_( "Secondary Attack" ),                      {} },
+	{ "+attack3",       N_( "Tertiary Attack" ),                       {} },
 	{ "reload",         N_( "Reload" ),                                {} },
 	{ "buy ammo",       N_( "Buy Ammo" ),                              {} },
 	{ "itemact medkit", N_( "Use Medkit" ),                            {} },
@@ -227,8 +227,8 @@ static void CG_AlienBuilderText( char *text, playerState_t *ps )
 	if ( ps->stats[ STAT_CLASS ] == PCL_ALIEN_BUILDER0_UPG )
 	{
 		Q_strcat( text, MAX_TUTORIAL_TEXT,
-		          va( _( "Press %s to launch a projectile\n" ),
-		              CG_KeyNameForCommand( "+useitem" ) ) );
+		          va( _( "Press %s to spit\n" ),
+		              CG_KeyNameForCommand( "+attack3" ) ) );
 
 		Q_strcat( text, MAX_TUTORIAL_TEXT,
 		          va( _( "Press %s to walk on walls\n" ),
@@ -307,8 +307,8 @@ static void CG_AlienLevel3Text( char *text, playerState_t *ps )
 	if ( ps->stats[ STAT_CLASS ] == PCL_ALIEN_LEVEL3_UPG )
 	{
 		Q_strcat( text, MAX_TUTORIAL_TEXT,
-		          va( _( "Press %s to launch a projectile\n" ),
-		              CG_KeyNameForCommand( "+useitem" ) ) );
+		          va( _( "Press %s to launch a barb\n" ),
+		              CG_KeyNameForCommand( "+attack3" ) ) );
 	}
 
 	Q_strcat( text, MAX_TUTORIAL_TEXT,
@@ -351,19 +351,6 @@ CG_HumanText
 */
 static void CG_HumanText( char *text, playerState_t *ps )
 {
-	const char *name;
-	upgrade_t upgrade = UP_NONE;
-
-	if ( cg.weaponSelect < 32 )
-	{
-		name = cg_weapons[ cg.weaponSelect ].humanName;
-	}
-	else
-	{
-		name = cg_upgrades[ cg.weaponSelect - 32 ].humanName;
-		upgrade = (upgrade_t) ( cg.weaponSelect - 32 );
-	}
-
 	if ( !ps->ammo && !ps->clips && !BG_Weapon( ps->weapon )->infiniteAmmo )
 	{
 		//no ammo
@@ -444,6 +431,22 @@ static void CG_HumanText( char *text, playerState_t *ps )
 		}
 	}
 
+	upgrade_t upgrade = UP_NONE;
+	for ( const auto u : { UP_GRENADE, UP_FIREBOMB } )
+	{
+		if ( BG_InventoryContainsUpgrade( u, ps->stats ) )
+		{
+			upgrade = u;
+		}
+	}
+
+	if ( upgrade != UP_NONE )
+	{
+		Q_strcat( text, MAX_TUTORIAL_TEXT, va( _( "Press %s to throw the %s\n" ),
+			CG_KeyNameForCommand( "+itemact grenade" ),
+			_( BG_Upgrade( upgrade )->humanName ) ));
+	}
+
 	// Find next weapon in inventory.
 	weapon_t nextWeapon = CG_FindNextWeapon( ps );
 
@@ -487,14 +490,6 @@ static void CG_HumanText( char *text, playerState_t *ps )
 	Q_strcat( text, MAX_TUTORIAL_TEXT,
 	          va( _( "Press %s and any direction to sprint\n" ),
 	              CG_KeyNameForCommand( "+sprint" ) ) );
-
-	if ( BG_InventoryContainsUpgrade( UP_FIREBOMB, ps->stats ) ||
-		BG_InventoryContainsUpgrade( UP_GRENADE, ps->stats ) )
-	{
-		Q_strcat( text, MAX_TUTORIAL_TEXT, va( _( "Press %s to throw a grenade\n" ),
-			CG_KeyNameForCommand( "itemact grenade" )
-		));
-	}
 }
 
 /*
@@ -532,26 +527,26 @@ static void CG_SpectatorText( char *text, playerState_t *ps )
 		{
 			Q_strcat( text, MAX_TUTORIAL_TEXT,
 			          va( _( "Press %s to switch to chase-cam spectator mode\n" ),
-			              CG_KeyNameForCommand( "+useitem" ) ) );
+			              CG_KeyNameForCommand( "+attack3" ) ) );
 		}
 		else if ( cgs.clientinfo[ cg.clientNum ].team == TEAM_NONE )
 		{
 			Q_strcat( text, MAX_TUTORIAL_TEXT,
 			          va( _( "Press %s to return to free spectator mode\n" ),
-			              CG_KeyNameForCommand( "+useitem" ) ) );
+			              CG_KeyNameForCommand( "+attack3" ) ) );
 		}
 		else
 		{
 			Q_strcat( text, MAX_TUTORIAL_TEXT,
 			          va( _( "Press %s to stop following\n" ),
-			              CG_KeyNameForCommand( "+useitem" ) ) );
+			              CG_KeyNameForCommand( "+attack3" ) ) );
 		}
 	}
 	else
 	{
 		Q_strcat( text, MAX_TUTORIAL_TEXT,
 		          va( _( "Press %s to follow a player\n" ),
-		              CG_KeyNameForCommand( "+useitem" ) ) );
+		              CG_KeyNameForCommand( "+attack3" ) ) );
 	}
 }
 

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -54,8 +54,8 @@ static bind_t bindings[] =
 	{ "+activate",      N_( "Use Structure/Evolve" ),                  {} },
 	{ "modcase alt \"/deconstruct marked\" /deconstruct",
 	                    N_( "Deconstruct Structure" ),                 {} },
-	{ "weapprev",       N_( "Previous Upgrade" ),                      {} },
-	{ "weapnext",       N_( "Next Upgrade" ),                          {} },
+	{ "weapprev",       N_( "Previous Weapon" ),                       {} },
+	{ "weapnext",       N_( "Next Weapon" ),                           {} },
 	{ OPEN_CONSOLE_CMD, N_( "Toggle Console" ),                        {} },
 	{ "itemact grenade", N_( "Throw a grenade" ),                      {} }
 };
@@ -444,13 +444,15 @@ static void CG_HumanText( char *text, playerState_t *ps )
 		}
 	}
 
-	if ( upgrade == UP_NONE ||
-	     ( upgrade > UP_NONE && BG_Upgrade( upgrade )->usable ) )
+	// Find next weapon in inventory.
+	weapon_t nextWeapon = CG_FindNextWeapon( ps );
+
+	if ( nextWeapon != WP_NONE )
 	{
 		Q_strcat( text, MAX_TUTORIAL_TEXT,
 		          va( _( "Press %s to use the %s\n" ),
-		              CG_KeyNameForCommand( "+useitem" ),
-		              name ) );
+		              CG_KeyNameForCommand( "weapnext" ),
+		              _( BG_Weapon( nextWeapon )->humanName ) ) );
 	}
 
 	if ( ps->stats[ STAT_HEALTH ] <= 35 &&

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -462,6 +462,13 @@ static void CG_HumanText( char *text, playerState_t *ps )
 		              _( BG_Weapon( nextWeapon )->humanName ) ) );
 	}
 
+	if ( BG_InventoryContainsUpgrade( UP_JETPACK, ps->stats ) )
+	{
+		Q_strcat( text, MAX_TUTORIAL_TEXT, va( _( "Hold %s to use the %s\n" ),
+			CG_KeyNameForCommand( "+moveup" ),
+			_( BG_Upgrade( UP_JETPACK )->humanName ) ));
+	}
+
 	if ( ps->stats[ STAT_HEALTH ] <= 35 &&
 	     BG_InventoryContainsUpgrade( UP_MEDKIT, ps->stats ) )
 	{

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -536,30 +536,32 @@ static void CG_SpectatorText( char *text, playerState_t *ps )
 
 	if ( ps->pm_flags & PMF_FOLLOW )
 	{
+		Q_strcat( text, MAX_TUTORIAL_TEXT,
+		          va( _( "Press %s to stop following\n" ),
+		              CG_KeyNameForCommand( "+attack2" ) ) );
+
 		if ( !cg.chaseFollow )
 		{
 			Q_strcat( text, MAX_TUTORIAL_TEXT,
 			          va( _( "Press %s to switch to chase-cam spectator mode\n" ),
 			              CG_KeyNameForCommand( "+attack3" ) ) );
 		}
-		else if ( cgs.clientinfo[ cg.clientNum ].team == TEAM_NONE )
-		{
-			Q_strcat( text, MAX_TUTORIAL_TEXT,
-			          va( _( "Press %s to return to free spectator mode\n" ),
-			              CG_KeyNameForCommand( "+attack3" ) ) );
-		}
 		else
 		{
 			Q_strcat( text, MAX_TUTORIAL_TEXT,
-			          va( _( "Press %s to stop following\n" ),
+			          va( _( "Press %s to return to first-person spectator mode\n" ),
 			              CG_KeyNameForCommand( "+attack3" ) ) );
 		}
+
+		Q_strcat( text, MAX_TUTORIAL_TEXT,
+		          va( _( "Press %s to follow the next player\n" ),
+		              CG_KeyNameForCommand( "weapnext" ) ) );
 	}
 	else
 	{
 		Q_strcat( text, MAX_TUTORIAL_TEXT,
 		          va( _( "Press %s to follow a player\n" ),
-		              CG_KeyNameForCommand( "+attack3" ) ) );
+		              CG_KeyNameForCommand( "+attack2" ) ) );
 	}
 }
 

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -334,7 +334,7 @@ static void CG_AlienLevel4Text( char *text, playerState_t *ps )
 	              CG_KeyNameForCommand( "+attack" ) ) );
 
 	Q_strcat( text, MAX_TUTORIAL_TEXT,
-	          va( _( "Hold down and release %s while moving forwards to trample\n" ),
+	          va( _( "Hold down %s while moving forwards to trample\n" ),
 	              CG_KeyNameForCommand( "+attack2" ) ) );
 }
 

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -56,6 +56,8 @@ static bind_t bindings[] =
 	                    N_( "Deconstruct Structure" ),                 {} },
 	{ "weapprev",       N_( "Previous Weapon" ),                       {} },
 	{ "weapnext",       N_( "Next Weapon" ),                           {} },
+	{ "message_public", N_( "Global chat" ),                           {} },
+	{ "message_team",   N_( "Team chat" ),                             {} },
 	{ OPEN_CONSOLE_CMD, N_( "Toggle Console" ),                        {} },
 	{ "itemact grenade", N_( "Throw a grenade" ),                      {} }
 };
@@ -662,6 +664,14 @@ const char *CG_TutorialText()
 
 	if ( !cg.demoPlayback )
 	{
+		if ( cgs.clientinfo[ cg.clientNum ].team == TEAM_NONE )
+		{
+			Q_strcat( text, MAX_TUTORIAL_TEXT, va( _( "Press %s to chat\n" ), CG_KeyNameForCommand( "message_public" ) ) );
+		}
+		else
+		{
+			Q_strcat( text, MAX_TUTORIAL_TEXT, va( _( "Press %s to chat or %s to chat to your team\n" ), CG_KeyNameForCommand( "message_public" ),  CG_KeyNameForCommand( "message_team" ) ) );
+		}
 		Q_strcat( text, MAX_TUTORIAL_TEXT, va( _( "Press %s to open the console\n" ), CG_KeyNameForCommand( "toggleconsole" ) ) );
 		Q_strcat( text, MAX_TUTORIAL_TEXT, _( "Press ESCAPE for the menu" ) );
 	}

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -49,7 +49,6 @@ static bind_t bindings[] =
 	{ "+attack2",       N_( "Secondary Attack" ),                      {} },
 	{ "+attack3",       N_( "Tertiary Attack" ),                       {} },
 	{ "reload",         N_( "Reload" ),                                {} },
-	{ "buy ammo",       N_( "Buy Ammo" ),                              {} },
 	{ "itemact medkit", N_( "Use Medkit" ),                            {} },
 	{ "+activate",      N_( "Use Structure/Evolve" ),                  {} },
 	{ "+deconstruct",   N_( "Deconstruct Structure" ),                 {} },

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -266,6 +266,10 @@ static void CG_AlienLevel1Text( char *text )
 	              CG_KeyNameForCommand( "+attack" ) ) );
 
 	Q_strcat( text, MAX_TUTORIAL_TEXT,
+	          va( _( "Press %s to lunge\n" ),
+	              CG_KeyNameForCommand( "+attack2" ) ) );
+
+	Q_strcat( text, MAX_TUTORIAL_TEXT,
 	          va( _( "Press %s to walk on walls\n" ),
 	              CG_KeyNameForCommand( "+movedown" ) ) );
 }

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -901,7 +901,7 @@ static int CG_CalcFov()
 	trap_GetUserCmd( cmdNum, &cmd );
 	trap_GetUserCmd( cmdNum - 1, &oldcmd );
 
-	// switch follow modes if necessary: cycle between free -> follow -> third-person follow
+	// Cycle between follow and third-person follow modes on mouse middle click.
 	if ( usercmdButtonPressed( cmd.buttons, BUTTON_ATTACK3 ) && !usercmdButtonPressed( oldcmd.buttons, BUTTON_ATTACK3 ) )
 	{
 		if ( cg.snap->ps.pm_flags & PMF_FOLLOW )
@@ -913,10 +913,15 @@ static int CG_CalcFov()
 			else
 			{
 				cg.chaseFollow = false;
-				trap_SendClientCommand( "follow\n" );
 			}
 		}
-		else if ( cg.snap->ps.persistant[ PERS_SPECSTATE ] != SPECTATOR_NOT )
+	}
+
+	// Start and stoop to follow on mouse right click.
+	if ( usercmdButtonPressed( cmd.buttons, BUTTON_ATTACK2 ) && !usercmdButtonPressed( oldcmd.buttons, BUTTON_ATTACK2 ) )
+	{
+		if ( ( cg.snap->ps.persistant[ PERS_SPECSTATE ] != SPECTATOR_NOT )
+			|| ( cg.snap->ps.pm_flags & PMF_FOLLOW ) )
 		{
 			trap_SendClientCommand( "follow\n" );
 		}

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -902,7 +902,7 @@ static int CG_CalcFov()
 	trap_GetUserCmd( cmdNum - 1, &oldcmd );
 
 	// switch follow modes if necessary: cycle between free -> follow -> third-person follow
-	if ( usercmdButtonPressed( cmd.buttons, BUTTON_USE_HOLDABLE ) && !usercmdButtonPressed( oldcmd.buttons, BUTTON_USE_HOLDABLE ) )
+	if ( usercmdButtonPressed( cmd.buttons, BUTTON_ATTACK3 ) && !usercmdButtonPressed( oldcmd.buttons, BUTTON_ATTACK3 ) )
 	{
 		if ( cg.snap->ps.pm_flags & PMF_FOLLOW )
 		{

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -2036,14 +2036,14 @@ void CG_DrawHumanInventory()
 		{
 			if ( !CG_WeaponSelectable( (weapon_t) cg.weaponSelect ) )
 			{
-				CG_NextWeapon_f();
+				CG_SelectNextInventoryItem_f();
 			}
 		}
 		else
 		{
 			if ( !CG_UpgradeSelectable( (upgrade_t) ( cg.weaponSelect - 32 ) ) )
 			{
-				CG_NextWeapon_f();
+				CG_SelectNextInventoryItem_f();
 			}
 		}
 	}
@@ -2196,9 +2196,6 @@ CG_NextWeapon_f
 */
 void CG_NextWeapon_f()
 {
-	int i;
-	int original;
-
 	if ( !cg.snap )
 	{
 		return;
@@ -2207,6 +2204,26 @@ void CG_NextWeapon_f()
 	if ( cg.snap->ps.pm_flags & PMF_FOLLOW )
 	{
 		trap_SendClientCommand( "followprev\n" );
+		return;
+	}
+
+	// HACK: This only works with two weapons.
+	// See: https://github.com/Unvanquished/Unvanquished/issues/544#issuecomment-619299752
+	trap_SendClientCommand( "itemtoggle blaster\n" );
+}
+
+/*
+===============
+CG_SelectNextInventoryItem_f
+===============
+*/
+void CG_SelectNextInventoryItem_f()
+{
+	int i;
+	int original;
+
+	if ( !cg.snap )
+	{
 		return;
 	}
 
@@ -2251,9 +2268,6 @@ CG_PrevWeapon_f
 */
 void CG_PrevWeapon_f()
 {
-	int i;
-	int original;
-
 	if ( !cg.snap )
 	{
 		return;
@@ -2262,6 +2276,26 @@ void CG_PrevWeapon_f()
 	if ( cg.snap->ps.pm_flags & PMF_FOLLOW )
 	{
 		trap_SendClientCommand( "follownext\n" );
+		return;
+	}
+
+	// HACK: This only works with two weapons.
+	// See: https://github.com/Unvanquished/Unvanquished/issues/544#issuecomment-619299752
+	trap_SendClientCommand( "itemtoggle blaster\n" );
+}
+
+/*
+===============
+CG_SelectPrevInventoryItem_f
+===============
+*/
+void CG_SelectPrevInventoryItem_f()
+{
+	int i;
+	int original;
+
+	if ( !cg.snap )
+	{
 		return;
 	}
 

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -2191,6 +2191,62 @@ void CG_DrawItemSelectText()
 
 /*
 ===============
+CG_FindNextWeapon
+Find next weapon in inventory.
+===============
+*/
+weapon_t CG_FindNextWeapon( playerState_t *ps )
+{
+	weapon_t nextWeapon = WP_NONE;
+
+	// For each weapon in the known weapon list from the beginning to the end:
+	// we can skip WP_NONE because there is no weapon in this slot:
+	for ( weapon_t w = weapon_t( WP_NONE + 1 ); w < WP_NUM_WEAPONS; w = weapon_t( w + 1 ) )
+	{
+		if ( w != cg.snap->ps.weapon && BG_InventoryContainsWeapon( w, cg.snap->ps.stats ) )
+		{
+			if ( w < cg.snap->ps.weapon )
+			{
+				if ( nextWeapon == WP_NONE )
+				{
+					// If this weapon is not the current player weapon,
+					// and if the player has this weapon in inventory,
+					// and this weapon is listed before the current player weapon,
+					// and that's the first weapon we find:
+					// Remember this weapon,
+					// and look at the one after.
+					nextWeapon = w;
+				}
+				// If this weapon is not the current player weapon,
+				// and if the player has this weapon in inventory,
+				// and this weapon is listed before the current player weapon,
+				// and that's not the first weapon we find:
+				// Ignore this weapon,
+				// and look at the one after.
+			}
+			else 
+			{
+				// If this weapon is not the current player weapon,
+				// and if the player has this weapon in inventory,
+				// and this weapon is not listed before the current player weapon,
+				// Remember it,
+				// replace the one we may already have found,
+				// and stop.
+				nextWeapon = w;
+				break;
+			}
+		}
+		// If the player does not have this weapon in inventory,
+		// and this weapon is listed before the current player weapon:
+		// Ignore this weapon,
+		// and look at the one after.
+	}
+
+	return nextWeapon;
+}
+
+/*
+===============
 CG_NextWeapon_f
 ===============
 */
@@ -2207,9 +2263,17 @@ void CG_NextWeapon_f()
 		return;
 	}
 
-	// HACK: This only works with two weapons.
-	// See: https://github.com/Unvanquished/Unvanquished/issues/544#issuecomment-619299752
-	trap_SendClientCommand( "itemtoggle blaster\n" );
+	weapon_t nextWeapon = CG_FindNextWeapon( &cg.snap->ps );
+
+	if ( nextWeapon != WP_NONE )
+	{
+		if ( !BG_PlayerCanChangeWeapon( &cg.snap->ps ) )
+		{
+			return;
+		}
+
+		trap_SendClientCommand( va( "itemact %s\n", BG_Weapon( nextWeapon )->name ) );
+	}
 }
 
 /*
@@ -2263,6 +2327,62 @@ void CG_SelectNextInventoryItem_f()
 
 /*
 ===============
+CG_FindPrevWeapon
+Find previous weapon in inventory.
+===============
+*/
+weapon_t CG_FindPrevWeapon( playerState_t *ps )
+{
+	weapon_t prevWeapon = WP_NONE;
+
+	// For each weapon in the known weapon list from the end to the beginning,
+	// we must skip WP_NUM_WEAPONS because it's not a weapon slot:
+	for ( weapon_t w = weapon_t( WP_NUM_WEAPONS - 1 ); w > WP_NONE; w = weapon_t( w - 1 ) )
+	{
+		if ( w != cg.snap->ps.weapon && BG_InventoryContainsWeapon( w, cg.snap->ps.stats ) )
+		{
+			if ( w > cg.snap->ps.weapon )
+			{
+				if ( prevWeapon == WP_NONE )
+				{
+					// If this weapon is not the current player weapon,
+					// and if the player has this weapon in inventory,
+					// and this weapon is listed after the current player weapon,
+					// and that's the first weapon we find:
+					// Remember this weapon,
+					// and look at the one before.
+					prevWeapon = w;
+				}
+				// If this weapon is not the current player weapon,
+				// and if the player has this weapon in inventory,
+				// and this weapon is listed after the current player weapon,
+				// and that's not the first weapon we find:
+				// Ignore this weapon,
+				// and look at the one before.
+			}
+			else 
+			{
+				// If this weapon is not the current player weapon,
+				// and if the player has this weapon in inventory,
+				// and this weapon is not listed after the current player weapon,
+				// Remember it,
+				// replace the one we may already have found,
+				// and stop.
+				prevWeapon = w;
+				break;
+			}
+		}
+		// If the player does not have this weapon in inventory,
+		// and this weapon is listed after the current player weapon:
+		// Ignore this weapon,
+		// and look at the one before.
+	}
+
+	return prevWeapon;
+}
+
+/*
+===============
 CG_PrevWeapon_f
 ===============
 */
@@ -2279,9 +2399,17 @@ void CG_PrevWeapon_f()
 		return;
 	}
 
-	// HACK: This only works with two weapons.
-	// See: https://github.com/Unvanquished/Unvanquished/issues/544#issuecomment-619299752
-	trap_SendClientCommand( "itemtoggle blaster\n" );
+	weapon_t prevWeapon = CG_FindPrevWeapon( &cg.snap->ps );
+
+	if ( prevWeapon != WP_NONE )
+	{
+		if ( !BG_PlayerCanChangeWeapon( &cg.snap->ps ) )
+		{
+			return;
+		}
+
+		trap_SendClientCommand( va( "itemact %s\n", BG_Weapon( prevWeapon )->name ) );
+	}
 }
 
 /*

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -1100,8 +1100,7 @@ void ClientIntermissionThink( gclient_t *client )
 	usercmdCopyButtons( client->oldbuttons, client->buttons );
 	usercmdCopyButtons( client->buttons, client->pers.cmd.buttons );
 
-	if ( ( usercmdButtonPressed( client->buttons, BUTTON_ATTACK ) ||
-	       usercmdButtonPressed( client->buttons, BUTTON_USE_HOLDABLE ) ) &&
+	if ( usercmdButtonPressed( client->buttons, BUTTON_ATTACK ) &&
 	     usercmdButtonsDiffer( client->oldbuttons, client->buttons ) )
 	{
 		client->readyToExit = 1;

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -690,7 +690,6 @@ void BotMoveToGoal( gentity_t *self )
 		usercmd_t *botCmdBuffer = &self->botMind->cmdBuffer;
 
 		usercmdReleaseButton( botCmdBuffer->buttons, BUTTON_SPRINT );
-		usercmdReleaseButton( botCmdBuffer->buttons, BUTTON_DODGE );
 
 		// walk to regain stamina
 		BotWalk( self, true );

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1470,7 +1470,7 @@ void BotFireWeapon( weaponMode_t mode, usercmd_t *botCmdBuffer )
 	}
 	else if ( mode == WPM_TERTIARY )
 	{
-		usercmdPressButton( botCmdBuffer->buttons, BUTTON_USE_HOLDABLE );
+		usercmdPressButton( botCmdBuffer->buttons, BUTTON_ATTACK3 );
 	}
 }
 void BotClassMovement( gentity_t *self, bool inAttackRange )

--- a/src/shared/bg_pmove.cpp
+++ b/src/shared/bg_pmove.cpp
@@ -4065,43 +4065,6 @@ static void PM_Weapon()
 	// again if lowering or raising
 	if ( BG_PlayerCanChangeWeapon( pm->ps ) )
 	{
-		// must press use to switch weapons
-		if ( usercmdButtonPressed( pm->cmd.buttons, BUTTON_USE_HOLDABLE ) )
-		{
-			if ( !( pm->ps->pm_flags & PMF_USE_ITEM_HELD ) )
-			{
-				if ( pm->cmd.weapon < 32 )
-				{
-					//if trying to select a weapon, select it
-					if ( pm->ps->weapon != pm->cmd.weapon )
-					{
-						PM_BeginWeaponChange( pm->cmd.weapon );
-					}
-				}
-				else
-				{
-					//if trying to toggle an upgrade, toggle it
-					if ( BG_InventoryContainsUpgrade( pm->cmd.weapon - 32, pm->ps->stats ) )  //sanity check
-					{
-						if ( BG_UpgradeIsActive( pm->cmd.weapon - 32, pm->ps->stats ) )
-						{
-							BG_DeactivateUpgrade( pm->cmd.weapon - 32, pm->ps->stats );
-						}
-						else
-						{
-							BG_ActivateUpgrade( pm->cmd.weapon - 32, pm->ps->stats );
-						}
-					}
-				}
-
-				pm->ps->pm_flags |= PMF_USE_ITEM_HELD;
-			}
-		}
-		else
-		{
-			pm->ps->pm_flags &= ~PMF_USE_ITEM_HELD;
-		}
-
 		//something external thinks a weapon change is necessary
 		if ( pm->ps->pm_flags & PMF_WEAPON_SWITCH )
 		{
@@ -4900,7 +4863,7 @@ void PmoveSingle( pmove_t *pmove )
 
 	// clear the respawned flag if attack and use are cleared
 	if ( pm->ps->stats[ STAT_HEALTH ] > 0 &&
-	     !( usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK ) || usercmdButtonPressed( pm->cmd.buttons, BUTTON_USE_HOLDABLE ) ) )
+	     !( usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK ) ) )
 	{
 		pm->ps->pm_flags &= ~PMF_RESPAWNED;
 	}

--- a/src/shared/bg_pmove.cpp
+++ b/src/shared/bg_pmove.cpp
@@ -3857,7 +3857,7 @@ static void PM_Weapon()
 	int      addTime = 200; //default addTime - should never be used
 	bool attack1 = usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK );
 	bool attack2 = usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK2 );
-	bool attack3 = usercmdButtonPressed( pm->cmd.buttons, BUTTON_USE_HOLDABLE );
+	bool attack3 = usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK3 );
 
 	// Ignore weapons in some cases
 	if ( pm->ps->persistant[ PERS_SPECSTATE ] != SPECTATOR_NOT )
@@ -4888,7 +4888,7 @@ void PmoveSingle( pmove_t *pmove )
 
 	// set the firing flag for continuous beam weapons
 	if ( !( pm->ps->pm_flags & PMF_RESPAWNED ) && pm->ps->pm_type != PM_INTERMISSION &&
-	     usercmdButtonPressed( pm->cmd.buttons, BUTTON_USE_HOLDABLE ) &&
+	     usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK3 ) &&
 	     ( ( pm->ps->ammo > 0 || pm->ps->clips > 0 ) || BG_Weapon( pm->ps->weapon )->infiniteAmmo ) )
 	{
 		pm->ps->eFlags |= EF_FIRING3;

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -242,7 +242,7 @@ enum weaponstate_t
 #define PMF_TIME_KNOCKBACK 0x000040 // pm_time is an air-accelerate only time
 #define PMF_TIME_WATERJUMP 0x000080 // pm_time is waterjump
 #define PMF_RESPAWNED      0x000100 // clear after attack and jump buttons come up
-#define PMF_USE_ITEM_HELD  0x000200
+// available               0x000200
 #define PMF_WEAPON_RELOAD  0x000400 // force a weapon switch
 #define PMF_FOLLOW         0x000800 // spectate following another player
 #define PMF_QUEUED         0x001000 // player is queued


### PR DESCRIPTION
Requires similar branches on `Dæmon`, `unvanquished_src.dpkdir` and `res-weapons_src.dpkdir`.

- https://github.com/DaemonEngine/Daemon/pull/330  
- https://github.com/UnvanquishedAssets/unvanquished_src.dpkdir/pull/15

Fix #1179, #1180, #1181, #1183, ref #544.