### PR TITLE
weapons: silent some switch warnings

### DIFF
--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -1950,6 +1950,9 @@ void G_FireWeapon( gentity_t *self, weapon_t weapon, weaponMode_t weaponMode )
 				case WP_HBUILD:
 					FireMarkDeconstruct( self );
 					break;
+
+				default:
+					break;
 			}
 			break;
 		}
@@ -1962,6 +1965,9 @@ void G_FireWeapon( gentity_t *self, weapon_t weapon, weaponMode_t weaponMode )
 				case WP_HBUILD:
 					DeconstructSelectTarget( self );
 					break;
+
+				default:
+					break;
 			}
 			break;
 		}
@@ -1973,6 +1979,9 @@ void G_FireWeapon( gentity_t *self, weapon_t weapon, weaponMode_t weaponMode )
 				case WP_ABUILD2:
 				case WP_HBUILD:
 					FireForceDeconstruct( self );
+					break;
+
+				default:
 					break;
 			}
 			break;


### PR DESCRIPTION
Prevent such warning log spam:

```
Unvanquished/src/sgame/sg_weapon.cpp: In function ‘void G_FireWeapon(gentity_t*, weapon_t, weaponMode_t)’:
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_NONE’ not handled in switch [-Wswitch]
 1946 |    switch ( weapon )
      |           ^
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_ALEVEL0’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_ALEVEL1’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_ALEVEL2’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_ALEVEL2_UPG’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_ALEVEL3’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_ALEVEL3_UPG’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_ALEVEL4’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_BLASTER’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_MACHINEGUN’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_PAIN_SAW’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_SHOTGUN’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_LAS_GUN’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_MASS_DRIVER’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_CHAINGUN’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_FLAMER’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_PULSE_RIFLE’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_LUCIFER_CANNON’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_LOCKBLOB_LAUNCHER’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_HIVE’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_ROCKETPOD’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_MGTURRET’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1946:11: warning: enumeration value ‘WP_NUM_WEAPONS’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_NONE’ not handled in switch [-Wswitch]
 1958 |    switch ( weapon )
      |           ^
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_ALEVEL0’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_ALEVEL1’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_ALEVEL2’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_ALEVEL2_UPG’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_ALEVEL3’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_ALEVEL3_UPG’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_ALEVEL4’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_BLASTER’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_MACHINEGUN’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_PAIN_SAW’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_SHOTGUN’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_LAS_GUN’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_MASS_DRIVER’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_CHAINGUN’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_FLAMER’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_PULSE_RIFLE’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_LUCIFER_CANNON’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_LOCKBLOB_LAUNCHER’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_HIVE’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_ROCKETPOD’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_MGTURRET’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1958:11: warning: enumeration value ‘WP_NUM_WEAPONS’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_NONE’ not handled in switch [-Wswitch]
 1970 |    switch ( weapon )
      |           ^
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_ALEVEL0’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_ALEVEL1’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_ALEVEL2’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_ALEVEL2_UPG’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_ALEVEL3’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_ALEVEL3_UPG’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_ALEVEL4’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_BLASTER’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_MACHINEGUN’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_PAIN_SAW’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_SHOTGUN’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_LAS_GUN’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_MASS_DRIVER’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_CHAINGUN’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_FLAMER’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_PULSE_RIFLE’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_LUCIFER_CANNON’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_LOCKBLOB_LAUNCHER’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_HIVE’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_ROCKETPOD’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_MGTURRET’ not handled in switch [-Wswitch]
Unvanquished/src/sgame/sg_weapon.cpp:1970:11: warning: enumeration value ‘WP_NUM_WEAPONS’ not handled in switch [-Wswitch]
```