### PR TITLE
Use a specific prefix for bots so they are not named UnnamedPlayer

### DIFF
--- a/src/sgame/sg_bot.h
+++ b/src/sgame/sg_bot.h
@@ -26,6 +26,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #ifndef __BOT_HEADER
 #define __BOT_HEADER
 
+#define UNNAMED_BOT "[bot] Bot"
+
 struct botEntityAndDistance_t
 {
 	gentity_t *ent;

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -644,6 +644,14 @@ bool G_IsUnnamed( const char *name )
 		return true;
 	}
 
+	length = strlen( g_unnamedBotNamePrefix.string );
+
+	if ( g_unnamedNumbering.integer && length &&
+	     !Q_strnicmp( testName, g_unnamedBotNamePrefix.string, length ) )
+	{
+		return true;
+	}
+
 	return false;
 }
 
@@ -710,9 +718,23 @@ static const char *G_UnnamedClientName( gclient_t *client )
 	}
 
 	client->pers.namelog->unnamedNumber = number;
-	Com_sprintf( name, sizeof( name ), "%.*s%d", (int)sizeof( name ) - 11,
-	             g_unnamedNamePrefix.string[ 0 ] ? g_unnamedNamePrefix.string : UNNAMED_PLAYER"#",
-	             number );
+
+	gentity_t *ent;
+	int clientNum = client - level.clients;
+	ent = g_entities + clientNum;
+
+	if ( ent->r.svFlags & SVF_BOT )
+	{
+		Com_sprintf( name, sizeof( name ), "%.*s%d", (int)sizeof( name ) - 11,
+			g_unnamedBotNamePrefix.string[ 0 ] ? g_unnamedBotNamePrefix.string : UNNAMED_BOT "#",
+			number );
+	}
+	else
+	{
+		Com_sprintf( name, sizeof( name ), "%.*s%d", (int)sizeof( name ) - 11,
+			g_unnamedNamePrefix.string[ 0 ] ? g_unnamedNamePrefix.string : UNNAMED_PLAYER "#",
+			number );
+	}
 
 	return name;
 }

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -148,6 +148,7 @@ extern  vmCvar_t g_layoutAuto;
 extern  vmCvar_t g_emoticonsAllowedInNames;
 extern  vmCvar_t g_unnamedNumbering;
 extern  vmCvar_t g_unnamedNamePrefix;
+extern  vmCvar_t g_unnamedBotNamePrefix;
 
 extern  vmCvar_t g_admin;
 extern  vmCvar_t g_adminWarn;

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -180,6 +180,7 @@ vmCvar_t           g_layoutAuto;
 vmCvar_t           g_emoticonsAllowedInNames;
 vmCvar_t           g_unnamedNumbering;
 vmCvar_t           g_unnamedNamePrefix;
+vmCvar_t           g_unnamedBotNamePrefix;
 
 vmCvar_t           g_admin;
 vmCvar_t           g_adminWarn;
@@ -321,7 +322,8 @@ static cvarTable_t gameCvarTable[] =
 	// clients: misc
 	{ &g_geoip,                       "g_geoip",                       "1",                                0,                                               0, false    , nullptr       },
 	{ &g_unnamedNumbering,            "g_unnamedNumbering",            "-1",                               0,                                               0, false    , nullptr       },
-	{ &g_unnamedNamePrefix,           "g_unnamedNamePrefix",           UNNAMED_PLAYER"#",                  0,                                               0, false    , nullptr       },
+	{ &g_unnamedNamePrefix,           "g_unnamedNamePrefix",           UNNAMED_PLAYER "#",                 0,                                               0, false    , nullptr       },
+	{ &g_unnamedBotNamePrefix,        "g_unnamedBotNamePrefix",        UNNAMED_BOT "#",                    0,                                               0, false    , nullptr       },
 
 	// admin system
 	{ &g_admin,                       "g_admin",                       "admin.dat",                        0,                                               0, false    , nullptr       },


### PR DESCRIPTION
Use a specific prefix for bots so they are not named `UnnamedPlayer#1`:

[![https://dl.illwieckz.net/b/unvanquished/shots/unnamed-bots/unvanquished_2020-09-05_220125_000.jpg](https://dl.illwieckz.net/b/unvanquished/shots/unnamed-bots/unvanquished_2020-09-05_220125_000.jpg)](https://dl.illwieckz.net/b/unvanquished/shots/unnamed-bots/unvanquished_2020-09-05_220125_000.jpg)

There is a `g_unnamedBotNamePrefix` cvar to customize the bot name prefix but even if I'm not happy with the name (it's not named the `g_bot_` way but like existing `g_unnamedBotNamePrefix`) it does the job.

The default bot name prefix is `[bot] Bot#`.