### PR TITLE
Fix errors detected by -fsanitize=float-cast-overflow

### DIFF
--- a/src/cgame/cg_particles.cpp
+++ b/src/cgame/cg_particles.cpp
@@ -204,6 +204,12 @@ static particle_t *CG_SpawnNewParticle( baseParticle_t *bp, particleEjector_t *p
 					bp->modelAnimation.frameLerp = p->lifeTime / bp->modelAnimation.numFrames;
 					bp->modelAnimation.initialLerp = p->lifeTime / bp->modelAnimation.numFrames;
 				}
+				else if ( bp->modelAnimation.frameLerp == 0 )
+				{
+					// Bypass calculations in CG_RunLerpFrame if there is no modelAnimation
+					// since it will try to divide by frameLerp
+					p->lf.animationTime = std::numeric_limits<int>::max();
+				}
 			}
 
 			if ( !CG_AttachmentPoint( &ps->attachment, attachmentPoint ) )

--- a/src/cgame/cg_trails.cpp
+++ b/src/cgame/cg_trails.cpp
@@ -92,6 +92,12 @@ alphaRange = tb->class_->backAlpha -
 		totalDistance += nodeDistances[ j ];
 	}
 
+	if ( !( totalDistance > 0 ) )
+	{
+		// HACK: prevent division by zero
+		totalDistance = 1e-6f;
+	}
+
 	for ( j = 0, i = tb->nodes; i; i = i->next, j++ )
 	{
 		if ( tb->class_->textureType == TBTT_STRETCH )

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -616,7 +616,7 @@ void BotDirectionToUsercmd( gentity_t *self, vec3_t dir, usercmd_t *cmd )
 		cmd->forwardmove = ClampChar( highestforward );
 		cmd->rightmove = ClampChar( highestright );
 	}
-	else
+	else if ( rightmove != 0 )
 	{
 		float highestright = rightmove < 0 ? -speed : speed;
 
@@ -624,6 +624,11 @@ void BotDirectionToUsercmd( gentity_t *self, vec3_t dir, usercmd_t *cmd )
 
 		cmd->forwardmove = ClampChar( highestforward );
 		cmd->rightmove = ClampChar( highestright );
+	}
+	else
+	{
+		cmd->forwardmove = 0;
+		cmd->rightmove = 0;
 	}
 }
 

--- a/src/sgame/sg_buildpoints.cpp
+++ b/src/sgame/sg_buildpoints.cpp
@@ -103,11 +103,13 @@ void G_RecoverBuildPoints() {
 	float rate = g_buildPointRecoveryInititalRate.value /
 	             std::pow(2.0f, (float)level.matchTime /
 	                            (60000.0f * g_buildPointRecoveryRateHalfLife.value));
-	int interval = (int)(60000.0f / rate);
-	int nextBuildPointTime = level.time + interval;
+	float interval = 60000.0f / rate;
 
-	// The interval grows exponentially, so check for an overflow.
-	if (nextBuildPointTime < level.time) return;
+	// The interval grows exponentially, so check for an excessively large value which could cause overflow.
+	// The maximum allowed game time is 0x70000000 (7 << 28); limit interval to 1 << 27.
+	if (interval > 0x1.0p27f) return;
+
+	int nextBuildPointTime = level.time + int(interval);
 
 	for (team_t team = TEAM_NONE; (team = G_IterateTeams(team)); ) {
 		if (!level.team[team].queuedBudget) {

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -1880,7 +1880,14 @@ void ClientSpawn( gentity_t *ent, gentity_t *spawn, const vec3_t origin, const v
 
 	// set default animations
 	client->ps.torsoAnim = TORSO_STAND;
-	client->ps.legsAnim = LEGS_IDLE;
+	if ( client->ps.persistant[ PERS_STATE ] & PS_NONSEGMODEL )
+	{
+		client->ps.legsAnim = NSPA_STAND;
+	}
+	else
+	{
+		client->ps.legsAnim = LEGS_IDLE;
+	}
 
 	if ( level.intermissiontime )
 	{


### PR DESCRIPTION
In C++, a floating point to integer conversion where the float is outside the integer type's range of representable values is undefined behavior. I ran the gamelogics built with GCC with the `-fsanitize=float-cast-overflow` option which prints a message when this type of UB occurs. I fixed all the errors I found, except one in libRocket's font handling.