### PR TITLE
Seed the Lua random number generator at initialization

### DIFF
--- a/src/cgame/rocket/rocket.cpp
+++ b/src/cgame/rocket/rocket.cpp
@@ -339,6 +339,7 @@ void Rocket_Init()
 
 	// Initialize Lua
 	Rocket::Core::Lua::Interpreter::Initialise();
+	Rocket::Core::Lua::Interpreter::DoString("math.randomseed(os.time())");
 	Rocket::Controls::Lua::RegisterTypes(Rocket::Core::Lua::Interpreter::GetLuaState());
 	Rocket::Core::Lua::LuaType<Rocket::Core::Lua::Cvar>::Register(Rocket::Core::Lua::Interpreter::GetLuaState());
 	Rocket::Core::Lua::LuaType<Rocket::Core::Lua::Cmd>::Register(Rocket::Core::Lua::Interpreter::GetLuaState());


### PR DESCRIPTION
This is needed for the script that generates a random name for the
player on first launch, so that it does not generate the same name
always.