### PR TITLE
cgame: add winner RML element, fix #434

### DIFF
--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -3445,6 +3445,14 @@ static void CG_Rocket_DrawLevelName()
 	Rocket_SetInnerRML( CG_ConfigString( CS_MESSAGE ), RP_QUAKE );
 }
 
+static void CG_Rocket_DrawWinner()
+{
+	char winnerMessage[ MAX_STRING_CHARS ];
+
+	trap_Cvar_VariableStringBuffer( "ui_winner", winnerMessage, sizeof( winnerMessage ) );
+	Rocket_SetInnerRML( winnerMessage, 0 );
+}
+
 static void CG_Rocket_DrawMOTD()
 {
 	const char *s;
@@ -3624,6 +3632,7 @@ static const elementRenderCmd_t elementRenderCmdList[] =
 	{ "votes", &CG_Rocket_DrawVote, ELEMENT_GAME },
 	{ "votes_team", &CG_Rocket_DrawTeamVote, ELEMENT_BOTH },
 	{ "warmup_time", &CG_Rocket_DrawWarmup, ELEMENT_GAME },
+	{ "winner", &CG_Rocket_DrawWinner, ELEMENT_ALL },
 };
 
 static const size_t elementRenderCmdListCount = ARRAY_LEN( elementRenderCmdList );


### PR DESCRIPTION
Add `winner` RML element, fix #434

In game:

[![winner in scoreboard](https://dl.illwieckz.net/b/unvanquished/bugs/winner-in-scoreboard/unvanquished_2020-09-26_053936_000.jpg)](https://dl.illwieckz.net/b/unvanquished/bugs/winner-in-scoreboard/unvanquished_2020-09-26_053936_000.jpg)

At game end:

[![winner in scoreboard](https://dl.illwieckz.net/b/unvanquished/bugs/winner-in-scoreboard/unvanquished_2020-09-26_053942_000.jpg)](https://dl.illwieckz.net/b/unvanquished/bugs/winner-in-scoreboard/unvanquished_2020-09-26_053942_000.jpg)

[![winner in scoreboard](https://dl.illwieckz.net/b/unvanquished/bugs/winner-in-scoreboard/unvanquished_2020-09-26_054120_000.jpg)](https://dl.illwieckz.net/b/unvanquished/bugs/winner-in-scoreboard/unvanquished_2020-09-26_054120_000.jpg)

[![winner in scoreboard](https://dl.illwieckz.net/b/unvanquished/bugs/winner-in-scoreboard/unvanquished_2020-09-26_054154_000.jpg)](https://dl.illwieckz.net/b/unvanquished/bugs/winner-in-scoreboard/unvanquished_2020-09-26_054154_000.jpg)

[![winner in scoreboard](https://dl.illwieckz.net/b/unvanquished/bugs/winner-in-scoreboard/unvanquished_2020-09-26_054836_000.jpg)](https://dl.illwieckz.net/b/unvanquished/bugs/winner-in-scoreboard/unvanquished_2020-09-26_054836_000.jpg)

Only useful with https://github.com/UnvanquishedAssets/unvanquished_src.dpkdir/pull/28