### PR TITLE
do not do picmip on UI elements, fix UnvanquishedAssets/unvanquished_src.dpkdir#21

### DIFF
--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -731,8 +731,8 @@ void CG_InitBuildables()
 		//icon
 		if ( ( buildableIcon = BG_Buildable( buildable )->icon ) )
 		{
-		        cg_buildables[ buildable ].buildableIcon = trap_R_RegisterShader( buildableIcon, RSF_DEFAULT );
-                }
+			cg_buildables[ buildable ].buildableIcon = trap_R_RegisterShader( buildableIcon, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+		}
 
 		cg.buildablesFraction = ( float ) buildable / ( float )( BA_NUM_BUILDABLES - 1 );
 		trap_UpdateScreen();
@@ -1432,8 +1432,7 @@ void CG_BuildableStatusParse( const char *filename, buildStat_t *bs )
 		{
 			if ( PC_String_Parse( handle, &s ) )
 			{
-				bs->frameShader = trap_R_RegisterShader(s,
-									RSF_DEFAULT);
+				bs->frameShader = trap_R_RegisterShader( s, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 			}
 
 			continue;
@@ -1442,8 +1441,7 @@ void CG_BuildableStatusParse( const char *filename, buildStat_t *bs )
 		{
 			if ( PC_String_Parse( handle, &s ) )
 			{
-				bs->overlayShader = trap_R_RegisterShader(s,
-									  RSF_DEFAULT);
+				bs->overlayShader = trap_R_RegisterShader( s, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 			}
 
 			continue;
@@ -1452,8 +1450,7 @@ void CG_BuildableStatusParse( const char *filename, buildStat_t *bs )
 		{
 			if ( PC_String_Parse( handle, &s ) )
 			{
-				bs->noPowerShader = trap_R_RegisterShader(s,
-									  RSF_DEFAULT);
+				bs->noPowerShader = trap_R_RegisterShader( s, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 			}
 
 			continue;
@@ -1462,8 +1459,7 @@ void CG_BuildableStatusParse( const char *filename, buildStat_t *bs )
 		{
 			if ( PC_String_Parse( handle, &s ) )
 			{
-				bs->markedShader = trap_R_RegisterShader(s,
-									 RSF_DEFAULT);
+				bs->markedShader = trap_R_RegisterShader( s, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 			}
 
 			continue;

--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -731,7 +731,7 @@ void CG_InitBuildables()
 		//icon
 		if ( ( buildableIcon = BG_Buildable( buildable )->icon ) )
 		{
-			cg_buildables[ buildable ].buildableIcon = trap_R_RegisterShader( buildableIcon, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+			cg_buildables[ buildable ].buildableIcon = trap_R_RegisterShader( buildableIcon, (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 		}
 
 		cg.buildablesFraction = ( float ) buildable / ( float )( BA_NUM_BUILDABLES - 1 );
@@ -1432,7 +1432,7 @@ void CG_BuildableStatusParse( const char *filename, buildStat_t *bs )
 		{
 			if ( PC_String_Parse( handle, &s ) )
 			{
-				bs->frameShader = trap_R_RegisterShader( s, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+				bs->frameShader = trap_R_RegisterShader( s, (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 			}
 
 			continue;
@@ -1441,7 +1441,7 @@ void CG_BuildableStatusParse( const char *filename, buildStat_t *bs )
 		{
 			if ( PC_String_Parse( handle, &s ) )
 			{
-				bs->overlayShader = trap_R_RegisterShader( s, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+				bs->overlayShader = trap_R_RegisterShader( s, (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 			}
 
 			continue;
@@ -1450,7 +1450,7 @@ void CG_BuildableStatusParse( const char *filename, buildStat_t *bs )
 		{
 			if ( PC_String_Parse( handle, &s ) )
 			{
-				bs->noPowerShader = trap_R_RegisterShader( s, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+				bs->noPowerShader = trap_R_RegisterShader( s, (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 			}
 
 			continue;
@@ -1459,7 +1459,7 @@ void CG_BuildableStatusParse( const char *filename, buildStat_t *bs )
 		{
 			if ( PC_String_Parse( handle, &s ) )
 			{
-				bs->markedShader = trap_R_RegisterShader( s, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+				bs->markedShader = trap_R_RegisterShader( s, (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 			}
 
 			continue;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1059,24 +1059,24 @@ static void CG_RegisterGraphics()
 	CG_UpdateLoadingStep( LOAD_ASSETS );
 	for ( i = 0; i < 11; i++ )
 	{
-		cgs.media.numberShaders[ i ] = trap_R_RegisterShader(sb_nums[i], (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+		cgs.media.numberShaders[ i ] = trap_R_RegisterShader(sb_nums[i], (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 	}
 
-	cgs.media.viewBloodShader = trap_R_RegisterShader("gfx/feedback/painblend", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+	cgs.media.viewBloodShader = trap_R_RegisterShader("gfx/feedback/painblend", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
-	cgs.media.connectionShader = trap_R_RegisterShader("gfx/feedback/net", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+	cgs.media.connectionShader = trap_R_RegisterShader("gfx/feedback/net", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
 	cgs.media.creepShader = trap_R_RegisterShader("gfx/buildables/creep/creep", (RegisterShaderFlags_t) RSF_DEFAULT );
 
-	cgs.media.scannerBlipShader = trap_R_RegisterShader("gfx/feedback/scanner/blip", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+	cgs.media.scannerBlipShader = trap_R_RegisterShader("gfx/feedback/scanner/blip", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
-	cgs.media.scannerBlipBldgShader = trap_R_RegisterShader("gfx/feedback/scanner/blip_bldg", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+	cgs.media.scannerBlipBldgShader = trap_R_RegisterShader("gfx/feedback/scanner/blip_bldg", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
-	cgs.media.scannerLineShader = trap_R_RegisterShader("gfx/feedback/scanner/stalk", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+	cgs.media.scannerLineShader = trap_R_RegisterShader("gfx/feedback/scanner/stalk", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
 	cgs.media.tracerShader = trap_R_RegisterShader("gfx/weapons/tracer/tracer", (RegisterShaderFlags_t) RSF_DEFAULT);
 
-	cgs.media.backTileShader = trap_R_RegisterShader("gfx/colors/backtile", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+	cgs.media.backTileShader = trap_R_RegisterShader("gfx/colors/backtile", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
 	// building shaders
 	cgs.media.greenBuildShader = trap_R_RegisterShader("gfx/buildables/common/greenbuild",(RegisterShaderFlags_t) RSF_DEFAULT );
@@ -1104,7 +1104,7 @@ static void CG_RegisterGraphics()
 
 	cgs.media.disconnectPS = CG_RegisterParticleSystem( "particles/feedback/disconnect" );
 
-	cgs.media.scopeShader = trap_R_RegisterShader( "gfx/weapons/scope", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+	cgs.media.scopeShader = trap_R_RegisterShader( "gfx/weapons/scope", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
 	CG_UpdateMediaFraction( 0.7f );
 
@@ -1155,11 +1155,11 @@ static void CG_RegisterGraphics()
 	CG_BuildableStatusParse( "ui/assets/human/buildstat.cfg", &cgs.humanBuildStat );
 	CG_BuildableStatusParse( "ui/assets/alien/buildstat.cfg", &cgs.alienBuildStat );
 
-	cgs.media.beaconIconArrow = trap_R_RegisterShader( "gfx/feedback/beacons/arrow", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
-	cgs.media.beaconNoTarget = trap_R_RegisterShader( "gfx/feedback/beacons/no-target", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
-	cgs.media.beaconTagScore = trap_R_RegisterShader( "gfx/feedback/beacons/tagscore", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+	cgs.media.beaconIconArrow = trap_R_RegisterShader( "gfx/feedback/beacons/arrow", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
+	cgs.media.beaconNoTarget = trap_R_RegisterShader( "gfx/feedback/beacons/no-target", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
+	cgs.media.beaconTagScore = trap_R_RegisterShader( "gfx/feedback/beacons/tagscore", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
-	cgs.media.damageIndicatorFont = trap_R_RegisterShader( "gfx/feedback/damage/font", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+	cgs.media.damageIndicatorFont = trap_R_RegisterShader( "gfx/feedback/damage/font", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
 	// register the inline models
 	cgs.numInlineModels = trap_CM_NumInlineModels();

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1059,73 +1059,48 @@ static void CG_RegisterGraphics()
 	CG_UpdateLoadingStep( LOAD_ASSETS );
 	for ( i = 0; i < 11; i++ )
 	{
-		cgs.media.numberShaders[ i ] = trap_R_RegisterShader(sb_nums[i],
-								     (RegisterShaderFlags_t) RSF_DEFAULT);
+		cgs.media.numberShaders[ i ] = trap_R_RegisterShader(sb_nums[i], (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 	}
 
-	cgs.media.viewBloodShader = trap_R_RegisterShader("gfx/feedback/painblend",
-							  (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.viewBloodShader = trap_R_RegisterShader("gfx/feedback/painblend", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 
-	cgs.media.connectionShader = trap_R_RegisterShader("gfx/feedback/net",
-							   (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.connectionShader = trap_R_RegisterShader("gfx/feedback/net", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 
-	cgs.media.creepShader = trap_R_RegisterShader("gfx/buildables/creep/creep", (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.creepShader = trap_R_RegisterShader("gfx/buildables/creep/creep", (RegisterShaderFlags_t) RSF_DEFAULT );
 
-	cgs.media.scannerBlipShader = trap_R_RegisterShader("gfx/feedback/scanner/blip",
-							    (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.scannerBlipShader = trap_R_RegisterShader("gfx/feedback/scanner/blip", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 
-	cgs.media.scannerBlipBldgShader = trap_R_RegisterShader("gfx/feedback/scanner/blip_bldg",
-								(RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.scannerBlipBldgShader = trap_R_RegisterShader("gfx/feedback/scanner/blip_bldg", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 
-	cgs.media.scannerLineShader = trap_R_RegisterShader("gfx/feedback/scanner/stalk",
-							    (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.scannerLineShader = trap_R_RegisterShader("gfx/feedback/scanner/stalk", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 
-	cgs.media.tracerShader = trap_R_RegisterShader("gfx/weapons/tracer/tracer",
-						       (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.tracerShader = trap_R_RegisterShader("gfx/weapons/tracer/tracer", (RegisterShaderFlags_t) RSF_DEFAULT);
 
-	cgs.media.backTileShader = trap_R_RegisterShader("gfx/colors/backtile",
-							 (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.backTileShader = trap_R_RegisterShader("gfx/colors/backtile", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 
 	// building shaders
-	cgs.media.greenBuildShader = trap_R_RegisterShader("gfx/buildables/common/greenbuild",
-							   (RegisterShaderFlags_t) RSF_DEFAULT);
-	cgs.media.redBuildShader = trap_R_RegisterShader("gfx/buildables/common/redbuild",
-							 (RegisterShaderFlags_t) RSF_DEFAULT);
-	cgs.media.humanSpawningShader = trap_R_RegisterShader("gfx/buildables/human_base/spawning",
-							      (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.greenBuildShader = trap_R_RegisterShader("gfx/buildables/common/greenbuild",(RegisterShaderFlags_t) RSF_DEFAULT );
+	cgs.media.redBuildShader = trap_R_RegisterShader("gfx/buildables/common/redbuild", (RegisterShaderFlags_t) RSF_DEFAULT );
+	cgs.media.humanSpawningShader = trap_R_RegisterShader("gfx/buildables/human_base/spawning", (RegisterShaderFlags_t) RSF_DEFAULT );
 
 	for ( i = 0; i < 8; i++ )
 	{
-		cgs.media.buildWeaponTimerPie[ i ] = trap_R_RegisterShader(buildWeaponTimerPieShaders[i],
-									   (RegisterShaderFlags_t) RSF_DEFAULT);
+		cgs.media.buildWeaponTimerPie[ i ] = trap_R_RegisterShader(buildWeaponTimerPieShaders[i], (RegisterShaderFlags_t) RSF_DEFAULT);
 	}
 
 	// player health cross shaders
-	cgs.media.healthCross = trap_R_RegisterShader("ui/assets/neutral/cross",
-						      (RegisterShaderFlags_t) RSF_DEFAULT);
-	cgs.media.healthCross2X = trap_R_RegisterShader("ui/assets/neutral/cross2",
-							(RegisterShaderFlags_t) RSF_DEFAULT);
-	cgs.media.healthCross3X = trap_R_RegisterShader("ui/assets/neutral/cross3",
-							(RegisterShaderFlags_t) RSF_DEFAULT);
-	cgs.media.healthCrossMedkit = trap_R_RegisterShader("ui/assets/neutral/cross_medkit",
-							    (RegisterShaderFlags_t) RSF_DEFAULT);
-	cgs.media.healthCrossPoisoned = trap_R_RegisterShader("ui/assets/neutral/cross_poison",
-							      (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.healthCross = trap_R_RegisterShader("ui/assets/neutral/cross", (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.healthCross2X = trap_R_RegisterShader("ui/assets/neutral/cross2", (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.healthCross3X = trap_R_RegisterShader("ui/assets/neutral/cross3", (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.healthCrossMedkit = trap_R_RegisterShader("ui/assets/neutral/cross_medkit", (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.healthCrossPoisoned = trap_R_RegisterShader("ui/assets/neutral/cross_poison", (RegisterShaderFlags_t) RSF_DEFAULT);
 
-	cgs.media.desaturatedCgrade = trap_R_RegisterShader("gfx/cgrading/desaturated",
-								 (RegisterShaderFlags_t) ( RSF_NOMIP | RSF_NOLIGHTSCALE ) );
+	cgs.media.desaturatedCgrade = trap_R_RegisterShader("gfx/cgrading/desaturated", (RegisterShaderFlags_t) ( RSF_NOMIP | RSF_NOLIGHTSCALE ) );
+	cgs.media.neutralCgrade = trap_R_RegisterShader("gfx/cgrading/neutral", (RegisterShaderFlags_t) ( RSF_NOMIP | RSF_NOLIGHTSCALE ) );
+	cgs.media.redCgrade = trap_R_RegisterShader("gfx/cgrading/red-only", (RegisterShaderFlags_t) ( RSF_NOMIP | RSF_NOLIGHTSCALE ) );
+	cgs.media.tealCgrade = trap_R_RegisterShader("gfx/cgrading/teal-only", (RegisterShaderFlags_t) ( RSF_NOMIP | RSF_NOLIGHTSCALE ) );
 
-	cgs.media.neutralCgrade = trap_R_RegisterShader("gfx/cgrading/neutral",
-								 (RegisterShaderFlags_t) ( RSF_NOMIP | RSF_NOLIGHTSCALE ) );
-
-	cgs.media.redCgrade = trap_R_RegisterShader("gfx/cgrading/red-only",
-								 (RegisterShaderFlags_t) ( RSF_NOMIP | RSF_NOLIGHTSCALE ) );
-
-	cgs.media.tealCgrade = trap_R_RegisterShader("gfx/cgrading/teal-only",
-								 (RegisterShaderFlags_t) ( RSF_NOMIP | RSF_NOLIGHTSCALE ) );
-
-	cgs.media.balloonShader = trap_R_RegisterShader("gfx/feedback/chatballoon",
-							(RegisterShaderFlags_t) RSF_SPRITE);
+	cgs.media.balloonShader = trap_R_RegisterShader("gfx/feedback/chatballoon", (RegisterShaderFlags_t) ( RSF_SPRITE | RSF_NOMIP ) );
 
 	cgs.media.disconnectPS = CG_RegisterParticleSystem( "particles/feedback/disconnect" );
 
@@ -1136,10 +1111,8 @@ static void CG_RegisterGraphics()
 	memset( cg_weapons, 0, sizeof( cg_weapons ) );
 	memset( cg_upgrades, 0, sizeof( cg_upgrades ) );
 
-	cgs.media.shadowMarkShader = trap_R_RegisterShader("gfx/players/common/shadow",
-							   (RegisterShaderFlags_t) RSF_DEFAULT);
-	cgs.media.wakeMarkShader = trap_R_RegisterShader("gfx/players/common/wake",
-							 (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.shadowMarkShader = trap_R_RegisterShader("gfx/players/common/shadow", (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.wakeMarkShader = trap_R_RegisterShader("gfx/players/common/wake", (RegisterShaderFlags_t) RSF_DEFAULT);
 
 	cgs.media.alienEvolvePS = CG_RegisterParticleSystem( "particles/players/alien_base/evolve" );
 	cgs.media.alienAcidTubePS = CG_RegisterParticleSystem( "particles/buildables/acide_tube/spore" );
@@ -1166,35 +1139,27 @@ static void CG_RegisterGraphics()
 	cgs.media.sphericalCone64Model = trap_R_RegisterModel( "models/generic/sphericalCone64.md3" );
 	cgs.media.sphericalCone240Model = trap_R_RegisterModel( "models/generic/sphericalCone240.md3" );
 
-	cgs.media.plainColorShader = trap_R_RegisterShader("gfx/colors/plain",
-							   (RegisterShaderFlags_t) RSF_DEFAULT);
-	cgs.media.binaryAlpha1Shader = trap_R_RegisterShader("gfx/binary/alpha1",
-							     (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.plainColorShader = trap_R_RegisterShader("gfx/colors/plain", (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.binaryAlpha1Shader = trap_R_RegisterShader("gfx/binary/alpha1", (RegisterShaderFlags_t) RSF_DEFAULT);
 
 	for ( i = 0; i < NUM_BINARY_SHADERS; ++i )
 	{
-		cgs.media.binaryShaders[ i ].f1 = trap_R_RegisterShader(va("gfx/binary/%03i_F1", i),
-									(RegisterShaderFlags_t) RSF_DEFAULT);
-		cgs.media.binaryShaders[ i ].f2 = trap_R_RegisterShader(va("gfx/binary/%03i_F2", i),
-									(RegisterShaderFlags_t) RSF_DEFAULT);
-		cgs.media.binaryShaders[ i ].f3 = trap_R_RegisterShader(va("gfx/binary/%03i_F3", i),
-									(RegisterShaderFlags_t) RSF_DEFAULT);
-		cgs.media.binaryShaders[ i ].b1 = trap_R_RegisterShader(va("gfx/binary/%03i_B1", i),
-									(RegisterShaderFlags_t) RSF_DEFAULT);
-		cgs.media.binaryShaders[ i ].b2 = trap_R_RegisterShader(va("gfx/binary/%03i_B2", i),
-									(RegisterShaderFlags_t) RSF_DEFAULT);
-		cgs.media.binaryShaders[ i ].b3 = trap_R_RegisterShader(va("gfx/binary/%03i_B3", i),
-									(RegisterShaderFlags_t) RSF_DEFAULT);
+		cgs.media.binaryShaders[ i ].f1 = trap_R_RegisterShader(va("gfx/binary/%03i_F1", i), (RegisterShaderFlags_t) RSF_DEFAULT);
+		cgs.media.binaryShaders[ i ].f2 = trap_R_RegisterShader(va("gfx/binary/%03i_F2", i), (RegisterShaderFlags_t) RSF_DEFAULT);
+		cgs.media.binaryShaders[ i ].f3 = trap_R_RegisterShader(va("gfx/binary/%03i_F3", i), (RegisterShaderFlags_t) RSF_DEFAULT);
+		cgs.media.binaryShaders[ i ].b1 = trap_R_RegisterShader(va("gfx/binary/%03i_B1", i), (RegisterShaderFlags_t) RSF_DEFAULT);
+		cgs.media.binaryShaders[ i ].b2 = trap_R_RegisterShader(va("gfx/binary/%03i_B2", i), (RegisterShaderFlags_t) RSF_DEFAULT);
+		cgs.media.binaryShaders[ i ].b3 = trap_R_RegisterShader(va("gfx/binary/%03i_B3", i), (RegisterShaderFlags_t) RSF_DEFAULT);
 	}
 
 	CG_BuildableStatusParse( "ui/assets/human/buildstat.cfg", &cgs.humanBuildStat );
 	CG_BuildableStatusParse( "ui/assets/alien/buildstat.cfg", &cgs.alienBuildStat );
 
-	cgs.media.beaconIconArrow = trap_R_RegisterShader( "gfx/feedback/beacons/arrow", RSF_DEFAULT );
-	cgs.media.beaconNoTarget = trap_R_RegisterShader( "gfx/feedback/beacons/no-target", RSF_DEFAULT );
-	cgs.media.beaconTagScore = trap_R_RegisterShader( "gfx/feedback/beacons/tagscore", RSF_DEFAULT );
+	cgs.media.beaconIconArrow = trap_R_RegisterShader( "gfx/feedback/beacons/arrow", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+	cgs.media.beaconNoTarget = trap_R_RegisterShader( "gfx/feedback/beacons/no-target", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+	cgs.media.beaconTagScore = trap_R_RegisterShader( "gfx/feedback/beacons/tagscore", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 
-	cgs.media.damageIndicatorFont = trap_R_RegisterShader( "gfx/feedback/damage/font", RSF_DEFAULT );
+	cgs.media.damageIndicatorFont = trap_R_RegisterShader( "gfx/feedback/damage/font", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 
 	// register the inline models
 	cgs.numInlineModels = trap_CM_NumInlineModels();
@@ -1250,8 +1215,7 @@ static void CG_RegisterGraphics()
 			break;
 		}
 
-		cgs.gameShaders[ i ] = trap_R_RegisterShader(shaderName,
-							     (RegisterShaderFlags_t) RSF_DEFAULT);
+		cgs.gameShaders[ i ] = trap_R_RegisterShader(shaderName, (RegisterShaderFlags_t) RSF_DEFAULT);
 	}
 
 	CG_UpdateMediaFraction( 0.77f );
@@ -1469,8 +1433,7 @@ void CG_Init( int serverMessageNum, int clientNum, const glconfig_t& gl, const G
 	// load a few needed things before we do any screen updates
 	trap_R_SetAltShaderTokens( "unpowered,destroyed,idle,idle2" );
 	cgs.media.whiteShader = trap_R_RegisterShader("gfx/colors/white", (RegisterShaderFlags_t) RSF_DEFAULT);
-	cgs.media.outlineShader = trap_R_RegisterShader("gfx/outline",
-							(RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.outlineShader = trap_R_RegisterShader("gfx/outline", (RegisterShaderFlags_t) RSF_DEFAULT);
 
 	BG_InitAllowedGameElements();
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1066,7 +1066,7 @@ static void CG_RegisterGraphics()
 
 	cgs.media.connectionShader = trap_R_RegisterShader("gfx/feedback/net", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
-	cgs.media.creepShader = trap_R_RegisterShader("gfx/buildables/creep/creep", (RegisterShaderFlags_t) RSF_DEFAULT );
+	cgs.media.creepShader = trap_R_RegisterShader("gfx/buildables/creep/creep", RSF_DEFAULT );
 
 	cgs.media.scannerBlipShader = trap_R_RegisterShader("gfx/feedback/scanner/blip", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
@@ -1074,26 +1074,26 @@ static void CG_RegisterGraphics()
 
 	cgs.media.scannerLineShader = trap_R_RegisterShader("gfx/feedback/scanner/stalk", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
-	cgs.media.tracerShader = trap_R_RegisterShader("gfx/weapons/tracer/tracer", (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.tracerShader = trap_R_RegisterShader("gfx/weapons/tracer/tracer", RSF_DEFAULT);
 
 	cgs.media.backTileShader = trap_R_RegisterShader("gfx/colors/backtile", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
 	// building shaders
-	cgs.media.greenBuildShader = trap_R_RegisterShader("gfx/buildables/common/greenbuild",(RegisterShaderFlags_t) RSF_DEFAULT );
-	cgs.media.redBuildShader = trap_R_RegisterShader("gfx/buildables/common/redbuild", (RegisterShaderFlags_t) RSF_DEFAULT );
-	cgs.media.humanSpawningShader = trap_R_RegisterShader("gfx/buildables/human_base/spawning", (RegisterShaderFlags_t) RSF_DEFAULT );
+	cgs.media.greenBuildShader = trap_R_RegisterShader("gfx/buildables/common/greenbuild", RSF_DEFAULT );
+	cgs.media.redBuildShader = trap_R_RegisterShader("gfx/buildables/common/redbuild", RSF_DEFAULT );
+	cgs.media.humanSpawningShader = trap_R_RegisterShader("gfx/buildables/human_base/spawning", RSF_DEFAULT );
 
 	for ( i = 0; i < 8; i++ )
 	{
-		cgs.media.buildWeaponTimerPie[ i ] = trap_R_RegisterShader(buildWeaponTimerPieShaders[i], (RegisterShaderFlags_t) RSF_DEFAULT);
+		cgs.media.buildWeaponTimerPie[ i ] = trap_R_RegisterShader(buildWeaponTimerPieShaders[i], RSF_DEFAULT);
 	}
 
 	// player health cross shaders
-	cgs.media.healthCross = trap_R_RegisterShader("ui/assets/neutral/cross", (RegisterShaderFlags_t) RSF_DEFAULT);
-	cgs.media.healthCross2X = trap_R_RegisterShader("ui/assets/neutral/cross2", (RegisterShaderFlags_t) RSF_DEFAULT);
-	cgs.media.healthCross3X = trap_R_RegisterShader("ui/assets/neutral/cross3", (RegisterShaderFlags_t) RSF_DEFAULT);
-	cgs.media.healthCrossMedkit = trap_R_RegisterShader("ui/assets/neutral/cross_medkit", (RegisterShaderFlags_t) RSF_DEFAULT);
-	cgs.media.healthCrossPoisoned = trap_R_RegisterShader("ui/assets/neutral/cross_poison", (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.healthCross = trap_R_RegisterShader("ui/assets/neutral/cross", RSF_DEFAULT);
+	cgs.media.healthCross2X = trap_R_RegisterShader("ui/assets/neutral/cross2", RSF_DEFAULT);
+	cgs.media.healthCross3X = trap_R_RegisterShader("ui/assets/neutral/cross3", RSF_DEFAULT);
+	cgs.media.healthCrossMedkit = trap_R_RegisterShader("ui/assets/neutral/cross_medkit", RSF_DEFAULT);
+	cgs.media.healthCrossPoisoned = trap_R_RegisterShader("ui/assets/neutral/cross_poison", RSF_DEFAULT);
 
 	cgs.media.desaturatedCgrade = trap_R_RegisterShader("gfx/cgrading/desaturated", (RegisterShaderFlags_t) ( RSF_NOMIP | RSF_NOLIGHTSCALE ) );
 	cgs.media.neutralCgrade = trap_R_RegisterShader("gfx/cgrading/neutral", (RegisterShaderFlags_t) ( RSF_NOMIP | RSF_NOLIGHTSCALE ) );
@@ -1111,8 +1111,8 @@ static void CG_RegisterGraphics()
 	memset( cg_weapons, 0, sizeof( cg_weapons ) );
 	memset( cg_upgrades, 0, sizeof( cg_upgrades ) );
 
-	cgs.media.shadowMarkShader = trap_R_RegisterShader("gfx/players/common/shadow", (RegisterShaderFlags_t) RSF_DEFAULT);
-	cgs.media.wakeMarkShader = trap_R_RegisterShader("gfx/players/common/wake", (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.shadowMarkShader = trap_R_RegisterShader("gfx/players/common/shadow", RSF_DEFAULT);
+	cgs.media.wakeMarkShader = trap_R_RegisterShader("gfx/players/common/wake", RSF_DEFAULT);
 
 	cgs.media.alienEvolvePS = CG_RegisterParticleSystem( "particles/players/alien_base/evolve" );
 	cgs.media.alienAcidTubePS = CG_RegisterParticleSystem( "particles/buildables/acide_tube/spore" );
@@ -1139,17 +1139,17 @@ static void CG_RegisterGraphics()
 	cgs.media.sphericalCone64Model = trap_R_RegisterModel( "models/generic/sphericalCone64.md3" );
 	cgs.media.sphericalCone240Model = trap_R_RegisterModel( "models/generic/sphericalCone240.md3" );
 
-	cgs.media.plainColorShader = trap_R_RegisterShader("gfx/colors/plain", (RegisterShaderFlags_t) RSF_DEFAULT);
-	cgs.media.binaryAlpha1Shader = trap_R_RegisterShader("gfx/binary/alpha1", (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.plainColorShader = trap_R_RegisterShader("gfx/colors/plain", RSF_DEFAULT);
+	cgs.media.binaryAlpha1Shader = trap_R_RegisterShader("gfx/binary/alpha1", RSF_DEFAULT);
 
 	for ( i = 0; i < NUM_BINARY_SHADERS; ++i )
 	{
-		cgs.media.binaryShaders[ i ].f1 = trap_R_RegisterShader(va("gfx/binary/%03i_F1", i), (RegisterShaderFlags_t) RSF_DEFAULT);
-		cgs.media.binaryShaders[ i ].f2 = trap_R_RegisterShader(va("gfx/binary/%03i_F2", i), (RegisterShaderFlags_t) RSF_DEFAULT);
-		cgs.media.binaryShaders[ i ].f3 = trap_R_RegisterShader(va("gfx/binary/%03i_F3", i), (RegisterShaderFlags_t) RSF_DEFAULT);
-		cgs.media.binaryShaders[ i ].b1 = trap_R_RegisterShader(va("gfx/binary/%03i_B1", i), (RegisterShaderFlags_t) RSF_DEFAULT);
-		cgs.media.binaryShaders[ i ].b2 = trap_R_RegisterShader(va("gfx/binary/%03i_B2", i), (RegisterShaderFlags_t) RSF_DEFAULT);
-		cgs.media.binaryShaders[ i ].b3 = trap_R_RegisterShader(va("gfx/binary/%03i_B3", i), (RegisterShaderFlags_t) RSF_DEFAULT);
+		cgs.media.binaryShaders[ i ].f1 = trap_R_RegisterShader(va("gfx/binary/%03i_F1", i), RSF_DEFAULT);
+		cgs.media.binaryShaders[ i ].f2 = trap_R_RegisterShader(va("gfx/binary/%03i_F2", i), RSF_DEFAULT);
+		cgs.media.binaryShaders[ i ].f3 = trap_R_RegisterShader(va("gfx/binary/%03i_F3", i), RSF_DEFAULT);
+		cgs.media.binaryShaders[ i ].b1 = trap_R_RegisterShader(va("gfx/binary/%03i_B1", i), RSF_DEFAULT);
+		cgs.media.binaryShaders[ i ].b2 = trap_R_RegisterShader(va("gfx/binary/%03i_B2", i), RSF_DEFAULT);
+		cgs.media.binaryShaders[ i ].b3 = trap_R_RegisterShader(va("gfx/binary/%03i_B3", i), RSF_DEFAULT);
 	}
 
 	CG_BuildableStatusParse( "ui/assets/human/buildstat.cfg", &cgs.humanBuildStat );
@@ -1215,7 +1215,7 @@ static void CG_RegisterGraphics()
 			break;
 		}
 
-		cgs.gameShaders[ i ] = trap_R_RegisterShader(shaderName, (RegisterShaderFlags_t) RSF_DEFAULT);
+		cgs.gameShaders[ i ] = trap_R_RegisterShader(shaderName, RSF_DEFAULT);
 	}
 
 	CG_UpdateMediaFraction( 0.77f );
@@ -1432,8 +1432,8 @@ void CG_Init( int serverMessageNum, int clientNum, const glconfig_t& gl, const G
 
 	// load a few needed things before we do any screen updates
 	trap_R_SetAltShaderTokens( "unpowered,destroyed,idle,idle2" );
-	cgs.media.whiteShader = trap_R_RegisterShader("gfx/colors/white", (RegisterShaderFlags_t) RSF_DEFAULT);
-	cgs.media.outlineShader = trap_R_RegisterShader("gfx/outline", (RegisterShaderFlags_t) RSF_DEFAULT);
+	cgs.media.whiteShader = trap_R_RegisterShader("gfx/colors/white", RSF_DEFAULT);
+	cgs.media.outlineShader = trap_R_RegisterShader("gfx/outline", RSF_DEFAULT);
 
 	BG_InitAllowedGameElements();
 

--- a/src/cgame/cg_minimap.cpp
+++ b/src/cgame/cg_minimap.cpp
@@ -104,7 +104,7 @@ static bool CG_ParseMinimapZone( minimapZone_t* z, const char **text )
                 Log::Warn("error while parsing the image name while parsing 'image'" );
             }
 
-            z->image = trap_R_RegisterShader( token, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+            z->image = trap_R_RegisterShader( token, (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
             if( !ParseFloats( z->imageMin, 2, text) || !ParseFloats( z->imageMax, 2, text) )
             {
@@ -649,8 +649,8 @@ void CG_InitMinimap()
         Log::Warn("the minimap did not define any zone." );
     }
 
-    m->gfx.playerArrow = trap_R_RegisterShader( "gfx/feedback/minimap/player-arrow", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
-    m->gfx.teamArrow = trap_R_RegisterShader( "gfx/feedback/minimap/team-arrow", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+    m->gfx.playerArrow = trap_R_RegisterShader( "gfx/feedback/minimap/player-arrow", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
+    m->gfx.teamArrow = trap_R_RegisterShader( "gfx/feedback/minimap/team-arrow", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
     CG_UpdateMinimapActive( m );
 }

--- a/src/cgame/cg_minimap.cpp
+++ b/src/cgame/cg_minimap.cpp
@@ -104,7 +104,7 @@ static bool CG_ParseMinimapZone( minimapZone_t* z, const char **text )
                 Log::Warn("error while parsing the image name while parsing 'image'" );
             }
 
-            z->image = trap_R_RegisterShader( token, RSF_DEFAULT );
+            z->image = trap_R_RegisterShader( token, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 
             if( !ParseFloats( z->imageMin, 2, text) || !ParseFloats( z->imageMax, 2, text) )
             {
@@ -649,8 +649,8 @@ void CG_InitMinimap()
         Log::Warn("the minimap did not define any zone." );
     }
 
-    m->gfx.playerArrow = trap_R_RegisterShader( "gfx/feedback/minimap/player-arrow", RSF_DEFAULT );
-    m->gfx.teamArrow = trap_R_RegisterShader( "gfx/feedback/minimap/team-arrow", RSF_DEFAULT );
+    m->gfx.playerArrow = trap_R_RegisterShader( "gfx/feedback/minimap/player-arrow", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+    m->gfx.teamArrow = trap_R_RegisterShader( "gfx/feedback/minimap/team-arrow", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 
     CG_UpdateMinimapActive( m );
 }

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -3752,7 +3752,7 @@ void CG_InitClasses()
 
 		if ( icon )
 		{
-			cg_classes[ i ].classIcon = trap_R_RegisterShader( icon, RSF_DEFAULT );
+			cg_classes[ i ].classIcon = trap_R_RegisterShader( icon, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 
 			if ( !cg_classes[ i ].classIcon )
 			{

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -3752,7 +3752,7 @@ void CG_InitClasses()
 
 		if ( icon )
 		{
-			cg_classes[ i ].classIcon = trap_R_RegisterShader( icon, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+			cg_classes[ i ].classIcon = trap_R_RegisterShader( icon, (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
 			if ( !cg_classes[ i ].classIcon )
 			{

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -1290,8 +1290,7 @@ static void CG_Rocket_DrawDisconnect()
 	x = 640 - 48;
 	y = 480 - 48;
 
-	CG_DrawPic( x, y, 48, 48, trap_R_RegisterShader( "gfx/feedback/net",
-				RSF_DEFAULT ) );
+	CG_DrawPic( x, y, 48, 48, trap_R_RegisterShader( "gfx/feedback/net", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) ) );
 }
 
 #define MAX_LAGOMETER_PING  900

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -1290,7 +1290,7 @@ static void CG_Rocket_DrawDisconnect()
 	x = 640 - 48;
 	y = 480 - 48;
 
-	CG_DrawPic( x, y, 48, 48, trap_R_RegisterShader( "gfx/feedback/net", (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) ) );
+	CG_DrawPic( x, y, 48, 48, trap_R_RegisterShader( "gfx/feedback/net", (RegisterShaderFlags_t) ( RSF_NOMIP ) ) );
 }
 
 #define MAX_LAGOMETER_PING  900

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -69,7 +69,7 @@ void CG_RegisterUpgrade( int upgradeNum )
 	icon = BG_Upgrade( upgradeNum )->icon;
 	if ( icon )
 	{
-		upgradeInfo->upgradeIcon = trap_R_RegisterShader( icon, RSF_DEFAULT );
+		upgradeInfo->upgradeIcon = trap_R_RegisterShader( icon, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 	}
 }
 
@@ -393,8 +393,7 @@ static bool CG_ParseWeaponModeSection( weaponInfoMode_t *wim, const char **text_
 				break;
 			}
 
-			wim->impactMark = trap_R_RegisterShader(token,
-								RSF_DEFAULT);
+			wim->impactMark = trap_R_RegisterShader(token, RSF_DEFAULT);
 			wim->impactMarkSize = size;
 
 			if ( !wim->impactMark )
@@ -1011,8 +1010,7 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 				break;
 			}
 
-			wi->weaponIcon = wi->ammoIcon = trap_R_RegisterShader(token,
-									      RSF_DEFAULT);
+			wi->weaponIcon = wi->ammoIcon = trap_R_RegisterShader( token, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 
 			if ( !wi->weaponIcon )
 			{
@@ -1030,7 +1028,7 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 				break;
 			}
 
-			wi->crossHair = trap_R_RegisterShader( token, RSF_DEFAULT );
+			wi->crossHair = trap_R_RegisterShader( token, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 
 			if ( !wi->crossHair )
 			{
@@ -1048,7 +1046,7 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 				break;
 			}
 
-			wi->crossHairIndicator = trap_R_RegisterShader( token, RSF_DEFAULT );
+			wi->crossHairIndicator = trap_R_RegisterShader( token, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 
 			if ( !wi->crossHairIndicator )
 			{

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -69,7 +69,7 @@ void CG_RegisterUpgrade( int upgradeNum )
 	icon = BG_Upgrade( upgradeNum )->icon;
 	if ( icon )
 	{
-		upgradeInfo->upgradeIcon = trap_R_RegisterShader( icon, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+		upgradeInfo->upgradeIcon = trap_R_RegisterShader( icon, (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 	}
 }
 
@@ -1010,7 +1010,7 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 				break;
 			}
 
-			wi->weaponIcon = wi->ammoIcon = trap_R_RegisterShader( token, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+			wi->weaponIcon = wi->ammoIcon = trap_R_RegisterShader( token, (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
 			if ( !wi->weaponIcon )
 			{
@@ -1028,7 +1028,7 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 				break;
 			}
 
-			wi->crossHair = trap_R_RegisterShader( token, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+			wi->crossHair = trap_R_RegisterShader( token, (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
 			if ( !wi->crossHair )
 			{
@@ -1046,7 +1046,7 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 				break;
 			}
 
-			wi->crossHairIndicator = trap_R_RegisterShader( token, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+			wi->crossHairIndicator = trap_R_RegisterShader( token, (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
 			if ( !wi->crossHairIndicator )
 			{

--- a/src/shared/bg_parse.cpp
+++ b/src/shared/bg_parse.cpp
@@ -2472,7 +2472,7 @@ void BG_ParseBeaconAttributeFile( const char *filename, beaconAttributes_t *ba )
 			if( index < 0 || index >= 4 )
 				Log::Warn( "Invalid beacon icon index %i in %s", index, filename );
 			else
-				ba->icon[ 0 ][ index ] = trap_R_RegisterShader( token, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+				ba->icon[ 0 ][ index ] = trap_R_RegisterShader( token, (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 #endif
 		}
 		else if ( !Q_stricmp( token, "hlIcon" ) )
@@ -2486,7 +2486,7 @@ void BG_ParseBeaconAttributeFile( const char *filename, beaconAttributes_t *ba )
 			if( index < 0 || index >= 4 )
 				Log::Warn( "Invalid beacon highlighted icon index %i in %s", index, filename );
 			else
-				ba->icon[ 1 ][ index ] = trap_R_RegisterShader( token, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
+				ba->icon[ 1 ][ index ] = trap_R_RegisterShader( token, (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 #endif
 		}
 		else if ( !Q_stricmp( token, "inSound" ) )

--- a/src/shared/bg_parse.cpp
+++ b/src/shared/bg_parse.cpp
@@ -2472,7 +2472,7 @@ void BG_ParseBeaconAttributeFile( const char *filename, beaconAttributes_t *ba )
 			if( index < 0 || index >= 4 )
 				Log::Warn( "Invalid beacon icon index %i in %s", index, filename );
 			else
-				ba->icon[ 0 ][ index ] = trap_R_RegisterShader( token, RSF_DEFAULT );
+				ba->icon[ 0 ][ index ] = trap_R_RegisterShader( token, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 #endif
 		}
 		else if ( !Q_stricmp( token, "hlIcon" ) )
@@ -2486,7 +2486,7 @@ void BG_ParseBeaconAttributeFile( const char *filename, beaconAttributes_t *ba )
 			if( index < 0 || index >= 4 )
 				Log::Warn( "Invalid beacon highlighted icon index %i in %s", index, filename );
 			else
-				ba->icon[ 1 ][ index ] = trap_R_RegisterShader( token, RSF_DEFAULT );
+				ba->icon[ 1 ][ index ] = trap_R_RegisterShader( token, (RegisterShaderFlags_t) ( RSF_DEFAULT | RSF_NOMIP ) );
 #endif
 		}
 		else if ( !Q_stricmp( token, "inSound" ) )


### PR DESCRIPTION
Do not do picmip on UI elements, fix UnvanquishedAssets/unvanquished_src.dpkdir#21

Before:

[![ui nopicmip](https://dl.illwieckz.net/b/unvanquished/bugs/ui-nopicmip/unvanquished_2020-10-27_173654_000.jpg)](https://dl.illwieckz.net/b/unvanquished/bugs/ui-nopicmip/unvanquished_2020-10-27_173654_000.jpg)

After:

[![ui nopicmip](https://dl.illwieckz.net/b/unvanquished/bugs/ui-nopicmip/unvanquished_2020-10-27_173750_000.jpg)](https://dl.illwieckz.net/b/unvanquished/bugs/ui-nopicmip/unvanquished_2020-10-27_173750_000.jpg)

It looks like some UI images used in libRocket things (like the circle menus) are not loaded correctly if I make a `.shader` file, so I did it on game code side.