### PR TITLE
BUGFIX: back slashes needed for the brackets in the regex

### DIFF
--- a/download-paks
+++ b/download-paks
@@ -52,7 +52,7 @@ colorPrintf () {
 }
 
 listCdn () {
-	(sed -e 's/#.*//g;s/[ \t]*//g' | grep -v '^$') <<-EOF
+	(sed -e 's/#.*//g;s/\[ \t\]*//g' | grep -v '^$') <<-EOF
 	# official
 	http://cdn.unvanquished.net
 	# Viech


### PR DESCRIPTION
This fixes the regex so the space and tab are treated as a character set as intended.
The regex was stripping all the 't's from the URLs