### PR TITLE
Display names of left/right function key scancodes

### DIFF
--- a/src/cgame/cg_key_name.cpp
+++ b/src/cgame/cg_key_name.cpp
@@ -33,6 +33,11 @@ std::string CG_KeyDisplayName(Key key) {
     switch (key.kind()) {
     case Key::Kind::SCANCODE:
     {
+        for (auto& functionKey : Keyboard::leftRightFunctionKeys) {
+            if (functionKey.scancode == key.AsScancode()) {
+                return functionKey.name;
+            }
+        }
         int character = trap_Key_GetCharForScancode(key.AsScancode());
         if (character) {
             return Keyboard::CharToString(character);


### PR DESCRIPTION
It is still not possible to bind these using the menu, as the keyNum_t
one (e.g. SHIFT) comes before the scancode one (e.g. hw:LSHIFT).