### PR TITLE
require time without damage for devolving

### DIFF
--- a/src/sgame/components/HealthComponent.cpp
+++ b/src/sgame/components/HealthComponent.cpp
@@ -130,6 +130,10 @@ Util::optional<Vec3> direction, int flags, meansOfDeath_t meansOfDeath) {
 		client->lastCombatTime = entity.oldEnt->client->lastCombatTime = level.time;
 	}
 
+	// Update damage timers
+	if ( source->client ) source->client->lastDamageTime = level.time;
+	if ( client ) client->lastDamageTime = entity.oldEnt->client->lastDamageTime = level.time;
+
 	if (client) {
 		// Save damage w/o armor modifier.
 		client->damage_received += (int)(amount + 0.5f);

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -2407,12 +2407,27 @@ static bool Cmd_Class_internal( gentity_t *ent, const char *s, bool report )
 				if ( cost != CANT_EVOLVE )
 				{
 
-					if ( ( cost < 0 || ( cost == 0 && currentClass == PCL_ALIEN_LEVEL0 ) )	&& ( G_DistanceToBase( ent ) >= g_devolveMaxBaseDistance.Get() ) ) {
-						if ( report )
-						{
-							G_TriggerMenu( clientNum, MN_A_NOTINBASE );
+					if ( ( cost < 0 || ( cost == 0 && currentClass == PCL_ALIEN_LEVEL0 ) ) ) {
+						if ( G_DistanceToBase( ent ) >= g_devolveMaxBaseDistance.Get() ) {
+							if ( report )
+							{
+								G_TriggerMenu( clientNum, MN_A_NOTINBASE );
+							}
+							return false;
 						}
-						return false;
+						if ( ent->client->lastDamageTime &&
+						     ent->client->lastDamageTime + g_devolveDamageCooldown.Get() * 1000 > level.time) {
+							if ( report )
+ 							{
+								float remaining = ( ( ent->client->lastDamageTime + g_devolveDamageCooldown.Get() * 1000 ) - level.time ) / 1000;
+								char* msg = va( "%s %i %.0f", QQ( N_("You cannot devolve until $1$ after combat. Try again in $2$s.") ),
+								                g_devolveDamageCooldown.Get(), remaining );
+								trap_SendServerCommand( ent - g_entities, va( "print_tr %s", msg ) );
+								trap_SendServerCommand( ent - g_entities, va( "cp_tr %s", msg ) );
+
+ 							}
+ 							return false;
+						}
 					}
 
 					ent->client->pers.evolveHealthFraction = ent->entity->Get<HealthComponent>()->HealthFraction();

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -171,6 +171,7 @@ extern  vmCvar_t g_instantBuilding;
 
 extern  Cvar::Cvar<float> g_evolveAroundHumans;
 extern  Cvar::Cvar<float> g_devolveMaxBaseDistance;
+extern  Cvar::Cvar<int>   g_devolveDamageCooldown;
 
 // bot buy cvars
 extern vmCvar_t g_bot_buy;

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -209,6 +209,7 @@ Cvar::Cvar<bool>   g_neverEnd("g_neverEnd", "cheat to never end a game, helpful 
 
 Cvar::Cvar<float>  g_evolveAroundHumans("g_evolveAroundHumans", "Ratio of alien buildings to human entities that always allow evolution", Cvar::NONE, 1.5f);
 Cvar::Cvar<float>  g_devolveMaxBaseDistance("g_devolveMaxBaseDistance", "Max Overmind distance to allow devolving", Cvar::NONE, 1000.0f);
+Cvar::Cvar<int>    g_devolveDamageCooldown("g_devolveDamageCooldown", "Time without damage required for devolving", Cvar::NONE, 5);
 
 // <bot stuff>
 

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -531,6 +531,7 @@ struct gclient_s
 	int        medKitIncrementTime;
 	int        lastCreepSlowTime; // time until creep can be removed
 	int        lastCombatTime; // time of last damage received/dealt from/to clients
+	int        lastDamageTime; // time of last damage received/dealt 
 	int        lastAmmoRefillTime;
 	int        lastFuelRefillTime;
 


### PR DESCRIPTION
slipher discovered that devolving can turn adv dragoons into deadly machinegun turrets. 🤯
With this change devolving is only possible when no damage was given or taken for the set amount.
That is 5 seconds by default, witch i think is already enough to prevent abuse and not affect normal usage.