### PR TITLE
Fix UI papercuts

### DIFF
--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -910,7 +910,8 @@ public:
 		if ( evos != value )
 		{
 			evos = value;
-			SetText( va( "%1.1f", evos ) );
+			// display it rounded down
+			SetText( va( "%1.1f", floorf(evos*10)/10 ) );
 		}
 	}
 


### PR DESCRIPTION
### Always allow buying upgrade when funds would be sufficient

Sometimes you have enough money to buy something but first need to sell
what conflicting gear you already have. For example when you want to
replace your heavy armor to put on on a light armor and have 100 credits
in your pocket. The game didn't allow you to buy it and required you to
sell it explicitely first. This commit fixes the annoyance.

Example test process:

* /devmap usstremor
* /give momentum 300 
* /give funds 400 
* *buy power armor*
* *try to buy anything else without selling your power armor*
note that if you give yourself 1000 credits on the 0.51, you can buy 
every update, even conflicting, but you can't do that if you have 400 
credits.

### Fix rounding annoyance in displayed morph points

as said on IRC:
    afontain:
            do you have some other ui papercuts in mind?
    peertubed:
            wrong rounding for evos
            like if you have 5.99 and you need 6 to evolve
            then it displays 6.0, but you can't [buy a dragoon]
            should round down

    With this commit, it now rounds down as it should.

Example test process:
 * `/devmap antares`
 * join aliens
 * `/give funds 1.99`
 * look at what's displayed on bottom-right