### PR TITLE
Allow visualisation of 2× healing

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1552,6 +1552,7 @@ struct cgMedia_t
 	qhandle_t   healthCross;
 	qhandle_t   healthCross2X;
 	qhandle_t   healthCross3X;
+	qhandle_t   healthCross4X;
 	qhandle_t   healthCrossMedkit;
 	qhandle_t   healthCrossPoisoned;
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1092,6 +1092,7 @@ static void CG_RegisterGraphics()
 	cgs.media.healthCross = trap_R_RegisterShader("ui/assets/neutral/cross", RSF_DEFAULT);
 	cgs.media.healthCross2X = trap_R_RegisterShader("ui/assets/neutral/cross2", RSF_DEFAULT);
 	cgs.media.healthCross3X = trap_R_RegisterShader("ui/assets/neutral/cross3", RSF_DEFAULT);
+	cgs.media.healthCross4X = trap_R_RegisterShader("ui/assets/neutral/cross4", RSF_DEFAULT);
 	cgs.media.healthCrossMedkit = trap_R_RegisterShader("ui/assets/neutral/cross_medkit", RSF_DEFAULT);
 	cgs.media.healthCrossPoisoned = trap_R_RegisterShader("ui/assets/neutral/cross_poison", RSF_DEFAULT);
 

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -2375,20 +2375,25 @@ void CG_Rocket_DrawPlayerHealthCross()
 
 	if ( cg.snap->ps.stats[ STAT_STATE ] & SS_HEALING_8X )
 	{
-		shader = cgs.media.healthCross3X;
+		shader = cgs.media.healthCross4X;
 	}
 
 	else if ( cg.snap->ps.stats[ STAT_STATE ] & SS_HEALING_4X )
 	{
 		if ( cg.snap->ps.persistant[ PERS_TEAM ] == TEAM_ALIENS )
 		{
-			shader = cgs.media.healthCross2X;
+			shader = cgs.media.healthCross3X;
 		}
 
 		else
 		{
 			shader = cgs.media.healthCrossMedkit;
 		}
+	}
+
+	else if ( cg.snap->ps.stats[ STAT_STATE ] & SS_HEALING_2X )
+	{
+		shader = cgs.media.healthCross2X;
 	}
 
 	else if ( cg.snap->ps.stats[ STAT_STATE ] & SS_POISONED )


### PR DESCRIPTION
it happens when an alien is not too far from another. It's a feature
that wasn't discoverable at all, and most people don't even know it
exists. Hopefully this change could make it a bit more obvious, even if
I still find it a bit confusing.

"Wait, why am I healing now? I didn't even move"

I think it adds a bit of noise, so we may want to look for a better solution instead.

otherwise, to be merged alongside https://github.com/UnvanquishedAssets/unvanquished_src.dpkdir/pull/33.