### PR TITLE
Refactor the evolve logic

### DIFF
--- a/src/cgame/cg_playerstate.cpp
+++ b/src/cgame/cg_playerstate.cpp
@@ -257,8 +257,10 @@ void CG_CheckLocalSounds( playerState_t *ps, playerState_t *ops )
 		return;
 	}
 
-	// health changes of more than -1 should make pain sounds
-	if ( ps->stats[ STAT_HEALTH ] < ops->stats[ STAT_HEALTH ] - 1 )
+	// health changes of more than -1 should make pain sounds, unless
+	// we devolved
+	if ( ps->stats[ STAT_HEALTH ] < ops->stats[ STAT_HEALTH ] - 1
+	  && ps->stats[ STAT_CLASS ] == ops->stats[ STAT_CLASS ] )
 	{
 		if ( ps->stats[ STAT_HEALTH ] > 0 )
 		{

--- a/src/cgame/cg_rocket_dataformatter.cpp
+++ b/src/cgame/cg_rocket_dataformatter.cpp
@@ -408,7 +408,7 @@ static void CG_Rocket_DFCMAlienEvolve( int handle, const char *data )
 	const char *CosmeticClass = "";
 	const char *Icon = "";
 	const char *action = "";
-	int cost = BG_ClassCanEvolveFromTo( cg.predictedPlayerState.stats[ STAT_CLASS ], alienClass, cg.predictedPlayerState.persistant[ PERS_CREDIT ] );
+	evolveInfo_t info = BG_ClassEvolveInfoFromTo( cg.predictedPlayerState.stats[ STAT_CLASS ], alienClass );
 
 	if( cg.predictedPlayerState.stats[ STAT_CLASS ] == alienClass )
 	{
@@ -416,13 +416,13 @@ static void CG_Rocket_DFCMAlienEvolve( int handle, const char *data )
 		//Check mark icon. UTF-8 encoding of \uf00c
 		Icon = "<icon class=\"current\">\xEF\x80\x8C</icon>";
 	}
-	else if ( !BG_ClassUnlocked( alienClass ) || BG_ClassDisabled( alienClass ) )
+	else if ( !info.classIsUnlocked )
 	{
 		FunctionalClass = "locked";
 		//Padlock icon. UTF-8 encoding of \uf023
 		Icon = "<icon>\xEF\x80\xA3</icon>";
 	}
-	else if ( cost == CANT_EVOLVE )
+	else if ( cg.predictedPlayerState.persistant[ PERS_CREDIT ] < info.evolveCost )
 	{
 
 		FunctionalClass = "expensive";

--- a/src/cgame/cg_rocket_datasource.cpp
+++ b/src/cgame/cg_rocket_datasource.cpp
@@ -1661,7 +1661,13 @@ void CG_Rocket_BuildAlienEvolveList( const char *table )
 			Info_SetValueForKey( buf, "num", va( "%d", i ), false );
 			Info_SetValueForKey( buf, "name", BG_ClassModelConfig( i )->humanName, false );
 			Info_SetValueForKey( buf, "description", BG_Class( i )->info, false );
-			Info_SetValueForKey( buf, "price", va( "%.1f", price / CREDITS_PER_EVO ), false );
+			if (price >= 0.0f) {
+				Info_SetValueForKey( buf, "price", va( "Price: %.1f", price / CREDITS_PER_EVO ), false );
+			}
+			else
+			{
+				Info_SetValueForKey( buf, "price", va( "Returned: %.1f", -price / CREDITS_PER_EVO ), false );
+			}
 
 			Rocket_DSAddRow( "alienEvolveList", "default", buf );
 

--- a/src/cgame/cg_rocket_datasource.cpp
+++ b/src/cgame/cg_rocket_datasource.cpp
@@ -1653,11 +1653,9 @@ void CG_Rocket_BuildAlienEvolveList( const char *table )
 			}
 
 			buf[ 0 ] = '\0';
-			price = BG_CostToEvolve( cg.predictedPlayerState.stats[ STAT_CLASS ], i );
-			if( price == CANT_EVOLVE){
-				price = 0;
-			}
-			if( price < 0 ){
+			price = static_cast<float>( BG_ClassEvolveInfoFromTo(
+						cg.predictedPlayerState.stats[ STAT_CLASS ], i ).evolveCost );
+			if( price < 0.0f ){
 				price *= (( float ) cg.predictedPlayerState.stats[ STAT_HEALTH ] / ( float ) BG_Class( cg.predictedPlayerState.stats[ STAT_CLASS ] )->health ) * DEVOLVE_RETURN_FRACTION;
 			}
 			Info_SetValueForKey( buf, "num", va( "%d", i ), false );
@@ -1680,8 +1678,9 @@ void CG_Rocket_SetAlienEvolveList( const char*, int index )
 void CG_Rocket_ExecAlienEvolveList( const char* )
 {
 	class_t evo = ( class_t ) rocketInfo.data.alienEvolveList[ rocketInfo.data.selectedAlienEvolve ];
+	evolveInfo_t info = BG_ClassEvolveInfoFromTo( cg.predictedPlayerState.stats[ STAT_CLASS ], evo );
 
-	if ( BG_Class( evo ) && BG_ClassCanEvolveFromTo( cg.predictedPlayerState.stats[ STAT_CLASS ], evo, cg.predictedPlayerState.persistant[ PERS_CREDIT ] ) >= 0 )
+	if ( BG_Class( evo ) && info.classIsUnlocked && cg.predictedPlayerState.persistant[ PERS_CREDIT ] >= info.evolveCost )
 	{
 		trap_SendClientCommand( va( "class %s", BG_Class( evo )->name ) );
 		Rocket_DocumentAction( rocketInfo.menu[ ROCKETMENU_ALIENEVOLVE ].id, "hide" );

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -2380,20 +2380,19 @@ void CG_Rocket_DrawPlayerHealthCross()
 
 	else if ( cg.snap->ps.stats[ STAT_STATE ] & SS_HEALING_4X )
 	{
-		if ( cg.snap->ps.persistant[ PERS_TEAM ] == TEAM_ALIENS )
-		{
-			shader = cgs.media.healthCross3X;
-		}
-
-		else
-		{
-			shader = cgs.media.healthCrossMedkit;
-		}
+		shader = cgs.media.healthCross3X;
 	}
 
 	else if ( cg.snap->ps.stats[ STAT_STATE ] & SS_HEALING_2X )
 	{
-		shader = cgs.media.healthCross2X;
+		if ( cg.snap->ps.persistant[ PERS_TEAM ] == TEAM_ALIENS )
+		{
+			shader = cgs.media.healthCross2X;
+		}
+		else
+		{
+			shader = cgs.media.healthCrossMedkit;
+		}
 	}
 
 	else if ( cg.snap->ps.stats[ STAT_STATE ] & SS_POISONED )

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -133,6 +133,13 @@ struct playerState_t
 	int           misc[ MAX_MISC ]; // misc data
 };
 
+// the possibility and the cost of evolving to an alien form
+struct evolveInfo_t {
+	bool classIsUnlocked;
+	bool isDevolving;
+	int  evolveCost;
+};
+
 // player teams
 enum team_t
 {
@@ -1128,7 +1135,6 @@ enum buttonNumber_t
 };
 
 #define DEVOLVE_RETURN_FRACTION 0.9f
-#define CANT_EVOLVE -999
 
 //---------------------------------------------------------
 
@@ -1498,8 +1504,7 @@ void                        BG_ClassBoundingBox( int pClass, vec3_t mins, vec3_t
 team_t                      BG_ClassTeam( int pClass );
 bool                    BG_ClassHasAbility( int pClass, int ability );
 
-int                         BG_CostToEvolve(int from, int to);
-int                         BG_ClassCanEvolveFromTo(int from, int to, int credits);
+evolveInfo_t            BG_ClassEvolveInfoFromTo(int from, int to);
 bool                    BG_AlienCanEvolve(int from, int credits);
 
 int                       BG_GetBarbRegenerationInterval(const playerState_t& ps);


### PR DESCRIPTION
Fixes the displayed cost in evolve list, before it was displayed that evolveCost is equal to 0 when it was impossible to evolve.

Includes a second commit for cleaner display of evo points (along with https://github.com/UnvanquishedAssets/unvanquished_src.dpkdir/pull/35).