### PR TITLE
Rework team damage handling

### DIFF
--- a/src/sgame/components/HealthComponent.cpp
+++ b/src/sgame/components/HealthComponent.cpp
@@ -3,6 +3,10 @@
 
 static Log::Logger healthLogger("sgame.health");
 
+static Cvar::Cvar<float>  g_friendlyFireAlienMultiplier("g_friendlyFireAlienMultiplier", "Damage multiplier for alien-to-alien damage (doesn't include buildings, or self)", Cvar::NONE, 0.5f);
+static Cvar::Cvar<float>  g_friendlyFireHumanMultiplier("g_friendlyFireHumanMultiplier", "Damage multiplier for human-to-human damage (doesn't include buildings, or self)", Cvar::NONE, 1.0f);
+static Cvar::Cvar<bool>   g_friendlyBuildableFire("g_friendlyBuildableFire", "Can one hurt the team's buildable?", Cvar::NONE, true);
+
 HealthComponent::HealthComponent(Entity& entity, float maxHealth)
 	: HealthComponentBase(entity, maxHealth), health(maxHealth)
 {}
@@ -76,9 +80,6 @@ Util::optional<Vec3> direction, int flags, meansOfDeath_t meansOfDeath) {
 	if (!(flags & DAMAGE_NO_PROTECTION)) {
 		// Check for protection from friendly damage.
 		if (entity.oldEnt != source && G_OnSameTeam(entity.oldEnt, source)) {
-			// Check if friendly fire has been disabled.
-			if (!g_friendlyFire.integer) return;
-
 			// Never do friendly damage on movement attacks.
 			switch (meansOfDeath) {
 				case MOD_LEVEL3_POUNCE:
@@ -111,7 +112,7 @@ Util::optional<Vec3> direction, int flags, meansOfDeath_t meansOfDeath) {
 		if (entity.oldEnt->s.eType == entityType_t::ET_BUILDABLE && source->client &&
 		    meansOfDeath != MOD_DECONSTRUCT && meansOfDeath != MOD_SUICIDE &&
 		    meansOfDeath != MOD_REPLACE) {
-			if (G_OnSameTeam(entity.oldEnt, source) && !g_friendlyBuildableFire.integer) {
+			if (G_OnSameTeam(entity.oldEnt, source) && !g_friendlyBuildableFire.Get()) {
 				return;
 			}
 		}
@@ -119,9 +120,32 @@ Util::optional<Vec3> direction, int flags, meansOfDeath_t meansOfDeath) {
 
 	float take = amount;
 
+	// reduce team damage according to the team, ignoring buildings.
+	// Note that team damage is reduced only for the *other* members of the
+	// team, otherwise you could simply, say, sit on a grenade and lure
+	// aliens to come to you.
+	if (entity.oldEnt != source && G_OnSameTeam(entity.oldEnt, source)
+			&& entity.oldEnt->s.eType != entityType_t::ET_BUILDABLE) {
+		if ( G_Team(source) == TEAM_ALIENS )
+		{
+			take *= g_friendlyFireAlienMultiplier.Get();
+		}
+		else
+		{
+			take *= g_friendlyFireHumanMultiplier.Get();
+		}
+	}
+
+
 	// Apply damage modifiers.
 	if (!(flags & DAMAGE_PURE)) {
 		entity.ApplyDamageModifier(take, location, direction, flags, meansOfDeath);
+	}
+
+	// if we don't actually take damage, stop here
+	if ( take == 0.0f )
+	{
+		return;
 	}
 
 	// Update combat timers.

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -54,8 +54,6 @@ extern  vmCvar_t g_maxNameChanges;
 
 extern  vmCvar_t g_showHelpOnConnection;
 extern  vmCvar_t g_timelimit;
-extern  vmCvar_t g_friendlyFire;
-extern  vmCvar_t g_friendlyBuildableFire;
 extern  vmCvar_t g_dretchPunt;
 extern  vmCvar_t g_password;
 extern  vmCvar_t g_needpass;

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -58,8 +58,6 @@ gclient_t          *g_clients;
 vmCvar_t           g_showHelpOnConnection;
 
 vmCvar_t           g_timelimit;
-vmCvar_t           g_friendlyFire;
-vmCvar_t           g_friendlyBuildableFire;
 vmCvar_t           g_dretchPunt;
 vmCvar_t           g_password;
 vmCvar_t           g_needpass;
@@ -366,8 +364,6 @@ static cvarTable_t gameCvarTable[] =
 
 	// gameplay: basic
 	{ &g_timelimit,                   "timelimit",                     "45",                               CVAR_SERVERINFO,                                 0, true     , nullptr       },
-	{ &g_friendlyFire,                "g_friendlyFire",                "1",                                CVAR_SERVERINFO,                                 0, true     , nullptr       },
-	{ &g_friendlyBuildableFire,       "g_friendlyBuildableFire",       "1",                                CVAR_SERVERINFO,                                 0, true     , nullptr       },
 
 	// gameplay: team balance
 	{ &g_teamForceBalance,            "g_teamForceBalance",            "0",                                0,                                               0, true     , nullptr       },


### PR DESCRIPTION
Fixes https://github.com/Unvanquished/gameplay/issues/10, at least partially.

Note that the team damage settings still does apply only to the *other* members of a team. Do we really want to keep that? IMO it makes no sense, as if a lucifer cannon is less dangerous for your friends, it makes sense if it's less dangerous for you. Idem for the barbs. Should we change this?

The first commit comes with the corresponding change in daemon: https://github.com/DaemonEngine/Daemon/pull/416.
