### PR TITLE
Zone damage (acid tube) damage rework

### DIFF
--- a/src/sgame/Entities.cpp
+++ b/src/sgame/Entities.cpp
@@ -119,8 +119,9 @@ bool Entities::AntiHumanRadiusDamage(Entity& entity, float amount, float range, 
 	ForEntities<HumanClassComponent>([&] (Entity& other, HumanClassComponent& humanClassComponent) {
 		// TODO: Add LocationComponent.
 		float distance = G_Distance(entity.oldEnt, other.oldEnt);
-		float damage   = amount * (1.0f - distance / range);
+		float damage   = amount * (1.0f - 0.7f * distance / range);
 
+		if (distance > range) return;
 		if (damage <= 0.0f) return;
 		if (!G_IsVisible(entity.oldEnt, other.oldEnt, MASK_SOLID)) return;
 

--- a/src/sgame/components/AcidTubeComponent.cpp
+++ b/src/sgame/components/AcidTubeComponent.cpp
@@ -1,7 +1,7 @@
 #include "AcidTubeComponent.h"
 #include "../Entities.h"
 
-const float AcidTubeComponent::ATTACK_DAMAGE      = 26.7f;
+const float AcidTubeComponent::ATTACK_DAMAGE      = 20.0f;
 const float AcidTubeComponent::ATTACK_RANGE       = ACIDTUBE_RANGE;
 const int   AcidTubeComponent::ATTACK_ANIM_PERIOD = 2000;
 


### PR DESCRIPTION
![graph](https://paste.gnugen.ch/paste/yVlx)

I find this makes the acid tubes quite more dangerous. So we may want to
reduce the base damage a bit more, then.

The intent of this commit is to avoid the situation where an human sits
at the border of the zone of action, and it looks like the acid tube is
doing something, while it really deals 1 damage per minute.