### PR TITLE
Only display the devolve button as activatable near the overmind

### DIFF
--- a/src/cgame/cg_animdelta.cpp
+++ b/src/cgame/cg_animdelta.cpp
@@ -51,7 +51,7 @@ bool AnimDelta::ParseConfiguration(clientInfo_t* ci, const char* token2, const c
 	char* token = COM_Parse2( data_p );
 	if ( !token || token[0] != '{' )
 	{
-		Log::Notice( "^1ERROR^*: Expected '{' but found '%s' in %s's character.cfg", token, ci->modelName );
+		Log::Warn( "Expected '{' but found '%s' in %s's AnimDelta", token, ci->modelName );
 		return true;
 	}
 	while ( 1 )

--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -2557,3 +2557,32 @@ void CG_Buildable( centity_t *cent )
 		CG_EndShadowCaster( );
 	}
 }
+
+// maybe move this to shared/ and add a prototype?
+static bool IsMainBuildable(buildable_t buildable)
+{
+	return buildable == BA_A_OVERMIND || buildable == BA_H_REACTOR;
+}
+
+const centity_t *CG_LookupMainBuildable()
+{
+	for( int beaconNum = 0; beaconNum < cg.beaconCount; beaconNum++ ) {
+		const auto b = cg.beacons[ beaconNum ];
+		if ( b->type == BCT_TAG && !(b->flags & (EF_BC_TAG_PLAYER|EF_BC_ENEMY))
+				&& IsMainBuildable( static_cast<buildable_t>(b->data) ) )
+		{
+			return &cg_entities[ b->target ];
+		}
+	}
+
+	return nullptr;
+}
+
+// keep in sync with G_DistanceToBase
+float CG_DistanceToBase()
+{
+	const centity_t *ent = CG_LookupMainBuildable();
+	if (!ent)
+		return 1e+37f; // in accordance to sgame
+	return Distance(cg.predictedPlayerEntity.lerpOrigin, ent->lerpOrigin);
+}

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1617,6 +1617,8 @@ struct cgs_t
 	int      maxclients;
 	char     mapname[ MAX_QPATH ];
 
+	float    devolveMaxBaseDistance; // used for evolve/devolve ui
+
 	float    momentumHalfLife; // used for momentum bar (un)lock markers
 	float    unlockableMinTime;  // used for momentum bar (un)lock markers
 
@@ -1999,6 +2001,8 @@ void     CG_InitBuildables();
 void     CG_HumanBuildableDying( buildable_t buildable, vec3_t origin );
 void     CG_HumanBuildableExplosion( buildable_t buildable, vec3_t origin, vec3_t dir );
 void     CG_AlienBuildableExplosion( vec3_t origin, vec3_t dir );
+const centity_t *CG_LookupMainBuildable();
+float    CG_DistanceToBase();
 
 //
 // cg_animation.c

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -161,7 +161,7 @@ static bool CG_ParseCharacterFile( const char *filename, clientInfo_t *ci )
 			char* token = COM_Parse2( &text_p );
 			if ( !token || *token != '{' )
 			{
-				Log::Notice( "^1ERROR^*: Expected '{' but found '%s' in %s's character.cfg", token, ci->modelName );
+				Log::Warn( "Expected '{' but found '%s' in %s's character.cfg, skipping", token, ci->modelName );
 				continue;
 			}
 			while ( 1 )

--- a/src/cgame/cg_rocket_datasource.cpp
+++ b/src/cgame/cg_rocket_datasource.cpp
@@ -1749,7 +1749,10 @@ static Str::StringRef EvolveAvailability( class_t alienClass )
 
 	if ( cg.predictedPlayerState.persistant[ PERS_CREDIT ] < info.evolveCost )
 		return "expensive";
-	
+
+	if ( info.isDevolving && CG_DistanceToBase() > cgs.devolveMaxBaseDistance )
+		return "overmindfar";
+
 	return "available";
 }
 

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -142,6 +142,8 @@ void CG_ParseServerinfo()
 	cgs.timelimit          = atoi( Info_ValueForKey( info, "timelimit" ) );
 	cgs.maxclients         = atoi( Info_ValueForKey( info, "sv_maxclients" ) );
 
+	cgs.devolveMaxBaseDistance = atof( Info_ValueForKey( info, "g_devolveMaxBaseDistance" ) );
+
 	cgs.momentumHalfLife  = atof( Info_ValueForKey( info, "g_momentumHalfLife" ) );
 	cgs.unlockableMinTime = atof( Info_ValueForKey( info, "g_unlockableMinTime" ) );
 

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -105,6 +105,8 @@ gentity_t *G_ActiveMainBuildable(team_t team) {
 
 /**
  * @return The distance of an entity to its own base or a huge value if the base is not found.
+ *
+ * Please keep it in sync with CG_DistanceToBase
  */
 float G_DistanceToBase(gentity_t *self) {
 	gentity_t *mainBuilding = G_MainBuildable(G_Team(self));

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -210,7 +210,7 @@ vmCvar_t           g_emptyTeamsSkipMapTime;
 Cvar::Cvar<bool>   g_neverEnd("g_neverEnd", "cheat to never end a game, helpful to load a map without spawn for testing purpose", Cvar::NONE, false);
 
 Cvar::Cvar<float>  g_evolveAroundHumans("g_evolveAroundHumans", "Ratio of alien buildings to human entities that always allow evolution", Cvar::NONE, 1.5f);
-Cvar::Cvar<float>  g_devolveMaxBaseDistance("g_devolveMaxBaseDistance", "Max Overmind distance to allow devolving", Cvar::NONE, 1000.0f);
+Cvar::Cvar<float>  g_devolveMaxBaseDistance("g_devolveMaxBaseDistance", "Max Overmind distance to allow devolving", Cvar::SERVERINFO, 1000.0f);
 
 Cvar::Cvar<bool>   g_autoPause("g_autoPause", "pause empty server", Cvar::NONE, true);
 


### PR DESCRIPTION
See the commits.

For the "too far from overmind" logo, I don't have a good one. Suggestions welcome.