### PR TITLE
Fix crash when bot moves to spectators

### DIFF
--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -651,7 +651,14 @@ void Cmd_Give_f( gentity_t *ent )
 		else
 		{
 			float amount = atof( name + strlen("health") );
-			ent->entity->Heal(amount, nullptr);
+			if (amount < 0)
+			{
+				ent->entity->Damage(-amount, nullptr, Util::nullopt, Util::nullopt, 0, MOD_LAVA);
+			}
+			else
+			{
+				ent->entity->Heal(amount, nullptr);
+			}
 		}
 	}
 

--- a/src/sgame/sg_team.cpp
+++ b/src/sgame/sg_team.cpp
@@ -254,6 +254,8 @@ void G_LeaveTeam( gentity_t *self )
 		}
 	}
 
+	trap_UnlinkEntity( self );
+
 	// cut all relevant zap beams
 	G_ClearPlayerZapEffects( self );
 


### PR DESCRIPTION
I believe this should fix the crash observed by @Gireen at https://github.com/Unvanquished/Unvanquished/blob/33ba538883367af00c8c957f46fbd78164a26a39/src/sgame/sg_buildable.cpp#L635. What happens is that if a bot is moved to spectators via an admin command, its entity is never unlinked from the BSP tree, so it may continue to show up for searches of entities in an area, such as the one done in medistation code. The bug is observed only on Gireen's server because it's got some funky script that does a bunch of `putteam` commands on bots. If the bots *disconnect*, which happens in most methods of getting rid of bots, the entity is unlinked as expected.