### PR TITLE
CVars work

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1434,8 +1434,6 @@ void CG_Init( int serverMessageNum, int clientNum, const glconfig_t& gl, const G
 	cgs.media.whiteShader = trap_R_RegisterShader("gfx/colors/white", RSF_DEFAULT);
 	cgs.media.outlineShader = trap_R_RegisterShader("gfx/outline", RSF_DEFAULT);
 
-	BG_InitAllowedGameElements();
-
 	// Initialize item locking state
 	BG_InitUnlockackables();
 

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -151,6 +151,10 @@ void CG_ParseServerinfo()
 	cgs.buildPointRecoveryInitialRate  = atof( Info_ValueForKey( info, "g_BPRecoveryInitialRate" ) );
 	cgs.buildPointRecoveryRateHalfLife = atof( Info_ValueForKey( info, "g_BPRecoveryRateHalfLife" ) );
 
+	BG_SetForbiddenEquipment(  std::string( Info_ValueForKey( info, "g_disabledEquipment"  ) ) );
+	BG_SetForbiddenClasses(    std::string( Info_ValueForKey( info, "g_disabledClasses"    ) ) );
+	BG_SetForbiddenBuildables( std::string( Info_ValueForKey( info, "g_disabledBuildables" ) ) );
+
 	Q_strncpyz( cgs.mapname, Info_ValueForKey( info, "mapname" ), sizeof(cgs.mapname) );
 
 	// pass some of these to UI

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -1960,7 +1960,7 @@ void ClientThink_real( gentity_t *self )
 	}
 
 	// copy global gravity to playerstate
-	client->ps.gravity = g_gravity.value;
+	client->ps.gravity = g_gravity.Get();
 
 	G_ReplenishHumanHealth( self );
 

--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -287,26 +287,30 @@ static AIValue_t randomChance( gentity_t*, const AIValue_t* )
 
 static AIValue_t cvarInt( gentity_t*, const AIValue_t *params )
 {
-	vmCvar_t *c = G_FindCvar( AIUnBoxString( params[ 0 ] ) );
+	// TODO: handle error reporting,
+	// TODO: improve about performance when the need arises
+	std::string str = Cvar::GetValue( AIUnBoxString( params[ 0 ] ) );
 
-	if ( !c )
+	if ( str == "" )
 	{
 		return AIBoxInt( 0 );
 	}
 
-	return AIBoxInt( c->integer );
+	return AIBoxInt( atoi(str.c_str()) );
 }
 
 static AIValue_t cvarFloat( gentity_t*, const AIValue_t *params )
 {
-	vmCvar_t *c = G_FindCvar( AIUnBoxString( params[ 0 ] ) );
+	// TODO: handle error reporting,
+	// TODO: improve about performance when the need arises
+	std::string str = Cvar::GetValue( AIUnBoxString( params[ 0 ] ) );
 
-	if ( !c )
+	if ( str == "" )
 	{
-		return AIBoxFloat( 0 );
+		return AIBoxFloat( 0.0f );
 	}
 
-	return AIBoxFloat( c->value );
+	return AIBoxFloat( atof(str.c_str()) );
 }
 
 static AIValue_t percentHealth( gentity_t *self, const AIValue_t *params )

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -1597,7 +1597,7 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 		}
 
 		// Check level permissions
-		if ( !g_alienAllowBuilding.integer )
+		if ( !g_alienAllowBuilding.Get() )
 		{
 			reason = IBE_DISABLED;
 		}
@@ -1620,7 +1620,7 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 		}
 
 		// Check level permissions
-		if ( !g_humanAllowBuilding.integer )
+		if ( !g_humanAllowBuilding.Get() )
 		{
 			reason = IBE_DISABLED;
 		}

--- a/src/sgame/sg_buildpoints.cpp
+++ b/src/sgame/sg_buildpoints.cpp
@@ -100,9 +100,9 @@ void G_UpdateBuildPointBudgets() {
 void G_RecoverBuildPoints() {
 	static int nextBuildPoint[NUM_TEAMS] = {0};
 
-	float rate = g_buildPointRecoveryInititalRate.value /
+	float rate = g_buildPointRecoveryInititalRate.Get() /
 	             std::pow(2.0f, (float)level.matchTime /
-	                            (60000.0f * g_buildPointRecoveryRateHalfLife.value));
+	                            (60000.0f * g_buildPointRecoveryRateHalfLife.Get()));
 	float interval = 60000.0f / rate;
 
 	// The interval grows exponentially, so check for an excessively large value which could cause overflow.

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -114,10 +114,10 @@ extern  vmCvar_t g_freeFundPeriod;
 
 extern  vmCvar_t g_unlagged;
 
-extern  vmCvar_t g_disabledEquipment;
-extern  vmCvar_t g_disabledClasses;
-extern  vmCvar_t g_disabledBuildables;
-extern  vmCvar_t g_disabledVoteCalls;
+extern Cvar::Callback<Cvar::Cvar<std::string>> g_disabledEquipment;
+extern Cvar::Callback<Cvar::Cvar<std::string>> g_disabledClasses;
+extern Cvar::Callback<Cvar::Cvar<std::string>> g_disabledBuildables;
+extern Cvar::Cvar<std::string> g_disabledVoteCalls;
 
 extern  vmCvar_t g_debugMapRotation;
 extern  vmCvar_t g_currentMapRotation;

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -91,8 +91,8 @@ extern  vmCvar_t g_smoothClients;
 
 extern  Cvar::Callback<Cvar::Cvar<int>> g_buildPointInitialBudget;
 extern  Cvar::Callback<Cvar::Cvar<int>> g_buildPointBudgetPerMiner;
-extern  vmCvar_t g_buildPointRecoveryInititalRate;
-extern  vmCvar_t g_buildPointRecoveryRateHalfLife;
+extern  Cvar::Callback<Cvar::Cvar<int>> g_buildPointRecoveryInititalRate;
+extern  Cvar::Callback<Cvar::Cvar<int>> g_buildPointRecoveryRateHalfLife;
 
 extern  vmCvar_t g_debugMomentum;
 extern  vmCvar_t g_momentumHalfLife;
@@ -104,8 +104,8 @@ extern  vmCvar_t g_momentumBuildMod;
 extern  vmCvar_t g_momentumDeconMod;
 extern  vmCvar_t g_momentumDestroyMod;
 
-extern  vmCvar_t g_humanAllowBuilding;
-extern  vmCvar_t g_alienAllowBuilding;
+extern Cvar::Cvar<bool> g_humanAllowBuilding;
+extern Cvar::Cvar<bool> g_alienAllowBuilding;
 
 extern  vmCvar_t g_alienOffCreepRegenHalfLife;
 

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -59,7 +59,7 @@ extern  vmCvar_t g_friendlyBuildableFire;
 extern  vmCvar_t g_dretchPunt;
 extern  vmCvar_t g_password;
 extern  vmCvar_t g_needpass;
-extern  vmCvar_t g_gravity;
+extern  Cvar::Range<Cvar::Cvar<int>> g_gravity;
 extern  vmCvar_t g_speed;
 extern  vmCvar_t g_inactivity;
 extern  vmCvar_t g_debugMove;

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -562,6 +562,7 @@ void G_FindEntityGroups()
 
 	Log::Notice( "%i groups with %i entities", groupCount, entityCount );
 }
+
 /*
 ================
 G_InitSetEntities
@@ -595,17 +596,14 @@ G_RegisterCvars
 */
 void G_RegisterCvars()
 {
-	unsigned i;
-	cvarTable_t *cvarTable;
-
-	for ( i = 0, cvarTable = gameCvarTable; i < gameCvarTableSize; i++, cvarTable++ )
+	for ( cvarTable_t &cvar : gameCvarTable )
 	{
-		trap_Cvar_Register( cvarTable->vmCvar, cvarTable->cvarName,
-		                    cvarTable->defaultString, cvarTable->cvarFlags );
+		trap_Cvar_Register( cvar.vmCvar, cvar.cvarName,
+		                    cvar.defaultString, cvar.cvarFlags );
 
-		if ( cvarTable->vmCvar )
+		if ( cvar.vmCvar )
 		{
-			cvarTable->modificationCount = cvarTable->vmCvar->modificationCount;
+			cvar.modificationCount = cvar.vmCvar->modificationCount;
 		}
 	}
 }
@@ -617,23 +615,20 @@ G_UpdateCvars
 */
 void G_UpdateCvars()
 {
-	unsigned i;
-	cvarTable_t *cv;
-
-	for ( i = 0, cv = gameCvarTable; i < gameCvarTableSize; i++, cv++ )
+	for ( cvarTable_t &cv : gameCvarTable )
 	{
-		if ( cv->vmCvar )
+		if ( cv.vmCvar )
 		{
-			trap_Cvar_Update( cv->vmCvar );
+			trap_Cvar_Update( cv.vmCvar );
 
-			if ( cv->modificationCount != cv->vmCvar->modificationCount )
+			if ( cv.modificationCount != cv.vmCvar->modificationCount )
 			{
-				cv->modificationCount = cv->vmCvar->modificationCount;
+				cv.modificationCount = cv.vmCvar->modificationCount;
 
-				if ( cv->trackChange )
+				if ( cv.trackChange )
 				{
 					trap_SendServerCommand( -1, va( "print_tr %s %s %s", QQ( N_("Server: $1$ changed to $2$") ),
-					                                Quote( cv->cvarName ), Quote( cv->vmCvar->string ) ) );
+					                                Quote( cv.cvarName ), Quote( cv.vmCvar->string ) ) );
 				}
 			}
 		}

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -43,12 +43,6 @@ struct cvarTable_t
 	int        cvarFlags;
 	int        modificationCount; // for tracking changes
 	bool   trackChange; // track this variable, and announce if changed
-
-	/* certain cvars can be set in worldspawn, but we don't want those values to
-	   persist, so keep track of non-worldspawn changes and restore that on map
-	   end. unfortunately, if the server crashes, the value set in worldspawn may
-	   persist */
-	char      *explicit_;
 };
 } //namespace
 
@@ -312,179 +306,179 @@ static cvarTable_t gameCvarTable[] =
 {
 	// special purpose (external source, read only, etc.)
 	// TODO: Split and comment this section
-	{ nullptr,                           "gamename",                      GAME_VERSION,                       CVAR_SERVERINFO | CVAR_ROM,                      0, false , nullptr          },
-	{ nullptr,                           "gamedate",                      __DATE__,                           CVAR_ROM,                                        0, false , nullptr          },
-	{ nullptr,                           "sv_mapname",                    "",                                 CVAR_SERVERINFO,                                 0, false , nullptr          },
-	{ nullptr,                           "P",                             "",                                 CVAR_SERVERINFO,                                 0, false , nullptr          },
-	{ nullptr,                           "B",                             "",                                 CVAR_SERVERINFO,                                 0, false , nullptr          },
-	{ nullptr,                           "g_mapStartupMessage",           "",                                 0,                                               0, false , nullptr          },
-	{ nullptr,                           "g_mapConfigsLoaded",            "0",                                0,                                               0, false , nullptr          },
-	{ &g_maxclients,                  "sv_maxclients",                 "24",                               CVAR_SERVERINFO | CVAR_LATCH,                    0, false    , nullptr       },
-	{ &g_mapRestarted,                "g_mapRestarted",                "0",                                0,                                               0, false    , nullptr       },
-	{ &g_lockTeamsAtStart,            "g_lockTeamsAtStart",            "0",                                0,                                               0, false    , nullptr       },
-	{ &g_tag,                         "g_tag",                         "unv",                              CVAR_INIT,                                       0, false    , nullptr       },
+	{ nullptr,                           "gamename",                      GAME_VERSION,                       CVAR_SERVERINFO | CVAR_ROM,                      0, false },
+	{ nullptr,                           "gamedate",                      __DATE__,                           CVAR_ROM,                                        0, false },
+	{ nullptr,                           "sv_mapname",                    "",                                 CVAR_SERVERINFO,                                 0, false },
+	{ nullptr,                           "P",                             "",                                 CVAR_SERVERINFO,                                 0, false },
+	{ nullptr,                           "B",                             "",                                 CVAR_SERVERINFO,                                 0, false },
+	{ nullptr,                           "g_mapStartupMessage",           "",                                 0,                                               0, false },
+	{ nullptr,                           "g_mapConfigsLoaded",            "0",                                0,                                               0, false },
+	{ &g_maxclients,                  "sv_maxclients",                 "24",                               CVAR_SERVERINFO | CVAR_LATCH,                    0, false    },
+	{ &g_mapRestarted,                "g_mapRestarted",                "0",                                0,                                               0, false    },
+	{ &g_lockTeamsAtStart,            "g_lockTeamsAtStart",            "0",                                0,                                               0, false    },
+	{ &g_tag,                         "g_tag",                         "unv",                              CVAR_INIT,                                       0, false    },
 
 
 	// server: basic
-	{ &g_maxGameClients,              "g_maxGameClients",              "0",                                CVAR_SERVERINFO,                                 0, false    , nullptr       },
-	{ &g_needpass,                    "g_needpass",                    "0",                                CVAR_SERVERINFO,                                 0, false    , nullptr       },
-	{ &g_password,                    "g_password",                    "",                                 CVAR_USERINFO,                                   0, false    , nullptr       },
-	{ &g_motd,                        "g_motd",                        "",                                 0,                                               0, false    , nullptr       },
-	{ &g_showHelpOnConnection,        "g_showHelpOnConnection",        "1",                                0,                                               0, false    , nullptr       },
+	{ &g_maxGameClients,              "g_maxGameClients",              "0",                                CVAR_SERVERINFO,                                 0, false },
+	{ &g_needpass,                    "g_needpass",                    "0",                                CVAR_SERVERINFO,                                 0, false },
+	{ &g_password,                    "g_password",                    "",                                 CVAR_USERINFO,                                   0, false },
+	{ &g_motd,                        "g_motd",                        "",                                 0,                                               0, false },
+	{ &g_showHelpOnConnection,        "g_showHelpOnConnection",        "1",                                0,                                               0, false },
 
 	// server: network related
-	{ &g_unlagged,                    "g_unlagged",                    "1",                                CVAR_SERVERINFO,                                 0, true     , nullptr       },
-	{ &g_smoothClients,               "g_smoothClients",               "1",                                0,                                               0, false    , nullptr       },
-	{ &g_synchronousClients,          "g_synchronousClients",          "0",                                0,                                               0, false    , nullptr       },
-	{ &pmove_fixed,                   "pmove_fixed",                   "0",                                0,                                               0, false    , nullptr       },
-	{ &pmove_msec,                    "pmove_msec",                    "8",                                0,                                               0, false    , nullptr       },
-	{ &pmove_accurate,                "pmove_accurate",                "1",                                0,                                               0, false    , nullptr       },
-	{ &g_floodMaxDemerits,            "g_floodMaxDemerits",            "5000",                             0,                                               0, false    , nullptr       },
-	{ &g_floodMinTime,                "g_floodMinTime",                "2000",                             0,                                               0, false    , nullptr       },
+	{ &g_unlagged,                    "g_unlagged",                    "1",                                CVAR_SERVERINFO,                                 0, true  },
+	{ &g_smoothClients,               "g_smoothClients",               "1",                                0,                                               0, false },
+	{ &g_synchronousClients,          "g_synchronousClients",          "0",                                0,                                               0, false },
+	{ &pmove_fixed,                   "pmove_fixed",                   "0",                                0,                                               0, false },
+	{ &pmove_msec,                    "pmove_msec",                    "8",                                0,                                               0, false },
+	{ &pmove_accurate,                "pmove_accurate",                "1",                                0,                                               0, false },
+	{ &g_floodMaxDemerits,            "g_floodMaxDemerits",            "5000",                             0,                                               0, false },
+	{ &g_floodMinTime,                "g_floodMinTime",                "2000",                             0,                                               0, false },
 
 	// clients: limits
-	{ &g_minNameChangePeriod,         "g_minNameChangePeriod",         "5",                                0,                                               0, false    , nullptr       },
-	{ &g_maxNameChanges,              "g_maxNameChanges",              "5",                                0,                                               0, false    , nullptr       },
-	{ &g_enableVsays,                 "g_voiceChats",                  "1",                                0,                                               0, false    , nullptr       },
-	{ &g_inactivity,                  "g_inactivity",                  "0",                                0,                                               0, true     , nullptr       },
-	{ &g_emoticonsAllowedInNames,     "g_emoticonsAllowedInNames",     "1",                                0,                                               0, false    , nullptr       },
-	{ &g_privateMessages,             "g_privateMessages",             "1",                                0,                                               0, false    , nullptr       },
-	{ &g_specChat,                    "g_specChat",                    "1",                                0,                                               0, false    , nullptr       },
+	{ &g_minNameChangePeriod,         "g_minNameChangePeriod",         "5",                                0,                                               0, false },
+	{ &g_maxNameChanges,              "g_maxNameChanges",              "5",                                0,                                               0, false },
+	{ &g_enableVsays,                 "g_voiceChats",                  "1",                                0,                                               0, false },
+	{ &g_inactivity,                  "g_inactivity",                  "0",                                0,                                               0, true  },
+	{ &g_emoticonsAllowedInNames,     "g_emoticonsAllowedInNames",     "1",                                0,                                               0, false },
+	{ &g_privateMessages,             "g_privateMessages",             "1",                                0,                                               0, false },
+	{ &g_specChat,                    "g_specChat",                    "1",                                0,                                               0, false },
 
 	// clients: voting
-	{ &g_allowVote,                   "g_allowVote",                   "1",                                0,                                               0, false    , nullptr       },
-	{ &g_voteLimit,                   "g_voteLimit",                   "5",                                0,                                               0, false    , nullptr       },
-	{ &g_extendVotesPercent,          "g_extendVotesPercent",          "74",                               0,                                               0, false    , nullptr       },
-	{ &g_extendVotesTime,             "g_extendVotesTime",             "10",                               0,                                               0, false    , nullptr       },
-	{ &g_kickVotesPercent,            "g_kickVotesPercent",            "51",                               0,                                               0, true     , nullptr       },
-	{ &g_denyVotesPercent,            "g_denyVotesPercent",            "51",                               0,                                               0, true     , nullptr       },
-	{ &g_mapVotesPercent,             "g_mapVotesPercent",             "51",                               0,                                               0, true     , nullptr       },
-	{ &g_mapVotesBefore,              "g_mapVotesBefore",              "5",                                0,                                               0, true     , nullptr       },
-	{ &g_nextMapVotesPercent,         "g_nextMapVotesPercent",         "51",                               0,                                               0, true     , nullptr       },
-	{ &g_drawVotesPercent,            "g_drawVotesPercent",            "51",                               0,                                               0, true     , nullptr       },
-	{ &g_drawVotesAfter,              "g_drawVotesAfter",              "0",                                0,                                               0, true     , nullptr       },
-	{ &g_drawVoteReasonRequired,      "g_drawVoteReasonRequired",      "0",                                0,                                               0, true     , nullptr       },
-	{ &g_admitDefeatVotesPercent,     "g_admitDefeatVotesPercent",     "74",                               0,                                               0, true     , nullptr       },
-	{ &g_pollVotesPercent,            "g_pollVotesPercent",            "0",                                0,                                               0, true     , nullptr       },
-	{ &g_botKickVotesAllowed,         "g_botKickVotesAllowed",         "1",                                0,                                               0, true     , nullptr       },
-	{ &g_botKickVotesAllowedThisMap,  "g_botKickVotesAllowedThisMap",  "1",                                0,                                               0, true     , nullptr       },
+	{ &g_allowVote,                   "g_allowVote",                   "1",                                0,                                               0, false },
+	{ &g_voteLimit,                   "g_voteLimit",                   "5",                                0,                                               0, false },
+	{ &g_extendVotesPercent,          "g_extendVotesPercent",          "74",                               0,                                               0, false },
+	{ &g_extendVotesTime,             "g_extendVotesTime",             "10",                               0,                                               0, false },
+	{ &g_kickVotesPercent,            "g_kickVotesPercent",            "51",                               0,                                               0, true  },
+	{ &g_denyVotesPercent,            "g_denyVotesPercent",            "51",                               0,                                               0, true  },
+	{ &g_mapVotesPercent,             "g_mapVotesPercent",             "51",                               0,                                               0, true  },
+	{ &g_mapVotesBefore,              "g_mapVotesBefore",              "5",                                0,                                               0, true  },
+	{ &g_nextMapVotesPercent,         "g_nextMapVotesPercent",         "51",                               0,                                               0, true  },
+	{ &g_drawVotesPercent,            "g_drawVotesPercent",            "51",                               0,                                               0, true  },
+	{ &g_drawVotesAfter,              "g_drawVotesAfter",              "0",                                0,                                               0, true  },
+	{ &g_drawVoteReasonRequired,      "g_drawVoteReasonRequired",      "0",                                0,                                               0, true  },
+	{ &g_admitDefeatVotesPercent,     "g_admitDefeatVotesPercent",     "74",                               0,                                               0, true  },
+	{ &g_pollVotesPercent,            "g_pollVotesPercent",            "0",                                0,                                               0, true  },
+	{ &g_botKickVotesAllowed,         "g_botKickVotesAllowed",         "1",                                0,                                               0, true  },
+	{ &g_botKickVotesAllowedThisMap,  "g_botKickVotesAllowedThisMap",  "1",                                0,                                               0, true  },
 
 	// clients: misc
-	{ &g_geoip,                       "g_geoip",                       "1",                                0,                                               0, false    , nullptr       },
-	{ &g_unnamedNumbering,            "g_unnamedNumbering",            "-1",                               0,                                               0, false    , nullptr       },
-	{ &g_unnamedNamePrefix,           "g_unnamedNamePrefix",           UNNAMED_PLAYER "#",                 0,                                               0, false    , nullptr       },
-	{ &g_unnamedBotNamePrefix,        "g_unnamedBotNamePrefix",        UNNAMED_BOT "#",                    0,                                               0, false    , nullptr       },
+	{ &g_geoip,                       "g_geoip",                       "1",                                0,                                               0, false },
+	{ &g_unnamedNumbering,            "g_unnamedNumbering",            "-1",                               0,                                               0, false },
+	{ &g_unnamedNamePrefix,           "g_unnamedNamePrefix",           UNNAMED_PLAYER "#",                 0,                                               0, false },
+	{ &g_unnamedBotNamePrefix,        "g_unnamedBotNamePrefix",        UNNAMED_BOT "#",                    0,                                               0, false },
 
 	// admin system
-	{ &g_admin,                       "g_admin",                       "admin.dat",                        0,                                               0, false    , nullptr       },
-	{ &g_adminWarn,                   "g_adminWarn",                   "1h",                               0,                                               0, false    , nullptr       },
-	{ &g_adminTempBan,                "g_adminTempBan",                "2m",                               0,                                               0, false    , nullptr       },
-	{ &g_adminMaxBan,                 "g_adminMaxBan",                 "2w",                               0,                                               0, false    , nullptr       },
-	{ &g_adminRetainExpiredBans,      "g_adminRetainExpiredBans",      "1",                                0,                                               0, false    , nullptr       },
-	{ &g_publicAdminMessages,         "g_publicAdminMessages",         "1",                                0,                                               0, false    , nullptr       },
+	{ &g_admin,                       "g_admin",                       "admin.dat",                        0,                                               0, false },
+	{ &g_adminWarn,                   "g_adminWarn",                   "1h",                               0,                                               0, false },
+	{ &g_adminTempBan,                "g_adminTempBan",                "2m",                               0,                                               0, false },
+	{ &g_adminMaxBan,                 "g_adminMaxBan",                 "2w",                               0,                                               0, false },
+	{ &g_adminRetainExpiredBans,      "g_adminRetainExpiredBans",      "1",                                0,                                               0, false },
+	{ &g_publicAdminMessages,         "g_publicAdminMessages",         "1",                                0,                                               0, false },
 
 	// logging
-	{ &g_logFile,                     "g_logFile",                     "games.log",                        0,                                               0, false    , nullptr       },
-	{ &g_logGameplayStatsFrequency,   "g_logGameplayStatsFrequency",   "10",                               0,                                               0, false    , nullptr       },
-	{ &g_logFileSync,                 "g_logFileSync",                 "0",                                0,                                               0, false    , nullptr       },
+	{ &g_logFile,                     "g_logFile",                     "games.log",                        0,                                               0, false },
+	{ &g_logGameplayStatsFrequency,   "g_logGameplayStatsFrequency",   "10",                               0,                                               0, false },
+	{ &g_logFileSync,                 "g_logFileSync",                 "0",                                0,                                               0, false },
 
 	// maps, layouts & rotation
-	{ &g_currentMapRotation,          "g_currentMapRotation",          "-1",                               0,                                               0, false    , nullptr       },
-	{ &g_mapRotationNodes,            "g_mapRotationNodes",            "",                                 0,                                               0, false    , nullptr       },
-	{ &g_mapRotationStack,            "g_mapRotationStack",            "",                                 0,                                               0, false    , nullptr       },
-	{ &g_nextMap,                     "g_nextMap",                     "",                                 0,                                               0, true     , nullptr       },
-	{ &g_nextMapLayouts,              "g_nextMapLayouts",              "",                                 0,                                               0, true     , nullptr       },
-	{ &g_initialMapRotation,          "g_initialMapRotation",          "rotation1",                        0,                                               0, false    , nullptr       },
-	{ &g_mapLog,                      "g_mapLog",                      "",                                 0,                                               0, false    , nullptr       },
-	{ &g_mapStartupMessageDelay,      "g_mapStartupMessageDelay",      "5000",                             CVAR_LATCH,                                      0, false    , nullptr       },
-	{ &g_mapConfigs,                  "g_mapConfigs",                  "",                                 0,                                               0, false    , nullptr       },
-	{ &g_defaultLayouts,              "g_defaultLayouts",              "",                                 CVAR_LATCH,                                      0, false    , nullptr       },
-	{ &g_layouts,                     "g_layouts",                     "",                                 CVAR_LATCH,                                      0, false    , nullptr       },
-	{ &g_layoutAuto,                  "g_layoutAuto",                  "0",                                0,                                               0, false    , nullptr       },
+	{ &g_currentMapRotation,          "g_currentMapRotation",          "-1",                               0,                                               0, false },
+	{ &g_mapRotationNodes,            "g_mapRotationNodes",            "",                                 0,                                               0, false },
+	{ &g_mapRotationStack,            "g_mapRotationStack",            "",                                 0,                                               0, false },
+	{ &g_nextMap,                     "g_nextMap",                     "",                                 0,                                               0, true  },
+	{ &g_nextMapLayouts,              "g_nextMapLayouts",              "",                                 0,                                               0, true  },
+	{ &g_initialMapRotation,          "g_initialMapRotation",          "rotation1",                        0,                                               0, false },
+	{ &g_mapLog,                      "g_mapLog",                      "",                                 0,                                               0, false },
+	{ &g_mapStartupMessageDelay,      "g_mapStartupMessageDelay",      "5000",                             CVAR_LATCH,                                      0, false },
+	{ &g_mapConfigs,                  "g_mapConfigs",                  "",                                 0,                                               0, false },
+	{ &g_defaultLayouts,              "g_defaultLayouts",              "",                                 CVAR_LATCH,                                      0, false },
+	{ &g_layouts,                     "g_layouts",                     "",                                 CVAR_LATCH,                                      0, false },
+	{ &g_layoutAuto,                  "g_layoutAuto",                  "0",                                0,                                               0, false },
 
 	// debug switches
-	{ &g_debugMove,                   "g_debugMove",                   "0",                                0,                                               0, false    , nullptr       },
-	{ &g_debugDamage,                 "g_debugDamage",                 "0",                                0,                                               0, false    , nullptr       },
-	{ &g_debugKnockback,              "g_debugKnockback",              "0",                                0,                                               0, false    , nullptr       },
-	{ &g_debugTurrets,                "g_debugTurrets",                "0",                                0,                                               0, false    , nullptr       },
-	{ &g_debugMomentum,               "g_debugMomentum",               "0",                                0,                                               0, false    , nullptr       },
-	{ &g_debugMapRotation,            "g_debugMapRotation",            "0",                                0,                                               0, false    , nullptr       },
-	{ &g_debugVoices,                 "g_debugVoices",                 "0",                                0,                                               0, false    , nullptr       },
-	{ &g_debugEntities,               "g_debugEntities",               "0",                                0,                                               0, false    , nullptr       },
-	{ &g_debugFire,                   "g_debugFire",                   "0",                                0,                                               0, false    , nullptr       },
+	{ &g_debugMove,                   "g_debugMove",                   "0",                                0,                                               0, false },
+	{ &g_debugDamage,                 "g_debugDamage",                 "0",                                0,                                               0, false },
+	{ &g_debugKnockback,              "g_debugKnockback",              "0",                                0,                                               0, false },
+	{ &g_debugTurrets,                "g_debugTurrets",                "0",                                0,                                               0, false },
+	{ &g_debugMomentum,               "g_debugMomentum",               "0",                                0,                                               0, false },
+	{ &g_debugMapRotation,            "g_debugMapRotation",            "0",                                0,                                               0, false },
+	{ &g_debugVoices,                 "g_debugVoices",                 "0",                                0,                                               0, false },
+	{ &g_debugEntities,               "g_debugEntities",               "0",                                0,                                               0, false },
+	{ &g_debugFire,                   "g_debugFire",                   "0",                                0,                                               0, false },
 
 	// gameplay: basic
-	{ &g_timelimit,                   "timelimit",                     "45",                               CVAR_SERVERINFO,                                 0, true     , nullptr       },
-	{ &g_friendlyFire,                "g_friendlyFire",                "1",                                CVAR_SERVERINFO,                                 0, true     , nullptr       },
-	{ &g_friendlyBuildableFire,       "g_friendlyBuildableFire",       "1",                                CVAR_SERVERINFO,                                 0, true     , nullptr       },
+	{ &g_timelimit,                   "timelimit",                     "45",                               CVAR_SERVERINFO,                                 0, true  },
+	{ &g_friendlyFire,                "g_friendlyFire",                "1",                                CVAR_SERVERINFO,                                 0, true  },
+	{ &g_friendlyBuildableFire,       "g_friendlyBuildableFire",       "1",                                CVAR_SERVERINFO,                                 0, true  },
 
 	// gameplay: team balance
-	{ &g_teamForceBalance,            "g_teamForceBalance",            "0",                                0,                                               0, true     , nullptr       },
-	{ &g_teamImbalanceWarnings,       "g_teamImbalanceWarnings",       "30",                               0,                                               0, false    , nullptr       },
-	{ &g_warmup,                      "g_warmup",                      "10",                               0,                                               0, true     , nullptr       },
-	{ &g_doWarmup,                    "g_doWarmup",                    "0",                                0,                                               0, true     , nullptr       },
+	{ &g_teamForceBalance,            "g_teamForceBalance",            "0",                                0,                                               0, true  },
+	{ &g_teamImbalanceWarnings,       "g_teamImbalanceWarnings",       "30",                               0,                                               0, false },
+	{ &g_warmup,                      "g_warmup",                      "10",                               0,                                               0, true  },
+	{ &g_doWarmup,                    "g_doWarmup",                    "0",                                0,                                               0, true  },
 
 	// gameplay: momentum
-	{ &g_unlockableMinTime,           "g_unlockableMinTime",           DEFAULT_UNLOCKABLE_MIN_TIME,        CVAR_SERVERINFO,                                 0, false    , nullptr       },
-	{ &g_momentumHalfLife,            "g_momentumHalfLife",            DEFAULT_MOMENTUM_HALF_LIFE,         CVAR_SERVERINFO,                                 0, false    , nullptr       },
-	{ &g_momentumRewardDoubleTime,    "g_momentumRewardDoubleTime",    DEFAULT_CONF_REWARD_DOUBLE_TIME,    0,                                               0, false    , nullptr       },
-	{ &g_momentumBaseMod,             "g_momentumBaseMod",             DEFAULT_MOMENTUM_BASE_MOD,          0,                                               0, false    , nullptr       },
-	{ &g_momentumKillMod,             "g_momentumKillMod",             DEFAULT_MOMENTUM_KILL_MOD,          0,                                               0, false    , nullptr       },
-	{ &g_momentumBuildMod,            "g_momentumBuildMod",            DEFAULT_MOMENTUM_BUILD_MOD,         0,                                               0, false    , nullptr       },
-	{ &g_momentumDeconMod,            "g_momentumDeconMod",            DEFAULT_MOMENTUM_DECON_MOD,         0,                                               0, false    , nullptr       },
-	{ &g_momentumDestroyMod,          "g_momentumDestroyMod",          DEFAULT_MOMENTUM_DESTROY_MOD,       0,                                               0, false    , nullptr       },
+	{ &g_unlockableMinTime,           "g_unlockableMinTime",           DEFAULT_UNLOCKABLE_MIN_TIME,        CVAR_SERVERINFO,                                 0, false },
+	{ &g_momentumHalfLife,            "g_momentumHalfLife",            DEFAULT_MOMENTUM_HALF_LIFE,         CVAR_SERVERINFO,                                 0, false },
+	{ &g_momentumRewardDoubleTime,    "g_momentumRewardDoubleTime",    DEFAULT_CONF_REWARD_DOUBLE_TIME,    0,                                               0, false },
+	{ &g_momentumBaseMod,             "g_momentumBaseMod",             DEFAULT_MOMENTUM_BASE_MOD,          0,                                               0, false },
+	{ &g_momentumKillMod,             "g_momentumKillMod",             DEFAULT_MOMENTUM_KILL_MOD,          0,                                               0, false },
+	{ &g_momentumBuildMod,            "g_momentumBuildMod",            DEFAULT_MOMENTUM_BUILD_MOD,         0,                                               0, false },
+	{ &g_momentumDeconMod,            "g_momentumDeconMod",            DEFAULT_MOMENTUM_DECON_MOD,         0,                                               0, false },
+	{ &g_momentumDestroyMod,          "g_momentumDestroyMod",          DEFAULT_MOMENTUM_DESTROY_MOD,       0,                                               0, false },
 
 	// gameplay: misc
-	{ &g_alienOffCreepRegenHalfLife,  "g_alienOffCreepRegenHalfLife",  "0",                                0,                                               0, false    , nullptr       },
-	{ &g_freeFundPeriod,              "g_freeFundPeriod",              DEFAULT_FREEKILL_PERIOD,            0,                                               0, true     , nullptr       },
-	{ &g_sayAreaRange,                "g_sayAreaRange",                "1000",                             0,                                               0, true     , nullptr       },
-	{ &g_speed,                       "g_speed",                       "320",                              0,                                               0, true     , nullptr       },
-	{ &g_antiSpawnBlock,              "g_antiSpawnBlock",              "0",                                0,                                               0, false    , nullptr       },
-	{ &g_shove,                       "g_shove",                       "0.0",                              0,                                               0, false    , nullptr       },
-	{ &g_dretchPunt,                  "g_dretchPunt",                  "1",                                0,                                               0, true     , nullptr       },
-	{ &g_allowTeamOverlay,            "g_allowTeamOverlay",            "1",                                0,                                               0, true     , nullptr       },
-	{ &g_showKillerHP,                "g_showKillerHP",                "0",                                0,                                               0, false    , nullptr       },
-	{ &g_combatCooldown,              "g_combatCooldown",              "15",                               0,                                               0, false    , nullptr       },
+	{ &g_alienOffCreepRegenHalfLife,  "g_alienOffCreepRegenHalfLife",  "0",                                0,                                               0, false },
+	{ &g_freeFundPeriod,              "g_freeFundPeriod",              DEFAULT_FREEKILL_PERIOD,            0,                                               0, true  },
+	{ &g_sayAreaRange,                "g_sayAreaRange",                "1000",                             0,                                               0, true  },
+	{ &g_speed,                       "g_speed",                       "320",                              0,                                               0, true  },
+	{ &g_antiSpawnBlock,              "g_antiSpawnBlock",              "0",                                0,                                               0, false },
+	{ &g_shove,                       "g_shove",                       "0.0",                              0,                                               0, false },
+	{ &g_dretchPunt,                  "g_dretchPunt",                  "1",                                0,                                               0, true  },
+	{ &g_allowTeamOverlay,            "g_allowTeamOverlay",            "1",                                0,                                               0, true  },
+	{ &g_showKillerHP,                "g_showKillerHP",                "0",                                0,                                               0, false },
+	{ &g_combatCooldown,              "g_combatCooldown",              "15",                               0,                                               0, false },
 
-	{ &g_instantBuilding,             "g_instantBuilding",             "0",                                0,                                               0, true     , nullptr       },
+	{ &g_instantBuilding,             "g_instantBuilding",             "0",                                0,                                               0, true  },
 
-	{ &g_emptyTeamsSkipMapTime,       "g_emptyTeamsSkipMapTime",       "0",                                0,                                               0, true     , nullptr       },
+	{ &g_emptyTeamsSkipMapTime,       "g_emptyTeamsSkipMapTime",       "0",                                0,                                               0, true  },
 
 	// bots: buying
-	{ &g_bot_buy, "g_bot_buy", "1",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_rifle, "g_bot_rifle", "1",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_painsaw, "g_bot_painsaw", "1",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_shotgun, "g_bot_shotgun", "1",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_lasgun, "g_bot_lasgun", "1",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_mdriver, "g_bot_mdriver", "1",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_chaingun, "g_bot_chain", "1",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_prifle, "g_bot_prifle", "1",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_flamer, "g_bot_flamer", "1",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_lcannon, "g_bot_lcannon", "1",  CVAR_NORESTART, 0, false, nullptr },
+	{ &g_bot_buy, "g_bot_buy", "1",  CVAR_NORESTART, 0, false },
+	{ &g_bot_rifle, "g_bot_rifle", "1",  CVAR_NORESTART, 0, false },
+	{ &g_bot_painsaw, "g_bot_painsaw", "1",  CVAR_NORESTART, 0, false },
+	{ &g_bot_shotgun, "g_bot_shotgun", "1",  CVAR_NORESTART, 0, false },
+	{ &g_bot_lasgun, "g_bot_lasgun", "1",  CVAR_NORESTART, 0, false },
+	{ &g_bot_mdriver, "g_bot_mdriver", "1",  CVAR_NORESTART, 0, false },
+	{ &g_bot_chaingun, "g_bot_chain", "1",  CVAR_NORESTART, 0, false },
+	{ &g_bot_prifle, "g_bot_prifle", "1",  CVAR_NORESTART, 0, false },
+	{ &g_bot_flamer, "g_bot_flamer", "1",  CVAR_NORESTART, 0, false },
+	{ &g_bot_lcannon, "g_bot_lcannon", "1",  CVAR_NORESTART, 0, false },
 
 	// bots: evolution
-	{ &g_bot_evolve, "g_bot_evolve", "1", CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_level1, "g_bot_level1", "1", CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_level2, "g_bot_level2", "1", CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_level2upg, "g_bot_level2upg", "1", CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_level3, "g_bot_level3", "1", CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_level3upg, "g_bot_level3upg", "1", CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_level4, "g_bot_level4", "1", CVAR_NORESTART, 0, false, nullptr },
+	{ &g_bot_evolve, "g_bot_evolve", "1", CVAR_NORESTART, 0, false },
+	{ &g_bot_level1, "g_bot_level1", "1", CVAR_NORESTART, 0, false },
+	{ &g_bot_level2, "g_bot_level2", "1", CVAR_NORESTART, 0, false },
+	{ &g_bot_level2upg, "g_bot_level2upg", "1", CVAR_NORESTART, 0, false },
+	{ &g_bot_level3, "g_bot_level3", "1", CVAR_NORESTART, 0, false },
+	{ &g_bot_level3upg, "g_bot_level3upg", "1", CVAR_NORESTART, 0, false },
+	{ &g_bot_level4, "g_bot_level4", "1", CVAR_NORESTART, 0, false },
 
 	// bots: misc
-	{ &g_bot_attackStruct, "g_bot_attackStruct", "1",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_roam, "g_bot_roam", "1",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_rush, "g_bot_rush", "1",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_repair, "g_bot_repair", "1",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_build, "g_bot_build", "1",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_retreat, "g_bot_retreat", "1",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_fov, "g_bot_fov", "125",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_chasetime, "g_bot_chasetime", "5000",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_reactiontime, "g_bot_reactiontime", "500",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_infinite_funds, "g_bot_infinite_funds", "0",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_numInGroup, "g_bot_numInGroup", "3",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_debug, "g_bot_debug", "0",  CVAR_NORESTART, 0, false, nullptr },
-	{ &g_bot_buildLayout, "g_bot_buildLayout", "botbuild",  CVAR_NORESTART, 0, false, nullptr }
+	{ &g_bot_attackStruct, "g_bot_attackStruct", "1",  CVAR_NORESTART, 0, false },
+	{ &g_bot_roam, "g_bot_roam", "1",  CVAR_NORESTART, 0, false },
+	{ &g_bot_rush, "g_bot_rush", "1",  CVAR_NORESTART, 0, false },
+	{ &g_bot_repair, "g_bot_repair", "1",  CVAR_NORESTART, 0, false },
+	{ &g_bot_build, "g_bot_build", "1",  CVAR_NORESTART, 0, false },
+	{ &g_bot_retreat, "g_bot_retreat", "1",  CVAR_NORESTART, 0, false },
+	{ &g_bot_fov, "g_bot_fov", "125",  CVAR_NORESTART, 0, false },
+	{ &g_bot_chasetime, "g_bot_chasetime", "5000",  CVAR_NORESTART, 0, false },
+	{ &g_bot_reactiontime, "g_bot_reactiontime", "500",  CVAR_NORESTART, 0, false },
+	{ &g_bot_infinite_funds, "g_bot_infinite_funds", "0",  CVAR_NORESTART, 0, false },
+	{ &g_bot_numInGroup, "g_bot_numInGroup", "3",  CVAR_NORESTART, 0, false },
+	{ &g_bot_debug, "g_bot_debug", "0",  CVAR_NORESTART, 0, false },
+	{ &g_bot_buildLayout, "g_bot_buildLayout", "botbuild",  CVAR_NORESTART, 0, false }
 };
 
 static const size_t gameCvarTableSize = ARRAY_LEN( gameCvarTable );
@@ -615,11 +609,6 @@ void G_RegisterCvars()
 		if ( cvarTable->vmCvar )
 		{
 			cvarTable->modificationCount = cvarTable->vmCvar->modificationCount;
-
-			if ( cvarTable->explicit_ )
-			{
-				strcpy( cvarTable->explicit_, cvarTable->vmCvar->string );
-			}
 		}
 	}
 }
@@ -649,31 +638,7 @@ void G_UpdateCvars()
 					trap_SendServerCommand( -1, va( "print_tr %s %s %s", QQ( N_("Server: $1$ changed to $2$") ),
 					                                Quote( cv->cvarName ), Quote( cv->vmCvar->string ) ) );
 				}
-
-				if ( !level.spawning && cv->explicit_ )
-				{
-					strcpy( cv->explicit_, cv->vmCvar->string );
-				}
 			}
-		}
-	}
-}
-
-/*
-=================
-G_RestoreCvars
-=================
-*/
-void G_RestoreCvars()
-{
-	unsigned i;
-	cvarTable_t *cv;
-
-	for ( i = 0, cv = gameCvarTable; i < gameCvarTableSize; i++, cv++ )
-	{
-		if ( cv->vmCvar && cv->explicit_ )
-		{
-			trap_Cvar_Set( cv->cvarName, cv->explicit_ );
 		}
 	}
 }
@@ -990,8 +955,6 @@ void G_ShutdownGame( int /* restart */ )
 {
 	// in case of a map_restart
 	G_ClearVotes( true );
-
-	G_RestoreCvars();
 
 	Log::Notice( "==== ShutdownGame ====" );
 

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -108,6 +108,7 @@ vmCvar_t           pmove_accurate;
 vmCvar_t           g_minNameChangePeriod;
 vmCvar_t           g_maxNameChanges;
 
+// gameplay: mining
 Cvar::Callback<Cvar::Cvar<int>> g_buildPointInitialBudget(
 		"g_BPInitialBudget",
 		"Initial Budget",
@@ -124,8 +125,22 @@ Cvar::Callback<Cvar::Cvar<int>> g_buildPointBudgetPerMiner(
 		[](int) {
 			G_UpdateBuildPointBudgets();
 		});
-vmCvar_t           g_buildPointRecoveryInititalRate;
-vmCvar_t           g_buildPointRecoveryRateHalfLife;
+Cvar::Callback<Cvar::Cvar<int>> g_buildPointRecoveryInititalRate(
+		"g_BPRecoveryInititalRate",
+		"The initial speed at which BP will be recovered (in BP per minute)",
+		Cvar::SERVERINFO,
+		DEFAULT_BP_RECOVERY_INITIAL_RATE,
+		[](int) {
+			G_UpdateBuildPointBudgets();
+		});
+Cvar::Callback<Cvar::Cvar<int>> g_buildPointRecoveryRateHalfLife(
+		"g_BPRecoveryRateHalfLife",
+		"The duration one will wait before BP recovery gets twice as slow (in minutes)",
+		Cvar::SERVERINFO,
+		DEFAULT_BP_RECOVERY_RATE_HALF_LIFE,
+		[](int) {
+			G_UpdateBuildPointBudgets();
+		});
 
 vmCvar_t           g_debugMomentum;
 vmCvar_t           g_momentumHalfLife;
@@ -137,8 +152,18 @@ vmCvar_t           g_momentumBuildMod;
 vmCvar_t           g_momentumDeconMod;
 vmCvar_t           g_momentumDestroyMod;
 
-vmCvar_t           g_humanAllowBuilding;
-vmCvar_t           g_alienAllowBuilding;
+
+Cvar::Cvar<bool> g_humanAllowBuilding(
+		"g_humanAllowBuilding",
+		"can human build",
+		Cvar::NONE,
+		true);
+
+Cvar::Cvar<bool> g_alienAllowBuilding(
+		"g_alienAllowBuilding",
+		"can aliens build",
+		Cvar::NONE,
+		true);
 
 vmCvar_t           g_alienOffCreepRegenHalfLife;
 
@@ -375,10 +400,6 @@ static cvarTable_t gameCvarTable[] =
 	{ &g_warmup,                      "g_warmup",                      "10",                               0,                                               0, true     , nullptr       },
 	{ &g_doWarmup,                    "g_doWarmup",                    "0",                                0,                                               0, true     , nullptr       },
 
-	// gameplay: mining
-	{ &g_buildPointRecoveryInititalRate, "g_BPRecoveryInitialRate",    DEFAULT_BP_RECOVERY_INITIAL_RATE,   CVAR_SERVERINFO,                                 0, false    , nullptr       },
-	{ &g_buildPointRecoveryRateHalfLife, "g_BPRecoveryRateHalfLife",   DEFAULT_BP_RECOVERY_RATE_HALF_LIFE, CVAR_SERVERINFO,                                 0, false    , nullptr       },
-
 	// gameplay: momentum
 	{ &g_unlockableMinTime,           "g_unlockableMinTime",           DEFAULT_UNLOCKABLE_MIN_TIME,        CVAR_SERVERINFO,                                 0, false    , nullptr       },
 	{ &g_momentumHalfLife,            "g_momentumHalfLife",            DEFAULT_MOMENTUM_HALF_LIFE,         CVAR_SERVERINFO,                                 0, false    , nullptr       },
@@ -390,8 +411,6 @@ static cvarTable_t gameCvarTable[] =
 	{ &g_momentumDestroyMod,          "g_momentumDestroyMod",          DEFAULT_MOMENTUM_DESTROY_MOD,       0,                                               0, false    , nullptr       },
 
 	// gameplay: limits
-	{ &g_humanAllowBuilding,          "g_humanAllowBuilding",          "1",                                0,                                               0, false    , nullptr       },
-	{ &g_alienAllowBuilding,          "g_alienAllowBuilding",          "1",                                0,                                               0, false    , nullptr       },
 	{ &g_disabledEquipment,           "g_disabledEquipment",           "",                                 CVAR_SYSTEMINFO,                                 0, false    , nullptr       },
 	{ &g_disabledClasses,             "g_disabledClasses",             "",                                 CVAR_SYSTEMINFO,                                 0, false    , nullptr       },
 	{ &g_disabledBuildables,          "g_disabledBuildables",          "",                                 CVAR_SYSTEMINFO,                                 0, false    , nullptr       },

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -598,9 +598,6 @@ void G_RegisterCvars()
 	unsigned i;
 	cvarTable_t *cvarTable;
 
-	// sort the table for fast lookup
-	qsort( gameCvarTable, gameCvarTableSize, sizeof( *gameCvarTable ), cvarCompare );
-
 	for ( i = 0, cvarTable = gameCvarTable; i < gameCvarTableSize; i++, cvarTable++ )
 	{
 		trap_Cvar_Register( cvarTable->vmCvar, cvarTable->cvarName,
@@ -641,21 +638,6 @@ void G_UpdateCvars()
 			}
 		}
 	}
-}
-
-vmCvar_t *G_FindCvar( const char *name )
-{
-	cvarTable_t *c = nullptr;
-	cvarTable_t comp;
-	comp.cvarName = name;
-	c = ( cvarTable_t * ) bsearch( &comp, gameCvarTable, gameCvarTableSize, sizeof( *gameCvarTable ), cvarCompare );
-
-	if ( !c )
-	{
-		return nullptr;
-	}
-
-	return c->vmCvar;
 }
 
 /*

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -57,6 +57,12 @@ gclient_t          *g_clients;
 
 vmCvar_t           g_showHelpOnConnection;
 
+Cvar::Range<Cvar::Cvar<int>> g_gravity(
+		"g_gravity",
+		"how strongly things will be attracted towards the ground",
+		Cvar::NONE,
+		800, 100, 2000);
+
 vmCvar_t           g_timelimit;
 vmCvar_t           g_friendlyFire;
 vmCvar_t           g_friendlyBuildableFire;
@@ -66,7 +72,6 @@ vmCvar_t           g_needpass;
 vmCvar_t           g_maxclients;
 vmCvar_t           g_maxGameClients;
 vmCvar_t           g_speed;
-vmCvar_t           g_gravity;
 vmCvar_t           g_cheats;
 vmCvar_t           g_inactivity;
 vmCvar_t           g_debugMove;
@@ -280,9 +285,6 @@ vmCvar_t g_bot_buildLayout;
 
 //</bot stuff>
 
-// copy cvars that can be set in worldspawn so they can be restored later
-static char        cv_gravity[ MAX_CVAR_VALUE_STRING ];
-
 static cvarTable_t gameCvarTable[] =
 {
 	// special purpose (external source, read only, etc.)
@@ -420,7 +422,6 @@ static cvarTable_t gameCvarTable[] =
 	{ &g_freeFundPeriod,              "g_freeFundPeriod",              DEFAULT_FREEKILL_PERIOD,            0,                                               0, true     , nullptr       },
 	{ &g_sayAreaRange,                "g_sayAreaRange",                "1000",                             0,                                               0, true     , nullptr       },
 	{ &g_speed,                       "g_speed",                       "320",                              0,                                               0, true     , nullptr       },
-	{ &g_gravity,                     "g_gravity",                     "800",                              0,                                               0, true, cv_gravity},
 	{ &g_antiSpawnBlock,              "g_antiSpawnBlock",              "0",                                0,                                               0, false    , nullptr       },
 	{ &g_shove,                       "g_shove",                       "0.0",                              0,                                               0, false    , nullptr       },
 	{ &g_dretchPunt,                  "g_dretchPunt",                  "1",                                0,                                               0, true     , nullptr       },

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -224,7 +224,6 @@ void              LogExit( const char *string );
 void              G_InitGame( int levelTime, int randomSeed, bool inClient );
 void              G_RunFrame( int levelTime );
 void              G_ShutdownGame( int restart );
-vmCvar_t          *G_FindCvar( const char *name );
 void              G_CheckPmoveParamChanges();
 void              G_SendClientPmoveParams(int client);
 void              G_PrepareEntityNetCode();

--- a/src/sgame/sg_spawn.cpp
+++ b/src/sgame/sg_spawn.cpp
@@ -60,29 +60,22 @@ bool G_SpawnString( const char *key, const char *defaultString, char **out )
 }
 
 /**
- * spawns a string and sets it as a cvar.
- *
- * use this with caution, as it might persist unprepared cvars (see cvartable)
+ * spawns a string and sets it as a cvar, or reset the cvar to its default
+ * value if not set.
+ * This allows loading values from the map, without keeping the garbage from
+ * the previous map if nothing is set.
  */
-static bool G_SpawnStringIntoCVarIfSet( const char *key, const char *cvarName )
+static void G_SpawnStringIntoCVar( const char *key, Cvar::CvarProxy& cvar )
 {
-	char     *tmpString;
-
-	if ( G_SpawnString( key, "", &tmpString ) )
+	char *str = nullptr;
+	if ( G_SpawnString( key, nullptr, &str ) )
 	{
-		trap_Cvar_Set( cvarName, tmpString );
-		return true;
+		Cvar::SetValue( cvar.Name(), str );
 	}
-
-	return false;
-}
-
-static void G_SpawnStringIntoCVar( const char *key, const char *cvarName )
-{
-	char     *tmpString;
-
-	G_SpawnString( key, "", &tmpString );
-	trap_Cvar_Set( cvarName, tmpString );
+	else
+	{
+		cvar.Reset();
+	}
 }
 
 bool G_SpawnBoolean( const char *key, bool defaultqboolean )
@@ -1064,14 +1057,19 @@ void SP_worldspawn()
 
 	trap_SetConfigstring( CS_MOTD, g_motd.string );  // message of the day
 
-	G_SpawnStringIntoCVarIfSet( "gravity", "g_gravity" );
+	G_SpawnStringIntoCVar( "gravity", g_gravity );
 
-	G_SpawnStringIntoCVarIfSet( "humanBuildPoints", "g_humanBuildPoints" );
-	G_SpawnStringIntoCVarIfSet( "alienBuildPoints", "g_alienBuildPoints" );
+	G_SpawnStringIntoCVar( "humanAllowBuilding", g_humanAllowBuilding );
+	G_SpawnStringIntoCVar( "alienAllowBuilding", g_alienAllowBuilding );
 
-	G_SpawnStringIntoCVar( "disabledEquipment", "g_disabledEquipment" );
-	G_SpawnStringIntoCVar( "disabledClasses", "g_disabledClasses" );
-	G_SpawnStringIntoCVar( "disabledBuildables", "g_disabledBuildables" );
+	G_SpawnStringIntoCVar( "BPInitialBudget", g_buildPointInitialBudget );
+	G_SpawnStringIntoCVar( "BPBudgetPerMiner", g_buildPointBudgetPerMiner );
+	G_SpawnStringIntoCVar( "BPBudgetPerMiner", g_buildPointBudgetPerMiner );
+	G_SpawnStringIntoCVar( "BPRecoveryRateHalfLife", g_buildPointRecoveryRateHalfLife );
+
+	G_SpawnStringIntoCVar( "disabledEquipment", g_disabledEquipment );
+	G_SpawnStringIntoCVar( "disabledClasses", g_disabledClasses );
+	G_SpawnStringIntoCVar( "disabledBuildables", g_disabledBuildables );
 
 	g_entities[ ENTITYNUM_WORLD ].s.number = ENTITYNUM_WORLD;
 	g_entities[ ENTITYNUM_WORLD ].r.ownerNum = ENTITYNUM_NONE;

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -2543,10 +2543,7 @@ PENDULUM
 
 void SP_func_pendulum( gentity_t *self )
 {
-	float frequency;
-	float length;
 	float phase;
-
 	G_SpawnFloat( "phase", "0", &phase );
 
 	G_ResetIntField(&self->damage, true, self->config.damage, self->eclass->config.damage, 2);
@@ -2554,11 +2551,11 @@ void SP_func_pendulum( gentity_t *self )
 	trap_SetBrushModel( self, self->model );
 
 	// find pendulum length
-	length = fabs( self->r.mins[ 2 ] );
+	float length = fabs( self->r.mins[ 2 ] );
 
-	if ( length < 8 )
+	if ( length < 8.0f )
 	{
-		length = 8;
+		length = 8.0f;
 	}
 
 	InitMover( self );
@@ -2569,7 +2566,7 @@ void SP_func_pendulum( gentity_t *self )
 
 	VectorCopy( self->s.angles, self->s.apos.trBase );
 
-	frequency = 1 / ( M_PI * 2 ) * sqrtf( g_gravity.value / ( 3 * length ) );
+	float frequency = 1.0f / ( M_PI * 2.0f ) * sqrtf( g_gravity.Get() / ( 3.0f * length ) );
 	self->s.apos.trDuration = 1000 / frequency;
 	self->s.apos.trTime = self->s.apos.trDuration * phase;
 	self->s.apos.trType = trType_t::TR_SINE;

--- a/src/sgame/sg_spawn_sensor.cpp
+++ b/src/sgame/sg_spawn_sensor.cpp
@@ -314,24 +314,20 @@ sensor_buildable
 
 bool sensor_buildable_match( gentity_t *self, gentity_t *activator )
 {
-	int i = 0;
-
 	if ( !activator )
 	{
 		return false;
 	}
 
 	//if there is no buildable list every buildable triggers
-	if ( self->conditions.buildables[ i ] == BA_NONE )
+	if ( self->conditions.buildables.empty() )
 	{
 		return true;
-	}
-	else
-	{
+	} else {
 		//otherwise check against the list
-		for ( i = 0; self->conditions.buildables[ i ] != BA_NONE; i++ )
+		for ( auto b : self->conditions.buildables )
 		{
-			if ( activator->s.modelindex == self->conditions.buildables[ i ] )
+			if ( activator->s.modelindex == b )
 			{
 				return true;
 			}
@@ -390,24 +386,22 @@ sensor_class_match
 */
 bool sensor_class_match( gentity_t *self, gentity_t *activator )
 {
-	int i = 0;
-
 	if ( !activator )
 	{
 		return false;
 	}
 
 	//if there is no class list every class triggers (stupid case)
-	if ( self->conditions.classes[ i ] == PCL_NONE )
+	if ( self->conditions.classes.empty() )
 	{
 		return true;
 	}
 	else
 	{
 		//otherwise check against the list
-		for ( i = 0; self->conditions.classes[ i ] != PCL_NONE; i++ )
+		for ( auto c : self->conditions.classes )
 		{
-			if ( activator->client->ps.stats[ STAT_CLASS ] == self->conditions.classes[ i ] )
+			if ( activator->client->ps.stats[ STAT_CLASS ] == c )
 			{
 				return true;
 			}
@@ -424,14 +418,12 @@ sensor_equipment_match
 */
 bool sensor_equipment_match( gentity_t *self, gentity_t *activator )
 {
-	int i = 0;
-
 	if ( !activator )
 	{
 		return false;
 	}
 
-	if ( self->conditions.weapons[ i ] == WP_NONE && self->conditions.upgrades[ i ] == UP_NONE )
+	if ( self->conditions.weapons.empty() && self->conditions.upgrades.empty() )
 	{
 		//if there is no equipment list all equipment triggers for the old behavior of target_equipment, but not the new or different one
 		return true;
@@ -439,17 +431,17 @@ bool sensor_equipment_match( gentity_t *self, gentity_t *activator )
 	else
 	{
 		//otherwise check against the lists
-		for ( i = 0; self->conditions.weapons[ i ] != WP_NONE; i++ )
+		for ( auto w : self->conditions.weapons )
 		{
-			if ( BG_InventoryContainsWeapon( self->conditions.weapons[ i ], activator->client->ps.stats ) )
+			if ( BG_InventoryContainsWeapon( w, activator->client->ps.stats ) )
 			{
 				return true;
 			}
 		}
 
-		for ( i = 0; self->conditions.upgrades[ i ] != UP_NONE; i++ )
+		for ( auto u : self->conditions.upgrades )
 		{
-			if ( BG_InventoryContainsUpgrade( self->conditions.upgrades[ i ], activator->client->ps.stats ) )
+			if ( BG_InventoryContainsUpgrade( u, activator->client->ps.stats ) )
 			{
 				return true;
 			}
@@ -479,11 +471,11 @@ void sensor_player_touch( gentity_t *self, gentity_t *activator, trace_t* )
 	if ( self->conditions.team && ( activator->client->pers.team != self->conditions.team ) )
 		return;
 
-	if ( ( self->conditions.upgrades[0] || self->conditions.weapons[0] ) && activator->client->pers.team == TEAM_HUMANS )
+	if ( ( self->conditions.upgrades.empty() || self->conditions.weapons.empty() ) && activator->client->pers.team == TEAM_HUMANS )
 	{
 		shouldFire = sensor_equipment_match( self, activator );
 	}
-	else if ( self->conditions.classes[0] && activator->client->pers.team == TEAM_ALIENS )
+	else if ( self->conditions.classes.empty() && activator->client->pers.team == TEAM_ALIENS )
 	{
 		shouldFire = sensor_class_match( self, activator );
 	}

--- a/src/sgame/sg_spawn_shared.cpp
+++ b/src/sgame/sg_spawn_shared.cpp
@@ -64,7 +64,6 @@ void think_aimAtTarget( gentity_t *self )
 {
 	gentity_t *pickedTarget;
 	vec3_t    origin;
-	float     height, gravity, time, forward;
 	float     distance;
 
 	VectorAdd( self->r.absmin, self->r.absmax, origin );
@@ -78,9 +77,9 @@ void think_aimAtTarget( gentity_t *self )
 		return;
 	}
 
-	height = pickedTarget->s.origin[ 2 ] - origin[ 2 ];
-	gravity = g_gravity.value;
-	time = sqrtf( height / ( 0.5f * gravity ) );
+	float height = pickedTarget->s.origin[ 2 ] - origin[ 2 ];
+	float gravity = static_cast<float>(g_gravity.Get());
+	float time = sqrtf( height / ( 0.5f * gravity ) );
 
 	if ( !time )
 	{
@@ -93,7 +92,7 @@ void think_aimAtTarget( gentity_t *self )
 	self->s.origin2[ 2 ] = 0;
 	distance = VectorNormalize( self->s.origin2 );
 
-	forward = distance / time;
+	float forward = distance / time;
 	VectorScale( self->s.origin2, forward, self->s.origin2 );
 
 	self->s.origin2[ 2 ] = time * gravity;

--- a/src/sgame/sg_spawn_shared.cpp
+++ b/src/sgame/sg_spawn_shared.cpp
@@ -200,16 +200,19 @@ shared field spawn functions
 void SP_ConditionFields( gentity_t *self ) {
 	char *buffer;
 
-	if ( G_SpawnString( "buildables", "", &buffer ) )
-		BG_ParseCSVBuildableList( buffer, self->conditions.buildables, BA_NUM_BUILDABLES );
+	if ( G_SpawnString( "buildables", "", &buffer ) ) {
+		self->conditions.buildables = BG_ParseBuildableList( buffer );
+	}
 
-	if ( G_SpawnString( "classes", "", &buffer ) )
-		BG_ParseCSVClassList( buffer, self->conditions.classes, PCL_NUM_CLASSES );
+	if ( G_SpawnString( "classes", "", &buffer ) ) {
+		self->conditions.classes = BG_ParseClassList( buffer );
+	}
 
-	if ( G_SpawnString( "equipment", "", &buffer ) )
-		BG_ParseCSVEquipmentList( buffer, self->conditions.weapons, WP_NUM_WEAPONS,
-	                          self->conditions.upgrades, UP_NUM_UPGRADES );
-
+	if ( G_SpawnString( "equipment", "", &buffer ) ) {
+		auto pair = BG_ParseEquipmentList( buffer );
+		self->conditions.weapons = pair.first;
+		self->conditions.upgrades = pair.second;
+	}
 }
 
 void SP_WaitFields( gentity_t *self, float defaultWait, float defaultWaitVariance ) {

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -40,10 +40,10 @@ struct gentityConditions_s
 	team_t   team;
 	int      stage;
 
-	class_t     classes[ PCL_NUM_CLASSES ];
-	weapon_t    weapons[ WP_NUM_WEAPONS ];
-	upgrade_t   upgrades[ UP_NUM_UPGRADES ];
-	buildable_t buildables[ BA_NUM_BUILDABLES ];
+	std::vector<class_t>     classes;
+	std::vector<weapon_t>    weapons;
+	std::vector<upgrade_t>   upgrades;
+	std::vector<buildable_t> buildables;
 
 	bool negated;
 };

--- a/src/shared/bg_gameplay.h
+++ b/src/shared/bg_gameplay.h
@@ -352,8 +352,8 @@ extern int   MEDKIT_STARTUP_SPEED;
 #define RGS_RANGE                          1000.0f // must be > 0
 #define DEFAULT_BP_INITIAL_BUDGET          80      // in BP
 #define DEFAULT_BP_BUDGET_PER_MINER        50      // in BP
-#define DEFAULT_BP_RECOVERY_INITIAL_RATE   "16"    // in BP/min
-#define DEFAULT_BP_RECOVERY_RATE_HALF_LIFE "10"    // in min
+#define DEFAULT_BP_RECOVERY_INITIAL_RATE   16      // in BP/min
+#define DEFAULT_BP_RECOVERY_RATE_HALF_LIFE 10      // in min
 
 // momentum
 #define MOMENTUM_MAX                     300.0f

--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -29,6 +29,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "engine/qcommon/q_shared.h"
 #include "common/FileSystem.h"
 #include "bg_public.h"
+#include "parse.h"
 
 #define N_(x) x
 
@@ -2307,256 +2308,127 @@ int BG_UnpackEntityNumbers( entityState_t *es, int *entityNums, unsigned int cou
 	return i;
 }
 
-/*
-===============
-BG_ParseCSVEquipmentList
-===============
-*/
-void BG_ParseCSVEquipmentList( const char *string, weapon_t *weapons, int weaponsSize,
-                               upgrade_t *upgrades, int upgradesSize )
+static struct gameElements_t
 {
-	char     buffer[ MAX_STRING_CHARS ];
-	int      i = 0, j = 0;
-	char     *p, *q;
-	bool EOS = false;
-
-	Q_strncpyz( buffer, string, MAX_STRING_CHARS );
-
-	p = q = buffer;
-
-	while ( *p != '\0' )
-	{
-		//skip to first , or EOS
-		while ( *p != ',' && *p != '\0' )
-		{
-			p++;
-		}
-
-		if ( *p == '\0' )
-		{
-			EOS = true;
-		}
-
-		*p = '\0';
-
-		//strip leading whitespace
-		while ( *q == ' ' )
-		{
-			q++;
-		}
-
-		if ( weaponsSize )
-		{
-			weapons[ i ] = BG_WeaponNumberByName( q );
-		}
-
-		if ( upgradesSize )
-		{
-			upgrades[ j ] = BG_UpgradeByName( q )->number;
-		}
-
-		if ( weaponsSize && weapons[ i ] == WP_NONE &&
-		     upgradesSize && upgrades[ j ] == UP_NONE )
-		{
-			Log::Warn( "unknown equipment %s", q );
-		}
-		else if ( weaponsSize && weapons[ i ] != WP_NONE )
-		{
-			i++;
-		}
-		else if ( upgradesSize && upgrades[ j ] != UP_NONE )
-		{
-			j++;
-		}
-
-		if ( !EOS )
-		{
-			p++;
-			q = p;
-		}
-		else
-		{
-			break;
-		}
-
-		if ( i == ( weaponsSize - 1 ) || j == ( upgradesSize - 1 ) )
-		{
-			break;
-		}
-	}
-
-	if ( weaponsSize )
-	{
-		weapons[ i ] = WP_NONE;
-	}
-
-	if ( upgradesSize )
-	{
-		upgrades[ j ] = UP_NONE;
-	}
-}
-
-/*
-===============
-BG_ParseCSVClassList
-===============
-*/
-void BG_ParseCSVClassList( const char *string, class_t *classes, int classesSize )
-{
-	char     buffer[ MAX_STRING_CHARS ];
-	int      i = 0;
-	char     *p, *q;
-	bool EOS = false;
-
-	Q_strncpyz( buffer, string, MAX_STRING_CHARS );
-
-	p = q = buffer;
-
-	while ( *p != '\0' && i < classesSize - 1 )
-	{
-		//skip to first , or EOS
-		while ( *p != ',' && *p != '\0' )
-		{
-			p++;
-		}
-
-		if ( *p == '\0' )
-		{
-			EOS = true;
-		}
-
-		*p = '\0';
-
-		//strip leading whitespace
-		while ( *q == ' ' )
-		{
-			q++;
-		}
-
-		classes[ i ] = BG_ClassByName( q )->number;
-
-		if ( classes[ i ] == PCL_NONE )
-		{
-			Log::Warn( "unknown class %s", q );
-		}
-		else
-		{
-			i++;
-		}
-
-		if ( !EOS )
-		{
-			p++;
-			q = p;
-		}
-		else
-		{
-			break;
-		}
-	}
-
-	classes[ i ] = PCL_NONE;
-}
-
-/*
-===============
-BG_ParseCSVBuildableList
-===============
-*/
-void BG_ParseCSVBuildableList( const char *string, buildable_t *buildables, int buildablesSize )
-{
-	char     buffer[ MAX_STRING_CHARS ];
-	int      i = 0;
-	char     *p, *q;
-	bool EOS = false;
-
-	Q_strncpyz( buffer, string, MAX_STRING_CHARS );
-
-	p = q = buffer;
-
-	while ( *p != '\0' && i < buildablesSize - 1 )
-	{
-		//skip to first , or EOS
-		while ( *p != ',' && *p != '\0' )
-		{
-			p++;
-		}
-
-		if ( *p == '\0' )
-		{
-			EOS = true;
-		}
-
-		*p = '\0';
-
-		//strip leading whitespace
-		while ( *q == ' ' )
-		{
-			q++;
-		}
-
-		buildables[ i ] = BG_BuildableByName( q )->number;
-
-		if ( buildables[ i ] == BA_NONE )
-		{
-			Log::Warn( "unknown buildable %s", q );
-		}
-		else
-		{
-			i++;
-		}
-
-		if ( !EOS )
-		{
-			p++;
-			q = p;
-		}
-		else
-		{
-			break;
-		}
-	}
-
-	buildables[ i ] = BA_NONE;
-}
-
-struct gameElements_t
-{
-	buildable_t buildables[ BA_NUM_BUILDABLES ];
-	class_t     classes[ PCL_NUM_CLASSES ];
-	weapon_t    weapons[ WP_NUM_WEAPONS ];
-	upgrade_t   upgrades[ UP_NUM_UPGRADES ];
-};
-
-static gameElements_t bg_disabledGameElements;
+	std::vector<buildable_t> buildables;
+	std::vector<class_t>     classes;
+	std::vector<weapon_t>    weapons;
+	std::vector<upgrade_t>   upgrades;
+} bg_disabledGameElements;
 
 /*
 ============
-BG_InitAllowedGameElements
+BG_ParseEquipmentList
 ============
 */
-void BG_InitAllowedGameElements()
+std::pair<std::vector<weapon_t>, std::vector<upgrade_t>> BG_ParseEquipmentList(const std::string &equipment)
 {
-	char cvar[ MAX_CVAR_VALUE_STRING ];
+	std::vector<weapon_t> weapons;
+	std::vector<upgrade_t> upgrades;
 
-	trap_Cvar_VariableStringBuffer( "g_disabledEquipment",
-	                                cvar, MAX_CVAR_VALUE_STRING );
+	for (Parse_WordListSplitter i(equipment); *i; ++i)
+	{
+		weapon_t result_w = BG_WeaponNumberByName(*i);
+		upgrade_t result_u = BG_UpgradeByName(*i)->number;
 
-	BG_ParseCSVEquipmentList( cvar,
-	                          bg_disabledGameElements.weapons, WP_NUM_WEAPONS,
-	                          bg_disabledGameElements.upgrades, UP_NUM_UPGRADES );
+		if (result_w != WP_NONE) {
+			weapons.push_back(result_w);
+		}
+		else if (result_u != UP_NONE)
+		{
+			upgrades.push_back(result_u);
+		}
+		else
+		{
+			Log::Warn( "unknown equipment %s", *i );
+		}
+	}
 
-	trap_Cvar_VariableStringBuffer( "g_disabledClasses",
-	                                cvar, MAX_CVAR_VALUE_STRING );
+	return { weapons, upgrades };
+}
 
-	BG_ParseCSVClassList( cvar,
-	                      bg_disabledGameElements.classes, PCL_NUM_CLASSES );
+/*
+============
+BG_ParseClassList
+============
+*/
+std::vector<class_t> BG_ParseClassList(const std::string &classes)
+{
+	std::vector<class_t> results;
 
-	trap_Cvar_VariableStringBuffer( "g_disabledBuildables",
-	                                cvar, MAX_CVAR_VALUE_STRING );
+	for (Parse_WordListSplitter i(classes); *i; ++i)
+	{
+		class_t result = BG_ClassByName(*i)->number;
 
-	BG_ParseCSVBuildableList( cvar,
-	                          bg_disabledGameElements.buildables, BA_NUM_BUILDABLES );
+		if (result != PCL_NONE) {
+			results.push_back(result);
+		}
+		else
+	       	{
+			Log::Warn( "unknown class %s", *i );
+		}
+	}
+
+	return results;
+}
+
+/*
+============
+BG_ParseBuildableList
+============
+*/
+std::vector<buildable_t> BG_ParseBuildableList(const std::string &allowed)
+{
+	std::vector<buildable_t> results;
+
+	for (Parse_WordListSplitter i(allowed); *i; ++i)
+	{
+		buildable_t result = BG_BuildableByName(*i)->number;
+
+		if (result != BA_NONE) {
+			results.push_back(result);
+		}
+		else
+	       	{
+			Log::Warn( "unknown buildable %s", *i );
+		}
+	}
+
+	return results;
+}
+
+/*
+============
+BG_SetForbiddenEquipment
+============
+*/
+void BG_SetForbiddenEquipment(std::string allowed)
+{
+	auto pair = BG_ParseEquipmentList( allowed );
+	bg_disabledGameElements.weapons = pair.first;
+	bg_disabledGameElements.upgrades = pair.second;
+}
+
+/*
+============
+BG_SetForbiddenClasses
+============
+*/
+void BG_SetForbiddenClasses(std::string allowed)
+{
+	bg_disabledGameElements.classes =
+		BG_ParseClassList( allowed );
+}
+
+/*
+============
+BG_SetForbiddenBuildables
+============
+*/
+void BG_SetForbiddenBuildables(std::string allowed)
+{
+	bg_disabledGameElements.buildables =
+		BG_ParseBuildableList( allowed );
 }
 
 /*
@@ -2566,17 +2438,11 @@ BG_WeaponIsAllowed
 */
 bool BG_WeaponDisabled( int weapon )
 {
-	int i;
-
-	for ( i = 0; i < WP_NUM_WEAPONS &&
-	      bg_disabledGameElements.weapons[ i ] != WP_NONE; i++ )
-	{
-		if ( bg_disabledGameElements.weapons[ i ] == weapon )
-		{
+	for ( auto w : bg_disabledGameElements.weapons ) {
+		if ( w == weapon ) {
 			return true;
 		}
 	}
-
 	return false;
 }
 
@@ -2587,17 +2453,11 @@ BG_UpgradeIsAllowed
 */
 bool BG_UpgradeDisabled( int upgrade )
 {
-	int i;
-
-	for ( i = 0; i < UP_NUM_UPGRADES &&
-	      bg_disabledGameElements.upgrades[ i ] != UP_NONE; i++ )
-	{
-		if ( bg_disabledGameElements.upgrades[ i ] == upgrade )
-		{
+	for ( auto u : bg_disabledGameElements.upgrades ) {
+		if ( u == upgrade ) {
 			return true;
 		}
 	}
-
 	return false;
 }
 
@@ -2608,17 +2468,11 @@ BG_ClassDisabled
 */
 bool BG_ClassDisabled( int class_ )
 {
-	int i;
-
-	for ( i = 0; i < PCL_NUM_CLASSES &&
-	      bg_disabledGameElements.classes[ i ] != PCL_NONE; i++ )
-	{
-		if ( bg_disabledGameElements.classes[ i ] == class_ )
-		{
+	for ( auto c : bg_disabledGameElements.classes ) {
+		if ( c == class_ ) {
 			return true;
 		}
 	}
-
 	return false;
 }
 
@@ -2629,17 +2483,11 @@ BG_BuildableIsAllowed
 */
 bool BG_BuildableDisabled( int buildable )
 {
-	int i;
-
-	for ( i = 0; i < BA_NUM_BUILDABLES &&
-	      bg_disabledGameElements.buildables[ i ] != BA_NONE; i++ )
-	{
-		if ( bg_disabledGameElements.buildables[ i ] == buildable )
-		{
+	for ( auto b : bg_disabledGameElements.buildables ) {
+		if ( b == buildable ) {
 			return true;
 		}
 	}
-
 	return false;
 }
 

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -1598,11 +1598,16 @@ void     BG_PlayerStateToEntityStateExtraPolate( playerState_t *ps, entityState_
 float    atof_neg( char *token, bool allowNegative );
 int      atoi_neg( char *token, bool allowNegative );
 
-void     BG_ParseCSVEquipmentList( const char *string, weapon_t *weapons, int weaponsSize,
-                                   upgrade_t *upgrades, int upgradesSize );
-void     BG_ParseCSVClassList( const char *string, class_t *classes, int classesSize );
-void     BG_ParseCSVBuildableList( const char *string, buildable_t *buildables, int buildablesSize );
-void     BG_InitAllowedGameElements();
+std::vector<buildable_t> BG_ParseBuildableList( const std::string& );
+std::vector<class_t> BG_ParseClassList( const std::string& );
+std::pair<std::vector<weapon_t>, std::vector<upgrade_t>> BG_ParseEquipmentList( const std::string& );
+
+// You are not supposed to call these, these are meant to be used by
+// g_disabled* cvar callbacks
+void BG_SetForbiddenEquipment(std::string forbidden_csv);
+void BG_SetForbiddenClasses(std::string forbidden_csv);
+void BG_SetForbiddenBuildables(std::string forbidden_csv);
+
 bool BG_WeaponDisabled( int weapon );
 bool BG_UpgradeDisabled( int upgrade );
 

--- a/src/shared/parse.h
+++ b/src/shared/parse.h
@@ -54,4 +54,48 @@ int Parse_FreeSourceHandle(int handle);
 bool Parse_ReadTokenHandle(int handle, pc_token_t *pc_token);
 int Parse_SourceFileAndLine(int handle, char (&filename)[MAX_QPATH], int *line);
 
+/*
+===============
+Parse_WordListSplitter
+
+Tokenize a list like "a, b, c" to "a", "b", "c".
+
+This is a partial implementation of an input interator: it can only go forward,
+and you don't know how many elements you will be able to read until you've read
+them all.
+
+Exemple usage:
+	for (Parse_WordListSplitter iterator(string); *iterator; ++iterator)
+	{
+		printf("C str: »%s«\n", *parser);
+	}
+
+This parser is quite tolerant: you can use one delimiter or another,
+or a variant of that: "a b,c ,d,,e    f" is equivalent to "a, b, c, d, e, f".
+
+The const char * it returns for each element (operator*) are not valid once
+the destructor is called.
+===============
+*/
+// We could have a template here to specify the delimiter.
+// But compilation times are large enough as is.
+class Parse_WordListSplitter {
+public:
+	Parse_WordListSplitter(const std::string &);
+	Parse_WordListSplitter(const char *);
+	~Parse_WordListSplitter();
+
+	const char *operator*() const;
+
+	Parse_WordListSplitter& operator++(); // only ++i is implemented. there is no i++.
+
+private:
+	char *_string; // the string
+	const size_t _len;   // size of the string
+	size_t _start; // start of this chunk
+	size_t _stop;  // stop of this chunk
+	size_t find_first_matching(size_t start = 0);
+	size_t find_first_not_matching(size_t start = 0);
+};
+
 #endif // SHARED_PARSE_H_


### PR DESCRIPTION
This
* update some cvars to the new style
* turn some arrays into vectors
* propagate changes in g_disabled* cvars to the client
* allow maps to set some settings about build points again (it probably broke one day). I think the bp thing makes sense in the map, for cases like the dretchstorm map with a large buildable count. I don't know how to set that in the map itself though :P
* DUBIOUS: reset such settings on map change, so that a map with, say, low gravity, wouldn't mess with the next one.

That's about it I think?