### PR TITLE
Fix animation load warning in 0.52 RC

### DIFF
--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -338,7 +338,7 @@ static bool CG_RegisterPlayerAnimation( clientInfo_t *ci, const char *modelName,
 	{
 		if ( cg_debugAnim.integer )
 		{
-			Log::Notice( "Failed to load animation file %s\n", filename );
+			Log::Warn( "Failed to load animation file %s", filename );
 		}
 
 		return false;
@@ -1175,7 +1175,7 @@ NSPA_STAND, "idle", true, false, false )
 
 	if ( !CG_ParseAnimationFile( filename, ci ) )
 	{
-		Log::Notice( "Failed to load animation file %s\n", filename );
+		Log::Warn( "Failed to load animation file %s", filename );
 		return false;
 	}
 

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -576,7 +576,7 @@ bool CG_RegisterWeaponAnimation( animation_t *anim, const char *filename, bool l
 
 	if ( !anim->handle )
 	{
-		Log::Notice( "Failed to load animation file %s\n", filename );
+		Log::Warn( "Failed to load animation file %s", filename );
 		return false;
 	}
 

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -729,24 +729,14 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 
 				switch( weapon )
 				{
-					case WP_MACHINEGUN:
-					case WP_SHOTGUN:
-					case WP_MASS_DRIVER:
-					case WP_PULSE_RIFLE:
-						CG_RegisterWeaponAnimation( &wi->animations[ WANIM_RAISE ],
-													va( "%s_view.iqm:raise", token2 ), false, false, false );
-						CG_RegisterWeaponAnimation( &wi->animations[ WANIM_DROP ],
-													va( "%s_view.iqm:lower", token2 ), false, false, false );
-						CG_RegisterWeaponAnimation( &wi->animations[ WANIM_RELOAD ],
-													va( "%s_view.iqm:reload", token2 ), false, false, false );
-						CG_RegisterWeaponAnimation( &wi->animations[ WANIM_ATTACK1 ],
-													va( "%s_view.iqm:fire", token2 ), false, false, false );
-						break;
-
 					case WP_LUCIFER_CANNON:
 						CG_RegisterWeaponAnimation( &wi->animations[ WANIM_ATTACK2 ],
 													va( "%s_view.iqm:fire2", token2 ), false, false, false );
 						DAEMON_FALLTHROUGH;
+					case WP_MACHINEGUN:
+					case WP_SHOTGUN:
+					case WP_MASS_DRIVER:
+					case WP_PULSE_RIFLE:
 					case WP_BLASTER:
 					case WP_PAIN_SAW:
 					case WP_LAS_GUN:
@@ -821,25 +811,14 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 
 				switch( weapon )
 				{
-					case WP_MACHINEGUN:
-					case WP_SHOTGUN:
-					case WP_MASS_DRIVER:
-					case WP_PULSE_RIFLE:
-
-						CG_RegisterWeaponAnimation( &wi->animations[ WANIM_RAISE ],
-									    va( "%s_view_raise.md5anim", token2 ), false, false, false );
-						CG_RegisterWeaponAnimation( &wi->animations[ WANIM_DROP ],
-									    va( "%s_view_lower.md5anim", token2 ), false, false, false );
-						CG_RegisterWeaponAnimation( &wi->animations[ WANIM_RELOAD ],
-									    va( "%s_view_reload.md5anim", token2 ), false, false, false );
-						CG_RegisterWeaponAnimation( &wi->animations[ WANIM_ATTACK1 ],
-									    va( "%s_view_fire.md5anim", token2 ), false, false, false );
-						break;
-
 					case WP_LUCIFER_CANNON:
 						CG_RegisterWeaponAnimation( &wi->animations[ WANIM_ATTACK2 ],
 									    va( "%s_view_fire2.md5anim", token2 ), false, false, false );
 						DAEMON_FALLTHROUGH;
+					case WP_MACHINEGUN:
+					case WP_SHOTGUN:
+					case WP_MASS_DRIVER:
+					case WP_PULSE_RIFLE:
 					case WP_BLASTER:
 					case WP_PAIN_SAW:
 					case WP_LAS_GUN:

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -746,8 +746,11 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 													va( "%s_view.iqm:raise", token2 ), false, false, false );
 						CG_RegisterWeaponAnimation( &wi->animations[ WANIM_DROP ],
 													va( "%s_view.iqm:lower", token2 ), false, false, false );
-						CG_RegisterWeaponAnimation( &wi->animations[ WANIM_RELOAD ],
-													va( "%s_view.iqm:reload", token2 ), false, false, false );
+						if ( BG_Weapon( weapon )->maxClips > 0 )
+						{
+							CG_RegisterWeaponAnimation( &wi->animations[ WANIM_RELOAD ],
+							                            va( "%s_view.iqm:reload", token2 ), false, false, false );
+						}
 						CG_RegisterWeaponAnimation( &wi->animations[ WANIM_ATTACK1 ],
 													va( "%s_view.iqm:fire", token2 ), false, false, false );
 						break;
@@ -828,8 +831,11 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 									    va( "%s_view_raise.md5anim", token2 ), false, false, false );
 						CG_RegisterWeaponAnimation( &wi->animations[ WANIM_DROP ],
 									    va( "%s_view_lower.md5anim", token2 ), false, false, false );
-						CG_RegisterWeaponAnimation( &wi->animations[ WANIM_RELOAD ],
-									    va( "%s_view_reload.md5anim", token2 ), false, false, false );
+						if ( BG_Weapon( weapon )->maxClips > 0 )
+						{
+							CG_RegisterWeaponAnimation( &wi->animations[ WANIM_RELOAD ],
+							                            va( "%s_view_reload.md5anim", token2 ), false, false, false );
+						}
 						CG_RegisterWeaponAnimation( &wi->animations[ WANIM_ATTACK1 ],
 									    va( "%s_view_fire.md5anim", token2 ), false, false, false );
 						break;


### PR DESCRIPTION
A new log message appeared: `Failed to load animation file models/weapons/lgun/lgun_view.iqm:reload`

But the lasgun cannot actually be reloaded. So, don't look for reload animations for guns without multiple clips.