### PR TITLE
Fix default map rotations

### DIFF
--- a/dist/configs/game/maprotation.cfg
+++ b/dist/configs/game/maprotation.cfg
@@ -1,14 +1,9 @@
+// For a complete example, see
+// https://github.com/UnvanquishedAssets/unvanquished_src.dpkdir/blob/master/default/maprotation.cfg
+// This rotation just delegates to that one.
+//
+// "rotation1' is designated by the default value of the cvar g_initialMapRotation.
 rotation1
 {
-	antares
-	if numPlayers < 15 chasm
-	forlorn
-	parpax
-	perseus
-	plat23
-	if numPlayers > 5 spacetracks
-	station15
-	if numPlayers > 9 thunder
-	if numPlayers > 3 vega
-	yocto
+    goto defaultRotation
 }

--- a/src/sgame/sg_maprotation.cpp
+++ b/src/sgame/sg_maprotation.cpp
@@ -613,7 +613,7 @@ static bool G_ParseMapRotationFile( const char *fileName )
 	for ( i = 0; i < mapRotations.numRotations; i++ )
 	{
 		mapRotation_t *mr = &mapRotations.rotations[ i ];
-		int           mapCount = 0;
+		bool empty = true;
 
 		for ( j = 0; j < mr->numNodes; j++ )
 		{
@@ -621,7 +621,7 @@ static bool G_ParseMapRotationFile( const char *fileName )
 
 			if ( node->type == NT_MAP )
 			{
-				mapCount++;
+				empty = false;
 
 				if ( !G_MapExists( node->u.map.name ) )
 				{
@@ -648,19 +648,23 @@ static bool G_ParseMapRotationFile( const char *fileName )
 				}
 			}
 
-			if ( ( node->type == NT_GOTO || node->type == NT_RESUME ) &&
-			     !G_LabelExists( i, node->u.label.name ) &&
-			     !G_RotationExists( node->u.label.name ) )
+			if ( node->type == NT_GOTO || node->type == NT_RESUME )
 			{
-				Log::Warn("goto destination named \"%s\" doesn't exist",
-				          node->u.label.name );
-				return false;
+				if ( G_RotationExists( node->u.label.name ) )
+				{
+					empty = false;
+				}
+				else if ( !G_LabelExists( i, node->u.label.name ) )
+				{
+					Log::Warn( "goto destination named \"%s\" doesn't exist", node->u.label.name );
+					return false;
+				}
 			}
 		}
 
-		if ( mapCount == 0 )
+		if ( empty )
 		{
-			Log::Warn("rotation \"%s\" needs at least one map entry",
+			Log::Warn("rotation \"%s\" has no maps",
 			          mr->name );
 			return false;
 		}

--- a/src/sgame/sg_spawn.cpp
+++ b/src/sgame/sg_spawn.cpp
@@ -576,8 +576,11 @@ bool G_CallSpawnFunction( gentity_t *spawnedEntity )
 		spawnedEntity->spawned = true;
 
 		if ( g_debugEntities.integer > 2 )
-			Log::Warn("Successfully spawned entity ^5#%i^* as ^3#%i^*th instance of ^5%s",
-					spawnedEntity->s.number, spawnedEntity->eclass->instanceCounter, spawnedClass->name);
+		{
+			std::string count = spawnedEntity->eclass ? std::to_string(spawnedEntity->eclass->instanceCounter) : "??";
+			Log::Notice("Successfully spawned entity ^5#%i^* as ^3#%s^*th instance of ^5%s",
+			            spawnedEntity->s.number, count, spawnedClass->name);
+		}
 
 		/*
 		 *  to allow each spawn function to test and handle for itself,


### PR DESCRIPTION
Move the default rotation to assets (see https://github.com/UnvanquishedAssets/unvanquished_src.dpkdir/pull/47) and make rotation1 delegate to it, so we don't have to have two copies.