### PR TITLE
Rewrite the behavior tree loading

### DIFF
--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -28,7 +28,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "Entities.h"
 
 static botMemory_t g_botMind[MAX_CLIENTS];
-static AITreeList_t treeList;
+static AITreeList treeList;
 
 /*
 =======================

--- a/src/sgame/sg_bot.h
+++ b/src/sgame/sg_bot.h
@@ -80,7 +80,7 @@ struct botMemory_t
 	botEntityAndDistance_t closestDamagedBuilding;
 	botEntityAndDistance_t closestBuildings[ BA_NUM_BUILDABLES ];
 
-	AIBehaviorTree_t *behaviorTree;
+	std::shared_ptr<AIBehaviorTree_t> behaviorTree;
 	AIGenericNode_t  *currentNode;
 	AIGenericNode_t  *runningNodes[ MAX_NODE_DEPTH ];
 	int              numRunningNodes;

--- a/src/sgame/sg_bot.h
+++ b/src/sgame/sg_bot.h
@@ -80,9 +80,9 @@ struct botMemory_t
 	botEntityAndDistance_t closestDamagedBuilding;
 	botEntityAndDistance_t closestBuildings[ BA_NUM_BUILDABLES ];
 
-	std::shared_ptr<AIBehaviorTree_t> behaviorTree;
-	AIGenericNode_t  *currentNode;
-	AIGenericNode_t  *runningNodes[ MAX_NODE_DEPTH ];
+	std::shared_ptr<AIBehaviorTree> behaviorTree;
+	AIGenericNode    *currentNode;
+	AIGenericNode    *runningNodes[ MAX_NODE_DEPTH ];
 	int              numRunningNodes;
 
 	int         futureAimTime;

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -117,7 +117,7 @@ int AIUnBoxInt( AIValue_t v )
 
 const char *AIUnBoxString( AIValue_t v )
 {
-	static char empty[] = "";
+	const static char empty[] = "";
 
 	switch ( v.valType )
 	{
@@ -426,11 +426,9 @@ returns failure otherwise
 */
 AINodeStatus_t BotConditionNode( gentity_t *self, AIGenericNode_t *node )
 {
-	bool success = false;
-
 	AIConditionNode_t *con = ( AIConditionNode_t * ) node;
 
-	success = EvalConditionExpression( self, con->exp );
+	bool success = EvalConditionExpression( self, con->exp );
 	if ( success )
 	{
 		if ( con->child )

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -230,11 +230,10 @@ A concurrent node succeeds if none of its child nodes fail
 AINodeStatus_t BotSelectorNode( gentity_t *self, AIGenericNode_t *node )
 {
 	AINodeList_t *selector = ( AINodeList_t * ) node;
-	int i = 0;
 
-	for ( ; i < selector->numNodes; i++ )
+	for ( const std::shared_ptr<AIGenericNode_t>& node : selector->list )
 	{
-		AINodeStatus_t status = BotEvaluateNode( self, selector->list[ i ] );
+		AINodeStatus_t status = BotEvaluateNode( self, node.get() );
 		if ( status == STATUS_FAILURE )
 		{
 			continue;
@@ -247,20 +246,20 @@ AINodeStatus_t BotSelectorNode( gentity_t *self, AIGenericNode_t *node )
 AINodeStatus_t BotSequenceNode( gentity_t *self, AIGenericNode_t *node )
 {
 	AINodeList_t *sequence = ( AINodeList_t * ) node;
-	int i = 0;
+	size_t i;
 
 	// find a previously running node and start there
-	for ( i = sequence->numNodes - 1; i > 0; i-- )
+	for ( i = sequence->list.size() - 1; i > 0; i-- )
 	{
-		if ( NodeIsRunning( self, sequence->list[ i ] ) )
+		if ( NodeIsRunning( self, sequence->list[ i ].get() ) )
 		{
 			break;
 		}
 	}
 
-	for ( ; i < sequence->numNodes; i++ )
+	for ( ; i < sequence->list.size(); i++ )
 	{
-		AINodeStatus_t status = BotEvaluateNode( self, sequence->list[ i ] );
+		AINodeStatus_t status = BotEvaluateNode( self, sequence->list[ i ].get() );
 		if ( status == STATUS_FAILURE )
 		{
 			return STATUS_FAILURE;
@@ -277,11 +276,11 @@ AINodeStatus_t BotSequenceNode( gentity_t *self, AIGenericNode_t *node )
 AINodeStatus_t BotConcurrentNode( gentity_t *self, AIGenericNode_t *node )
 {
 	AINodeList_t *con = ( AINodeList_t * ) node;
-	int i = 0;
+	size_t i;
 
-	for ( ; i < con->numNodes; i++ )
+	for ( i=0; i < con->list.size(); i++ )
 	{
-		AINodeStatus_t status = BotEvaluateNode( self, con->list[ i ] );
+		AINodeStatus_t status = BotEvaluateNode( self, con->list[ i ].get() );
 
 		if ( status == STATUS_FAILURE )
 		{
@@ -304,7 +303,7 @@ AINodeStatus_t BotDecoratorTimer( gentity_t *self, AIGenericNode_t *node )
 
 	if ( level.time > dec->data[ self->s.number ] )
 	{
-		AINodeStatus_t status = BotEvaluateNode( self, dec->child );
+		AINodeStatus_t status = BotEvaluateNode( self, dec->child.get() );
 
 		if ( status == STATUS_FAILURE )
 		{
@@ -323,7 +322,7 @@ AINodeStatus_t BotDecoratorReturn( gentity_t *self, AIGenericNode_t *node )
 
 	AINodeStatus_t status = ( AINodeStatus_t ) AIUnBoxInt( dec->params[ 0 ] );
 
-	BotEvaluateNode( self, dec->child );
+	BotEvaluateNode( self, dec->child.get() );
 	return status;
 }
 
@@ -436,7 +435,7 @@ AINodeStatus_t BotConditionNode( gentity_t *self, AIGenericNode_t *node )
 	{
 		if ( con->child )
 		{
-			return BotEvaluateNode( self, con->child );
+			return BotEvaluateNode( self, con->child.get() );
 		}
 		else
 		{
@@ -458,7 +457,7 @@ A behavior tree may contain multiple other behavior trees which are run in this 
 AINodeStatus_t BotBehaviorNode( gentity_t *self, AIGenericNode_t *node )
 {
 	AIBehaviorTree_t *tree = ( AIBehaviorTree_t * ) node;
-	return BotEvaluateNode( self, tree->root );
+	return BotEvaluateNode( self, tree->root.get() );
 }
 
 /*

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -191,7 +191,7 @@ botEntityAndDistance_t AIEntityToGentity( gentity_t *self, AIEntity_t e )
 	return ret;
 }
 
-static bool NodeIsRunning( gentity_t *self, AIGenericNode_t *node )
+static bool NodeIsRunning( gentity_t *self, AIGenericNode *node )
 {
 	int i;
 	for ( i = 0; i < self->botMind->numRunningNodes; i++ )
@@ -227,11 +227,11 @@ if one fails, the concurrent node will stop executing nodes and return failure
 A concurrent node succeeds if none of its child nodes fail
 ======================
 */
-AINodeStatus_t BotSelectorNode( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotSelectorNode( gentity_t *self, AIGenericNode *node )
 {
-	AINodeList_t *selector = ( AINodeList_t * ) node;
+	AINodeList *selector = ( AINodeList * ) node;
 
-	for ( const std::shared_ptr<AIGenericNode_t>& node : selector->list )
+	for ( const std::shared_ptr<AIGenericNode>& node : selector->list )
 	{
 		AINodeStatus_t status = BotEvaluateNode( self, node.get() );
 		if ( status == STATUS_FAILURE )
@@ -243,9 +243,9 @@ AINodeStatus_t BotSelectorNode( gentity_t *self, AIGenericNode_t *node )
 	return STATUS_FAILURE;
 }
 
-AINodeStatus_t BotSequenceNode( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotSequenceNode( gentity_t *self, AIGenericNode *node )
 {
-	AINodeList_t *sequence = ( AINodeList_t * ) node;
+	AINodeList *sequence = ( AINodeList * ) node;
 	size_t i;
 
 	// find a previously running node and start there
@@ -273,9 +273,9 @@ AINodeStatus_t BotSequenceNode( gentity_t *self, AIGenericNode_t *node )
 	return STATUS_SUCCESS;
 }
 
-AINodeStatus_t BotConcurrentNode( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotConcurrentNode( gentity_t *self, AIGenericNode *node )
 {
-	AINodeList_t *con = ( AINodeList_t * ) node;
+	AINodeList *con = ( AINodeList * ) node;
 	size_t i;
 
 	for ( i=0; i < con->list.size(); i++ )
@@ -297,9 +297,9 @@ Decorators
 Decorators are used to add functionality to the child node
 ======================
 */
-AINodeStatus_t BotDecoratorTimer( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotDecoratorTimer( gentity_t *self, AIGenericNode *node )
 {
-	AIDecoratorNode_t *dec = ( AIDecoratorNode_t * ) node;
+	AIDecoratorNode *dec = ( AIDecoratorNode * ) node;
 
 	if ( level.time > dec->data[ self->s.number ] )
 	{
@@ -316,9 +316,9 @@ AINodeStatus_t BotDecoratorTimer( gentity_t *self, AIGenericNode_t *node )
 	return STATUS_FAILURE;
 }
 
-AINodeStatus_t BotDecoratorReturn( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotDecoratorReturn( gentity_t *self, AIGenericNode *node )
 {
-	AIDecoratorNode_t *dec = ( AIDecoratorNode_t * ) node;
+	AIDecoratorNode *dec = ( AIDecoratorNode * ) node;
 
 	AINodeStatus_t status = ( AINodeStatus_t ) AIUnBoxInt( dec->params[ 0 ] );
 
@@ -424,9 +424,9 @@ If there is no child node, returns success if the conditon expression is true
 returns failure otherwise
 ======================
 */
-AINodeStatus_t BotConditionNode( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotConditionNode( gentity_t *self, AIGenericNode *node )
 {
-	AIConditionNode_t *con = ( AIConditionNode_t * ) node;
+	AIConditionNode *con = ( AIConditionNode * ) node;
 
 	bool success = EvalConditionExpression( self, con->exp );
 	if ( success )
@@ -452,9 +452,9 @@ Runs the root node of a behavior tree
 A behavior tree may contain multiple other behavior trees which are run in this way
 ======================
 */
-AINodeStatus_t BotBehaviorNode( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotBehaviorNode( gentity_t *self, AIGenericNode *node )
 {
-	AIBehaviorTree_t *tree = ( AIBehaviorTree_t * ) node;
+	AIBehaviorTree *tree = ( AIBehaviorTree * ) node;
 	return BotEvaluateNode( self, tree->root.get() );
 }
 
@@ -467,7 +467,7 @@ running information for sequences and selectors
 This should always be used instead of the node->run function pointer
 ======================
 */
-AINodeStatus_t BotEvaluateNode( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotEvaluateNode( gentity_t *self, AIGenericNode *node )
 {
 	AINodeStatus_t status = node->run( self, node );
 
@@ -521,7 +521,7 @@ to the rest of the behavior tree
 ======================
 */
 
-AINodeStatus_t BotActionFireWeapon( gentity_t *self, AIGenericNode_t* )
+AINodeStatus_t BotActionFireWeapon( gentity_t *self, AIGenericNode* )
 {
 	if ( WeaponIsEmpty( BG_GetPlayerWeapon( &self->client->ps ), &self->client->ps ) && self->client->pers.team == TEAM_HUMANS )
 	{
@@ -537,17 +537,17 @@ AINodeStatus_t BotActionFireWeapon( gentity_t *self, AIGenericNode_t* )
 	return STATUS_SUCCESS;
 }
 
-AINodeStatus_t BotActionTeleport( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotActionTeleport( gentity_t *self, AIGenericNode *node )
 {
-	AIActionNode_t *action = ( AIActionNode_t * ) node;
+	AIActionNode *action = ( AIActionNode * ) node;
 	vec3_t pos = {AIUnBoxFloat(action->params[0]),AIUnBoxFloat(action->params[1]),AIUnBoxFloat(action->params[2])};
 	VectorCopy( pos,self->client->ps.origin );
 	return STATUS_SUCCESS;
 }
 
-AINodeStatus_t BotActionActivateUpgrade( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotActionActivateUpgrade( gentity_t *self, AIGenericNode *node )
 {
-	AIActionNode_t *action = ( AIActionNode_t * ) node;
+	AIActionNode *action = ( AIActionNode * ) node;
 	upgrade_t u = ( upgrade_t ) AIUnBoxInt( action->params[ 0 ] );
 
 	if ( !BG_UpgradeIsActive( u, self->client->ps.stats ) &&
@@ -558,9 +558,9 @@ AINodeStatus_t BotActionActivateUpgrade( gentity_t *self, AIGenericNode_t *node 
 	return STATUS_SUCCESS;
 }
 
-AINodeStatus_t BotActionDeactivateUpgrade( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotActionDeactivateUpgrade( gentity_t *self, AIGenericNode *node )
 {
-	AIActionNode_t *action = ( AIActionNode_t * ) node;
+	AIActionNode *action = ( AIActionNode * ) node;
 	upgrade_t u = ( upgrade_t ) AIUnBoxInt( action->params[ 0 ] );
 
 	if ( BG_UpgradeIsActive( u, self->client->ps.stats ) &&
@@ -571,7 +571,7 @@ AINodeStatus_t BotActionDeactivateUpgrade( gentity_t *self, AIGenericNode_t *nod
 	return STATUS_SUCCESS;
 }
 
-AINodeStatus_t BotActionAimAtGoal( gentity_t *self, AIGenericNode_t* )
+AINodeStatus_t BotActionAimAtGoal( gentity_t *self, AIGenericNode* )
 {
 	if ( BotGetTargetTeam( self->botMind->goal ) != self->client->pers.team )
 	{
@@ -587,15 +587,15 @@ AINodeStatus_t BotActionAimAtGoal( gentity_t *self, AIGenericNode_t* )
 	return STATUS_SUCCESS;
 }
 
-AINodeStatus_t BotActionMoveToGoal( gentity_t *self, AIGenericNode_t* )
+AINodeStatus_t BotActionMoveToGoal( gentity_t *self, AIGenericNode* )
 {
 	BotMoveToGoal( self );
 	return STATUS_RUNNING;
 }
 
-AINodeStatus_t BotActionMoveInDir( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotActionMoveInDir( gentity_t *self, AIGenericNode *node )
 {
-	AIActionNode_t *a = ( AIActionNode_t * ) node;
+	AIActionNode *a = ( AIActionNode * ) node;
 	int dir = AIUnBoxInt( a->params[ 0 ] );
 	if ( a->nparams == 2 )
 	{
@@ -605,27 +605,27 @@ AINodeStatus_t BotActionMoveInDir( gentity_t *self, AIGenericNode_t *node )
 	return STATUS_SUCCESS;
 }
 
-AINodeStatus_t BotActionStrafeDodge( gentity_t *self, AIGenericNode_t* )
+AINodeStatus_t BotActionStrafeDodge( gentity_t *self, AIGenericNode* )
 {
 	BotStrafeDodge( self );
 	return STATUS_SUCCESS;
 }
 
-AINodeStatus_t BotActionAlternateStrafe( gentity_t *self, AIGenericNode_t* )
+AINodeStatus_t BotActionAlternateStrafe( gentity_t *self, AIGenericNode* )
 {
 	BotAlternateStrafe( self );
 	return STATUS_SUCCESS;
 }
 
-AINodeStatus_t BotActionClassDodge( gentity_t *self, AIGenericNode_t* )
+AINodeStatus_t BotActionClassDodge( gentity_t *self, AIGenericNode* )
 {
 	BotClassMovement( self, BotTargetInAttackRange( self, self->botMind->goal ) );
 	return STATUS_SUCCESS;
 }
 
-AINodeStatus_t BotActionChangeGoal( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotActionChangeGoal( gentity_t *self, AIGenericNode *node )
 {
-	AIActionNode_t *a = ( AIActionNode_t * ) node;
+	AIActionNode *a = ( AIActionNode * ) node;
 
 	if( a->nparams == 1 )
 	{
@@ -653,9 +653,9 @@ AINodeStatus_t BotActionChangeGoal( gentity_t *self, AIGenericNode_t *node )
 	return STATUS_SUCCESS;
 }
 
-AINodeStatus_t BotActionEvolveTo( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotActionEvolveTo( gentity_t *self, AIGenericNode *node )
 {
-	AIActionNode_t *action = ( AIActionNode_t * ) node;
+	AIActionNode *action = ( AIActionNode * ) node;
 	class_t c = ( class_t )  AIUnBoxInt( action->params[ 0 ] );
 
 	if ( self->client->ps.stats[ STAT_CLASS ] == c )
@@ -671,9 +671,9 @@ AINodeStatus_t BotActionEvolveTo( gentity_t *self, AIGenericNode_t *node )
 	return STATUS_FAILURE;
 }
 
-AINodeStatus_t BotActionSay( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotActionSay( gentity_t *self, AIGenericNode *node )
 {
-	AIActionNode_t *action = ( AIActionNode_t * ) node;
+	AIActionNode *action = ( AIActionNode * ) node;
 	const char *str = AIUnBoxString( action->params[ 0 ] );
 	saymode_t   say = ( saymode_t ) AIUnBoxInt( action->params[ 1 ] );
 	G_Say( self, say, str );
@@ -681,7 +681,7 @@ AINodeStatus_t BotActionSay( gentity_t *self, AIGenericNode_t *node )
 }
 
 // TODO: Move decision making out of these actions and into the rest of the behavior tree
-AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode *node )
 {
 	team_t myTeam = ( team_t ) self->client->pers.team;
 
@@ -810,7 +810,7 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 	return STATUS_RUNNING;
 }
 
-AINodeStatus_t BotActionFlee( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotActionFlee( gentity_t *self, AIGenericNode *node )
 {
 	if ( node != self->botMind->currentNode )
 	{
@@ -838,9 +838,9 @@ AINodeStatus_t BotActionFlee( gentity_t *self, AIGenericNode_t *node )
 	return STATUS_RUNNING;
 }
 
-AINodeStatus_t BotActionRoamInRadius( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotActionRoamInRadius( gentity_t *self, AIGenericNode *node )
 {
-	AIActionNode_t *a = ( AIActionNode_t * ) node;
+	AIActionNode *a = ( AIActionNode * ) node;
 	AIEntity_t e = ( AIEntity_t ) AIUnBoxInt( a->params[ 0 ] );
 	float radius = AIUnBoxFloat( a->params[ 1 ] );
 
@@ -878,7 +878,7 @@ AINodeStatus_t BotActionRoamInRadius( gentity_t *self, AIGenericNode_t *node )
 	return STATUS_RUNNING;
 }
 
-AINodeStatus_t BotActionRoam( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotActionRoam( gentity_t *self, AIGenericNode *node )
 {
 	// we are just starting to roam, get a target location
 	if ( node != self->botMind->currentNode )
@@ -910,10 +910,10 @@ botTarget_t BotGetMoveToTarget( gentity_t *self, AIEntity_t e )
 	return target;
 }
 
-AINodeStatus_t BotActionMoveTo( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotActionMoveTo( gentity_t *self, AIGenericNode *node )
 {
 	float radius = 0;
-	AIActionNode_t *moveTo = ( AIActionNode_t * ) node;
+	AIActionNode *moveTo = ( AIActionNode * ) node;
 	AIEntity_t ent = ( AIEntity_t ) AIUnBoxInt( moveTo->params[ 0 ] );
 
 	if ( moveTo->nparams > 1 )
@@ -958,7 +958,7 @@ AINodeStatus_t BotActionMoveTo( gentity_t *self, AIGenericNode_t *node )
 	return STATUS_RUNNING;
 }
 
-AINodeStatus_t BotActionRush( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotActionRush( gentity_t *self, AIGenericNode *node )
 {
 	if ( self->botMind->currentNode != node )
 	{
@@ -991,7 +991,7 @@ AINodeStatus_t BotActionRush( gentity_t *self, AIGenericNode_t *node )
 	return STATUS_RUNNING;
 }
 
-AINodeStatus_t BotActionHeal( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotActionHeal( gentity_t *self, AIGenericNode *node )
 {
 	if ( self->client->pers.team == TEAM_HUMANS )
 	{
@@ -1003,24 +1003,24 @@ AINodeStatus_t BotActionHeal( gentity_t *self, AIGenericNode_t *node )
 	}
 }
 
-AINodeStatus_t BotActionSuicide( gentity_t *self, AIGenericNode_t* )
+AINodeStatus_t BotActionSuicide( gentity_t *self, AIGenericNode* )
 {
 	Entities::Kill( self, MOD_SUICIDE );
 	return AINodeStatus_t::STATUS_SUCCESS;
 }
 
-AINodeStatus_t BotActionJump( gentity_t *self, AIGenericNode_t* )
+AINodeStatus_t BotActionJump( gentity_t *self, AIGenericNode* )
 {
 	return BotJump( self ) ? AINodeStatus_t::STATUS_SUCCESS : AINodeStatus_t::STATUS_FAILURE;
 }
 
-AINodeStatus_t BotActionResetStuckTime( gentity_t *self, AIGenericNode_t* )
+AINodeStatus_t BotActionResetStuckTime( gentity_t *self, AIGenericNode* )
 {
 	BotResetStuckTime( self );
 	return AINodeStatus_t::STATUS_SUCCESS;
 }
 
-AINodeStatus_t BotActionGesture( gentity_t *self, AIGenericNode_t* )
+AINodeStatus_t BotActionGesture( gentity_t *self, AIGenericNode* )
 {
 	usercmd_t *botCmdBuffer = &self->botMind->cmdBuffer;
 	usercmdPressButton( botCmdBuffer->buttons, BUTTON_GESTURE );
@@ -1030,7 +1030,7 @@ AINodeStatus_t BotActionGesture( gentity_t *self, AIGenericNode_t* )
 /*
 	alien specific actions
 */
-AINodeStatus_t BotActionEvolve ( gentity_t *self, AIGenericNode_t* )
+AINodeStatus_t BotActionEvolve ( gentity_t *self, AIGenericNode* )
 {
 	AINodeStatus_t status = STATUS_FAILURE;
 	if ( !g_bot_evolve.integer )
@@ -1093,7 +1093,7 @@ AINodeStatus_t BotActionEvolve ( gentity_t *self, AIGenericNode_t* )
 	return status;
 }
 
-AINodeStatus_t BotActionHealA( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotActionHealA( gentity_t *self, AIGenericNode *node )
 {
 	gentity_t *healTarget = nullptr;
 
@@ -1163,7 +1163,7 @@ AINodeStatus_t BotActionHealA( gentity_t *self, AIGenericNode_t *node )
 /*
 	human specific actions
 */
-AINodeStatus_t BotActionHealH( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotActionHealH( gentity_t *self, AIGenericNode *node )
 {
 	vec3_t targetPos;
 	vec3_t myPos;
@@ -1224,7 +1224,7 @@ AINodeStatus_t BotActionHealH( gentity_t *self, AIGenericNode_t *node )
 	}
 	return STATUS_RUNNING;
 }
-AINodeStatus_t BotActionRepair( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotActionRepair( gentity_t *self, AIGenericNode *node )
 {
 	vec3_t forward;
 	vec3_t targetPos;
@@ -1278,9 +1278,9 @@ AINodeStatus_t BotActionRepair( gentity_t *self, AIGenericNode_t *node )
 	}
 	return STATUS_RUNNING;
 }
-AINodeStatus_t BotActionBuy( gentity_t *self, AIGenericNode_t *node )
+AINodeStatus_t BotActionBuy( gentity_t *self, AIGenericNode *node )
 {
-	AIActionNode_t *buy = ( AIActionNode_t * ) node;
+	AIActionNode *buy = ( AIActionNode * ) node;
 	weapon_t  weapon;
 	upgrade_t upgrades[4];
 	int numUpgrades;

--- a/src/sgame/sg_bot_ai.h
+++ b/src/sgame/sg_bot_ai.h
@@ -196,7 +196,7 @@ struct AIConditionNode_t : public AIGenericNode_t
 struct AIDecoratorNode_t : public AIGenericNode_t
 {
 	AIDecoratorNode_t( pc_token_list **list );
-	~AIDecoratorNode_t() { BG_Free( params ); };
+	~AIDecoratorNode_t() { for(int i=0; i<nparams; i++) AIDestroyValue( params[i] ); BG_Free( params ); };
 	std::shared_ptr<AIGenericNode_t> child;
 	AIValue_t *params;
 	int        nparams;

--- a/src/sgame/sg_bot_ai.h
+++ b/src/sgame/sg_bot_ai.h
@@ -159,54 +159,54 @@ enum AINode_t
 	DECORATOR_NODE
 };
 
-struct AIGenericNode_t;
-typedef AINodeStatus_t ( *AINodeRunner )( gentity_t *, AIGenericNode_t * );
+struct AIGenericNode;
+typedef AINodeStatus_t ( *AINodeRunner )( gentity_t *, AIGenericNode * );
 
 // all behavior tree nodes must conform to this interface
-struct AIGenericNode_t
+struct AIGenericNode
 {
 	AINode_t type;
 	AINodeRunner run;
 };
 
 struct pc_token_list;
-struct AINodeList_t : public AIGenericNode_t
+struct AINodeList : public AIGenericNode
 {
-	std::vector<std::shared_ptr<AIGenericNode_t>> list;
-	AINodeList_t(AINodeRunner, pc_token_list **);
+	std::vector<std::shared_ptr<AIGenericNode>> list;
+	AINodeList(AINodeRunner, pc_token_list **);
 };
 
-struct AIBehaviorTree_t : public AIGenericNode_t
+struct AIBehaviorTree : public AIGenericNode
 {
-	AIBehaviorTree_t( std::string filename );
+	AIBehaviorTree( std::string filename );
 	std::string name;
-	std::shared_ptr<AIGenericNode_t> root;
+	std::shared_ptr<AIGenericNode> root;
 };
-using AITreeList_t = std::vector<std::shared_ptr<AIBehaviorTree_t>>;
+using AITreeList = std::vector<std::shared_ptr<AIBehaviorTree>>;
 
 void FreeExpression( AIExpType_t *exp );
-struct AIConditionNode_t : public AIGenericNode_t
+struct AIConditionNode : public AIGenericNode
 {
-	AIConditionNode_t(pc_token_list **);
-	~AIConditionNode_t() { FreeExpression(exp); }
-	std::shared_ptr<AIGenericNode_t> child;
+	AIConditionNode(pc_token_list **);
+	~AIConditionNode() { FreeExpression(exp); }
+	std::shared_ptr<AIGenericNode> child;
 	AIExpType_t     *exp;
 };
 
-struct AIDecoratorNode_t : public AIGenericNode_t
+struct AIDecoratorNode : public AIGenericNode
 {
-	AIDecoratorNode_t( pc_token_list **list );
-	~AIDecoratorNode_t() { for(int i=0; i<nparams; i++) AIDestroyValue( params[i] ); BG_Free( params ); };
-	std::shared_ptr<AIGenericNode_t> child;
+	AIDecoratorNode( pc_token_list **list );
+	~AIDecoratorNode() { for(int i=0; i<nparams; i++) AIDestroyValue( params[i] ); BG_Free( params ); };
+	std::shared_ptr<AIGenericNode> child;
 	AIValue_t *params;
 	int        nparams;
 	int        data[ MAX_CLIENTS ]; // bot specific data
 };
 
-struct AIActionNode_t : public AIGenericNode_t
+struct AIActionNode : public AIGenericNode
 {
-	AIActionNode_t( pc_token_list **list );
-	~AIActionNode_t() { for(int i=0; i<nparams; i++) AIDestroyValue( params[i] ); BG_Free(params); };
+	AIActionNode( pc_token_list **list );
+	~AIActionNode() { for(int i=0; i<nparams; i++) AIDestroyValue( params[i] ); BG_Free(params); };
 	AIValue_t *params;
 	int        nparams;
 };
@@ -223,48 +223,48 @@ const char *AIUnBoxString( AIValue_t v );
 botEntityAndDistance_t AIEntityToGentity( gentity_t *self, AIEntity_t e );
 
 // standard behavior tree control-flow nodes
-AINodeStatus_t BotEvaluateNode( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotConditionNode( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotSelectorNode( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotSequenceNode( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotConcurrentNode( gentity_t *self, AIGenericNode_t *node );
+AINodeStatus_t BotEvaluateNode( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotConditionNode( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotSelectorNode( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotSequenceNode( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotConcurrentNode( gentity_t *self, AIGenericNode *node );
 
 // decorator nodes
-AINodeStatus_t BotDecoratorTimer( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotDecoratorReturn( gentity_t *self, AIGenericNode_t *node );
+AINodeStatus_t BotDecoratorTimer( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotDecoratorReturn( gentity_t *self, AIGenericNode *node );
 
 // included behavior trees
-AINodeStatus_t BotBehaviorNode( gentity_t *self, AIGenericNode_t *node );
+AINodeStatus_t BotBehaviorNode( gentity_t *self, AIGenericNode *node );
 
 // action nodes
-AINodeStatus_t BotActionChangeGoal( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionMoveToGoal( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionFireWeapon( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionAimAtGoal( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionAlternateStrafe( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionStrafeDodge( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionMoveInDir( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionClassDodge( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionTeleport( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionActivateUpgrade( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionDeactivateUpgrade( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionEvolveTo( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionSay( gentity_t *self, AIGenericNode_t *node );
+AINodeStatus_t BotActionChangeGoal( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionMoveToGoal( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionFireWeapon( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionAimAtGoal( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionAlternateStrafe( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionStrafeDodge( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionMoveInDir( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionClassDodge( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionTeleport( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionActivateUpgrade( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionDeactivateUpgrade( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionEvolveTo( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionSay( gentity_t *self, AIGenericNode *node );
 
-AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionBuy( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionRepair( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionEvolve ( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionHealH( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionHealA( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionHeal( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionFlee( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionRoam( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionRoamInRadius( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionMoveTo( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionRush( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionSuicide( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionJump( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionResetStuckTime( gentity_t *self, AIGenericNode_t *node );
-AINodeStatus_t BotActionGesture( gentity_t *self, AIGenericNode_t* );
+AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionBuy( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionRepair( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionEvolve ( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionHealH( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionHealA( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionHeal( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionFlee( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionRoam( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionRoamInRadius( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionMoveTo( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionRush( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionSuicide( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionJump( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionResetStuckTime( gentity_t *self, AIGenericNode *node );
+AINodeStatus_t BotActionGesture( gentity_t *self, AIGenericNode* );
 #endif

--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -998,7 +998,7 @@ std::shared_ptr<AIBehaviorTree> ReadBehaviorTree(const char *name, AITreeList *l
 	return behavior;
 }
 
-std::shared_ptr<AIBehaviorTree> ReadBehaviorTreeInclude( pc_token_list **tokenlist )
+static std::shared_ptr<AIGenericNode> ReadBehaviorTreeInclude( pc_token_list **tokenlist )
 {
 	pc_token_list *first = *tokenlist;
 	pc_token_list *current = first;
@@ -1021,7 +1021,7 @@ std::shared_ptr<AIBehaviorTree> ReadBehaviorTreeInclude( pc_token_list **tokenli
 	}
 
 	*tokenlist = current->next;
-	return behavior;
+	return behavior->root;
 }
 
 /*
@@ -1067,7 +1067,7 @@ std::shared_ptr<AIGenericNode> ReadNode( pc_token_list **tokenlist )
 	}
 	else if ( !Q_stricmp( current->token.string, "behavior" ) )
 	{
-		node = (std::shared_ptr<AIGenericNode>) ReadBehaviorTreeInclude( &current );
+		node = ReadBehaviorTreeInclude( &current );
 	}
 	else
 	{

--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -751,9 +751,9 @@ static AIExpType_t *Primary( pc_token_list **list )
 
 /*
 ======================
-AIConditionNode_t constructor
+AIConditionNode constructor
 
-Parses and creates an AIConditionNode_t from a token list
+Parses and creates an AIConditionNode from a token list
 The token list pointer is modified to point to the beginning of the next node text block
 
 A condition node has the form:
@@ -768,8 +768,8 @@ condition [expression]
 ======================
 */
 
-AIConditionNode_t::AIConditionNode_t( pc_token_list **tokenlist )
-	: AIGenericNode_t{ CONDITION_NODE, BotConditionNode },
+AIConditionNode::AIConditionNode( pc_token_list **tokenlist )
+	: AIGenericNode{ CONDITION_NODE, BotConditionNode },
 	  child(nullptr), exp(nullptr)
 {
 	pc_token_list *current = *tokenlist;
@@ -830,7 +830,7 @@ static const struct AIDecoratorMap_s
 
 /*
 ======================
-AIDecoratorNode_t constructor
+AIDecoratorNode constructor
 
 Parses and creates an DecoratorNode_t from a token list
 The token list pointer is modified to point to the beginning of the next node text block
@@ -845,8 +845,8 @@ and will trigger when that value is returned, or each TIME milliseconds.
 ======================
 */
 
-AIDecoratorNode_t::AIDecoratorNode_t( pc_token_list **list )
-	: AIGenericNode_t{ DECORATOR_NODE, nullptr },
+AIDecoratorNode::AIDecoratorNode( pc_token_list **list )
+	: AIGenericNode{ DECORATOR_NODE, nullptr },
 	  child(nullptr), params(nullptr), nparams(0), data{}
 {
 	pc_token_list *current = *list;
@@ -946,9 +946,9 @@ static const struct AIActionMap_s
 
 /*
 ======================
-AIActionNode_t constructor
+AIActionNode constructor
 
-Parses and creates an AIGenericNode_t with the type ACTION_NODE from a token list
+Parses and creates an AIGenericNode with the type ACTION_NODE from a token list
 The token list pointer is modified to point to the beginning of the next node text block after reading
 
 An action node has the form:
@@ -958,8 +958,8 @@ Where name defines the action to execute, and the parameters are surrounded by p
 ======================
 */
 
-AIActionNode_t::AIActionNode_t( pc_token_list **tokenlist )
-	: AIGenericNode_t{ ACTION_NODE, nullptr }, params(nullptr), nparams(0)
+AIActionNode::AIActionNode( pc_token_list **tokenlist )
+	: AIGenericNode{ ACTION_NODE, nullptr }, params(nullptr), nparams(0)
 {
 	pc_token_list *current = *tokenlist;
 	pc_token_list *parenBegin;
@@ -1003,15 +1003,15 @@ AIActionNode_t::AIActionNode_t( pc_token_list **tokenlist )
 
 /*
 ======================
-AINodeList_t constructor
+AINodeList constructor
 
-Parses and creates an AINodeList_t from a token list
+Parses and creates an AINodeList from a token list
 The token list pointer is modified to point to the beginning of the next node text block after reading
 ======================
 */
 
-AINodeList_t::AINodeList_t( AINodeRunner _run, pc_token_list **tokenlist )
-	: AIGenericNode_t{ SELECTOR_NODE, _run }, list()
+AINodeList::AINodeList( AINodeRunner _run, pc_token_list **tokenlist )
+	: AIGenericNode{ SELECTOR_NODE, _run }, list()
 {
 	pc_token_list *current = (*tokenlist)->next; // TODO: check throw works
 
@@ -1022,7 +1022,7 @@ AINodeList_t::AINodeList_t( AINodeRunner _run, pc_token_list **tokenlist )
 
 	while ( Q_stricmp( current->token.string, "}" ) )
 	{
-		std::shared_ptr<AIGenericNode_t> node = ReadNode( &current );
+		std::shared_ptr<AIGenericNode> node = ReadNode( &current );
 		if ( node )
 		{
 			list.push_back( node );
@@ -1043,15 +1043,15 @@ AINodeList_t::AINodeList_t( AINodeRunner _run, pc_token_list **tokenlist )
 	*tokenlist = current->next;
 }
 
-static AITreeList_t *currentList = nullptr;
+static AITreeList *currentList = nullptr;
 
-std::shared_ptr<AIBehaviorTree_t> ReadBehaviorTree(const char *name, AITreeList_t *list)
+std::shared_ptr<AIBehaviorTree> ReadBehaviorTree(const char *name, AITreeList *list)
 {
 	std::string behavior_name = name;
 	currentList = list;
 
 	// check if this behavior tree has already been loaded
-	for ( const std::shared_ptr<AIBehaviorTree_t>& behavior : *currentList )
+	for ( const std::shared_ptr<AIBehaviorTree>& behavior : *currentList )
 	{
 		if ( behavior->name == behavior_name )
 		{
@@ -1059,7 +1059,7 @@ std::shared_ptr<AIBehaviorTree_t> ReadBehaviorTree(const char *name, AITreeList_
 		}
 	}
 
-	auto behavior = std::make_shared<AIBehaviorTree_t>( std::move(behavior_name) );
+	auto behavior = std::make_shared<AIBehaviorTree>( std::move(behavior_name) );
 
 	if ( behavior )
 	{
@@ -1068,7 +1068,7 @@ std::shared_ptr<AIBehaviorTree_t> ReadBehaviorTree(const char *name, AITreeList_
 	return behavior;
 }
 
-std::shared_ptr<AIBehaviorTree_t> ReadBehaviorTreeInclude( pc_token_list **tokenlist )
+std::shared_ptr<AIBehaviorTree> ReadBehaviorTreeInclude( pc_token_list **tokenlist )
 {
 	pc_token_list *first = *tokenlist;
 	pc_token_list *current = first;
@@ -1081,7 +1081,7 @@ std::shared_ptr<AIBehaviorTree_t> ReadBehaviorTreeInclude( pc_token_list **token
 		throw parseError("unexpected end of file while parsing external file");
 	}
 
-	std::shared_ptr<AIBehaviorTree_t> behavior =
+	std::shared_ptr<AIBehaviorTree> behavior =
 		ReadBehaviorTree( current->token.string, currentList );
 
 	if ( !behavior->root )
@@ -1098,7 +1098,7 @@ std::shared_ptr<AIBehaviorTree_t> ReadBehaviorTreeInclude( pc_token_list **token
 ======================
 ReadNode
 
-Parses and creates an AIGenericNode_t from a token list
+Parses and creates an AIGenericNode from a token list
 The token list pointer is modified to point to the next node text block after reading
 
 This function delegates the reading to the sub functions
@@ -1106,38 +1106,38 @@ ReadNodeList, ReadActionNode, and ReadConditionNode depending on the first token
 ======================
 */
 
-std::shared_ptr<AIGenericNode_t> ReadNode( pc_token_list **tokenlist )
+std::shared_ptr<AIGenericNode> ReadNode( pc_token_list **tokenlist )
 {
 	pc_token_list *current = *tokenlist;
-	std::shared_ptr<AIGenericNode_t> node;
+	std::shared_ptr<AIGenericNode> node;
 
 	if ( !Q_stricmp( current->token.string, "selector" ) )
 	{
-		node = (std::shared_ptr<AIGenericNode_t>) std::make_shared<AINodeList_t>( BotSelectorNode, &current );
+		node = (std::shared_ptr<AIGenericNode>) std::make_shared<AINodeList>( BotSelectorNode, &current );
 	}
 	else if ( !Q_stricmp( current->token.string, "sequence" ) )
 	{
-		node = (std::shared_ptr<AIGenericNode_t>) std::make_shared<AINodeList_t>( BotSequenceNode, &current );
+		node = (std::shared_ptr<AIGenericNode>) std::make_shared<AINodeList>( BotSequenceNode, &current );
 	}
 	else if ( !Q_stricmp( current->token.string, "concurrent" ) )
 	{
-		node = (std::shared_ptr<AIGenericNode_t>) std::make_shared<AINodeList_t>( BotConcurrentNode, &current );
+		node = (std::shared_ptr<AIGenericNode>) std::make_shared<AINodeList>( BotConcurrentNode, &current );
 	}
 	else if ( !Q_stricmp( current->token.string, "action" ) )
 	{
-		node = (std::shared_ptr<AIGenericNode_t>) std::make_shared<AIActionNode_t>( &current );
+		node = (std::shared_ptr<AIGenericNode>) std::make_shared<AIActionNode>( &current );
 	}
 	else if ( !Q_stricmp( current->token.string, "condition" ) )
 	{
-		node = (std::shared_ptr<AIGenericNode_t>) std::make_shared<AIConditionNode_t>( &current );
+		node = (std::shared_ptr<AIGenericNode>) std::make_shared<AIConditionNode>( &current );
 	}
 	else if ( !Q_stricmp( current->token.string, "decorator" ) )
 	{
-		node = (std::shared_ptr<AIGenericNode_t>) std::make_shared<AIDecoratorNode_t>( &current );
+		node = (std::shared_ptr<AIGenericNode>) std::make_shared<AIDecoratorNode>( &current );
 	}
 	else if ( !Q_stricmp( current->token.string, "behavior" ) )
 	{
-		node = (std::shared_ptr<AIGenericNode_t>) ReadBehaviorTreeInclude( &current );
+		node = (std::shared_ptr<AIGenericNode>) ReadBehaviorTreeInclude( &current );
 	}
 	else
 	{
@@ -1150,14 +1150,14 @@ std::shared_ptr<AIGenericNode_t> ReadNode( pc_token_list **tokenlist )
 
 /*
 ======================
-AIBehaviorTree_t constructor
+AIBehaviorTree constructor
 
 Load a behavior tree of the given name from a file
 ======================
 */
 
-AIBehaviorTree_t::AIBehaviorTree_t( std::string _name )
-	: AIGenericNode_t{ BEHAVIOR_NODE, BotBehaviorNode },
+AIBehaviorTree::AIBehaviorTree( std::string _name )
+	: AIGenericNode{ BEHAVIOR_NODE, BotBehaviorNode },
 	  name(std::move(_name)), root(nullptr)
 {
 	char treefilename[ MAX_QPATH ];
@@ -1313,7 +1313,7 @@ void FreeTokenList( pc_token_list *list )
 	}
 }
 
-void RemoveTreeFromList( AIBehaviorTree_t *tree, AITreeList_t *list )
+void RemoveTreeFromList( AIBehaviorTree *tree, AITreeList *list )
 {
 	for ( auto t = list->begin(); t != list->end(); ++t )
 	{

--- a/src/sgame/sg_bot_parse.h
+++ b/src/sgame/sg_bot_parse.h
@@ -66,8 +66,8 @@ struct pc_token_list
 pc_token_list *CreateTokenList( int handle );
 void           FreeTokenList( pc_token_list *list );
 
-std::shared_ptr<AIGenericNode_t>  ReadNode( pc_token_list **tokenlist );
-std::shared_ptr<AIBehaviorTree_t> ReadBehaviorTree( const char *name, AITreeList_t *tree );
+std::shared_ptr<AIGenericNode>  ReadNode( pc_token_list **tokenlist );
+std::shared_ptr<AIBehaviorTree> ReadBehaviorTree( const char *name, AITreeList *tree );
 
 struct parseError {
 	parseError(const char *_message, int _line = 0)

--- a/src/sgame/sg_bot_parse.h
+++ b/src/sgame/sg_bot_parse.h
@@ -77,9 +77,4 @@ struct parseError {
 };
 void WarnAboutParseError( parseError p );
 
-void FreeOp( AIOp_t *op );
-void FreeExpression( AIExpType_t *exp );
-void FreeValueFunc( AIValueFunc_t *v );
-void FreeValue( AIValue_t *v );
-
 #endif

--- a/src/sgame/sg_bot_parse.h
+++ b/src/sgame/sg_bot_parse.h
@@ -56,39 +56,27 @@ struct pc_token_stripped_t
 	int   line;
 };
 
-typedef struct pc_token_list_s
+struct pc_token_list
 {
-	pc_token_stripped_t    token;
-	struct pc_token_list_s *prev;
-	struct pc_token_list_s *next;
-} pc_token_list;
-
-struct AITreeList_t
-{
-	AIBehaviorTree_t **trees;
-	int numTrees;
-	int maxTrees;
+	pc_token_stripped_t token;
+	struct pc_token_list *prev;
+	struct pc_token_list *next;
 };
-
-void              InitTreeList( AITreeList_t *list );
-void              AddTreeToList( AITreeList_t *list, AIBehaviorTree_t *tree );
-void              RemoveTreeFromList( AITreeList_t *list, AIBehaviorTree_t *tree );
-void              FreeTreeList( AITreeList_t *list );
 
 pc_token_list *CreateTokenList( int handle );
 void           FreeTokenList( pc_token_list *list );
 
-AIGenericNode_t  *ReadNode( pc_token_list **tokenlist );
-AIGenericNode_t  *ReadConditionNode( pc_token_list **tokenlist );
-AIGenericNode_t  *ReadActionNode( pc_token_list **tokenlist );
-AIGenericNode_t  *ReadNodeList( pc_token_list **tokenlist );
-AIBehaviorTree_t *ReadBehaviorTree( const char *name, AITreeList_t *list );
+std::shared_ptr<AIGenericNode_t>  ReadNode( pc_token_list **tokenlist );
+std::shared_ptr<AIBehaviorTree_t> ReadBehaviorTree( const char *name, AITreeList_t *tree );
 
-void FreeBehaviorTree( AIBehaviorTree_t *tree );
-void FreeActionNode( AIActionNode_t *action );
-void FreeConditionNode( AIConditionNode_t *node );
-void FreeNodeList( AINodeList_t *node );
-void FreeNode( AIGenericNode_t *node );
+struct parseError {
+	parseError(const char *_message, int _line = 0)
+		: message(_message), line(_line) {};
+	const char *message;
+	int line;
+};
+void WarnAboutParseError( parseError p );
+
 void FreeOp( AIOp_t *op );
 void FreeExpression( AIExpType_t *exp );
 void FreeValueFunc( AIValueFunc_t *v );

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -614,11 +614,6 @@ gentity_t* BotFindBestEnemy( gentity_t *self )
 			continue;
 		}
 
-		if ( target == self->botMind->goal.ent )
-		{
-			continue;
-		}
-
 		newScore = BotGetEnemyPriority( self, target );
 
 		if ( newScore > bestVisibleEnemyScore && BotEntityIsVisible( self, target, MASK_SHOT ) )

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -966,7 +966,7 @@ bool BotTargetInAttackRange( gentity_t *self, botTarget_t target )
 	float width = 0, height = 0;
 
 	AngleVectors( self->client->ps.viewangles, forward, right, up );
-	G_CalcMuzzlePoint( self, forward, right, up , muzzle );
+	G_CalcMuzzlePoint( self, forward, right, up, muzzle );
 	BotGetTargetPos( target, targetPos );
 	switch ( self->client->ps.weapon )
 	{

--- a/src/sgame/sg_session.cpp
+++ b/src/sgame/sg_session.cpp
@@ -57,7 +57,7 @@ static void G_WriteClientSessionData( int clientNum )
 	        client->sess.restartTeam,
 	        client->sess.seenWelcome,
 	        mind ? mind->botSkill.level : 0,
-	        ( mind && mind->behaviorTree ) ? mind->behaviorTree->name : "default",
+	        ( mind && mind->behaviorTree ) ? mind->behaviorTree->name.c_str() : "default",
 	        Com_ClientListString( &client->sess.ignoreList )
 	      );
 


### PR DESCRIPTION
Use more C++ and fix a double free (where an included tree would be freed when removed from the cached list of behaviour trees, in addition to be freed as usual).

The file surely could use even more C++, but it's something. And the part of the file that's still to rewrite seems to be working fine