### PR TITLE
cmake: bring back old CMake compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 2.8.12)
 project(Unvanquished C CXX)
 
 # When we build in the source dir, the daemon executable cannot be create


### PR DESCRIPTION
Counterpart of DaemonEngine/Daemon#476

Reverts f8c0e253ea5099acc73b42e583abbc66b8f49f4e

Now the CMake code in engine is testing for CMake version
to use newer features when available.