### PR TITLE
Ignore bots when checking team balance

### DIFF
--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -910,7 +910,7 @@ void Cmd_Team_f( gentity_t *ent )
 					force = true;
 				}
 
-				if ( !force && g_teamForceBalance.integer && players[ TEAM_ALIENS ] > players[ TEAM_HUMANS ])
+				if ( !force && g_teamForceBalance.integer && G_PlayerCountForBalance( TEAM_ALIENS ) > G_PlayerCountForBalance( TEAM_HUMANS ) )
 				{
 					G_TriggerMenu( ent - g_entities, MN_A_TEAMFULL );
 					return;
@@ -931,7 +931,7 @@ void Cmd_Team_f( gentity_t *ent )
 					force = true;
 				}
 
-				if ( !force && g_teamForceBalance.integer && players[ TEAM_HUMANS ] > players[ TEAM_ALIENS ] )
+				if ( !force && g_teamForceBalance.integer && G_PlayerCountForBalance( TEAM_HUMANS ) > G_PlayerCountForBalance( TEAM_ALIENS ) )
 				{
 					G_TriggerMenu( ent - g_entities, MN_H_TEAMFULL );
 					return;

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -277,6 +277,7 @@ void              G_LeaveTeam( gentity_t *self );
 void              G_ChangeTeam( gentity_t *ent, team_t newTeam );
 gentity_t         *GetCloseLocationEntity( gentity_t *ent );
 void              TeamplayInfoMessage( gentity_t *ent );
+int               G_PlayerCountForBalance( team_t team );
 void              CheckTeamStatus();
 void              G_UpdateTeamConfigStrings();
 

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -744,7 +744,7 @@ struct level_locals_s
 		// gameplay state
 		int              numSpawns;
 		int              numClients;
-		int              numPlayers;
+		int              numPlayers; // non-bot clients
 		int              numBots;
 		float            averageNumClients;
 		float            averageNumPlayers;

--- a/src/sgame/sg_team.cpp
+++ b/src/sgame/sg_team.cpp
@@ -508,6 +508,12 @@ void TeamplayInfoMessage( gentity_t *ent )
 	}
 }
 
+static Cvar::Cvar<bool> countBots("g_teamBalanceCountBots", "include bots when checking team size", Cvar::NONE, false);
+int G_PlayerCountForBalance( team_t team )
+{
+	return countBots.Get() ? level.team[ team ].numClients : level.team[ team ].numPlayers;
+}
+
 void CheckTeamStatus()
 {
 	int       i;
@@ -572,14 +578,14 @@ void CheckTeamStatus()
 		level.lastTeamImbalancedTime = level.time;
 
 		if ( level.team[ TEAM_ALIENS ].numSpawns > 0 &&
-		     level.team[ TEAM_HUMANS ].numClients - level.team[ TEAM_ALIENS ].numClients > 2 )
+		     G_PlayerCountForBalance( TEAM_HUMANS ) - G_PlayerCountForBalance( TEAM_ALIENS ) > 2 )
 		{
 			trap_SendServerCommand( -1, "print_tr \"" N_("Teams are imbalanced. "
 			                        "Humans have more players.") "\"" );
 			level.numTeamImbalanceWarnings++;
 		}
 		else if ( level.team[ TEAM_HUMANS ].numSpawns > 0 &&
-		          level.team[ TEAM_ALIENS ].numClients - level.team[ TEAM_HUMANS ].numClients > 2 )
+		          G_PlayerCountForBalance( TEAM_ALIENS ) - G_PlayerCountForBalance( TEAM_HUMANS ) > 2 )
 		{
 			trap_SendServerCommand( -1, "print_tr \"" N_("Teams are imbalanced. "
 			                        "Aliens have more players.") "\"" );


### PR DESCRIPTION
So if you have bots and team balance enforcement enabled, people can't all join the same team.