### PR TITLE
Fall back to old paths of missile configs

### DIFF
--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -825,9 +825,17 @@ void BG_InitMissileAttributes()
 		ma->name   = md->name;
 		ma->number = md->number;
 
-		// for simplicity, read both from a single file
-		BG_ParseMissileAttributeFile( va( "configs/missiles/%s.attr.cfg", ma->name ), ma );
-		BG_ParseMissileDisplayFile(   va( "configs/missiles/%s.model.cfg", ma->name ), ma );
+		if ( FS::PakPath::FileExists( va( "configs/missiles/%s.attr.cfg", ma->name ) ) )
+		{
+			BG_ParseMissileAttributeFile( va( "configs/missiles/%s.attr.cfg", ma->name ), ma );
+			BG_ParseMissileDisplayFile(   va( "configs/missiles/%s.model.cfg", ma->name ), ma );
+		}
+		else
+		{
+			// TODO(0.53): Remove this fallback
+			BG_ParseMissileAttributeFile( va( "configs/missiles/%s.missile.cfg", ma->name ), ma );
+			BG_ParseMissileDisplayFile(   va( "configs/missiles/%s.missile.cfg", ma->name ), ma );
+		}
 	}
 }
 


### PR DESCRIPTION
88850e97 broke compatibility with the 0.52 asset packages. This is bad for development - see [Compatibility](https://wiki.unvanquished.net/wiki/Compatibility) "Develop Unvanquished on master, using latest-release DPKs".