### PR TITLE
Fix Warn: Cvar cannot be registered twice

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -1583,17 +1583,13 @@ bool G_admin_cmd_check( gentity_t *ent )
 	if ( ( c = G_admin_command( command ) ) )
 	{
 		int j;
-		trap_Cvar_Register( nullptr, "arg_all", "", CVAR_TEMP | CVAR_ROM | CVAR_USER_CREATED );
 		trap_Cvar_Set( "arg_all", ConcatArgs( 1 ) );
-		trap_Cvar_Register( nullptr, "arg_count", "", CVAR_TEMP | CVAR_ROM | CVAR_USER_CREATED );
 		trap_Cvar_Set( "arg_count", va( "%i", trap_Argc() - ( 1 ) ) );
-		trap_Cvar_Register( nullptr, "arg_client", "", CVAR_TEMP | CVAR_ROM | CVAR_USER_CREATED );
 		trap_Cvar_Set( "arg_client", G_admin_name( ent ) );
 
 		for ( j = trap_Argc() - ( 1 ); j; j-- )
 		{
 			char this_arg[ MAX_CVAR_VALUE_STRING ];
-			trap_Cvar_Register( nullptr, va( "arg_%i", j ), "", CVAR_TEMP | CVAR_ROM | CVAR_USER_CREATED );
 			trap_Argv( j, this_arg, sizeof( this_arg ) );
 			trap_Cvar_Set( va( "arg_%i", j ), this_arg );
 		}


### PR DESCRIPTION
for custom admin commands

If a custom command was used the second time it would show this error message
Warn: Cvar arg_all cannot be registered twice 
for every one of this cvars