### PR TITLE
Add autocompletion of the command name for devteam

### DIFF
--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -457,6 +457,7 @@ static const struct
 	{ "destroy",          0,                       0                },
 	{ "destroyTestPS",    CG_DestroyTestPS_f,      0                },
 	{ "destroyTestTS",    CG_DestroyTestTS_f,      0                },
+	{ "devteam",          0,                       0                },
 	{ "follow",           0,                       CG_CompleteName  },
 	{ "follownext",       0,                       0                },
 	{ "followprev",       0,                       0                },


### PR DESCRIPTION
https://github.com/Unvanquished/Unvanquished/pull/1235 missed this. A bit above the list this PR touched, there is a `// keep the list synchronized with the list in cg_consolecmds for completion.`