### PR TITLE
sgame: fix various env_afx_gravity and func_bobbing bugs <3 Gireen

### DIFF
--- a/src/sgame/sg_spawn_afx.cpp
+++ b/src/sgame/sg_spawn_afx.cpp
@@ -283,6 +283,9 @@ void SP_env_afx_gravity( gentity_t *self )
 	self->act = env_afx_toggle;
 	self->reset = env_afx_gravity_reset;
 
+	// Remove CONTENTS_SOLID flag.
+	self->r.contents &= ~CONTENTS_SOLID;
+
 	InitEnvAFXEntity( self, true );
 }
 

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -2510,11 +2510,12 @@ void SP_func_bobbing( gentity_t *self )
 
 	trap_SetBrushModel( self, self->model );
 	InitMover( self );
+	reset_moverspeed( self, 4 );
 
 	VectorCopy( self->s.origin, self->s.pos.trBase );
 	VectorCopy( self->s.origin, self->r.currentOrigin );
 
-	self->s.pos.trDuration = self->config.speed * 1000;
+	self->s.pos.trDuration = self->speed * 1000;
 	self->s.pos.trTime = self->s.pos.trDuration * phase;
 	self->s.pos.trType = trType_t::TR_SINE;
 


### PR DESCRIPTION
sgame: remove solid flag on env_afx_gravity / trigger_gravity <3 @Gireen

The`env_afx_gravity` brushes are likely to use the `caulk` texture which is a solid texture, meaning the whole content of the `trigger_gravity` entity is solid, preventing buildables to spawn and players to move, being literally stuck in a wall.

[![non solid gravity](https://dl.illwieckz.net/b/unvanquished/bugs/non-solid-gravity/20210810-125112-000.netradiant-mission-one-redux.png)](https://dl.illwieckz.net/b/unvanquished/bugs/non-solid-gravity/20210810-125112-000.netradiant-mission-one-redux.png)

This patch always removes the solid content parm on such `env_afx_gravity`. It was verified to workaround properly the issue on map using obsolete `trigger_gravity` or recommended `env_afx_gravity`.

I tested it with maps:

- mission one redux (`trigger_gravity` replaced by `env_afx_gravity` using [Esquirel](https://github.com/DaemonEngine/Urcheon)) \
  https://betaserv.tk/pk3/pk3/2055
- mission one (`trigger_gravity`) \
  https://betaserv.tk/pk3/map/913
- hq (`trigger_gravity`) \
  https://betaserv.tk/pk3/pk3/557

[![non solid gravity](https://dl.illwieckz.net/b/unvanquished/bugs/non-solid-gravity/unvanquished_2021-08-10_123950_000.jpg)](https://dl.illwieckz.net/b/unvanquished/bugs/non-solid-gravity/unvanquished_2021-08-10_123950_000.jpg)

[![non solid gravity](https://dl.illwieckz.net/b/unvanquished/bugs/non-solid-gravity/unvanquished_2021-08-10_124021_000.jpg)](https://dl.illwieckz.net/b/unvanquished/bugs/non-solid-gravity/unvanquished_2021-08-10_124021_000.jpg)

[![non solid gravity](https://dl.illwieckz.net/b/unvanquished/bugs/non-solid-gravity/unvanquished_2021-08-10_124117_000.jpg)](https://dl.illwieckz.net/b/unvanquished/bugs/non-solid-gravity/unvanquished_2021-08-10_124117_000.jpg)
