### PR TITLE
sg_bot_parse: order alphabetically behavior tree function names

### DIFF
--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -340,8 +340,8 @@ static const struct AIConditionMap_s
 	int           nparams;
 } conditionFuncs[] =
 {
+	// It looks like behavior tree function names must be ordered alphabetically.
 	{ "alertedToEnemy",    VALUE_INT,   alertedToEnemy,    0 },
-	{ "momentum",          VALUE_INT,   momentum,          1 },
 	{ "aliveTime",         VALUE_INT,   aliveTime,         0 },
 	{ "baseRushScore",     VALUE_FLOAT, baseRushScore,     0 },
 	{ "buildingIsDamaged", VALUE_INT,   buildingIsDamaged, 0 },
@@ -361,6 +361,7 @@ static const struct AIConditionMap_s
 	{ "inAttackRange",     VALUE_INT,   inAttackRange,     1 },
 	{ "isVisible",         VALUE_INT,   isVisible,         1 },
 	{ "matchTime",         VALUE_INT,   matchTime,         0 },
+	{ "momentum",          VALUE_INT,   momentum,          1 },
 	{ "percentAmmo",       VALUE_FLOAT, percentAmmo,       0 },
 	{ "percentHealth",     VALUE_FLOAT, percentHealth,     1 },
 	{ "random",            VALUE_FLOAT, randomChance,      0 },


### PR DESCRIPTION
fixes:

```
Warn: Unknown function: aliveTime on line 71
Warn: Expected token ) but found > on line 71
Warn: Failed to parse child node of condition on line 69
Warn: Problem when loading behavior tree default, trying default
Warn: Unknown function: aliveTime on line 71
Warn: Expected token ) but found > on line 71
Warn: Failed to parse child node of condition on line 69
Warn: Problem when loading default behavior tree
```