### PR TITLE
sg_buildable: also disable building on surfaces of brushes with nobuild contentflag

### DIFF
--- a/src/sgame/CustomSurfaceFlags.h
+++ b/src/sgame/CustomSurfaceFlags.h
@@ -37,4 +37,4 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // custom content flags
 #define CUSTOM_CONTENTS_NOALIENBUILD    BIT( 12 ) // disallow alien building
 #define CUSTOM_CONTENTS_NOHUMANBUILD    BIT( 13 ) // disallow human building
-#define CUSTOM_CONTENTS_NOBUILD         BIT( 14 ) // disallow building,       override CONTENTS_MOVER
+#define CUSTOM_CONTENTS_NOBUILD         BIT( 14 ) // disallow building,       override CONTENTS_MOVER from RTCW and Wolf:ET we inherit through ET:XreaL, Q3 and Tremulous did not defined any flag there

--- a/src/sgame/CustomSurfaceFlags.h
+++ b/src/sgame/CustomSurfaceFlags.h
@@ -38,6 +38,3 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CUSTOM_CONTENTS_NOALIENBUILD    BIT( 12 ) // disallow alien building
 #define CUSTOM_CONTENTS_NOHUMANBUILD    BIT( 13 ) // disallow human building
 #define CUSTOM_CONTENTS_NOBUILD         BIT( 14 ) // disallow building,       override CONTENTS_MOVER
-
-// custom surface flags
-#define CUSTOM_SURF_NOBUILD             BIT( 21 ) // disallow building,       override SURF_GLASS

--- a/src/sgame/CustomSurfaceFlags.h
+++ b/src/sgame/CustomSurfaceFlags.h
@@ -40,6 +40,4 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CUSTOM_CONTENTS_NOBUILD         BIT( 14 ) // disallow building,       override CONTENTS_MOVER
 
 // custom surface flags
-#define CUSTOM_SURF_NOALIENBUILD        BIT( 19 ) // disallow alien building, override SURF_GRASS
-#define CUSTOM_SURF_NOHUMANBUILD        BIT( 20 ) // disallow human building, override SURF_GRAVEL
 #define CUSTOM_SURF_NOBUILD             BIT( 21 ) // disallow building,       override SURF_GLASS

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -1591,7 +1591,9 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 		}
 
 		// Check surface permissions
-		if ( (tr1.surfaceFlags & (CUSTOM_SURF_NOALIENBUILD | CUSTOM_SURF_NOBUILD)) || (contents & (CUSTOM_CONTENTS_NOALIENBUILD | CUSTOM_CONTENTS_NOBUILD)) )
+		if ( (tr1.surfaceFlags & (CUSTOM_SURF_NOALIENBUILD | CUSTOM_SURF_NOBUILD))
+			|| (tr1.contents & (CUSTOM_CONTENTS_NOALIENBUILD | CUSTOM_CONTENTS_NOBUILD))
+			|| (contents & (CUSTOM_CONTENTS_NOALIENBUILD | CUSTOM_CONTENTS_NOBUILD)) )
 		{
 			reason = IBE_SURFACE;
 		}
@@ -1614,7 +1616,9 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 		}
 
 		// Check permissions
-		if ( (tr1.surfaceFlags & (CUSTOM_SURF_NOHUMANBUILD | CUSTOM_SURF_NOBUILD)) || (contents & (CUSTOM_CONTENTS_NOHUMANBUILD | CUSTOM_CONTENTS_NOBUILD)) )
+		if ( (tr1.surfaceFlags & (CUSTOM_SURF_NOHUMANBUILD | CUSTOM_SURF_NOBUILD))
+			|| (tr1.contents & (CUSTOM_CONTENTS_NOHUMANBUILD | CUSTOM_CONTENTS_NOBUILD))
+			|| (contents & (CUSTOM_CONTENTS_NOHUMANBUILD | CUSTOM_CONTENTS_NOBUILD)) )
 		{
 			reason = IBE_SURFACE;
 		}

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -1591,7 +1591,7 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 		}
 
 		// Check surface permissions
-		if ( (tr1.surfaceFlags & (CUSTOM_SURF_NOALIENBUILD | CUSTOM_SURF_NOBUILD))
+		if ( (tr1.surfaceFlags & CUSTOM_SURF_NOBUILD)
 			|| (tr1.contents & (CUSTOM_CONTENTS_NOALIENBUILD | CUSTOM_CONTENTS_NOBUILD))
 			|| (contents & (CUSTOM_CONTENTS_NOALIENBUILD | CUSTOM_CONTENTS_NOBUILD)) )
 		{
@@ -1616,7 +1616,7 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 		}
 
 		// Check permissions
-		if ( (tr1.surfaceFlags & (CUSTOM_SURF_NOHUMANBUILD | CUSTOM_SURF_NOBUILD))
+		if ( (tr1.surfaceFlags & CUSTOM_SURF_NOBUILD)
 			|| (tr1.contents & (CUSTOM_CONTENTS_NOHUMANBUILD | CUSTOM_CONTENTS_NOBUILD))
 			|| (contents & (CUSTOM_CONTENTS_NOHUMANBUILD | CUSTOM_CONTENTS_NOBUILD)) )
 		{

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -1591,8 +1591,7 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 		}
 
 		// Check surface permissions
-		if ( (tr1.surfaceFlags & CUSTOM_SURF_NOBUILD)
-			|| (tr1.contents & (CUSTOM_CONTENTS_NOALIENBUILD | CUSTOM_CONTENTS_NOBUILD))
+		if ( (tr1.contents & (CUSTOM_CONTENTS_NOALIENBUILD | CUSTOM_CONTENTS_NOBUILD))
 			|| (contents & (CUSTOM_CONTENTS_NOALIENBUILD | CUSTOM_CONTENTS_NOBUILD)) )
 		{
 			reason = IBE_SURFACE;
@@ -1616,8 +1615,7 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 		}
 
 		// Check permissions
-		if ( (tr1.surfaceFlags & CUSTOM_SURF_NOBUILD)
-			|| (tr1.contents & (CUSTOM_CONTENTS_NOHUMANBUILD | CUSTOM_CONTENTS_NOBUILD))
+		if ( (tr1.contents & (CUSTOM_CONTENTS_NOHUMANBUILD | CUSTOM_CONTENTS_NOBUILD))
 			|| (contents & (CUSTOM_CONTENTS_NOHUMANBUILD | CUSTOM_CONTENTS_NOBUILD)) )
 		{
 			reason = IBE_SURFACE;


### PR DESCRIPTION
When a brush has the `nobuild` content flag, building is forbidden inside the brush, but still allowed on the surfaces of the brush. This means even setting `surfaceparm nobuild` (which sets the `nobuild` content parm) on a sky surface or on a playerclip between player and sky does not prevent to build on it (and there is no way to build inside anyway):

Note: material syntax uses `surfaceparm` keyword for both surfaceparm and contentparm, so `surfaceparm nobuild` sets a contentparm).

[![nobuild surface](https://dl.illwieckz.net/b/unvanquished/bugs/nobuild-surface/unvanquished_2021-09-08_032711_000.jpg)](https://dl.illwieckz.net/b/unvanquished/bugs/nobuild-surface/unvanquished_2021-09-08_032711_000.jpg)

***I'm looking for comments about the idea itself.***

Do we want to do that? Do you think it's a good idea?

Another solution that may look better at first glance would be to use the `nobuildsurface` surfaceparm, but in fact, while the code for it is implemented in the game and it is listed in `custinforparms.txt` read by q3map2, it was probably never used by Unvanquished (`common` textures do not set `nobuildsurface`, neither the `space` skyboxes), and it was almost unused in Tremulous (or `nobuild` was used anyway). Also, I see no situation were it would be needed to set it on content but not on surface, or on surface but not on content.

Do you see any reason to set a `nobuildsurface` on a brush without `nobuild` content?
Do you see any reason to set `nobuild` on a brush without `nobuildsurface` ?

If you see no reason, we can just rely on `nobuild` contentparm to both forbid building on content and surface.

The `nobuildsurface` surface only makes sense on solid brush (so nothing is buildable inside even if `nobuild` content is not set), and non-solid brushes to forbid building inside an area (like the `common/nobuild` material) are meant to not be solid, since it's to forbid to build where a player can go (so if it's not solid there is no surface to apply `nobuildsurface` on). And if the non-solid `common/nobuild` is used to forbid to build where a player can't go (outside of a fence or an ajar door, for example), that material is still non-solid so `nobuildsurface` would be useless anyway.

As noted [there](https://github.com/Unvanquished/Unvanquished/issues/1373#issuecomment-821862567), on 1575 Tremulous bsp, only 62 are using `nobuildsurface`, 38 use `nobuildsurface` without `nobuild`. If I deduplicate maps with different case in name and different versions, only 19 maps uses `nobuildsurface` without `nobuild`: `atcs3 atcs3a atestcs3 cage e1m2test1 gantry0 intent labyrinth loop monka1 oasys reiseb1 rtb sokolov thermal thule traps tremor volcano`. We can fix those maps when porting them if we chose to entirely drop `nobuildsurface`.

The contentparm and surfaceparm bits are very precious, and custom contentparm and surfaceparm are colliding with engines we are inheriting from.