### PR TITLE
fix "addition of unsigned offset ..."

### DIFF
--- a/src/shared/parse.cpp
+++ b/src/shared/parse.cpp
@@ -1123,14 +1123,22 @@ Parse_StripDoubleQuotes
 */
 static void Parse_StripDoubleQuotes( char *string )
 {
-	if ( *string == '\"' )
+	if ( string == nullptr || *string == '\0' )
 	{
-		memmove( string, string + 1, strlen( string ) + 1 );
+		Log::Warn( "Parse_StripDoubleQuotes called with invalid or empty string" );
+		return;
 	}
 
-	if ( string[ strlen( string ) - 1 ] == '\"' )
+	size_t len = strlen( string );
+	if ( *string == '\"' )
 	{
-		string[ strlen( string ) - 1 ] = '\0';
+		memmove( string, string + 1, len );
+		--len;
+	}
+
+	if ( len > 0 && string[ len - 1 ] == '\"' )
+	{
+		string[ len - 1 ] = '\0';
 	}
 }
 


### PR DESCRIPTION
Found by UBsan.
Returning without action and emitting a warning only, if string is invalid or empty. I think the problem's root is likely  above in the call stack, but this patch will at least no longer make it happening and corrupting memory silently.