### PR TITLE
Query the engine to know if an extension-independent image path exists, check for multiple levelshot paths

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1899,6 +1899,7 @@ bool   CG_ClientIsReady( int clientNum );
 void       CG_BuildSpectatorString();
 
 bool   CG_FileExists( const char *filename );
+bool       CG_ImageExists( const char *filename );
 void       CG_UpdateBuildableRangeMarkerMask();
 void       CG_RegisterGrading( int slot, const char *str );
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -722,6 +722,11 @@ bool CG_FileExists( const char *filename )
 	return trap_FS_FOpenFile( filename, nullptr, fsMode_t::FS_READ );
 }
 
+bool CG_ImageExists( const char *filename )
+{
+	return trap_ImageExists( filename );
+}
+
 /*
 ======================
 CG_UpdateLoadingProgress

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -1744,6 +1744,32 @@ private:
 	float momentum_;
 };
 
+std::string GetLevelShotPath( const char* mapName )
+{
+	std::string levelShotPath = Str::Format( "meta/%s/%s", mapName, mapName );
+
+	if( CG_ImageExists( levelShotPath.c_str() ) )
+	{
+		Log::Warn( "Loading level shot %s", levelShotPath.c_str() );
+		return levelShotPath;
+	}
+	else
+	{
+		std::string legacyLevelShotPath = Str::Format( "levelshots/%s", mapName );
+
+		if( CG_ImageExists( legacyLevelShotPath.c_str() ) )
+		{
+			Log::Warn( "Loading legacy Quake 3 level shot %s", legacyLevelShotPath.c_str() );
+			return legacyLevelShotPath;
+		}
+		else
+		{
+			Log::Warn( "Level shot not found for map %s", mapName );
+			return "";
+		}
+	}
+}
+
 class LevelshotElement : public HudElement
 {
 public:
@@ -1761,9 +1787,17 @@ public:
 		if ( mapIndex != rocketInfo.data.mapIndex )
 		{
 			mapIndex = rocketInfo.data.mapIndex;
-			SetInnerRML( va( "<img class='levelshot' src='/meta/%s/%s' />",
-							 rocketInfo.data.mapList[ mapIndex ].mapLoadName,
-					rocketInfo.data.mapList[ mapIndex ].mapLoadName ) );
+
+			std::string levelShotPath = GetLevelShotPath( rocketInfo.data.mapList[ mapIndex ].mapLoadName );
+
+			if ( levelShotPath.length() != 0 )
+			{
+				SetInnerRML( va( "<img class='levelshot' src='/%s' />", levelShotPath.c_str() ) );
+			}
+			else
+			{
+				SetInnerRML( va("<div class='levelshot' style='background-color: black;'>%s</div>", "Missing Levelshot") );
+			}
 		}
 	}
 
@@ -1799,7 +1833,16 @@ public:
 		if ( map != newMap )
 		{
 			map = newMap;
-			SetInnerRML( va( "<img class='levelshot' src='/meta/%s/%s' />", newMap, newMap ) );
+			std::string levelShotPath = GetLevelShotPath( map.CString() );
+
+			if ( levelShotPath.length() != 0 )
+			{
+				SetInnerRML( va( "<img class='levelshot' src='/%s' />", levelShotPath.c_str() ) );
+			}
+			else
+			{
+				SetInnerRML( va("<div class='levelshot' style='background-color: black;'>%s</div>", "Missing Levelshot") );
+			}
 		}
 	}
 


### PR DESCRIPTION
https://github.com/DaemonEngine/Daemon/pull/528 makes possible for the game to query the engine to know if an extension-independent image path exists.

A secondary commit showcase the use of it: the code checks if Unvanquished's `meta/<name>/<mapname>` levelshot exists, but if it does not exist, try to load Quake3-like `levelshot/<name>` instead.