### PR TITLE
Fix memset warning

### DIFF
--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -485,7 +485,10 @@ AINodeStatus_t BotEvaluateNode( gentity_t *self, AIGenericNode_t *node )
 	// reset running information on node success so sequences and selectors reset their state
 	if ( NodeIsRunning( self, node ) && status == STATUS_SUCCESS )
 	{
-		memset( self->botMind->runningNodes, 0, sizeof( self->botMind->runningNodes ) );
+		for (auto &node : self->botMind->runningNodes)
+		{
+			node = nullptr;
+		}
 		self->botMind->numRunningNodes = 0;
 	}
 


### PR DESCRIPTION
```
[7/84] Building CXX object CMakeFiles/sgame-native-dll.dir/src/sgame/sg_bot.cpp.o
../src/sgame/sg_bot.cpp: In function ‘bool G_BotSetBehavior(botMemory_t*, const char*)’:
../src/sgame/sg_bot.cpp:195:68: warning: ‘memset’ used with length equal to number of elements without multiplication by element size [-Wmemset-elt-size]
  195 |  memset( botMind->runningNodes, 0, sizeof( botMind->runningNodes ) );
      |                                                                    ^
```