### PR TITLE
Fix the armory use distance situation

### DIFF
--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -1072,35 +1072,24 @@ public:
 	{
 		vec3_t        view, point;
 		trace_t       trace;
-		entityState_t *es;
 
 		AngleVectors( cg.refdefViewAngles, view, nullptr, nullptr );
 		VectorMA( cg.refdef.vieworg, ENTITY_USE_RANGE, view, point );
 		CG_Trace( &trace, cg.refdef.vieworg, nullptr, nullptr,
 				  point, cg.predictedPlayerState.clientNum, MASK_SHOT, 0 );
 
-		es = &cg_entities[ trace.entityNum ].currentState;
+		const entityState_t &es = cg_entities[ trace.entityNum ].currentState;
 
-		if ( es->eType == entityType_t::ET_BUILDABLE && BG_Buildable( es->modelindex )->usable &&
-			CG_IsOnMyTeam(*es) )
+		if ( es.eType == entityType_t::ET_BUILDABLE
+				&& es.modelindex == BA_H_ARMOURY
+				&& Distance(cg.predictedPlayerState.origin, es.origin) < ENTITY_USE_RANGE - 0.2f // use an epsilon to account for rounding errors
+				&& CG_IsOnMyTeam(es) )
 		{
-			//hack to prevent showing the usable buildable when you aren't carrying an energy weapon
-			if ( es->modelindex == BA_H_REACTOR &&
-				( !BG_Weapon( cg.snap->ps.weapon )->usesEnergy ||
-				BG_Weapon( cg.snap->ps.weapon )->infiniteAmmo ) )
+			if ( !IsVisible() )
 			{
-				cg.nearUsableBuildable = BA_NONE;
-				SetProperty( "display", "none" );
-				return;
+				SetProperty( "display", display );
+				cg.nearUsableBuildable = es.modelindex;
 			}
-
-			if ( IsVisible() )
-			{
-				return;
-			}
-
-			SetProperty( "display", display );
-			cg.nearUsableBuildable = es->modelindex;
 		}
 		else
 		{

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -1075,7 +1075,7 @@ public:
 		entityState_t *es;
 
 		AngleVectors( cg.refdefViewAngles, view, nullptr, nullptr );
-		VectorMA( cg.refdef.vieworg, 64, view, point );
+		VectorMA( cg.refdef.vieworg, ENTITY_USE_RANGE, view, point );
 		CG_Trace( &trace, cg.refdef.vieworg, nullptr, nullptr,
 				  point, cg.predictedPlayerState.clientNum, MASK_SHOT, 0 );
 

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -140,7 +140,7 @@ static entityState_t *CG_BuildableInRange( playerState_t *ps, float *healthFract
 	trace_t       trace;
 
 	AngleVectors( cg.refdefViewAngles, view, nullptr, nullptr );
-	VectorMA( cg.refdef.vieworg, 64, view, point );
+	VectorMA( cg.refdef.vieworg, ENTITY_USE_RANGE - 0.2f, view, point );
 	CG_Trace( &trace, cg.refdef.vieworg, nullptr, nullptr, point, ps->clientNum, MASK_SHOT, 0 );
 
 	entityState_t &es = cg_entities[ trace.entityNum ].currentState;

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -2185,7 +2185,8 @@ void ClientThink_real( gentity_t *self )
 
 		if ( ent && ent->use &&
 		     ( !ent->buildableTeam   || ent->buildableTeam   == client->pers.team ) &&
-		     ( !ent->conditions.team || ent->conditions.team == client->pers.team ) )
+		     ( !ent->conditions.team || ent->conditions.team == client->pers.team ) &&
+		     Distance( self->s.origin, ent->s.origin ) < ENTITY_USE_RANGE )
 		{
 			if ( g_debugEntities.Get() > 1 )
 			{

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1244,7 +1244,7 @@ AINodeStatus_t BotActionBuy( gentity_t *self, AIGenericNode_t *node )
 		return STATUS_FAILURE;
 	}
 
-	if ( GoalInRange( self, ENTITY_BUY_RANGE ) )
+	if ( GoalInRange( self, ENTITY_USE_RANGE ) )
 	{
 		if ( !desiredUpgrades.empty() )
 		{

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -2117,7 +2117,7 @@ void BotSellWeapons( gentity_t *self )
 	int i;
 
 	//no armoury nearby
-	if ( !G_BuildableInRange( self->client->ps.origin, ENTITY_BUY_RANGE, BA_H_ARMOURY ) )
+	if ( !G_BuildableInRange( self->client->ps.origin, ENTITY_USE_RANGE, BA_H_ARMOURY ) )
 	{
 		return;
 	}
@@ -2157,7 +2157,7 @@ void BotSellUpgrades( gentity_t *self )
 	int i;
 
 	//no armoury nearby
-	if ( !G_BuildableInRange( self->client->ps.origin, ENTITY_BUY_RANGE, BA_H_ARMOURY ) )
+	if ( !G_BuildableInRange( self->client->ps.origin, ENTITY_USE_RANGE, BA_H_ARMOURY ) )
 	{
 		return;
 	}

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -2975,7 +2975,7 @@ static bool Cmd_Sell_internal( gentity_t *ent, const char *s )
 	upgrade_t upgrade;
 
 	//no armoury nearby
-	if ( !G_BuildableInRange( ent->client->ps.origin, ENTITY_BUY_RANGE, BA_H_ARMOURY ) )
+	if ( !G_BuildableInRange( ent->client->ps.origin, ENTITY_USE_RANGE, BA_H_ARMOURY ) )
 	{
 		G_TriggerMenu( ent->client->ps.clientNum, MN_H_NOARMOURYHERE );
 		return false;
@@ -3129,7 +3129,7 @@ static bool Cmd_Buy_internal( gentity_t *ent, const char *s, bool sellConflictin
 	upgrade = BG_UpgradeByName( s )->number;
 
 	// check if armoury is in reach
-	if ( !G_BuildableInRange( ent->client->ps.origin, ENTITY_BUY_RANGE, BA_H_ARMOURY ) )
+	if ( !G_BuildableInRange( ent->client->ps.origin, ENTITY_USE_RANGE, BA_H_ARMOURY ) )
 	{
 		G_TriggerMenu( ent->client->ps.clientNum, MN_H_NOARMOURYHERE );
 

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -231,7 +231,7 @@ bool G_FindAmmo( gentity_t *self )
 	}
 
 	// search for ammo source
-	while ( ( neighbor = G_IterateEntitiesWithinRadius( neighbor, self->s.origin, ENTITY_BUY_RANGE ) ) )
+	while ( ( neighbor = G_IterateEntitiesWithinRadius( neighbor, self->s.origin, ENTITY_USE_RANGE ) ) )
 	{
 		// only friendly, living and powered buildables provide ammo
 		if ( neighbor->s.eType != entityType_t::ET_BUILDABLE || !G_OnSameTeam( self, neighbor ) ||
@@ -278,7 +278,7 @@ bool G_FindFuel( gentity_t *self )
 	}
 
 	// search for fuel source
-	while ( ( neighbor = G_IterateEntitiesWithinRadius( neighbor, self->s.origin, ENTITY_BUY_RANGE ) ) )
+	while ( ( neighbor = G_IterateEntitiesWithinRadius( neighbor, self->s.origin, ENTITY_USE_RANGE ) ) )
 	{
 		// only friendly, living and powered buildables provide fuel
 		if ( neighbor->s.eType != entityType_t::ET_BUILDABLE || !G_OnSameTeam( self, neighbor ) ||

--- a/src/shared/bg_gameplay.h
+++ b/src/shared/bg_gameplay.h
@@ -308,7 +308,6 @@ extern int   MEDKIT_STARTUP_SPEED;
 #define QU_TO_METER                        0.03125 // in m/qu
 
 #define ENTITY_USE_RANGE                   64.0f
-#define ENTITY_BUY_RANGE                   128.0f
 
 // fire
 #define FIRE_MIN_DISTANCE                  20.0f


### PR DESCRIPTION
Currently, there are 4 (four!) slightly different experiences in game when trying to buy stuff

* "how far the bots see the armory" which is the same as "how far (using binds or commands) you might use the armory"
* "the tutorial says you can open the armory with the q key"
* "the hand button that hints you can open the armory appears"
* "when you press q the menu opens"

This PR makes the experience nicer and make it look and feel much more consistent. I tried to avoid making a larger refactoring to avoid breaking stuff in the process (for example maybe some maps have activatable buttons?).