### PR TITLE
cg_tutorial: display the medkit and ammo feedback in orange

### DIFF
--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -2903,7 +2903,7 @@ void CG_Rocket_DrawTutorial()
 		return;
 	}
 
-	Rocket_SetInnerRML( CG_TutorialText(), RP_EMOTICONS );
+	Rocket_SetInnerRML( CG_TutorialText(), RP_EMOTICONS | RP_QUAKE );
 }
 
 void CG_Rocket_DrawStaminaBolt()

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -159,6 +159,8 @@ static entityState_t *CG_BuildableInRange( playerState_t *ps, float *healthFract
 	return &es;
 }
 
+#define COLOR_ALARM "^8" // Orange
+
 /*
 ===============
 CG_BuilderText
@@ -362,6 +364,7 @@ static void CG_HumanText( char *text, playerState_t *ps )
 			case WP_CHAINGUN:
 			case WP_SHOTGUN:
 			case WP_FLAMER:
+				Q_strcat( text, MAX_TUTORIAL_TEXT, COLOR_ALARM );
 				Q_strcat( text, MAX_TUTORIAL_TEXT,
 				          _( "Find an Armoury for more ammo\n" ) );
 				break;
@@ -370,6 +373,7 @@ static void CG_HumanText( char *text, playerState_t *ps )
 			case WP_PULSE_RIFLE:
 			case WP_MASS_DRIVER:
 			case WP_LUCIFER_CANNON:
+				Q_strcat( text, MAX_TUTORIAL_TEXT, COLOR_ALARM );
 				Q_strcat( text, MAX_TUTORIAL_TEXT,
 				          _( "Find an Armoury or Reactor for more ammo\n" ) );
 				break;
@@ -470,6 +474,7 @@ static void CG_HumanText( char *text, playerState_t *ps )
 	if ( ps->stats[ STAT_HEALTH ] <= 35 &&
 	     BG_InventoryContainsUpgrade( UP_MEDKIT, ps->stats ) )
 	{
+		Q_strcat( text, MAX_TUTORIAL_TEXT, COLOR_ALARM );
 		Q_strcat( text, MAX_TUTORIAL_TEXT,
 		          va( _( "Press %s to use your %s\n" ),
 		              CG_KeyNameForCommand( "itemact medkit" ),


### PR DESCRIPTION
Not perfect, but better than what we have.

[![tutorial medkit red message](https://dl.illwieckz.net/b/unvanquished/bugs/tutorial-medkit-red-message/unvanquished_2021-11-02_235331_000.jpg)](https://dl.illwieckz.net/b/unvanquished/bugs/tutorial-medkit-red-message/unvanquished_2021-11-02_235331_000.jpg)

[![tutorial medkit red message](https://dl.illwieckz.net/b/unvanquished/bugs/tutorial-medkit-red-message/unvanquished_2021-11-02_235906_000.jpg)](https://dl.illwieckz.net/b/unvanquished/bugs/tutorial-medkit-red-message/unvanquished_2021-11-02_235906_000.jpg)