### PR TITLE
Fix corpse team: ps.clientNum is actually reused for the corpse model

### DIFF
--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -1376,7 +1376,6 @@ team_t CG_Team(const entityState_t &es)
 	switch (es.eType)
 	{
 		case entityType_t::ET_PLAYER:
-		case entityType_t::ET_CORPSE:
 		{
 			clientInfo_t &ci = cgs.clientinfo[es.clientNum];
 			return (team_t) ci.team;


### PR DESCRIPTION
The function is not supposed to be used on a corpse anywhere AFAIK, but let's avoid a potential bug.