### PR TITLE
Drop custom Com_Memset and Com_Memcpy

### DIFF
--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -3715,7 +3715,7 @@ void CG_InitClasses()
 {
 	int i;
 
-	Com_Memset( cg_classes, 0, sizeof( cg_classes ) );
+	memset( cg_classes, 0, sizeof( cg_classes ) );
 
 	for ( i = PCL_NONE + 1; i < PCL_NUM_CLASSES; i++ )
 	{

--- a/src/cgame/cg_rocket_datasource.cpp
+++ b/src/cgame/cg_rocket_datasource.cpp
@@ -268,7 +268,7 @@ void CG_Rocket_BuildServerList( const char *args )
 			char info[ MAX_STRING_CHARS ];
 			int ping, bots, clients, maxClients;
 
-			Com_Memset( &data, 0, sizeof( data ) );
+			memset( &data, 0, sizeof( data ) );
 
 			if ( !trap_LAN_ServerIsVisible( netSrc, i ) )
 			{

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -206,7 +206,7 @@ void CG_InitUpgrades()
 {
 	int i;
 
-	Com_Memset( cg_upgrades, 0, sizeof( cg_upgrades ) );
+	memset( cg_upgrades, 0, sizeof( cg_upgrades ) );
 
 	for ( i = UP_NONE + 1; i < UP_NUM_UPGRADES; i++ )
 	{
@@ -1164,7 +1164,7 @@ void CG_InitWeapons()
 {
 	int i;
 
-	Com_Memset( cg_weapons, 0, sizeof( cg_weapons ) );
+	memset( cg_weapons, 0, sizeof( cg_weapons ) );
 
 	for ( i = WP_NONE + 1; i < WP_NUM_WEAPONS; i++ )
 	{

--- a/src/cgame/rocket/rocket.cpp
+++ b/src/cgame/rocket/rocket.cpp
@@ -174,7 +174,7 @@ public:
 		this->verts = createVertexArray( verticies, numVerticies );
 
 		this->indices = new int[ _numIndicies ];
-		Com_Memcpy( indices, _indices, _numIndicies * sizeof( int ) );
+		memcpy( indices, _indices, _numIndicies * sizeof( int ) );
 
 		this->shader = shader;
 	}

--- a/src/cgame/rocket/rocketDataFormatter.h
+++ b/src/cgame/rocket/rocketDataFormatter.h
@@ -53,7 +53,7 @@ public:
 
 	void FormatData( Rocket::Core::String &formatted_data, const Rocket::Core::StringList &raw_data )
 	{
-		Com_Memset( &data, 0, sizeof( data ) );
+		memset( &data, 0, sizeof( data ) );
 
 		for ( size_t i = 0; i < raw_data.size(); ++i )
 		{

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -1910,7 +1910,7 @@ void CheckIntermissionExit()
 	// see which players are ready
 	ready = 0;
 	notReady = 0;
-	Com_Memset( &readyMasks, 0, sizeof( readyMasks ) );
+	memset( &readyMasks, 0, sizeof( readyMasks ) );
 
 	for ( i = 0; i < level.maxclients; i++ )
 	{

--- a/src/sgame/sg_team.cpp
+++ b/src/sgame/sg_team.cpp
@@ -151,7 +151,7 @@ static clientList_t G_ClientListForTeam( team_t team )
 	int          i;
 	clientList_t clientList;
 
-	Com_Memset( &clientList, 0, sizeof( clientList_t ) );
+	memset( &clientList, 0, sizeof( clientList_t ) );
 
 	for ( i = 0; i < level.maxclients; i++ )
 	{
@@ -184,8 +184,8 @@ void G_UpdateTeamConfigStrings()
 	if ( level.intermissiontime )
 	{
 		// No restrictions once the game has ended
-		Com_Memset( &alienTeam, 0, sizeof( clientList_t ) );
-		Com_Memset( &humanTeam, 0, sizeof( clientList_t ) );
+		memset( &alienTeam, 0, sizeof( clientList_t ) );
+		memset( &humanTeam, 0, sizeof( clientList_t ) );
 	}
 
 	trap_SetConfigstringRestrictions( CS_VOTE_TIME + TEAM_ALIENS,   &humanTeam );

--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -138,7 +138,7 @@ void BG_InitBuildableAttributes()
 		ba = &bg_buildableList[i];
 
 		//Initialise default values for buildables
-		Com_Memset( ba, 0, sizeof( buildableAttributes_t ) );
+		memset( ba, 0, sizeof( buildableAttributes_t ) );
 
 		ba->number = bh->number;
 		ba->name = bh->name;
@@ -198,7 +198,7 @@ void BG_InitBuildableModelConfigs()
 	for ( i = BA_NONE + 1; i < BA_NUM_BUILDABLES; i++ )
 	{
 		bc = BG_BuildableModelConfig( i );
-		Com_Memset( bc, 0, sizeof( buildableModelConfig_t ) );
+		memset( bc, 0, sizeof( buildableModelConfig_t ) );
 
 		BG_ParseBuildableModelFile( va( "configs/buildables/%s.model.cfg",
 		                           BG_Buildable( i )->name ), bc );
@@ -651,7 +651,7 @@ void BG_InitWeaponAttributes()
 		wd = &bg_weaponsData[i];
 		wa = &bg_weapons[i];
 
-		Com_Memset( wa, 0, sizeof( weaponAttributes_t ) );
+		memset( wa, 0, sizeof( weaponAttributes_t ) );
 
 		wa->number = wd->number;
 		wa->name   = wd->name;
@@ -740,7 +740,7 @@ void BG_InitUpgradeAttributes()
 		ua = &bg_upgrades[i];
 
 		//Initialise default values for buildables
-		Com_Memset( ua, 0, sizeof( upgradeAttributes_t ) );
+		memset( ua, 0, sizeof( upgradeAttributes_t ) );
 
 		ua->number = ud->number;
 		ua->name = ud->name;
@@ -829,7 +829,7 @@ void BG_InitMissileAttributes()
 		md = &bg_missilesData[i];
 		ma = &bg_missiles[i];
 
-		Com_Memset( ma, 0, sizeof( missileAttributes_t ) );
+		memset( ma, 0, sizeof( missileAttributes_t ) );
 
 		ma->name   = md->name;
 		ma->number = md->number;
@@ -990,7 +990,7 @@ void BG_InitBeaconAttributes()
 		bd = bg_beaconsData + i;
 		ba = bg_beacons + i;
 
-		Com_Memset( ba, 0, sizeof( beaconAttributes_t ) );
+		memset( ba, 0, sizeof( beaconAttributes_t ) );
 
 		ba->number = bd->number;
 		ba->name = bd->name;

--- a/src/shared/parse.cpp
+++ b/src/shared/parse.cpp
@@ -339,7 +339,7 @@ static void Parse_CreatePunctuationTable( script_t *script, punctuation_t *punct
 		                           Z_Malloc( 256 * sizeof( punctuation_t * ) );
 	}
 
-	Com_Memset( script->punctuationtable, 0, 256 * sizeof( punctuation_t * ) );
+	memset( script->punctuationtable, 0, 256 * sizeof( punctuation_t * ) );
 
 	//add the punctuations in the list to the punctuation table
 	for ( i = 0; punctuations[ i ].p; i++ )
@@ -1041,7 +1041,7 @@ static int Parse_ReadPrimitive( script_t *script, token_t *token )
 	token->string[ len ] = 0;
 
 	//copy the token into the script structure
-	Com_Memcpy( &script->token, token, sizeof( token_t ) );
+	memcpy( &script->token, token, sizeof( token_t ) );
 
 	//primitive reading successful
 	return 1;
@@ -1059,7 +1059,7 @@ static int Parse_ReadScriptToken( script_t *script, token_t *token )
 	//save line counter
 	script->lastline = script->line;
 	//clear the token stuff
-	Com_Memset( token, 0, sizeof( token_t ) );
+	memset( token, 0, sizeof( token_t ) );
 	//start of the white space
 	script->whitespace_p = script->script_p;
 	token->whitespace_p = script->script_p;
@@ -1111,7 +1111,7 @@ static int Parse_ReadScriptToken( script_t *script, token_t *token )
 	}
 
 	//copy the token into the script structure
-	Com_Memcpy( &script->token, token, sizeof( token_t ) );
+	memcpy( &script->token, token, sizeof( token_t ) );
 	//successfully read a token
 	return 1;
 }
@@ -1169,10 +1169,10 @@ static script_t *Parse_LoadScriptFile( const char *filename )
 	if ( !fp ) { return nullptr; }
 
 	buffer = Z_Malloc( sizeof( script_t ) + length + 1 );
-	Com_Memset( buffer, 0, sizeof( script_t ) + length + 1 );
+	memset( buffer, 0, sizeof( script_t ) + length + 1 );
 
 	script = ( script_t * ) buffer;
-	Com_Memset( script, 0, sizeof( script_t ) );
+	memset( script, 0, sizeof( script_t ) );
 	Q_strncpyz( script->filename, filename, sizeof( script->filename ) );
 	script->buffer = ( char * ) buffer + sizeof( script_t );
 	script->buffer[ length ] = 0;
@@ -1207,10 +1207,10 @@ static script_t *Parse_LoadScriptMemory( const char *ptr, int length, const char
 	script_t *script;
 
 	buffer = Z_Malloc( sizeof( script_t ) + length + 1 );
-	Com_Memset( buffer, 0, sizeof( script_t ) + length + 1 );
+	memset( buffer, 0, sizeof( script_t ) + length + 1 );
 
 	script = ( script_t * ) buffer;
-	Com_Memset( script, 0, sizeof( script_t ) );
+	memset( script, 0, sizeof( script_t ) );
 	Q_strncpyz( script->filename, name, sizeof( script->filename ) );
 	script->buffer = ( char * ) buffer + sizeof( script_t );
 	script->buffer[ length ] = 0;
@@ -1227,7 +1227,7 @@ static script_t *Parse_LoadScriptMemory( const char *ptr, int length, const char
 	//
 	Parse_SetScriptPunctuations( script, nullptr );
 	//
-	Com_Memcpy( script->buffer, ptr, length );
+	memcpy( script->buffer, ptr, length );
 	//
 	return script;
 }
@@ -1362,7 +1362,7 @@ static token_t *Parse_CopyToken( const token_t *token )
 	}
 
 //  freetokens = freetokens->next;
-	Com_Memcpy( t, token, sizeof( token_t ) );
+	memcpy( t, token, sizeof( token_t ) );
 	t->next = nullptr;
 	numtokens++;
 	return t;
@@ -1440,7 +1440,7 @@ static int Parse_ReadSourceToken( source_t *source, token_t *token )
 	}
 
 	//copy the already available token
-	Com_Memcpy( token, source->tokens, sizeof( token_t ) );
+	memcpy( token, source->tokens, sizeof( token_t ) );
 	//free the read token
 	t = source->tokens;
 	source->tokens = source->tokens->next;
@@ -3881,7 +3881,7 @@ static bool Parse_ReadToken( source_t *source, token_t *token )
 		}
 
 		//copy token for unreading
-		Com_Memcpy( &source->token, token, sizeof( token_t ) );
+		memcpy( &source->token, token, sizeof( token_t ) );
 		//found a token
 		return true;
 	}
@@ -3902,11 +3902,11 @@ static define_t *Parse_DefineFromString( const char *string )
 
 	script = Parse_LoadScriptMemory( string, strlen( string ), "*extern" );
 	//create a new source
-	Com_Memset( &src, 0, sizeof( source_t ) );
+	memset( &src, 0, sizeof( source_t ) );
 	Q_strncpyz( src.filename, "*extern", MAX_QPATH );
 	src.scriptstack = script;
 	src.definehash = (define_t**) Z_Malloc( DEFINEHASHSIZE * sizeof( define_t * ) );
-	Com_Memset( src.definehash, 0, DEFINEHASHSIZE * sizeof( define_t * ) );
+	memset( src.definehash, 0, DEFINEHASHSIZE * sizeof( define_t * ) );
 	//create a define from the source
 	res = Parse_Directive_define( &src );
 
@@ -4088,7 +4088,7 @@ static source_t *Parse_LoadSourceFile( const char *filename )
 	script->next = nullptr;
 
 	source = ( source_t * ) Z_Malloc( sizeof( source_t ) );
-	Com_Memset( source, 0, sizeof( source_t ) );
+	memset( source, 0, sizeof( source_t ) );
 
 	Q_strncpyz( source->filename, filename, MAX_QPATH );
 	source->scriptstack = script;
@@ -4098,7 +4098,7 @@ static source_t *Parse_LoadSourceFile( const char *filename )
 	source->skip = 0;
 
 	source->definehash = (define_t**) Z_Malloc( DEFINEHASHSIZE * sizeof( define_t * ) );
-	Com_Memset( source->definehash, 0, DEFINEHASHSIZE * sizeof( define_t * ) );
+	memset( source->definehash, 0, DEFINEHASHSIZE * sizeof( define_t * ) );
 	Parse_AddGlobalDefinesToSource( source );
 	return source;
 }


### PR DESCRIPTION
They are only hiding compiler warnings, which makes debugging harder