### PR TITLE
Introduce a new way to iterate entities

### DIFF
--- a/src.cmake
+++ b/src.cmake
@@ -205,6 +205,8 @@ set(SGAMELIST
     ${GAMELOGIC_DIR}/sgame/sg_definitions.h
     ${GAMELOGIC_DIR}/sgame/sg_entities.cpp
     ${GAMELOGIC_DIR}/sgame/sg_entities.h
+    ${GAMELOGIC_DIR}/sgame/sg_entities_iterator.cpp
+    ${GAMELOGIC_DIR}/sgame/sg_entities_iterator.h
     ${GAMELOGIC_DIR}/sgame/sg_extern.h
     ${GAMELOGIC_DIR}/sgame/sg_local.h
     ${GAMELOGIC_DIR}/sgame/sg_main.cpp

--- a/src/sgame/Beacon.cpp
+++ b/src/sgame/Beacon.cpp
@@ -26,6 +26,7 @@ along with Daemon.  If not, see <http://www.gnu.org/licenses/>.
 // handle the server-side beacon-related stuff
 
 #include "sg_local.h"
+#include "sg_entities_iterator.h"
 #include "Entities.h"
 
 // entityState_t   | cbeacon_t    | description
@@ -603,8 +604,8 @@ namespace Beacon //this should eventually become a class
 	gentity_t *TagTrace( const vec3_t begin, const vec3_t end, int skip, int mask, team_t team, bool refreshTagged )
 	{
 		tagtrace_ent_t list[ MAX_GENTITIES ];
-		int i, count = 0;
-		gentity_t *ent, *reticleEnt = nullptr;
+		int count = 0;
+		gentity_t *reticleEnt = nullptr;
 		vec3_t seg, delta;
 		float dot;
 
@@ -622,17 +623,12 @@ namespace Beacon //this should eventually become a class
 			}
 		}
 
-		for( i = 0; i < level.num_entities; i++ )
+		for( gentity_t *ent : iterate_entities )
 		{
-			ent = g_entities + i;
-
 			if( ent == reticleEnt )
 				continue;
 
-			if( !ent->inuse )
-				continue;
-
-			if( !EntityTaggable( i, team, true ) )
+			if( !EntityTaggable( ent - g_entities, team, true ) )
 				continue;
 
 			VectorSubtract( ent->r.currentOrigin, begin, delta );
@@ -648,7 +644,7 @@ namespace Beacon //this should eventually become a class
 			{
 				trace_t tr;
 				trap_Trace( &tr, begin, nullptr, nullptr, ent->r.currentOrigin, skip, mask, 0 );
-				if( tr.entityNum != i )
+				if( &g_entities[tr.entityNum] != ent )
 					continue;
 			}
 

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "sg_bot_parse.h"
 #include "sg_bot_util.h"
+#include "sg_entities_iterator.h"
 #include "Entities.h"
 
 static botMemory_t g_botMind[MAX_CLIENTS];
@@ -360,12 +361,9 @@ void G_BotDel( int clientNum )
 
 void G_BotDelAllBots()
 {
-	for ( int i = 0; i < MAX_CLIENTS; i++ )
+	for ( gentity_t *bot : iterate_bot_entities )
 	{
-		if ( g_entities[i].r.svFlags & SVF_BOT && level.clients[i].pers.connected != CON_DISCONNECTED )
-		{
-			G_BotDel( i );
-		}
+		G_BotDel( bot - g_entities );
 	}
 
 	for ( auto &teamsBotNames : botNames )
@@ -565,12 +563,9 @@ bool G_BotInit()
 
 void G_BotCleanup()
 {
-	for ( int i = 0; i < MAX_CLIENTS; ++i )
+	for ( gentity_t *bot : iterate_bot_entities )
 	{
-		if ( g_entities[i].r.svFlags & SVF_BOT && level.clients[i].pers.connected != CON_DISCONNECTED )
-		{
-			G_BotDel( i );
-		}
+		G_BotDel( bot - g_entities );
 	}
 
 	G_BotClearNames();

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -839,12 +839,11 @@ gentity_t* BotFindBestEnemy( gentity_t *self )
 	float bestInvisibleEnemyScore = 0.0f;
 	gentity_t *bestVisibleEnemy = nullptr;
 	gentity_t *bestInvisibleEnemy = nullptr;
-	gentity_t *target;
 	team_t    team = G_Team( self );
 	bool  hasRadar = ( team == TEAM_ALIENS ) ||
 	                     ( team == TEAM_HUMANS && BG_InventoryContainsUpgrade( UP_RADAR, self->client->ps.stats ) );
 
-	for ( target = g_entities; target < &g_entities[level.num_entities - 1]; target++ )
+	for ( gentity_t *target : iterate_entities )
 	{
 		float newScore;
 
@@ -898,16 +897,10 @@ gentity_t* BotFindClosestEnemy( gentity_t *self )
 {
 	gentity_t* closestEnemy = nullptr;
 	float minDistance = Square( ALIENSENSE_RANGE );
-	gentity_t *target;
 
-	for ( target = g_entities; target < &g_entities[level.num_entities - 1]; target++ )
+	for ( gentity_t *target : iterate_entities )
 	{
 		float newDistance;
-		//ignore entities that arnt in use
-		if ( !target->inuse )
-		{
-			continue;
-		}
 
 		if ( !BotEntityIsValidEnemyTarget( self, target ) )
 		{

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -681,17 +681,10 @@ gentity_t* BotFindBuilding( gentity_t *self, int buildingType, int range )
 	gentity_t* closestBuilding = nullptr;
 	float newDistance;
 	float rangeSquared = Square( range );
-	gentity_t *target = &g_entities[MAX_CLIENTS];
-	int i;
 
-	for ( i = MAX_CLIENTS; i < level.num_entities; i++, target++ )
+	for ( gentity_t *target : iterate_buildable_entities )
 	{
-		if ( !target->inuse )
-		{
-			continue;
-		}
-		if ( target->s.eType == entityType_t::ET_BUILDABLE &&
-		     target->s.modelindex == buildingType &&
+		if ( target->s.modelindex == buildingType &&
 		     target->powered && target->spawned &&
 		     Entities::IsAlive( target ) )
 		{
@@ -765,26 +758,13 @@ void BotFindDamagedFriendlyStructure( gentity_t *self )
 {
 	float minDistSqr;
 
-	gentity_t *target;
 	self->botMind->closestDamagedBuilding.ent = nullptr;
 	self->botMind->closestDamagedBuilding.distance = std::numeric_limits<float>::max();
 
 	minDistSqr = Square( self->botMind->closestDamagedBuilding.distance );
 
-	for ( target = &g_entities[MAX_CLIENTS]; target < &g_entities[level.num_entities]; target++ )
+	for ( gentity_t *target : iterate_buildable_entities )
 	{
-		float distSqr;
-
-		if ( !target->inuse )
-		{
-			continue;
-		}
-
-		if ( target->s.eType != entityType_t::ET_BUILDABLE )
-		{
-			continue;
-		}
-
 		if ( target->buildableTeam != self->client->pers.team )
 		{
 			continue;
@@ -805,7 +785,7 @@ void BotFindDamagedFriendlyStructure( gentity_t *self )
 			continue;
 		}
 
-		distSqr = DistanceSquared( self->s.origin, target->s.origin );
+		float distSqr = DistanceSquared( self->s.origin, target->s.origin );
 		if ( distSqr < minDistSqr )
 		{
 			self->botMind->closestDamagedBuilding.ent = target;

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "sg_bot_ai.h"
 #include "sg_bot_util.h"
 #include "botlib/bot_api.h"
+#include "sg_entities_iterator.h"
 #include "CBSE.h"
 #include "shared/bg_local.h" // MIN_WALK_NORMAL
 #include "Entities.h"
@@ -1530,26 +1531,6 @@ Bot Team Querys
 ========================
 */
 
-int FindBots( int *botEntityNumbers, int maxBots, team_t team )
-{
-	gentity_t *testEntity;
-	int numBots = 0;
-	int i;
-	memset( botEntityNumbers, 0, sizeof( int )*maxBots );
-	for ( i = 0; i < MAX_CLIENTS; i++ )
-	{
-		testEntity = &g_entities[i];
-		if ( testEntity->r.svFlags & SVF_BOT )
-		{
-			if ( testEntity->client->pers.team == team && numBots < maxBots )
-			{
-				botEntityNumbers[numBots++] = i;
-			}
-		}
-	}
-	return numBots;
-}
-
 bool PlayersBehindBotInSpawnQueue( gentity_t *self )
 {
 	//this function only checks if there are Humans in the SpawnQueue
@@ -1648,21 +1629,17 @@ static void ListTeamEquipment( gentity_t *self, unsigned int (&numUpgrades)[UP_N
 
 bool BotTeamateHasWeapon( gentity_t *self, int weapon )
 {
-	int botNumbers[MAX_CLIENTS];
-	int i;
-	int numBots = FindBots( botNumbers, MAX_CLIENTS, ( team_t ) self->client->pers.team );
-
-	for ( i = 0; i < numBots; i++ )
+	for ( const gentity_t *bot : iterate_bot_entities )
 	{
-		gentity_t *bot = &g_entities[botNumbers[i]];
 		if ( bot == self )
-		{
 			continue;
-		}
-		if ( BG_InventoryContainsWeapon( weapon, bot->client->ps.stats ) )
-		{
+
+		if ( !G_OnSameTeam( self, bot ) )
+			continue;
+
+		if ( BG_InventoryContainsWeapon( weapon,
+				bot->client->ps.stats ) )
 			return true;
-		}
 	}
 	return false;
 }

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -705,9 +705,6 @@ gentity_t* BotFindBuilding( gentity_t *self, int buildingType, int range )
 
 void BotFindClosestBuildings( gentity_t *self )
 {
-	gentity_t *testEnt;
-	botEntityAndDistance_t *ent;
-
 	// clear out building list
 	for ( unsigned i = 0; i < ARRAY_LEN( self->botMind->closestBuildings ); i++ )
 	{
@@ -715,21 +712,8 @@ void BotFindClosestBuildings( gentity_t *self )
 		self->botMind->closestBuildings[ i ].distance = std::numeric_limits<float>::max();
 	}
 
-	for ( testEnt = &g_entities[MAX_CLIENTS]; testEnt < &g_entities[level.num_entities - 1]; testEnt++ )
+	for ( gentity_t *testEnt : iterate_buildable_entities )
 	{
-		float newDist;
-		// ignore entities that aren't in use
-		if ( !testEnt->inuse )
-		{
-			continue;
-		}
-
-		// skip non buildings
-		if ( testEnt->s.eType != entityType_t::ET_BUILDABLE )
-		{
-			continue;
-		}
-
 		// ignore dead targets
 		if ( Entities::IsDead( testEnt ) )
 		{
@@ -742,9 +726,9 @@ void BotFindClosestBuildings( gentity_t *self )
 			continue;
 		}
 
-		newDist = Distance( self->s.origin, testEnt->s.origin );
+		float newDist = Distance( self->s.origin, testEnt->s.origin );
 
-		ent = &self->botMind->closestBuildings[ testEnt->s.modelindex ];
+		botEntityAndDistance_t *ent = &self->botMind->closestBuildings[ testEnt->s.modelindex ];
 
 		if ( newDist < ent->distance )
 		{

--- a/src/sgame/sg_bot_util.h
+++ b/src/sgame/sg_bot_util.h
@@ -39,7 +39,6 @@ void BotCalculateStuckTime( gentity_t *self );
 void BotResetStuckTime( gentity_t *self );
 
 // entity queries
-int        FindBots( int *botEntityNumbers, int maxBots, team_t team );
 gentity_t* BotFindClosestEnemy( gentity_t *self );
 gentity_t* BotFindBestEnemy( gentity_t *self );
 void       BotFindClosestBuildings( gentity_t *self );

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "common/FileSystem.h"
 #include "sg_local.h"
+#include "sg_entities_iterator.h"
 #include "CustomSurfaceFlags.h"
 #include "Entities.h"
 #include "CBSE.h"
@@ -1314,8 +1315,8 @@ static itemBuildError_t BuildableReplacementChecks( buildable_t oldBuildable, bu
  */
 static itemBuildError_t PrepareBuildableReplacement( buildable_t buildable, vec3_t origin )
 {
-	int              entNum, listLen;
-	gentity_t        *ent, *list[ MAX_GENTITIES ];
+	int listLen;
+	gentity_t *list[ MAX_GENTITIES ];
 	const buildableAttributes_t *attr;
 
 	// resource related
@@ -1331,7 +1332,7 @@ static itemBuildError_t PrepareBuildableReplacement( buildable_t buildable, vec3
 
 	if ( buildable == BA_H_REACTOR )
 	{
-		ent = G_Reactor();
+		gentity_t *ent = G_Reactor();
 
 		if ( ent )
 		{
@@ -1347,7 +1348,7 @@ static itemBuildError_t PrepareBuildableReplacement( buildable_t buildable, vec3
 	}
 	else if ( buildable == BA_A_OVERMIND )
 	{
-		ent = G_Overmind();
+		gentity_t *ent = G_Overmind();
 
 		if ( ent )
 		{
@@ -1412,9 +1413,9 @@ static itemBuildError_t PrepareBuildableReplacement( buildable_t buildable, vec3
 	}
 
 	// if we already have set buildables for removal, decrease cost
-	for ( entNum = 0; entNum < level.numBuildablesForRemoval; entNum++ )
+	for ( int i = 0; i < level.numBuildablesForRemoval; i++ )
 	{
-		cost -= G_BuildableDeconValue( level.markedBuildables[ entNum ] );
+		cost -= G_BuildableDeconValue( level.markedBuildables[ i ] );
 	}
 
 	// check if we can already afford the new buildable
@@ -1426,12 +1427,10 @@ static itemBuildError_t PrepareBuildableReplacement( buildable_t buildable, vec3
 	// build a list of additional buildables that can be deconstructed
 	listLen = 0;
 
-	for ( entNum = MAX_CLIENTS; entNum < level.num_entities; entNum++ )
+	for ( gentity_t *ent : iterate_buildable_entities )
 	{
-		ent = &g_entities[ entNum ];
-
 		// check if buildable of own team
-		if ( ent->s.eType != entityType_t::ET_BUILDABLE || ent->buildableTeam != attr->team )
+		if ( ent->buildableTeam != attr->team )
 		{
 			continue;
 		}
@@ -1462,9 +1461,9 @@ static itemBuildError_t PrepareBuildableReplacement( buildable_t buildable, vec3
 	qsort( list, listLen, sizeof( gentity_t* ), CompareBuildablesForRemoval );
 
 	// set buildables for deconstruction until we can pay for the new buildable
-	for ( entNum = 0; entNum < listLen; entNum++ )
+	for ( int i = 0; i < listLen; i++ )
 	{
-		ent = list[ entNum ];
+		gentity_t *ent = list[ i ];
 
 		level.markedBuildables[ level.numBuildablesForRemoval++ ] = ent;
 
@@ -1496,16 +1495,8 @@ static itemBuildError_t PrepareBuildableReplacement( buildable_t buildable, vec3
 
 static void SetBuildableLinkState( bool link )
 {
-	int       i;
-	gentity_t *ent;
-
-	for ( i = MAX_CLIENTS, ent = g_entities + i; i < level.num_entities; i++, ent++ )
+	for ( gentity_t *ent : iterate_buildable_entities )
 	{
-		if ( ent->s.eType != entityType_t::ET_BUILDABLE )
-		{
-			continue;
-		}
-
 		if ( link )
 		{
 			trap_LinkEntity( ent );
@@ -1519,12 +1510,9 @@ static void SetBuildableLinkState( bool link )
 
 static void SetBuildableMarkedLinkState( bool link )
 {
-	int       i;
-	gentity_t *ent;
-
-	for ( i = 0; i < level.numBuildablesForRemoval; i++ )
+	for ( int i = 0; i < level.numBuildablesForRemoval; i++ )
 	{
-		ent = level.markedBuildables[ i ];
+		gentity_t *ent = level.markedBuildables[ i ];
 
 		if ( link )
 		{
@@ -2236,9 +2224,6 @@ void G_LayoutSave( const char *name )
 	char         map[ MAX_QPATH ];
 	char         fileName[ MAX_OSPATH ];
 	fileHandle_t f;
-	int          len;
-	int          i;
-	gentity_t    *ent;
 	char         *s;
 
 	trap_Cvar_VariableStringBuffer( "mapname", map, sizeof( map ) );
@@ -2251,7 +2236,7 @@ void G_LayoutSave( const char *name )
 
 	Com_sprintf( fileName, sizeof( fileName ), "layouts/%s/%s.dat", map, name );
 
-	len = trap_FS_FOpenFile( fileName, &f, fsMode_t::FS_WRITE );
+	int len = trap_FS_FOpenFile( fileName, &f, fsMode_t::FS_WRITE );
 
 	if ( len < 0 )
 	{
@@ -2261,15 +2246,8 @@ void G_LayoutSave( const char *name )
 
 	Log::Notice( "layoutsave: saving layout to %s", fileName );
 
-	for ( i = MAX_CLIENTS; i < level.num_entities; i++ )
+	for ( const gentity_t *ent : iterate_buildable_entities )
 	{
-		ent = &level.gentities[ i ];
-
-		if ( ent->s.eType != entityType_t::ET_BUILDABLE )
-		{
-			continue;
-		}
-
 		s = va( "%s %f %f %f %f %f %f %f %f %f %f %f %f\n",
 		        BG_Buildable( ent->s.modelindex )->name,
 		        ent->s.pos.trBase[ 0 ],
@@ -2532,18 +2510,8 @@ void G_LayoutLoad()
 
 void G_BaseSelfDestruct( team_t team )
 {
-	int       i;
-	gentity_t *ent;
-
-	for ( i = MAX_CLIENTS; i < level.num_entities; i++ )
+	for ( gentity_t *ent : iterate_buildable_entities )
 	{
-		ent = &level.gentities[ i ];
-
-		if ( ent->s.eType != entityType_t::ET_BUILDABLE )
-		{
-			continue;
-		}
-
 		if ( ent->buildableTeam != team )
 		{
 			continue;
@@ -2650,10 +2618,7 @@ static void G_BuildLogRevertThink( gentity_t *ent )
 
 void G_BuildLogRevert( int id )
 {
-	buildLog_t *log;
-	gentity_t  *ent;
 	vec3_t     dist;
-	gentity_t  *buildable;
 	float      momentumChange[ NUM_TEAMS ] = { 0 };
 
 	level.numBuildablesForRemoval = 0;
@@ -2662,15 +2627,13 @@ void G_BuildLogRevert( int id )
 
 	while ( level.buildId > id )
 	{
-		log = &level.buildLog[ --level.buildId % MAX_BUILDLOG ];
+		buildLog_t *log = &level.buildLog[ --level.buildId % MAX_BUILDLOG ];
 
 		switch ( log->fate )
 		{
 		case BF_CONSTRUCT:
-			for ( int entityNum = MAX_CLIENTS; entityNum < level.num_entities; entityNum++ )
+			for ( gentity_t *ent : iterate_non_client_entities )
 			{
-				ent = &g_entities[ entityNum ];
-
 				if ( ( ( ent->s.eType == entityType_t::ET_BUILDABLE && Entities::IsAlive( ent ) ) ||
 					   ( ent->s.eType == entityType_t::ET_GENERAL && ent->think == G_BuildLogRevertThink ) ) &&
 					 ent->s.modelindex == log->modelindex )
@@ -2706,11 +2669,11 @@ void G_BuildLogRevert( int id )
 
 				// Fall through to default
 				DAEMON_FALLTHROUGH;
-
 		default:
+		{
 			// Spawn buildable
 			// HACK: Uses legacy pseudo entity. TODO: CBSE-ify.
-			buildable = G_NewEntity();
+			gentity_t *buildable = G_NewEntity();
 			VectorCopy( log->origin, buildable->s.pos.trBase );
 			VectorCopy( log->angles, buildable->s.angles );
 			VectorCopy( log->origin2, buildable->s.origin2 );
@@ -2722,6 +2685,7 @@ void G_BuildLogRevert( int id )
 			buildable->think = G_BuildLogRevertThink;
 			buildable->nextthink = level.time + FRAMETIME;
 			buildable->suicideTime = 30; // number of thinks before killing players in the way
+		}
 		}
 	}
 

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 #include "sg_local.h"
+#include "sg_entities_iterator.h"
 #include "engine/qcommon/q_unicode.h"
 #include "botlib/bot_api.h"
 #include <common/FileSystem.h>
@@ -1641,7 +1642,6 @@ static void Cmd_CallVote_f( gentity_t *ent )
 	int    id = -1;
 	int    voteId;
 	team_t team;
-	int    i;
 
 	trap_Argv( 0, cmd, sizeof( cmd ) );
 	team = (team_t) ( ( !Q_stricmp( cmd, "callteamvote" ) ) ? ent->client->pers.team : TEAM_NONE );
@@ -1880,16 +1880,17 @@ static void Cmd_CallVote_f( gentity_t *ent )
 		break;
 
 	case VOTE_BOT_KICK:
-		for ( i = 0; i < MAX_CLIENTS; ++i )
+	{
+		bool bot_playing = false;
+		for ( const gentity_t *bot : iterate_bot_entities )
 		{
-			if ( g_entities[i].r.svFlags & SVF_BOT &&
-			     g_entities[i].client->pers.team != TEAM_NONE )
+			if ( G_Team(bot) != TEAM_NONE )
 			{
-				break;
+				bot_playing = true;
 			}
 		}
 
-		if ( i == MAX_CLIENTS )
+		if ( !bot_playing )
 		{
 			trap_SendServerCommand( ent - g_entities,
 			                        va( "print_tr %s %s", QQ( N_("$1$: there are no active bots") ), cmd ) );
@@ -1900,6 +1901,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 		Com_sprintf( level.team[ team ].voteDisplayString, sizeof( level.team[ team ].voteDisplayString ), N_("Remove all bots") );
 
 		break;
+	}
 
 	case VOTE_BOT_FILL:
 		{

--- a/src/sgame/sg_entities_iterator.cpp
+++ b/src/sgame/sg_entities_iterator.cpp
@@ -1,0 +1,8 @@
+#include "sg_entities_iterator.h"
+
+// generic
+
+static bool entity_in_use(const gentity_t *ent) {
+	return ent->inuse;
+}
+const entity_iterator iterate_entities(entity_in_use);

--- a/src/sgame/sg_entities_iterator.cpp
+++ b/src/sgame/sg_entities_iterator.cpp
@@ -6,3 +6,13 @@ static bool entity_in_use(const gentity_t *ent) {
 	return ent->inuse;
 }
 const entity_iterator iterate_entities(entity_in_use);
+
+
+// clients
+
+static bool entity_is_bot(const gentity_t *ent) {
+	return ent->inuse && (ent->r.svFlags & SVF_BOT);
+}
+
+const client_entity_iterator iterate_client_entities(entity_in_use);
+const client_entity_iterator iterate_bot_entities(entity_is_bot);

--- a/src/sgame/sg_entities_iterator.cpp
+++ b/src/sgame/sg_entities_iterator.cpp
@@ -16,3 +16,13 @@ static bool entity_is_bot(const gentity_t *ent) {
 
 const client_entity_iterator iterate_client_entities(entity_in_use);
 const client_entity_iterator iterate_bot_entities(entity_is_bot);
+
+
+// non-clients
+
+static bool entity_is_buildable(const gentity_t *ent) {
+	return ent->inuse && ent->s.eType == entityType_t::ET_BUILDABLE;
+}
+
+const non_client_entity_iterator iterate_non_client_entities(entity_in_use);
+const non_client_entity_iterator iterate_buildable_entities(entity_is_buildable);

--- a/src/sgame/sg_entities_iterator.h
+++ b/src/sgame/sg_entities_iterator.h
@@ -160,4 +160,26 @@ public:
 extern const entity_iterator iterate_entities;
 
 
+struct client_entity_iterator {
+private:
+	EntityIterator::predicate_t predicate;
+
+public:
+	client_entity_iterator(EntityIterator::predicate_t predicate_)
+		: predicate(predicate_) {}
+
+	EntityIterator begin() const {
+		return ++EntityIterator(-1, predicate, 0, level.maxclients);
+	}
+	EntityIterator end() const {
+		return EntityIterator(level.maxclients, predicate, 0, level.maxclients);
+	}
+};
+
+// iterate over the entity of each connected client
+extern const client_entity_iterator iterate_client_entities;
+
+// iterate over the entity of each bot
+extern const client_entity_iterator iterate_bot_entities;
+
 #endif /* SG_ENTITIES_ITERATOR_H_ */

--- a/src/sgame/sg_entities_iterator.h
+++ b/src/sgame/sg_entities_iterator.h
@@ -182,4 +182,29 @@ extern const client_entity_iterator iterate_client_entities;
 // iterate over the entity of each bot
 extern const client_entity_iterator iterate_bot_entities;
 
+
+struct non_client_entity_iterator {
+private:
+	EntityIterator::predicate_t predicate;
+
+public:
+	non_client_entity_iterator(EntityIterator::predicate_t predicate_)
+		: predicate(predicate_) {}
+
+	EntityIterator begin() const {
+		return ++EntityIterator(MAX_CLIENTS-1, predicate, MAX_CLIENTS, level.num_entities);
+	}
+	EntityIterator end() const {
+		return EntityIterator(level.num_entities, predicate, MAX_CLIENTS, level.num_entities);
+	}
+};
+
+
+// iterate over the entity of each non-client entity
+extern const non_client_entity_iterator iterate_non_client_entities;
+
+// iterate over the entity of each buildable
+extern const non_client_entity_iterator iterate_buildable_entities;
+
+
 #endif /* SG_ENTITIES_ITERATOR_H_ */

--- a/src/sgame/sg_entities_iterator.h
+++ b/src/sgame/sg_entities_iterator.h
@@ -1,0 +1,163 @@
+/*
+===========================================================================
+
+Unvanquished GPL Source Code
+Copyright (C) 2021 Unvanquished Developers
+
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
+
+Unvanquished Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Unvanquished Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+
+#ifndef SG_ENTITIES_ITERATOR_H_
+#define SG_ENTITIES_ITERATOR_H_
+
+#include "sg_local.h"
+
+//==================================================================
+
+/*
+ * An iterator type that allows checking for a condition on every element
+ *
+ * (Note this will stop at ENTITYNUM_MAX_NORMAL, so you technically
+ * can iterate on every entity, except ENTITYNUM_WORLD. But if you want to do
+ * something with it, you probably should special-case it in all case.)
+ */
+class EntityIterator
+{
+public:
+	using predicate_t = bool (*)(const gentity_t *);
+private:
+	int index;
+	predicate_t predicate;
+	int min;
+	int max;
+public:
+	using value_type        = gentity_t*; // see remark on operator*()
+	using difference_type   = std::ptrdiff_t;
+	using pointer           = gentity_t*;
+	using reference         = gentity_t&;
+	using iterator_category = std::bidirectional_iterator_tag;
+
+	// Note that dereferencing this may provide an incorrect result.
+	// It is present only because you need this function to provide
+	// a forward or bidirectional iterator.
+	EntityIterator() : index(0), predicate(nullptr), min(0), max(0) {}
+
+	EntityIterator(const EntityIterator &other)
+		: index(other.index), predicate(other.predicate),
+		  min(other.min), max(other.max) {}
+
+	// Note that this assumes a correct index, or that the calling code
+	// uses "++" or "--" on the operator afterwards to reach an index
+	// that satisfies the predicate
+	EntityIterator(int index_, predicate_t predicate_, int min_, int max_)
+		: index(index_), predicate(predicate_), min(min_), max(max_) {}
+
+	EntityIterator& operator=(const EntityIterator &other) {
+		index = other.index;
+		predicate = other.predicate;
+		min = other.min;
+		max = other.max;
+		return *this;
+	}
+
+	// this really should be gentity_t& operator*(), but this is
+	// just so practical. CHECKME: is this fine?
+	gentity_t* operator*() const { return &g_entities[index]; }
+
+	// automatic casting to gentity_t* for convenience
+	operator gentity_t*() const { return &g_entities[index]; }
+
+	// the rest of the things needed to make a bidirectional iterator
+	bool operator==(const EntityIterator& other) const {
+		return index == other.index;
+	}
+	bool operator!=(const EntityIterator& other) const {
+		return index != other.index;
+	}
+	EntityIterator operator++(int) {
+		EntityIterator saved_copy(*this);
+		++*this;
+		return saved_copy;
+	}
+	EntityIterator& operator++() {
+		while (++index < max)
+		{
+			if (!predicate || (*predicate)(&g_entities[index]))
+			{
+				break;
+			}
+		}
+		return *this;
+	}
+	EntityIterator operator--(int) {
+		EntityIterator saved_copy(*this);
+		--*this;
+		return saved_copy;
+	}
+	EntityIterator& operator--() {
+		while (--index >= min)
+		{
+			if (!predicate || (*predicate)(&g_entities[index]))
+			{
+				break;
+			}
+		}
+		return *this;
+	}
+	void swap(EntityIterator &other) {
+		std::swap(other.predicate, predicate);
+		std::swap(other.index, index);
+	}
+};
+
+
+/*
+ * Practical classes for iterating over using C++11 loops
+ */
+
+struct entity_iterator {
+private:
+	EntityIterator::predicate_t predicate;
+
+public:
+	entity_iterator(EntityIterator::predicate_t predicate_)
+		: predicate(predicate_) {}
+
+	EntityIterator begin() const {
+		return ++EntityIterator(-1, predicate, 0, level.maxclients);
+	}
+	EntityIterator end() const {
+		return EntityIterator(level.maxclients, predicate, 0, level.maxclients);
+	}
+};
+
+// iterate over each entity that is in use
+extern const entity_iterator iterate_entities;
+
+
+#endif /* SG_ENTITIES_ITERATOR_H_ */

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "sg_local.h"
 #include "shared/parse.h"
+#include "sg_entities_iterator.h"
 #include "Entities.h"
 #include "CBSE.h"
 #include "backend/CBSEBackend.h"
@@ -1547,33 +1548,15 @@ Calculates the average amount of spare credits as well as the value of each team
 */
 static void GetAverageCredits( int teamCredits[], int teamValue[] )
 {
-	int       teamCnt[ NUM_TEAMS ];
-	int       playerNum;
-	gentity_t *playerEnt;
-	gclient_t *client;
+	int       teamCnt[ NUM_TEAMS ] = {};
 	int       team;
 
-	for ( team = TEAM_ALIENS ; team < NUM_TEAMS ; ++team)
+	for ( gentity_t *player : iterate_client_entities )
 	{
-		teamCnt[ team ] = 0;
-		teamCredits[ team ] = 0;
-		teamValue[ team ] = 0;
-	}
+		team = G_Team( player );
 
-	for ( playerNum = 0; playerNum < MAX_CLIENTS; playerNum++ )
-	{
-		playerEnt = &g_entities[ playerNum ];
-		client = playerEnt->client;
-
-		if ( !client )
-		{
-			continue;
-		}
-
-		team = client->pers.team;
-
-		teamCredits[ team ] += client->pers.credit;
-		teamValue[ team ] += BG_GetPlayerValue( client->ps );
+		teamCredits[ team ] += player->client->pers.credit;
+		teamValue[ team ] += BG_GetPlayerValue( player->client->ps );
 		teamCnt[ team ]++;
 	}
 
@@ -2307,7 +2290,6 @@ Advances the non-player objects in the world
 void G_RunFrame( int levelTime )
 {
 	int        i;
-	gentity_t  *ent;
 	int        msec;
 	static int ptime3000 = 0;
 
@@ -2385,7 +2367,7 @@ void G_RunFrame( int levelTime )
 	G_CheckPmoveParamChanges();
 
 	// go through all allocated objects
-	ent = &g_entities[ 0 ];
+	gentity_t *ent = &g_entities[ 0 ];
 	for ( i = 0; i < level.num_entities; i++, ent++ )
 	{
 		if ( !ent->inuse ) continue;
@@ -2479,14 +2461,9 @@ void G_RunFrame( int levelTime )
 	});
 
 	// perform final fixups on the players
-	ent = &g_entities[ 0 ];
-
-	for ( i = 0; i < level.maxclients; i++, ent++ )
+	for ( gentity_t *ent : iterate_client_entities )
 	{
-		if ( ent->inuse )
-		{
-			ClientEndFrame( ent );
-		}
+		ClientEndFrame( ent );
 	}
 
 	// save position information for all active clients

--- a/src/sgame/sg_spawn_fx.cpp
+++ b/src/sgame/sg_spawn_fx.cpp
@@ -34,6 +34,7 @@ Maryland 20850 USA.
 
 #include "sg_local.h"
 #include "sg_spawn.h"
+#include "sg_entities_iterator.h"
 
 /*
 =================================================================================
@@ -127,26 +128,13 @@ env_rumble
 */
 static void fx_rumble_think( gentity_t *self )
 {
-	int       i;
-	gentity_t *ent;
-
 	if ( self->last_move_time < level.time )
 	{
 		self->last_move_time = level.time + 0.5;
 	}
 
-	for ( i = 0, ent = g_entities + i; i < level.num_entities; i++, ent++ )
+	for ( gentity_t *ent : iterate_client_entities )
 	{
-		if ( !ent->inuse )
-		{
-			continue;
-		}
-
-		if ( !ent->client )
-		{
-			continue;
-		}
-
 		if ( ent->client->ps.groundEntityNum == ENTITYNUM_NONE )
 		{
 			continue;

--- a/src/sgame/sg_svcmds.cpp
+++ b/src/sgame/sg_svcmds.cpp
@@ -35,6 +35,7 @@ Maryland 20850 USA.
 // this file holds commands that can be executed by the server console, but not remote clients
 
 #include "sg_local.h"
+#include "sg_entities_iterator.h"
 
 #define IS_NON_NULL_VEC3(vec3tor) (vec3tor[0] || vec3tor[1] || vec3tor[2])
 
@@ -89,7 +90,7 @@ static void Svcmd_EntityFire_f()
 }
 
 
-static inline void PrintEntityOverviewLine( gentity_t *entity )
+static inline void PrintEntityOverviewLine( const gentity_t *entity )
 {
 	Log::Notice( "%3i: %15s/^5%-24s^*%s%s",
 			entity->s.number, Com_EntityTypeName( entity->s.eType ), entity->classname,
@@ -210,13 +211,9 @@ Svcmd_EntityList_f
 
 static void  Svcmd_EntityList_f()
 {
-	int       entityNum;
 	int i;
-	int currentEntityCount;
-	gentity_t *displayedEntity;
+	int currentEntityCount = 0;
 	char* filter;
-
-	displayedEntity = g_entities;
 
 	if(trap_Argc() > 1)
 	{
@@ -227,27 +224,23 @@ static void  Svcmd_EntityList_f()
 		filter = nullptr;
 	}
 
-	for ( entityNum = 0, currentEntityCount = 0; entityNum < level.num_entities; entityNum++, displayedEntity++ )
+	for ( const gentity_t *ent : iterate_entities )
 	{
-		if ( !displayedEntity->inuse )
-		{
-			continue;
-		}
 		currentEntityCount++;
 
-		if(filter && !Com_Filter(filter, displayedEntity->classname, false) )
+		if(filter && !Com_Filter(filter, ent->classname, false) )
 		{
-			for (i = 0; i < MAX_ENTITY_ALIASES && displayedEntity->names[i]; ++i)
+			for (i = 0; i < MAX_ENTITY_ALIASES && ent->names[i]; ++i)
 			{
-				if( Com_Filter(filter, displayedEntity->names[i], false) )
+				if( Com_Filter(filter, ent->names[i], false) )
 				{
-					PrintEntityOverviewLine( displayedEntity );
+					PrintEntityOverviewLine( ent );
 					break;
 				}
 			}
 			continue;
 		}
-		PrintEntityOverviewLine( displayedEntity );
+		PrintEntityOverviewLine( ent );
 	}
 
 	Log::Notice( "A total of %i entities are currently in use.", currentEntityCount);

--- a/src/sgame/sg_team.cpp
+++ b/src/sgame/sg_team.cpp
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 #include "sg_local.h"
+#include "sg_entities_iterator.h"
 #include "Entities.h"
 
 /*
@@ -208,8 +209,6 @@ G_LeaveTeam
 void G_LeaveTeam( gentity_t *self )
 {
 	team_t    team = (team_t) self->client->pers.team;
-	gentity_t *ent;
-	int       i;
 
 	if ( G_IsPlayableTeam( team ) )
 	{
@@ -231,15 +230,8 @@ void G_LeaveTeam( gentity_t *self )
 	G_Vote( self, team, false );
 	self->suicideTime = 0;
 
-	for ( i = 0; i < level.num_entities; i++ )
+	for ( gentity_t *ent : iterate_entities )
 	{
-		ent = &g_entities[ i ];
-
-		if ( !ent->inuse )
-		{
-			continue;
-		}
-
 		if ( ent->client && ent->client->pers.connected == CON_CONNECTED )
 		{
 			// cure poison

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // perform the server side effects of a weapon firing
 
 #include "sg_local.h"
+#include "sg_entities_iterator.h"
 #include "Entities.h"
 #include "CBSE.h"
 
@@ -630,9 +631,7 @@ static void HiveMissileThink( gentity_t *self )
 {
 	vec3_t    dir;
 	trace_t   tr;
-	gentity_t *ent;
-	int       i;
-	float     d, nearest;
+	float     d;
 
 	if ( level.time > self->timestamp ) // swarm lifetime exceeded
 	{
@@ -646,17 +645,14 @@ static void HiveMissileThink( gentity_t *self )
 		return;
 	}
 
-	nearest = DistanceSquared( self->r.currentOrigin, self->target->r.currentOrigin );
+	float nearest = DistanceSquared( self->r.currentOrigin, self->target->r.currentOrigin );
 
 	//find the closest human
-	for ( i = 0; i < MAX_CLIENTS; i++ )
+	for ( gentity_t *ent : iterate_client_entities )
 	{
-		ent = &g_entities[ i ];
-
-		if ( !ent->inuse ) continue;
 		if ( ent->flags & FL_NOTARGET ) continue;
 
-		if ( ent->client && Entities::IsAlive( ent ) && G_Team( ent ) == TEAM_HUMANS &&
+		if ( Entities::IsAlive( ent ) && G_Team( ent ) == TEAM_HUMANS &&
 		     nearest > ( d = DistanceSquared( ent->r.currentOrigin, self->r.currentOrigin ) ) )
 		{
 			trap_Trace( &tr, self->r.currentOrigin, self->r.mins, self->r.maxs,


### PR DESCRIPTION
The point of this PR is to indroduce a new way to iterate entities, that will be more convenient and more extensible, and hopefully has a lower running cost (this really would need to be mesured though).

Here is an example of how it could be used:

```C++
gentity_t *FindOvermind()
{
    for ( gentity_t *ent : iterate_buildable_entities )
    {
        if ( ent->s.modelindex == BA_A_OVERMIND )
            return ent;
    }
    return nullptr;
}
```

Each individual commit in the history compiles, in case this would be to be merged in several steps. I think this needs some extensive testing. From a quick check everything seems to work.

Further work that could be done in the following PRs:
* add more `iterate_*_entities`
* use std::function to allow for any function-like predicates, and consider providing functions to things such as `for ( gentity_t *ent :iterate_client_entities_in_team(TEAM_ALIENS) )`
* maybe introduce a `iterate_entity_with_component<>` and see if we can replace `ForEntities`
* replace the `G_IterateEntities{,OfClass,WithinRadius,WithField}` functions