### PR TITLE
cg_drawBBOX - show ground fires

### DIFF
--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -1363,6 +1363,11 @@ void CG_AddPacketEntities()
 					CG_DrawBoundingBox( cg_drawBBOX.Get(), cent->lerpOrigin, mins, maxs );
 					break;
 
+				case entityType_t::ET_FIRE:
+					CG_DrawSphere( es->origin, FIRE_DAMAGE_RADIUS,
+					               cgs.media.plainColorShader, Color::Color(1, 0, 0, 0.2) );
+					break;
+
 				default:
 					break;
 			}

--- a/src/sgame/components/IgnitableComponent.cpp
+++ b/src/sgame/components/IgnitableComponent.cpp
@@ -28,7 +28,6 @@ static Log::Logger fireLogger("sgame.fire");
 
 const float IgnitableComponent::SELF_DAMAGE             = 12.5f;
 const float IgnitableComponent::SPLASH_DAMAGE           = 20.0f;
-const float IgnitableComponent::SPLASH_DAMAGE_RADIUS    = 60.0f;
 const int   IgnitableComponent::MIN_BURN_TIME           = 4000;
 const int   IgnitableComponent::BASE_AVERAGE_BURN_TIME  = 8000;
 const int   IgnitableComponent::EXTRA_AVERAGE_BURN_TIME = 5000;
@@ -140,7 +139,7 @@ void IgnitableComponent::DamageArea(int timeDelta) {
 
 	float damage = SPLASH_DAMAGE * timeDelta * 0.001f;
 
-	if (G_SelectiveRadiusDamage(entity.oldEnt->s.origin, fireStarter, damage, SPLASH_DAMAGE_RADIUS,
+	if (G_SelectiveRadiusDamage(entity.oldEnt->s.origin, fireStarter, damage, FIRE_DAMAGE_RADIUS,
 			entity.oldEnt, MOD_BURN, TEAM_NONE)) {
 		fireLogger.Debug("Area burn damage of %.1f (%.1f/s) was dealt.", damage, SPLASH_DAMAGE);
 	}

--- a/src/sgame/components/IgnitableComponent.h
+++ b/src/sgame/components/IgnitableComponent.h
@@ -34,7 +34,6 @@ class IgnitableComponent: public IgnitableComponentBase {
 	public:
 		const static float SELF_DAMAGE;
 		const static float SPLASH_DAMAGE;
-		const static float SPLASH_DAMAGE_RADIUS;
 
 		/** The minimum time any fire will burn. */
 		const static int   MIN_BURN_TIME;

--- a/src/shared/bg_gameplay.h
+++ b/src/shared/bg_gameplay.h
@@ -312,6 +312,7 @@ extern int   MEDKIT_STARTUP_SPEED;
 
 // fire
 #define FIRE_MIN_DISTANCE                  20.0f
+#define FIRE_DAMAGE_RADIUS                 60.0f
 
 // fall distance
 #define MIN_FALL_DISTANCE                  30.0f  // the fall distance at which fall damage kicks in


### PR DESCRIPTION
A sphere is drawn around ET_FIRE entities showing the damage zone.