### PR TITLE
yellow blueprints when place is valid but reqs are not met

### DIFF
--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -1129,7 +1129,8 @@ void CG_GhostBuildable( int buildableInfo )
 	vec3_t        mins, maxs;
 	trace_t       tr;
 	float         scale;
-	buildable_t   buildable = (buildable_t)( buildableInfo & SB_BUILDABLE_MASK ); // assumed not BA_NONE
+	buildable_t   buildable = (buildable_t)( buildableInfo & SB_BUILDABLE_MASK );
+	ASSERT( BA_NONE < buildable && buildable < BA_NUM_BUILDABLES );
 	const buildableModelConfig_t *bmc = BG_BuildableModelConfig( buildable );
 
 	ps = &cg.predictedPlayerState;
@@ -1156,8 +1157,19 @@ void CG_GhostBuildable( int buildableInfo )
 
 	ent.hModel = cg_buildables[ buildable ].models[ 0 ];
 
-	ent.customShader = ( SB_BUILDABLE_TO_IBE( buildableInfo ) == IBE_NONE )
-	                     ? cgs.media.greenBuildShader : cgs.media.redBuildShader;
+	int reason = SB_BUILDABLE_TO_IBE( buildableInfo );
+	if ( reason == IBE_NONE ) // can build
+	{
+		ent.customShader = cgs.media.greenBuildShader;
+	}
+	else if ( reason == IBE_NORMAL || reason == IBE_NOROOM || reason == IBE_SURFACE )
+	{
+		ent.customShader = cgs.media.redBuildShader;
+	}
+	else
+	{
+		ent.customShader = cgs.media.yellowBuildShader;
+	}
 
 	scale = bmc->modelScale;
 	if ( !scale ) scale = 1.0f;

--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -1122,6 +1122,12 @@ static void CG_DrawBuildableRangeMarker( buildable_t buildable, const vec3_t ori
 CG_GhostBuildable
 ==================
 */
+// draw "ghost" buildings, that is, (probably) the blueprints showed to allow
+// player to visualize where the building will go, and not (human) buildings
+// which already entered the construction phase (and appear ghostly, too).
+//
+// buildableInfo is a 16 bits integer, with a valid buildable_t on the 8 lower
+// bits, and a mask on the 8 higher bits (see SB_BUILDABLE_STATE_MASK).
 void CG_GhostBuildable( int buildableInfo )
 {
 	playerState_t *ps;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1444,6 +1444,7 @@ struct cgMedia_t
 
 	// buildable shaders
 	qhandle_t             greenBuildShader;
+	qhandle_t             yellowBuildShader;
 	qhandle_t             redBuildShader;
 	qhandle_t             humanSpawningShader;
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -789,6 +789,7 @@ static void CG_RegisterGraphics()
 
 	// building shaders
 	cgs.media.greenBuildShader = trap_R_RegisterShader("gfx/buildables/common/greenbuild", RSF_DEFAULT );
+	cgs.media.yellowBuildShader = trap_R_RegisterShader("gfx/buildables/common/yellowbuild", RSF_DEFAULT );
 	cgs.media.redBuildShader = trap_R_RegisterShader("gfx/buildables/common/redbuild", RSF_DEFAULT );
 	cgs.media.humanSpawningShader = trap_R_RegisterShader("gfx/buildables/human_base/spawning", RSF_DEFAULT );
 


### PR DESCRIPTION
Requires a PR into unvanquished_src.dpkdir before merging.
This allows to have 3 ghostly colours for blueprints:

* green: place is ok, pre-requisites are ok
* yellow: place is ok, pre-requisites are not (BP, momentum, RC/OM absent, etc etc)
* red: place is not ok