### PR TITLE
make gamelogic responsible for more BUTTON/btn definitions

### DIFF
--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -584,7 +584,6 @@ void CG_InitConsoleCommands()
 		trap_AddCommand( commands[ i ].cmd );
 	}
 
-	// Defined in src/engine/qcommon/q_shared.h, see BUTTON_ATTACK etc.
 	trap_RegisterButtonCommands(
 	    // 0      123     45      6        78       9       ABCD           E      <- bit nos.
 	      "attack,,,taunt,,sprint,activate,,attack2,attack3,,,,deconstruct,rally"

--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -584,6 +584,7 @@ void CG_InitConsoleCommands()
 		trap_AddCommand( commands[ i ].cmd );
 	}
 
+	// defined in enum buttonNumber_t in file src/shared/bg_public.h
 	trap_RegisterButtonCommands(
 	    // 0      123     45      6        78       9       ABCD           E      <- bit nos.
 	      "attack,,,taunt,,sprint,activate,,attack2,attack3,,,,deconstruct,rally"

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1204,9 +1204,9 @@ struct cg_t
 	bool                testGun;
 
 	int                     spawnTime; // fovwarp
-	int                     weapon1Time; // time when btn_attack went t->f f->t
-	int                     weapon2Time; // time when btn_attack2 went t->f f->t
-	int                     weapon3Time; // time when btn_attack3 went t->f f->t
+	int                     weapon1Time; // time when BTN_ATTACK went t->f f->t
+	int                     weapon2Time; // time when BTN_ATTACK2 went t->f f->t
+	int                     weapon3Time; // time when BTN_ATTACK3 went t->f f->t
 	bool                weapon1Firing;
 	bool                weapon2Firing;
 	bool                weapon3Firing;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1204,9 +1204,9 @@ struct cg_t
 	bool                testGun;
 
 	int                     spawnTime; // fovwarp
-	int                     weapon1Time; // time when BUTTON_ATTACK went t->f f->t
-	int                     weapon2Time; // time when BUTTON_ATTACK2 went t->f f->t
-	int                     weapon3Time; // time when BUTTON_ATTACK3 went t->f f->t
+	int                     weapon1Time; // time when btn_attack went t->f f->t
+	int                     weapon2Time; // time when btn_attack2 went t->f f->t
+	int                     weapon3Time; // time when btn_attack3 went t->f f->t
 	bool                weapon1Firing;
 	bool                weapon2Firing;
 	bool                weapon3Firing;

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -896,7 +896,7 @@ static int CG_CalcFov()
 	trap_GetUserCmd( cmdNum - 1, &oldcmd );
 
 	// Cycle between follow and third-person follow modes on mouse middle click.
-	if ( usercmdButtonPressed( cmd.buttons, BUTTON_ATTACK3 ) && !usercmdButtonPressed( oldcmd.buttons, BUTTON_ATTACK3 ) )
+	if ( usercmdButtonPressed( cmd.buttons, btn_attack3 ) && !usercmdButtonPressed( oldcmd.buttons, btn_attack3 ) )
 	{
 		if ( cg.snap->ps.pm_flags & PMF_FOLLOW )
 		{
@@ -912,7 +912,7 @@ static int CG_CalcFov()
 	}
 
 	// Start and stoop to follow on mouse right click.
-	if ( usercmdButtonPressed( cmd.buttons, BUTTON_ATTACK2 ) && !usercmdButtonPressed( oldcmd.buttons, BUTTON_ATTACK2 ) )
+	if ( usercmdButtonPressed( cmd.buttons, btn_attack2 ) && !usercmdButtonPressed( oldcmd.buttons, btn_attack2 ) )
 	{
 		if ( ( cg.snap->ps.persistant[ PERS_SPECSTATE ] != SPECTATOR_NOT )
 			|| ( cg.snap->ps.pm_flags & PMF_FOLLOW ) )
@@ -955,7 +955,7 @@ static int CG_CalcFov()
 		zoomFov = Math::Clamp( zoomFov, 1.0f, attribFov );
 
 		// only do all the zoom stuff if the client CAN zoom
-		// FIXME: zoom control is currently hard coded to WBUTTON_ATTACK2
+		// FIXME: zoom control is currently hard coded to Wbtn_attack2
 		if ( BG_Weapon( cg.predictedPlayerState.weapon )->canZoom )
 		{
 			if ( cg.zoomed )
@@ -971,8 +971,8 @@ static int CG_CalcFov()
 					fov_y = fov_y + f * ( zoomFov - fov_y );
 				}
 
-				// WBUTTON_ATTACK2 isn't held so unzoom next time
-				if ( !usercmdButtonPressed( cmd.buttons, BUTTON_ATTACK2 ) || cg.snap->ps.weaponstate == WEAPON_RELOADING )
+				// Wbtn_attack2 isn't held so unzoom next time
+				if ( !usercmdButtonPressed( cmd.buttons, btn_attack2 ) || cg.snap->ps.weaponstate == WEAPON_RELOADING )
 				{
 					cg.zoomed = false;
 					cg.zoomTime = std::min( cg.time,
@@ -988,8 +988,8 @@ static int CG_CalcFov()
 					fov_y = zoomFov + f * ( fov_y - zoomFov );
 				}
 
-				// WBUTTON_ATTACK2 is held so zoom next time
-				if ( usercmdButtonPressed( cmd.buttons, BUTTON_ATTACK2 ) && cg.snap->ps.weaponstate != WEAPON_RELOADING )
+				// Wbtn_attack2 is held so zoom next time
+				if ( usercmdButtonPressed( cmd.buttons, btn_attack2 ) && cg.snap->ps.weaponstate != WEAPON_RELOADING )
 				{
 					cg.zoomed = true;
 					cg.zoomTime = std::min( cg.time,

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -896,7 +896,7 @@ static int CG_CalcFov()
 	trap_GetUserCmd( cmdNum - 1, &oldcmd );
 
 	// Cycle between follow and third-person follow modes on mouse middle click.
-	if ( usercmdButtonPressed( cmd.buttons, btn_attack3 ) && !usercmdButtonPressed( oldcmd.buttons, btn_attack3 ) )
+	if ( usercmdButtonPressed( cmd.buttons, BTN_ATTACK3 ) && !usercmdButtonPressed( oldcmd.buttons, BTN_ATTACK3 ) )
 	{
 		if ( cg.snap->ps.pm_flags & PMF_FOLLOW )
 		{
@@ -912,7 +912,7 @@ static int CG_CalcFov()
 	}
 
 	// Start and stoop to follow on mouse right click.
-	if ( usercmdButtonPressed( cmd.buttons, btn_attack2 ) && !usercmdButtonPressed( oldcmd.buttons, btn_attack2 ) )
+	if ( usercmdButtonPressed( cmd.buttons, BTN_ATTACK2 ) && !usercmdButtonPressed( oldcmd.buttons, BTN_ATTACK2 ) )
 	{
 		if ( ( cg.snap->ps.persistant[ PERS_SPECSTATE ] != SPECTATOR_NOT )
 			|| ( cg.snap->ps.pm_flags & PMF_FOLLOW ) )
@@ -955,7 +955,7 @@ static int CG_CalcFov()
 		zoomFov = Math::Clamp( zoomFov, 1.0f, attribFov );
 
 		// only do all the zoom stuff if the client CAN zoom
-		// FIXME: zoom control is currently hard coded to Wbtn_attack2
+		// FIXME: zoom control is currently hard coded to WBTN_ATTACK2
 		if ( BG_Weapon( cg.predictedPlayerState.weapon )->canZoom )
 		{
 			if ( cg.zoomed )
@@ -971,8 +971,8 @@ static int CG_CalcFov()
 					fov_y = fov_y + f * ( zoomFov - fov_y );
 				}
 
-				// Wbtn_attack2 isn't held so unzoom next time
-				if ( !usercmdButtonPressed( cmd.buttons, btn_attack2 ) || cg.snap->ps.weaponstate == WEAPON_RELOADING )
+				// WBTN_ATTACK2 isn't held so unzoom next time
+				if ( !usercmdButtonPressed( cmd.buttons, BTN_ATTACK2 ) || cg.snap->ps.weaponstate == WEAPON_RELOADING )
 				{
 					cg.zoomed = false;
 					cg.zoomTime = std::min( cg.time,
@@ -988,8 +988,8 @@ static int CG_CalcFov()
 					fov_y = zoomFov + f * ( fov_y - zoomFov );
 				}
 
-				// Wbtn_attack2 is held so zoom next time
-				if ( usercmdButtonPressed( cmd.buttons, btn_attack2 ) && cg.snap->ps.weaponstate != WEAPON_RELOADING )
+				// WBTN_ATTACK2 is held so zoom next time
+				if ( usercmdButtonPressed( cmd.buttons, BTN_ATTACK2 ) && cg.snap->ps.weaponstate != WEAPON_RELOADING )
 				{
 					cg.zoomed = true;
 					cg.zoomTime = std::min( cg.time,

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -521,11 +521,11 @@ void SpectatorThink( gentity_t *ent, usercmd_t *ucmd )
 	usercmdCopyButtons( client->oldbuttons, client->buttons );
 	usercmdCopyButtons( client->buttons, ucmd->buttons );
 
-	attack1 = usercmdButtonPressed( client->buttons, btn_attack ) &&
-	          !usercmdButtonPressed( client->oldbuttons, btn_attack );
+	attack1 = usercmdButtonPressed( client->buttons, BTN_ATTACK ) &&
+	          !usercmdButtonPressed( client->oldbuttons, BTN_ATTACK );
 
-	attackReleased = !usercmdButtonPressed( client->buttons, btn_attack ) &&
-		  usercmdButtonPressed( client->oldbuttons, btn_attack );
+	attackReleased = !usercmdButtonPressed( client->buttons, BTN_ATTACK ) &&
+		  usercmdButtonPressed( client->oldbuttons, BTN_ATTACK );
 
 	//if bot
 	if( ent->r.svFlags & SVF_BOT ) {
@@ -695,7 +695,7 @@ bool ClientInactivityTimer( gentity_t *ent, bool active )
 	          client->pers.cmd.forwardmove ||
 	          client->pers.cmd.rightmove ||
 	          client->pers.cmd.upmove ||
-	          usercmdButtonPressed( client->pers.cmd.buttons, btn_attack ) )
+	          usercmdButtonPressed( client->pers.cmd.buttons, BTN_ATTACK ) )
 	{
 		client->inactivityTime = level.time + inactivityTime * 1000;
 		client->inactivityWarning = false;
@@ -1110,7 +1110,7 @@ void ClientIntermissionThink( gclient_t *client )
 	usercmdCopyButtons( client->oldbuttons, client->buttons );
 	usercmdCopyButtons( client->buttons, client->pers.cmd.buttons );
 
-	if ( usercmdButtonPressed( client->buttons, btn_attack ) &&
+	if ( usercmdButtonPressed( client->buttons, BTN_ATTACK ) &&
 	     usercmdButtonsDiffer( client->oldbuttons, client->buttons ) )
 	{
 		client->readyToExit = 1;
@@ -2024,7 +2024,7 @@ void ClientThink_real( gentity_t *self )
 	if ( self->flags & FL_FORCE_GESTURE )
 	{
 		self->flags &= ~FL_FORCE_GESTURE;
-		usercmdPressButton( client->pers.cmd.buttons, btn_gesture );
+		usercmdPressButton( client->pers.cmd.buttons, BTN_GESTURE );
 	}
 
 	// clear fall impact velocity before every pmove
@@ -2173,8 +2173,8 @@ void ClientThink_real( gentity_t *self )
 	usercmdCopyButtons( client->buttons, ucmd->buttons );
 	usercmdLatchButtons( client->latched_buttons, client->buttons, client->oldbuttons );
 
-	if ( usercmdButtonPressed( client->buttons, btn_activate ) &&
-	     !usercmdButtonPressed( client->oldbuttons, btn_activate ) &&
+	if ( usercmdButtonPressed( client->buttons, BTN_ACTIVATE ) &&
+	     !usercmdButtonPressed( client->oldbuttons, BTN_ACTIVATE ) &&
 	     Entities::IsAlive( self ) )
 	{
 		trace_t   trace;

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -521,11 +521,11 @@ void SpectatorThink( gentity_t *ent, usercmd_t *ucmd )
 	usercmdCopyButtons( client->oldbuttons, client->buttons );
 	usercmdCopyButtons( client->buttons, ucmd->buttons );
 
-	attack1 = usercmdButtonPressed( client->buttons, BUTTON_ATTACK ) &&
-	          !usercmdButtonPressed( client->oldbuttons, BUTTON_ATTACK );
+	attack1 = usercmdButtonPressed( client->buttons, btn_attack ) &&
+	          !usercmdButtonPressed( client->oldbuttons, btn_attack );
 
-	attackReleased = !usercmdButtonPressed( client->buttons, BUTTON_ATTACK ) &&
-		  usercmdButtonPressed( client->oldbuttons, BUTTON_ATTACK );
+	attackReleased = !usercmdButtonPressed( client->buttons, btn_attack ) &&
+		  usercmdButtonPressed( client->oldbuttons, btn_attack );
 
 	//if bot
 	if( ent->r.svFlags & SVF_BOT ) {
@@ -695,7 +695,7 @@ bool ClientInactivityTimer( gentity_t *ent, bool active )
 	          client->pers.cmd.forwardmove ||
 	          client->pers.cmd.rightmove ||
 	          client->pers.cmd.upmove ||
-	          usercmdButtonPressed( client->pers.cmd.buttons, BUTTON_ATTACK ) )
+	          usercmdButtonPressed( client->pers.cmd.buttons, btn_attack ) )
 	{
 		client->inactivityTime = level.time + inactivityTime * 1000;
 		client->inactivityWarning = false;
@@ -1110,7 +1110,7 @@ void ClientIntermissionThink( gclient_t *client )
 	usercmdCopyButtons( client->oldbuttons, client->buttons );
 	usercmdCopyButtons( client->buttons, client->pers.cmd.buttons );
 
-	if ( usercmdButtonPressed( client->buttons, BUTTON_ATTACK ) &&
+	if ( usercmdButtonPressed( client->buttons, btn_attack ) &&
 	     usercmdButtonsDiffer( client->oldbuttons, client->buttons ) )
 	{
 		client->readyToExit = 1;
@@ -2024,7 +2024,7 @@ void ClientThink_real( gentity_t *self )
 	if ( self->flags & FL_FORCE_GESTURE )
 	{
 		self->flags &= ~FL_FORCE_GESTURE;
-		usercmdPressButton( client->pers.cmd.buttons, BUTTON_GESTURE );
+		usercmdPressButton( client->pers.cmd.buttons, btn_gesture );
 	}
 
 	// clear fall impact velocity before every pmove
@@ -2173,8 +2173,8 @@ void ClientThink_real( gentity_t *self )
 	usercmdCopyButtons( client->buttons, ucmd->buttons );
 	usercmdLatchButtons( client->latched_buttons, client->buttons, client->oldbuttons );
 
-	if ( usercmdButtonPressed( client->buttons, BUTTON_ACTIVATE ) &&
-	     !usercmdButtonPressed( client->oldbuttons, BUTTON_ACTIVATE ) &&
+	if ( usercmdButtonPressed( client->buttons, btn_activate ) &&
+	     !usercmdButtonPressed( client->oldbuttons, btn_activate ) &&
 	     Entities::IsAlive( self ) )
 	{
 		trace_t   trace;

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -639,11 +639,11 @@ void botMemory_t::doSprint( int jumpCost, int stamina, usercmd_t& cmd )
 	exhausted = exhausted || ( botSkill.level >= 5 && stamina <= jumpCost + jumpCost / 10 );
 	if ( !exhausted && wantSprinting )
 	{
-		usercmdPressButton( cmd.buttons, btn_sprint );
+		usercmdPressButton( cmd.buttons, BTN_SPRINT );
 	}
 	else
 	{
-		usercmdReleaseButton( cmd.buttons, btn_sprint );
+		usercmdReleaseButton( cmd.buttons, BTN_SPRINT );
 	}
 
 	exhausted = exhausted && stamina <= jumpCost * 2;

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -639,11 +639,11 @@ void botMemory_t::doSprint( int jumpCost, int stamina, usercmd_t& cmd )
 	exhausted = exhausted || ( botSkill.level >= 5 && stamina <= jumpCost + jumpCost / 10 );
 	if ( !exhausted && wantSprinting )
 	{
-		usercmdPressButton( cmd.buttons, BUTTON_SPRINT );
+		usercmdPressButton( cmd.buttons, btn_sprint );
 	}
 	else
 	{
-		usercmdReleaseButton( cmd.buttons, BUTTON_SPRINT );
+		usercmdReleaseButton( cmd.buttons, btn_sprint );
 	}
 
 	exhausted = exhausted && stamina <= jumpCost * 2;

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1065,7 +1065,7 @@ AINodeStatus_t BotActionResetStuckTime( gentity_t *self, AIGenericNode_t* )
 AINodeStatus_t BotActionGesture( gentity_t *self, AIGenericNode_t* )
 {
 	usercmd_t *botCmdBuffer = &self->botMind->cmdBuffer;
-	usercmdPressButton( botCmdBuffer->buttons, btn_gesture );
+	usercmdPressButton( botCmdBuffer->buttons, BTN_GESTURE );
 	return AINodeStatus_t::STATUS_SUCCESS;
 }
 

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1065,7 +1065,7 @@ AINodeStatus_t BotActionResetStuckTime( gentity_t *self, AIGenericNode_t* )
 AINodeStatus_t BotActionGesture( gentity_t *self, AIGenericNode_t* )
 {
 	usercmd_t *botCmdBuffer = &self->botMind->cmdBuffer;
-	usercmdPressButton( botCmdBuffer->buttons, BUTTON_GESTURE );
+	usercmdPressButton( botCmdBuffer->buttons, btn_gesture );
 	return AINodeStatus_t::STATUS_SUCCESS;
 }
 

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -229,7 +229,7 @@ Local Bot Navigation
 
 signed char BotGetMaxMoveSpeed( gentity_t *self )
 {
-	if ( usercmdButtonPressed( self->botMind->cmdBuffer.buttons, btn_walking ) )
+	if ( usercmdButtonPressed( self->botMind->cmdBuffer.buttons, BTN_WALKING ) )
 	{
 		return 63;
 	}
@@ -333,13 +333,13 @@ bool BotSprint( gentity_t *self, bool enable )
 	usercmd_t *botCmdBuffer = &self->botMind->cmdBuffer;
 	int jumpCost = BG_Class( self->client->ps.stats[ STAT_CLASS ] )->staminaJumpCost;
 	int stamina = self->client->ps.stats[ STAT_STAMINA ];
-	bool sprinting = usercmdButtonPressed( botCmdBuffer->buttons, btn_sprint );
+	bool sprinting = usercmdButtonPressed( botCmdBuffer->buttons, BTN_SPRINT );
 
 	if ( !enable )
 	{
 		if ( sprinting )
 		{
-			usercmdReleaseButton( botCmdBuffer->buttons, btn_sprint );
+			usercmdReleaseButton( botCmdBuffer->buttons, BTN_SPRINT );
 			BotWalk( self, true );
 		}
 		return false;
@@ -350,7 +350,7 @@ bool BotSprint( gentity_t *self, bool enable )
 	{
 		if ( sprinting && stamina <= jumpCost )
 		{
-			usercmdReleaseButton( botCmdBuffer->buttons, btn_sprint );
+			usercmdReleaseButton( botCmdBuffer->buttons, BTN_SPRINT );
 			BotWalk( self, true );
 			return false;
 		}
@@ -359,7 +359,7 @@ bool BotSprint( gentity_t *self, bool enable )
 			return false;
 		}
 	}
-	usercmdPressButton( botCmdBuffer->buttons, btn_sprint );
+	usercmdPressButton( botCmdBuffer->buttons, BTN_SPRINT );
 	BotWalk( self, false );
 	return true;
 }
@@ -370,18 +370,18 @@ void BotWalk( gentity_t *self, bool enable )
 
 	if ( !enable )
 	{
-		if ( usercmdButtonPressed( botCmdBuffer->buttons, btn_walking ) )
+		if ( usercmdButtonPressed( botCmdBuffer->buttons, BTN_WALKING ) )
 		{
-			usercmdReleaseButton( botCmdBuffer->buttons, btn_walking );
+			usercmdReleaseButton( botCmdBuffer->buttons, BTN_WALKING );
 			botCmdBuffer->forwardmove *= 2;
 			botCmdBuffer->rightmove *= 2;
 		}
 		return;
 	}
 
-	if ( !usercmdButtonPressed( botCmdBuffer->buttons, btn_walking ) )
+	if ( !usercmdButtonPressed( botCmdBuffer->buttons, BTN_WALKING ) )
 	{
-		usercmdPressButton( botCmdBuffer->buttons, btn_walking );
+		usercmdPressButton( botCmdBuffer->buttons, BTN_WALKING );
 		botCmdBuffer->forwardmove /= 2;
 		botCmdBuffer->rightmove /= 2;
 	}

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -229,7 +229,7 @@ Local Bot Navigation
 
 signed char BotGetMaxMoveSpeed( gentity_t *self )
 {
-	if ( usercmdButtonPressed( self->botMind->cmdBuffer.buttons, BUTTON_WALKING ) )
+	if ( usercmdButtonPressed( self->botMind->cmdBuffer.buttons, btn_walking ) )
 	{
 		return 63;
 	}
@@ -333,13 +333,13 @@ bool BotSprint( gentity_t *self, bool enable )
 	usercmd_t *botCmdBuffer = &self->botMind->cmdBuffer;
 	int jumpCost = BG_Class( self->client->ps.stats[ STAT_CLASS ] )->staminaJumpCost;
 	int stamina = self->client->ps.stats[ STAT_STAMINA ];
-	bool sprinting = usercmdButtonPressed( botCmdBuffer->buttons, BUTTON_SPRINT );
+	bool sprinting = usercmdButtonPressed( botCmdBuffer->buttons, btn_sprint );
 
 	if ( !enable )
 	{
 		if ( sprinting )
 		{
-			usercmdReleaseButton( botCmdBuffer->buttons, BUTTON_SPRINT );
+			usercmdReleaseButton( botCmdBuffer->buttons, btn_sprint );
 			BotWalk( self, true );
 		}
 		return false;
@@ -350,7 +350,7 @@ bool BotSprint( gentity_t *self, bool enable )
 	{
 		if ( sprinting && stamina <= jumpCost )
 		{
-			usercmdReleaseButton( botCmdBuffer->buttons, BUTTON_SPRINT );
+			usercmdReleaseButton( botCmdBuffer->buttons, btn_sprint );
 			BotWalk( self, true );
 			return false;
 		}
@@ -359,7 +359,7 @@ bool BotSprint( gentity_t *self, bool enable )
 			return false;
 		}
 	}
-	usercmdPressButton( botCmdBuffer->buttons, BUTTON_SPRINT );
+	usercmdPressButton( botCmdBuffer->buttons, btn_sprint );
 	BotWalk( self, false );
 	return true;
 }
@@ -370,18 +370,18 @@ void BotWalk( gentity_t *self, bool enable )
 
 	if ( !enable )
 	{
-		if ( usercmdButtonPressed( botCmdBuffer->buttons, BUTTON_WALKING ) )
+		if ( usercmdButtonPressed( botCmdBuffer->buttons, btn_walking ) )
 		{
-			usercmdReleaseButton( botCmdBuffer->buttons, BUTTON_WALKING );
+			usercmdReleaseButton( botCmdBuffer->buttons, btn_walking );
 			botCmdBuffer->forwardmove *= 2;
 			botCmdBuffer->rightmove *= 2;
 		}
 		return;
 	}
 
-	if ( !usercmdButtonPressed( botCmdBuffer->buttons, BUTTON_WALKING ) )
+	if ( !usercmdButtonPressed( botCmdBuffer->buttons, btn_walking ) )
 	{
-		usercmdPressButton( botCmdBuffer->buttons, BUTTON_WALKING );
+		usercmdPressButton( botCmdBuffer->buttons, btn_walking );
 		botCmdBuffer->forwardmove /= 2;
 		botCmdBuffer->rightmove /= 2;
 	}

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1669,15 +1669,15 @@ void BotFireWeapon( weaponMode_t mode, usercmd_t *botCmdBuffer )
 {
 	if ( mode == WPM_PRIMARY )
 	{
-		usercmdPressButton( botCmdBuffer->buttons, BUTTON_ATTACK );
+		usercmdPressButton( botCmdBuffer->buttons, btn_attack );
 	}
 	else if ( mode == WPM_SECONDARY )
 	{
-		usercmdPressButton( botCmdBuffer->buttons, BUTTON_ATTACK2 );
+		usercmdPressButton( botCmdBuffer->buttons, btn_attack2 );
 	}
 	else if ( mode == WPM_TERTIARY )
 	{
-		usercmdPressButton( botCmdBuffer->buttons, BUTTON_ATTACK3 );
+		usercmdPressButton( botCmdBuffer->buttons, btn_attack3 );
 	}
 }
 void BotClassMovement( gentity_t *self, bool inAttackRange )
@@ -1818,7 +1818,7 @@ void BotFireWeaponAI( gentity_t *self )
 			}
 			else
 			{
-				usercmdPressButton( botCmdBuffer->buttons, BUTTON_GESTURE );    //make cute granger sounds to ward off the would be attackers
+				usercmdPressButton( botCmdBuffer->buttons, btn_gesture );    //make cute granger sounds to ward off the would be attackers
 			}
 			break;
 		case WP_ABUILD2:

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1669,15 +1669,15 @@ void BotFireWeapon( weaponMode_t mode, usercmd_t *botCmdBuffer )
 {
 	if ( mode == WPM_PRIMARY )
 	{
-		usercmdPressButton( botCmdBuffer->buttons, btn_attack );
+		usercmdPressButton( botCmdBuffer->buttons, BTN_ATTACK );
 	}
 	else if ( mode == WPM_SECONDARY )
 	{
-		usercmdPressButton( botCmdBuffer->buttons, btn_attack2 );
+		usercmdPressButton( botCmdBuffer->buttons, BTN_ATTACK2 );
 	}
 	else if ( mode == WPM_TERTIARY )
 	{
-		usercmdPressButton( botCmdBuffer->buttons, btn_attack3 );
+		usercmdPressButton( botCmdBuffer->buttons, BTN_ATTACK3 );
 	}
 }
 void BotClassMovement( gentity_t *self, bool inAttackRange )
@@ -1818,7 +1818,7 @@ void BotFireWeaponAI( gentity_t *self )
 			}
 			else
 			{
-				usercmdPressButton( botCmdBuffer->buttons, btn_gesture );    //make cute granger sounds to ward off the would be attackers
+				usercmdPressButton( botCmdBuffer->buttons, BTN_GESTURE );    //make cute granger sounds to ward off the would be attackers
 			}
 			break;
 		case WP_ABUILD2:

--- a/src/shared/bg_pmove.cpp
+++ b/src/shared/bg_pmove.cpp
@@ -401,14 +401,14 @@ static float PM_CmdScale( usercmd_t *cmd, bool zFlight )
 		if ( pm->ps->persistant[ PERS_STATE ] & PS_SPRINTTOGGLE )
 		{
 			// toggle mode
-			if ( usercmdButtonPressed( cmd->buttons, btn_sprint ) &&
+			if ( usercmdButtonPressed( cmd->buttons, BTN_SPRINT ) &&
 			     !( pm->ps->pm_flags & PMF_SPRINTHELD ) )
 			{
 				sprint = !sprint;
 				pm->ps->pm_flags |= PMF_SPRINTHELD;
 			}
 			else if ( pm->ps->pm_flags & PMF_SPRINTHELD &&
-			          !usercmdButtonPressed( cmd->buttons, btn_sprint ) )
+			          !usercmdButtonPressed( cmd->buttons, BTN_SPRINT ) )
 			{
 				pm->ps->pm_flags &= ~PMF_SPRINTHELD;
 			}
@@ -416,7 +416,7 @@ static float PM_CmdScale( usercmd_t *cmd, bool zFlight )
 		else
 		{
 			// non-toggle mode
-			sprint = usercmdButtonPressed( cmd->buttons, btn_sprint );
+			sprint = usercmdButtonPressed( cmd->buttons, BTN_SPRINT );
 		}
 
 		// check if sprinting is allowed
@@ -448,7 +448,7 @@ static float PM_CmdScale( usercmd_t *cmd, bool zFlight )
 		// above but don't apply the modifier, and in g_active we skip taking
 		// the stamina too.
 		// TODO: Try to move code upwards so sprinting isn't activated in the first place.
-		if ( sprint && !usercmdButtonPressed( cmd->buttons, btn_walking ) )
+		if ( sprint && !usercmdButtonPressed( cmd->buttons, BTN_WALKING ) )
 		{
 			modifier *= BG_Class( pm->ps->stats[ STAT_CLASS ] )->sprintMod;
 		}
@@ -505,7 +505,7 @@ static float PM_CmdScale( usercmd_t *cmd, bool zFlight )
 
 	// Slow down when charging up for a pounce
 	if ( ( pm->ps->weapon == WP_ALEVEL3 || pm->ps->weapon == WP_ALEVEL3_UPG ) &&
-	     usercmdButtonPressed( cmd->buttons, btn_attack2 ) )
+	     usercmdButtonPressed( cmd->buttons, BTN_ATTACK2 ) )
 	{
 		modifier *= LEVEL3_POUNCE_SPEED_MOD;
 	}
@@ -616,7 +616,7 @@ static void PM_CheckCharge()
 		return;
 	}
 
-	if ( usercmdButtonPressed( pm->cmd.buttons, btn_attack2 ) &&
+	if ( usercmdButtonPressed( pm->cmd.buttons, BTN_ATTACK2 ) &&
 	     !( pm->ps->stats[ STAT_STATE ] & SS_CHARGING ) )
 	{
 		pm->ps->pm_flags &= ~PMF_CHARGE;
@@ -750,7 +750,7 @@ static bool PM_CheckPounce()
 	{
 		case WP_ALEVEL1:
 			// Check if player wants to pounce
-			if ( !usercmdButtonPressed( pm->cmd.buttons, btn_attack2 ) )
+			if ( !usercmdButtonPressed( pm->cmd.buttons, BTN_ATTACK2 ) )
 			{
 				return false;
 			}
@@ -765,7 +765,7 @@ static bool PM_CheckPounce()
 		case WP_ALEVEL3:
 		case WP_ALEVEL3_UPG:
 			// Don't pounce while still charging
-			if ( usercmdButtonPressed( pm->cmd.buttons, btn_attack2 ) )
+			if ( usercmdButtonPressed( pm->cmd.buttons, BTN_ATTACK2 ) )
 			{
 				pm->ps->pm_flags &= ~PMF_CHARGE;
 
@@ -3457,7 +3457,7 @@ static void PM_Footsteps()
 	}
 	else
 	{
-		if ( !usercmdButtonPressed( pm->cmd.buttons, btn_walking ) )
+		if ( !usercmdButtonPressed( pm->cmd.buttons, BTN_WALKING ) )
 		{
 			bobmove = 0.4f; // faster speeds bob faster
 
@@ -3729,7 +3729,7 @@ static void PM_FinishWeaponChange()
 
 static void HandleDeconstructButton()
 {
-	if ( usercmdButtonPressed( pm->cmd.buttons, btn_attack ) ||
+	if ( usercmdButtonPressed( pm->cmd.buttons, BTN_ATTACK ) ||
 	     ( pm->ps->weaponstate != WEAPON_READY && pm->ps->weaponstate != WEAPON_FIRING ) )
 	{
 		// cancel if player starts to build something, or if the weapon is in a weird state
@@ -3740,14 +3740,14 @@ static void HandleDeconstructButton()
 	if ( pm->ps->weaponCharge < 0 )
 	{
 		// weaponCharge==-1 is analogous to the WEAPON_NEEDS_RESET state when overcharging the luci
-		if ( !usercmdButtonPressed( pm->cmd.buttons, btn_deconstruct ) )
+		if ( !usercmdButtonPressed( pm->cmd.buttons, BTN_DECONSTRUCT ) )
 		{
 			pm->ps->weaponCharge = 0;
 		}
 		return;
 	}
 
-	if ( usercmdButtonPressed( pm->cmd.buttons, btn_deconstruct ) )
+	if ( usercmdButtonPressed( pm->cmd.buttons, BTN_DECONSTRUCT ) )
 	{
 		if ( pm->ps->weaponCharge >= BUILDER_MAX_SHORT_DECONSTRUCT_CHARGE && pm->pmext->cancelDeconstructCharge )
 		{
@@ -3813,9 +3813,9 @@ Generates weapon events and modifies the weapon counter
 static void PM_Weapon()
 {
 	int      addTime = 200; //default addTime - should never be used
-	bool attack1 = usercmdButtonPressed( pm->cmd.buttons, btn_attack );
-	bool attack2 = usercmdButtonPressed( pm->cmd.buttons, btn_attack2 );
-	bool attack3 = usercmdButtonPressed( pm->cmd.buttons, btn_attack3 );
+	bool attack1 = usercmdButtonPressed( pm->cmd.buttons, BTN_ATTACK );
+	bool attack2 = usercmdButtonPressed( pm->cmd.buttons, BTN_ATTACK2 );
+	bool attack3 = usercmdButtonPressed( pm->cmd.buttons, BTN_ATTACK3 );
 
 	// Ignore weapons in some cases
 	if ( pm->ps->persistant[ PERS_SPECSTATE ] != SPECTATOR_NOT )
@@ -3848,7 +3848,7 @@ static void PM_Weapon()
 
 		max = pm->ps->weapon == WP_ALEVEL3 ? LEVEL3_POUNCE_TIME : LEVEL3_POUNCE_TIME_UPG;
 
-		if ( usercmdButtonPressed( pm->cmd.buttons, btn_attack2 ) )
+		if ( usercmdButtonPressed( pm->cmd.buttons, BTN_ATTACK2 ) )
 		{
 			pm->ps->weaponCharge += pml.msec;
 		}
@@ -3875,7 +3875,7 @@ static void PM_Weapon()
 		{
 			// Charge button held
 			if ( pm->ps->weaponCharge < LEVEL4_TRAMPLE_CHARGE_TRIGGER &&
-			     usercmdButtonPressed( pm->cmd.buttons, btn_attack2 ) )
+			     usercmdButtonPressed( pm->cmd.buttons, BTN_ATTACK2 ) )
 			{
 				pm->ps->stats[ STAT_STATE ] &= ~SS_CHARGING;
 
@@ -3958,7 +3958,7 @@ static void PM_Weapon()
 	{
 		// Charging up
 		if ( !pm->ps->weaponTime && pm->ps->weaponstate != WEAPON_NEEDS_RESET &&
-		     usercmdButtonPressed( pm->cmd.buttons, btn_attack ) )
+		     usercmdButtonPressed( pm->cmd.buttons, BTN_ATTACK ) )
 		{
 			pm->ps->weaponCharge += pml.msec;
 
@@ -3995,7 +3995,7 @@ static void PM_Weapon()
 
 	// no bite during pounce
 	if ( ( pm->ps->weapon == WP_ALEVEL3 || pm->ps->weapon == WP_ALEVEL3_UPG )
-	     && usercmdButtonPressed( pm->cmd.buttons, btn_attack )
+	     && usercmdButtonPressed( pm->cmd.buttons, BTN_ATTACK )
 	     && ( pm->ps->pm_flags & PMF_CHARGE ) )
 	{
 		return;
@@ -4453,7 +4453,7 @@ static void PM_Animate()
 		return;
 	}
 
-	if ( usercmdButtonPressed( pm->cmd.buttons, btn_gesture ) )
+	if ( usercmdButtonPressed( pm->cmd.buttons, BTN_GESTURE ) )
 	{
 		if ( pm->ps->tauntTimer > 0 )
 		{
@@ -4486,7 +4486,7 @@ static void PM_Animate()
 		}
 	}
 
-	if ( usercmdButtonPressed( pm->cmd.buttons, btn_rally ) )
+	if ( usercmdButtonPressed( pm->cmd.buttons, BTN_RALLY ) )
 	{
 		if ( pm->ps->tauntTimer > 0 )
 		{
@@ -4711,7 +4711,7 @@ static void PM_HumanStaminaEffects()
 	ca        = BG_Class( stats[ STAT_CLASS ] );
 	stopped   = ( pm->cmd.forwardmove == 0 && pm->cmd.rightmove == 0 );
 	crouching = ( pm->ps->pm_flags & PMF_DUCKED );
-	walking   = usercmdButtonPressed( pm->cmd.buttons, btn_walking );
+	walking   = usercmdButtonPressed( pm->cmd.buttons, BTN_WALKING );
 
 	// Use/Restore stamina
 	if ( stats[ STAT_STATE2 ] & SS2_JETPACK_WARM )
@@ -4780,12 +4780,12 @@ void PmoveSingle( pmove_t *pmove )
 	// proxy no-footsteps cheats
 	if ( abs( pm->cmd.forwardmove ) > 64 || abs( pm->cmd.rightmove ) > 64 )
 	{
-		usercmdReleaseButton( pm->cmd.buttons, btn_walking );
+		usercmdReleaseButton( pm->cmd.buttons, BTN_WALKING );
 	}
 
 	// set the firing flag for continuous beam weapons
 	if ( !( pm->ps->pm_flags & PMF_RESPAWNED ) && pm->ps->pm_type != PM_INTERMISSION &&
-	     usercmdButtonPressed( pm->cmd.buttons, btn_attack ) &&
+	     usercmdButtonPressed( pm->cmd.buttons, BTN_ATTACK ) &&
 	     ( ( pm->ps->ammo > 0 || pm->ps->clips > 0 ) || BG_Weapon( pm->ps->weapon )->infiniteAmmo ) )
 	{
 		pm->ps->eFlags |= EF_FIRING;
@@ -4797,7 +4797,7 @@ void PmoveSingle( pmove_t *pmove )
 
 	// set the firing flag for continuous beam weapons
 	if ( !( pm->ps->pm_flags & PMF_RESPAWNED ) && pm->ps->pm_type != PM_INTERMISSION &&
-	     usercmdButtonPressed( pm->cmd.buttons, btn_attack2 ) &&
+	     usercmdButtonPressed( pm->cmd.buttons, BTN_ATTACK2 ) &&
 	     ( ( pm->ps->ammo > 0 || pm->ps->clips > 0 ) || BG_Weapon( pm->ps->weapon )->infiniteAmmo ) )
 	{
 		pm->ps->eFlags |= EF_FIRING2;
@@ -4809,7 +4809,7 @@ void PmoveSingle( pmove_t *pmove )
 
 	// set the firing flag for continuous beam weapons
 	if ( !( pm->ps->pm_flags & PMF_RESPAWNED ) && pm->ps->pm_type != PM_INTERMISSION &&
-	     usercmdButtonPressed( pm->cmd.buttons, btn_attack3 ) &&
+	     usercmdButtonPressed( pm->cmd.buttons, BTN_ATTACK3 ) &&
 	     ( ( pm->ps->ammo > 0 || pm->ps->clips > 0 ) || BG_Weapon( pm->ps->weapon )->infiniteAmmo ) )
 	{
 		pm->ps->eFlags |= EF_FIRING3;
@@ -4821,7 +4821,7 @@ void PmoveSingle( pmove_t *pmove )
 
 	// clear the respawned flag if attack and use are cleared
 	if ( pm->ps->stats[ STAT_HEALTH ] > 0 &&
-	     !( usercmdButtonPressed( pm->cmd.buttons, btn_attack ) ) )
+	     !( usercmdButtonPressed( pm->cmd.buttons, BTN_ATTACK ) ) )
 	{
 		pm->ps->pm_flags &= ~PMF_RESPAWNED;
 	}
@@ -4829,10 +4829,10 @@ void PmoveSingle( pmove_t *pmove )
 	// if talk button is down, disallow all other input
 	// this is to prevent any possible intercept proxy from
 	// adding fake talk balloons
-	if ( usercmdButtonPressed( pmove->cmd.buttons, btn_talk ) )
+	if ( usercmdButtonPressed( pmove->cmd.buttons, BTN_TALK ) )
 	{
 		usercmdClearButtons( pmove->cmd.buttons );
-		usercmdPressButton( pmove->cmd.buttons, btn_talk );
+		usercmdPressButton( pmove->cmd.buttons, BTN_TALK );
 		pmove->cmd.forwardmove = 0;
 		pmove->cmd.rightmove = 0;
 

--- a/src/shared/bg_pmove.cpp
+++ b/src/shared/bg_pmove.cpp
@@ -401,14 +401,14 @@ static float PM_CmdScale( usercmd_t *cmd, bool zFlight )
 		if ( pm->ps->persistant[ PERS_STATE ] & PS_SPRINTTOGGLE )
 		{
 			// toggle mode
-			if ( usercmdButtonPressed( cmd->buttons, BUTTON_SPRINT ) &&
+			if ( usercmdButtonPressed( cmd->buttons, btn_sprint ) &&
 			     !( pm->ps->pm_flags & PMF_SPRINTHELD ) )
 			{
 				sprint = !sprint;
 				pm->ps->pm_flags |= PMF_SPRINTHELD;
 			}
 			else if ( pm->ps->pm_flags & PMF_SPRINTHELD &&
-			          !usercmdButtonPressed( cmd->buttons, BUTTON_SPRINT ) )
+			          !usercmdButtonPressed( cmd->buttons, btn_sprint ) )
 			{
 				pm->ps->pm_flags &= ~PMF_SPRINTHELD;
 			}
@@ -416,7 +416,7 @@ static float PM_CmdScale( usercmd_t *cmd, bool zFlight )
 		else
 		{
 			// non-toggle mode
-			sprint = usercmdButtonPressed( cmd->buttons, BUTTON_SPRINT );
+			sprint = usercmdButtonPressed( cmd->buttons, btn_sprint );
 		}
 
 		// check if sprinting is allowed
@@ -448,7 +448,7 @@ static float PM_CmdScale( usercmd_t *cmd, bool zFlight )
 		// above but don't apply the modifier, and in g_active we skip taking
 		// the stamina too.
 		// TODO: Try to move code upwards so sprinting isn't activated in the first place.
-		if ( sprint && !usercmdButtonPressed( cmd->buttons, BUTTON_WALKING ) )
+		if ( sprint && !usercmdButtonPressed( cmd->buttons, btn_walking ) )
 		{
 			modifier *= BG_Class( pm->ps->stats[ STAT_CLASS ] )->sprintMod;
 		}
@@ -505,7 +505,7 @@ static float PM_CmdScale( usercmd_t *cmd, bool zFlight )
 
 	// Slow down when charging up for a pounce
 	if ( ( pm->ps->weapon == WP_ALEVEL3 || pm->ps->weapon == WP_ALEVEL3_UPG ) &&
-	     usercmdButtonPressed( cmd->buttons, BUTTON_ATTACK2 ) )
+	     usercmdButtonPressed( cmd->buttons, btn_attack2 ) )
 	{
 		modifier *= LEVEL3_POUNCE_SPEED_MOD;
 	}
@@ -616,7 +616,7 @@ static void PM_CheckCharge()
 		return;
 	}
 
-	if ( usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK2 ) &&
+	if ( usercmdButtonPressed( pm->cmd.buttons, btn_attack2 ) &&
 	     !( pm->ps->stats[ STAT_STATE ] & SS_CHARGING ) )
 	{
 		pm->ps->pm_flags &= ~PMF_CHARGE;
@@ -750,7 +750,7 @@ static bool PM_CheckPounce()
 	{
 		case WP_ALEVEL1:
 			// Check if player wants to pounce
-			if ( !usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK2 ) )
+			if ( !usercmdButtonPressed( pm->cmd.buttons, btn_attack2 ) )
 			{
 				return false;
 			}
@@ -765,7 +765,7 @@ static bool PM_CheckPounce()
 		case WP_ALEVEL3:
 		case WP_ALEVEL3_UPG:
 			// Don't pounce while still charging
-			if ( usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK2 ) )
+			if ( usercmdButtonPressed( pm->cmd.buttons, btn_attack2 ) )
 			{
 				pm->ps->pm_flags &= ~PMF_CHARGE;
 
@@ -3457,7 +3457,7 @@ static void PM_Footsteps()
 	}
 	else
 	{
-		if ( !usercmdButtonPressed( pm->cmd.buttons, BUTTON_WALKING ) )
+		if ( !usercmdButtonPressed( pm->cmd.buttons, btn_walking ) )
 		{
 			bobmove = 0.4f; // faster speeds bob faster
 
@@ -3729,7 +3729,7 @@ static void PM_FinishWeaponChange()
 
 static void HandleDeconstructButton()
 {
-	if ( usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK ) ||
+	if ( usercmdButtonPressed( pm->cmd.buttons, btn_attack ) ||
 	     ( pm->ps->weaponstate != WEAPON_READY && pm->ps->weaponstate != WEAPON_FIRING ) )
 	{
 		// cancel if player starts to build something, or if the weapon is in a weird state
@@ -3740,14 +3740,14 @@ static void HandleDeconstructButton()
 	if ( pm->ps->weaponCharge < 0 )
 	{
 		// weaponCharge==-1 is analogous to the WEAPON_NEEDS_RESET state when overcharging the luci
-		if ( !usercmdButtonPressed( pm->cmd.buttons, BUTTON_DECONSTRUCT ) )
+		if ( !usercmdButtonPressed( pm->cmd.buttons, btn_deconstruct ) )
 		{
 			pm->ps->weaponCharge = 0;
 		}
 		return;
 	}
 
-	if ( usercmdButtonPressed( pm->cmd.buttons, BUTTON_DECONSTRUCT ) )
+	if ( usercmdButtonPressed( pm->cmd.buttons, btn_deconstruct ) )
 	{
 		if ( pm->ps->weaponCharge >= BUILDER_MAX_SHORT_DECONSTRUCT_CHARGE && pm->pmext->cancelDeconstructCharge )
 		{
@@ -3813,9 +3813,9 @@ Generates weapon events and modifies the weapon counter
 static void PM_Weapon()
 {
 	int      addTime = 200; //default addTime - should never be used
-	bool attack1 = usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK );
-	bool attack2 = usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK2 );
-	bool attack3 = usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK3 );
+	bool attack1 = usercmdButtonPressed( pm->cmd.buttons, btn_attack );
+	bool attack2 = usercmdButtonPressed( pm->cmd.buttons, btn_attack2 );
+	bool attack3 = usercmdButtonPressed( pm->cmd.buttons, btn_attack3 );
 
 	// Ignore weapons in some cases
 	if ( pm->ps->persistant[ PERS_SPECSTATE ] != SPECTATOR_NOT )
@@ -3848,7 +3848,7 @@ static void PM_Weapon()
 
 		max = pm->ps->weapon == WP_ALEVEL3 ? LEVEL3_POUNCE_TIME : LEVEL3_POUNCE_TIME_UPG;
 
-		if ( usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK2 ) )
+		if ( usercmdButtonPressed( pm->cmd.buttons, btn_attack2 ) )
 		{
 			pm->ps->weaponCharge += pml.msec;
 		}
@@ -3875,7 +3875,7 @@ static void PM_Weapon()
 		{
 			// Charge button held
 			if ( pm->ps->weaponCharge < LEVEL4_TRAMPLE_CHARGE_TRIGGER &&
-			     usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK2 ) )
+			     usercmdButtonPressed( pm->cmd.buttons, btn_attack2 ) )
 			{
 				pm->ps->stats[ STAT_STATE ] &= ~SS_CHARGING;
 
@@ -3958,7 +3958,7 @@ static void PM_Weapon()
 	{
 		// Charging up
 		if ( !pm->ps->weaponTime && pm->ps->weaponstate != WEAPON_NEEDS_RESET &&
-		     usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK ) )
+		     usercmdButtonPressed( pm->cmd.buttons, btn_attack ) )
 		{
 			pm->ps->weaponCharge += pml.msec;
 
@@ -3995,7 +3995,7 @@ static void PM_Weapon()
 
 	// no bite during pounce
 	if ( ( pm->ps->weapon == WP_ALEVEL3 || pm->ps->weapon == WP_ALEVEL3_UPG )
-	     && usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK )
+	     && usercmdButtonPressed( pm->cmd.buttons, btn_attack )
 	     && ( pm->ps->pm_flags & PMF_CHARGE ) )
 	{
 		return;
@@ -4453,7 +4453,7 @@ static void PM_Animate()
 		return;
 	}
 
-	if ( usercmdButtonPressed( pm->cmd.buttons, BUTTON_GESTURE ) )
+	if ( usercmdButtonPressed( pm->cmd.buttons, btn_gesture ) )
 	{
 		if ( pm->ps->tauntTimer > 0 )
 		{
@@ -4486,7 +4486,7 @@ static void PM_Animate()
 		}
 	}
 
-	if ( usercmdButtonPressed( pm->cmd.buttons, BUTTON_RALLY ) )
+	if ( usercmdButtonPressed( pm->cmd.buttons, btn_rally ) )
 	{
 		if ( pm->ps->tauntTimer > 0 )
 		{
@@ -4711,7 +4711,7 @@ static void PM_HumanStaminaEffects()
 	ca        = BG_Class( stats[ STAT_CLASS ] );
 	stopped   = ( pm->cmd.forwardmove == 0 && pm->cmd.rightmove == 0 );
 	crouching = ( pm->ps->pm_flags & PMF_DUCKED );
-	walking   = usercmdButtonPressed( pm->cmd.buttons, BUTTON_WALKING );
+	walking   = usercmdButtonPressed( pm->cmd.buttons, btn_walking );
 
 	// Use/Restore stamina
 	if ( stats[ STAT_STATE2 ] & SS2_JETPACK_WARM )
@@ -4780,12 +4780,12 @@ void PmoveSingle( pmove_t *pmove )
 	// proxy no-footsteps cheats
 	if ( abs( pm->cmd.forwardmove ) > 64 || abs( pm->cmd.rightmove ) > 64 )
 	{
-		usercmdReleaseButton( pm->cmd.buttons, BUTTON_WALKING );
+		usercmdReleaseButton( pm->cmd.buttons, btn_walking );
 	}
 
 	// set the firing flag for continuous beam weapons
 	if ( !( pm->ps->pm_flags & PMF_RESPAWNED ) && pm->ps->pm_type != PM_INTERMISSION &&
-	     usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK ) &&
+	     usercmdButtonPressed( pm->cmd.buttons, btn_attack ) &&
 	     ( ( pm->ps->ammo > 0 || pm->ps->clips > 0 ) || BG_Weapon( pm->ps->weapon )->infiniteAmmo ) )
 	{
 		pm->ps->eFlags |= EF_FIRING;
@@ -4797,7 +4797,7 @@ void PmoveSingle( pmove_t *pmove )
 
 	// set the firing flag for continuous beam weapons
 	if ( !( pm->ps->pm_flags & PMF_RESPAWNED ) && pm->ps->pm_type != PM_INTERMISSION &&
-	     usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK2 ) &&
+	     usercmdButtonPressed( pm->cmd.buttons, btn_attack2 ) &&
 	     ( ( pm->ps->ammo > 0 || pm->ps->clips > 0 ) || BG_Weapon( pm->ps->weapon )->infiniteAmmo ) )
 	{
 		pm->ps->eFlags |= EF_FIRING2;
@@ -4809,7 +4809,7 @@ void PmoveSingle( pmove_t *pmove )
 
 	// set the firing flag for continuous beam weapons
 	if ( !( pm->ps->pm_flags & PMF_RESPAWNED ) && pm->ps->pm_type != PM_INTERMISSION &&
-	     usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK3 ) &&
+	     usercmdButtonPressed( pm->cmd.buttons, btn_attack3 ) &&
 	     ( ( pm->ps->ammo > 0 || pm->ps->clips > 0 ) || BG_Weapon( pm->ps->weapon )->infiniteAmmo ) )
 	{
 		pm->ps->eFlags |= EF_FIRING3;
@@ -4821,7 +4821,7 @@ void PmoveSingle( pmove_t *pmove )
 
 	// clear the respawned flag if attack and use are cleared
 	if ( pm->ps->stats[ STAT_HEALTH ] > 0 &&
-	     !( usercmdButtonPressed( pm->cmd.buttons, BUTTON_ATTACK ) ) )
+	     !( usercmdButtonPressed( pm->cmd.buttons, btn_attack ) ) )
 	{
 		pm->ps->pm_flags &= ~PMF_RESPAWNED;
 	}
@@ -4829,10 +4829,10 @@ void PmoveSingle( pmove_t *pmove )
 	// if talk button is down, disallow all other input
 	// this is to prevent any possible intercept proxy from
 	// adding fake talk balloons
-	if ( usercmdButtonPressed( pmove->cmd.buttons, BUTTON_TALK ) )
+	if ( usercmdButtonPressed( pmove->cmd.buttons, btn_talk ) )
 	{
 		usercmdClearButtons( pmove->cmd.buttons );
-		usercmdPressButton( pmove->cmd.buttons, BUTTON_TALK );
+		usercmdPressButton( pmove->cmd.buttons, btn_talk );
 		pmove->cmd.forwardmove = 0;
 		pmove->cmd.rightmove = 0;
 

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -1127,9 +1127,23 @@ enum meansOfDeath_t
 // TODO: move other button definitions into gamelogic
 enum buttonNumber_t
 {
-  BUTTON_ATTACK3 = 9,
-  BUTTON_DECONSTRUCT = 13,
+	btn_attack       = 0,
+	// defined by daemon
+	btn_talk         = BUTTON_TALK, // = 1, // disables actions
+	btn_use_holdable = 2,
+	btn_gesture      = 3,
+	// defined by daemon
+	btn_walking      = BUTTON_WALKING, // = 4, // walking can't just be inferred from MOVE_RUN
+	btn_sprint       = 5,
+	btn_activate     = 6,
+	// defined by daemon
+	btn_any          = BUTTON_ANY, // = 7, // if any key is pressed
+	btn_attack2      = 8,
+	btn_attack3      = 9,
+	btn_deconstruct  = 13,
+	btn_rally        = 14 // also named "taunt" in some places
 };
+
 
 #define DEVOLVE_RETURN_FRACTION 0.9f
 

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -1127,21 +1127,21 @@ enum meansOfDeath_t
 // TODO: move other button definitions into gamelogic
 enum buttonNumber_t
 {
-	btn_attack       = 0,
+	BTN_ATTACK       = 0,
 	// defined by daemon
-	btn_talk         = BUTTON_TALK, // = 1, // disables actions
-	btn_use_holdable = 2,
-	btn_gesture      = 3,
+	BTN_TALK         = BUTTON_TALK, // = 1, // disables actions
+	BTN_USE_HOLDABLE = 2,
+	BTN_GESTURE      = 3,
 	// defined by daemon
-	btn_walking      = BUTTON_WALKING, // = 4, // walking can't just be inferred from MOVE_RUN
-	btn_sprint       = 5,
-	btn_activate     = 6,
+	BTN_WALKING      = BUTTON_WALKING, // = 4, // walking can't just be inferred from MOVE_RUN
+	BTN_SPRINT       = 5,
+	BTN_ACTIVATE     = 6,
 	// defined by daemon
-	btn_any          = BUTTON_ANY, // = 7, // if any key is pressed
-	btn_attack2      = 8,
-	btn_attack3      = 9,
-	btn_deconstruct  = 13,
-	btn_rally        = 14 // also named "taunt" in some places
+	BTN_ANY          = BUTTON_ANY, // = 7, // if any key is pressed
+	BTN_ATTACK2      = 8,
+	BTN_ATTACK3      = 9,
+	BTN_DECONSTRUCT  = 13,
+	BTN_RALLY        = 14 // also named "taunt" in some places
 };
 
 

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -1124,7 +1124,8 @@ enum meansOfDeath_t
   MOD_REPLACE
 };
 
-// TODO: move other button definitions into gamelogic
+// NOTE: BUTTON_TALK, BUTTON_WALKING and BUTTON_ANY are defined in daemon
+// Not sure which one of BTN_GESTURE or BTN_RALLY is "taunt"
 enum buttonNumber_t
 {
 	BTN_ATTACK       = 0,
@@ -1138,7 +1139,7 @@ enum buttonNumber_t
 	BTN_ATTACK2      = 8,
 	BTN_ATTACK3      = 9,
 	BTN_DECONSTRUCT  = 13,
-	BTN_RALLY        = 14, // also named "taunt" in some places
+	BTN_RALLY        = 14,
 };
 
 

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -1128,20 +1128,17 @@ enum meansOfDeath_t
 enum buttonNumber_t
 {
 	BTN_ATTACK       = 0,
-	// defined by daemon
-	BTN_TALK         = BUTTON_TALK, // = 1, // disables actions
+	BTN_TALK         = BUTTON_TALK, // = 1, // disables actions (defined by daemon)
 	BTN_USE_HOLDABLE = 2,
 	BTN_GESTURE      = 3,
-	// defined by daemon
-	BTN_WALKING      = BUTTON_WALKING, // = 4, // walking can't just be inferred from MOVE_RUN
+	BTN_WALKING      = BUTTON_WALKING, // = 4, (defined by daemon)
 	BTN_SPRINT       = 5,
 	BTN_ACTIVATE     = 6,
-	// defined by daemon
-	BTN_ANY          = BUTTON_ANY, // = 7, // if any key is pressed
+	BTN_ANY          = BUTTON_ANY, // = 7, // if any key is pressed (defined by daemon)
 	BTN_ATTACK2      = 8,
 	BTN_ATTACK3      = 9,
 	BTN_DECONSTRUCT  = 13,
-	BTN_RALLY        = 14 // also named "taunt" in some places
+	BTN_RALLY        = 14, // also named "taunt" in some places
 };
 
 


### PR DESCRIPTION
This improves situation on #1202
Only (useful) remaining BUTTON_xxx occurrences in daemon are
BUTTON_WALKING, BUTTON_TALK and BUTTON_ANY, which are used to define
values for their btn_xxx equivalents.
Renaming from BUTTON_xxx to btn_xxx was done to avoid having any symbol
conflict between daemon and unvanquished.