### PR TITLE
Bot BT: add hysteresis node support

### DIFF
--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -202,8 +202,9 @@ void G_BotChangeBehavior( int clientNum, const char* behavior )
 
 bool G_BotSetBehavior( botMemory_t *botMind, const char* behavior )
 {
-	botMind->runningNodes.clear();
 	botMind->currentNode = nullptr;
+	BotClearRunningNodesHysteresisState( &g_entities[clientNum] );
+	botMind->runningNodes.clear();
 	memset( &botMind->nav, 0, sizeof( botMind->nav ) );
 	BotResetEnemyQueue( &botMind->enemyQueue );
 

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -444,6 +444,22 @@ bool EvalConditionExpression( gentity_t *self, AIExpType_t *exp )
 	return false;
 }
 
+void BotClearRunningNodesHysteresisState( gentity_t *self )
+{
+	int clientNum = self - g_entities;
+	botMemory_t *botMind = self->botMind;
+	for ( int i=0; i < botMind->numRunningNodes; i++ )
+	{
+		if ( botMind->runningNodes[i]->type == HYSTERESIS_NODE )
+		{
+			AIHysteresisNode_t *hyst =
+				reinterpret_cast<AIHysteresisNode_t *>(
+					botMind->runningNodes[i] );
+			hyst->currentlyOnForClient[clientNum] = false;
+		}
+	}
+}
+
 // TODO: fuse this with EvalConditionExpression into a function returning
 // AIValue_t and do proper type handling
 float EvalHysteresisExpression( gentity_t *self, AIExpType_t *exp )
@@ -566,6 +582,7 @@ AINodeStatus_t BotEvaluateNode( gentity_t *self, AIGenericNode_t *node )
 	// reset running information on node success so sequences and selectors reset their state
 	if ( NodeIsRunning( self, node ) && status == STATUS_SUCCESS )
 	{
+		BotClearRunningNodesHysteresisState( self );
 		self->botMind->runningNodes.clear();
 	}
 

--- a/src/sgame/sg_bot_ai.h
+++ b/src/sgame/sg_bot_ai.h
@@ -75,6 +75,7 @@ enum AINode_t
 	SELECTOR_NODE,
 	ACTION_NODE,
 	CONDITION_NODE,
+	HYSTERESIS_NODE,
 	BEHAVIOR_NODE,
 	DECORATOR_NODE
 };
@@ -191,6 +192,17 @@ struct AIConditionNode_t
 	AIExpType_t     *exp;
 };
 
+struct AIHysteresisNode_t
+{
+	AINode_t        type;
+	AINodeRunner    run;
+	AIGenericNode_t *child;
+	AIExpType_t     *exp;
+	float switchOffThresold;
+	float switchOnThresold;
+	bool currentlyOnForClient[MAX_CLIENTS];
+};
+
 struct AIDecoratorNode_t
 {
 	AINode_t        type;
@@ -228,6 +240,7 @@ botEntityAndDistance_t AIEntityToGentity( gentity_t *self, AIEntity_t e );
 // standard behavior tree control-flow nodes
 AINodeStatus_t BotEvaluateNode( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotConditionNode( gentity_t *self, AIGenericNode_t *node );
+AINodeStatus_t BotHysteresisNode( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotSelectorNode( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotSequenceNode( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotConcurrentNode( gentity_t *self, AIGenericNode_t *node );

--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -135,4 +135,6 @@ bool G_BotFindRoute( int botClientNum, const botRouteTarget_t *target, bool allo
 void G_BotUpdatePath( int botClientNum, const botRouteTarget_t *target, botNavCmd_t *cmd );
 bool G_BotNavTrace( int botClientNum, botTrace_t *botTrace, const vec3_t start, const vec3_t end );
 
+void BotClearRunningNodesHysteresisState( gentity_t *bot );
+
 #endif

--- a/src/sgame/sg_bot_parse.h
+++ b/src/sgame/sg_bot_parse.h
@@ -87,6 +87,7 @@ AIBehaviorTree_t *ReadBehaviorTree( const char *name, AITreeList_t *list );
 void FreeBehaviorTree( AIBehaviorTree_t *tree );
 void FreeActionNode( AIActionNode_t *action );
 void FreeConditionNode( AIConditionNode_t *node );
+void FreeHysteresisNode( AIHysteresisNode_t *node );
 void FreeNodeList( AINodeList_t *node );
 void FreeNode( AIGenericNode_t *node );
 void FreeOp( AIOp_t *op );


### PR DESCRIPTION
Bots have terrible remembrance of the past. One way we do currently add some persistance is with a `sequence { condition (x>300); action }`, but it has the terrible downside of continuing the action until the bot dies, or the action succeed or fail. This will allow for finer grained control where one can tell the bot to do an action *until* the score value goes down, or the action succeeds.

Tested with the following BT (designed for human bots only):
```javascript
selector
{
        hysteresis 100 300 distanceTo( E_H_MEDISTAT )
        {
                action moveTo( E_H_MEDISTAT )
        }

        action moveTo( E_A_OVERMIND )
}

```

@bmorel hopefully you'll like it a lot