### PR TITLE
Distinguish between VFS and homepath file access

### DIFF
--- a/src/cgame/cg_beacon.cpp
+++ b/src/cgame/cg_beacon.cpp
@@ -55,7 +55,7 @@ void CG_LoadBeaconsConfig()
 	bc->hudCenter[ 0 ] = vw / 2;
 	bc->hudCenter[ 1 ] = vh / 2;
 
-	fd = Parse_LoadSourceHandle( path );
+	fd = Parse_LoadSourceHandle( path, trap_FS_OpenPakFile );
 	if ( !fd )
 		return;
 

--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -366,37 +366,23 @@ models/buildables/hivemind/animation.cfg, etc
 static bool CG_ParseBuildableAnimationFile( const char *filename, buildable_t buildable )
 {
 	const char         *text_p;
-	int          len;
 	int          i;
 	char         *token;
 	float        fps;
-	char         text[ 20000 ];
-	fileHandle_t f;
 	animation_t  *animations;
 
 	animations = cg_buildables[ buildable ].animations;
 
-	// load the file
-	len = trap_FS_FOpenFile( filename, &f, fsMode_t::FS_READ );
-
-	if ( len < 0 )
+	std::error_code err;
+	std::string text = FS::PakPath::ReadFile( filename, err );
+	if ( err )
 	{
+		Log::Warn( "couldn't read buildable animation file '%s': %s", filename, err.message() );
 		return false;
 	}
-
-	if ( len == 0 || len + 1 >= (int) sizeof( text ) )
-	{
-		trap_FS_FCloseFile( f );
-		Log::Warn( len == 0 ? "File %s is empty" : "File %s is too long", filename );
-		return false;
-	}
-
-	trap_FS_Read( text, len, f );
-	text[ len ] = 0;
-	trap_FS_FCloseFile( f );
 
 	// parse the text
-	text_p = text;
+	text_p = text.c_str();
 
 	// read information for each frame
 	for ( i = BANIM_NONE + 1; i < MAX_BUILDABLE_ANIMATIONS; i++ )
@@ -480,36 +466,22 @@ sound/buildables/hivemind/sound.cfg, etc
 static bool CG_ParseBuildableSoundFile( const char *filename, buildable_t buildable )
 {
 	const char         *text_p;
-	int          len;
 	int          i;
 	char         *token;
-	char         text[ 20000 ];
-	fileHandle_t f;
 	sound_t      *sounds;
 
 	sounds = cg_buildables[ buildable ].sounds;
 
-	// load the file
-	len = trap_FS_FOpenFile( filename, &f, fsMode_t::FS_READ );
-
-	if ( len < 0 )
+	std::error_code err;
+	std::string text = FS::PakPath::ReadFile( filename, err );
+	if ( err )
 	{
+		Log::Warn( "couldn't read buildable sound file '%s': %s", filename, err.message() );
 		return false;
 	}
-
-	if ( len == 0 || len + 1 >= (int) sizeof( text ) )
-	{
-		trap_FS_FCloseFile( f );
-		Log::Warn( len == 0 ? "File %s is empty" : "File %s is too long", filename );
-		return false;
-	}
-
-	trap_FS_Read( text, len, f );
-	text[ len ] = 0;
-	trap_FS_FCloseFile( f );
 
 	// parse the text
-	text_p = text;
+	text_p = text.c_str();
 
 	// read information for each frame
 	for ( i = BANIM_NONE + 1; i < MAX_BUILDABLE_ANIMATIONS; i++ )

--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -1375,7 +1375,7 @@ void CG_BuildableStatusParse( const char *filename, buildStat_t *bs )
 	float      f;
 	Color::Color c;
 
-	handle = Parse_LoadSourceHandle( filename );
+	handle = Parse_LoadSourceHandle( filename, trap_FS_OpenPakFile );
 
 	if ( !handle )
 	{

--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -634,7 +634,7 @@ void CG_InitBuildables()
 		//Load models
 		//Prefer md5 models over md3
 
-		if ( CG_FileExists( va( "models/buildables/%s/%s.iqm", buildableName, buildableName ) ) &&
+		if ( FS::PakPath::FileExists( va( "models/buildables/%s/%s.iqm", buildableName, buildableName ) ) &&
 		     ( bi->models[ 0 ] = trap_R_RegisterModel( va( "models/buildables/%s/%s.iqm",
 		                                                   buildableName, buildableName ) ) ) )
 		{

--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -24,6 +24,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
+#include "common/FileSystem.h"
 #include "shared/parse.h"
 #include "cg_local.h"
 

--- a/src/cgame/cg_gameinfo.cpp
+++ b/src/cgame/cg_gameinfo.cpp
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // gameinfo.c
 //
 
+#include "common/FileSystem.h"
 #include "cg_local.h"
 
 //
@@ -120,31 +121,22 @@ CG_LoadArenasFromFile
 */
 static void CG_LoadArenasFromFile( char *filename )
 {
-	int          len;
-	fileHandle_t f;
-	char         buf[ MAX_ARENAS_TEXT ];
-
-	len = trap_FS_FOpenFile( filename, &f, fsMode_t::FS_READ );
-
-	if ( !f )
+	std::error_code err;
+	std::string text = FS::PakPath::ReadFile( filename, err );
+	if ( err )
 	{
-		Log::Warn( "%sfile not found: %s", Color::ToString( Color::Red ), filename );
+		Log::Warn( "file not found: %s", filename );
 		return;
 	}
 
-	if ( len >= MAX_ARENAS_TEXT )
+	if ( text.size() >= MAX_ARENAS_TEXT )
 	{
-		Log::Warn( "%sfile too large: %s is %i, max allowed is %i",
-			Color::ToString( Color::Red ), filename, len, MAX_ARENAS_TEXT );
-		trap_FS_FCloseFile( f );
+		Log::Warn( "file too large: %s is %i, max allowed is %i",
+			filename, text.size(), MAX_ARENAS_TEXT );
 		return;
 	}
 
-	trap_FS_Read( buf, len, f );
-	buf[ len ] = 0;
-	trap_FS_FCloseFile( f );
-
-	cg_numArenas += CG_ParseInfos( buf, MAX_ARENAS - cg_numArenas, &cg_arenaInfos[ cg_numArenas ] );
+	cg_numArenas += CG_ParseInfos( text.c_str(), MAX_ARENAS - cg_numArenas, &cg_arenaInfos[ cg_numArenas ] );
 }
 
 /*

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1861,7 +1861,6 @@ void       CG_FocusEvent( bool focus );
 bool   CG_ClientIsReady( int clientNum );
 void       CG_BuildSpectatorString();
 
-bool   CG_FileExists( const char *filename );
 void       CG_UpdateBuildableRangeMarkerMask();
 void       CG_RegisterGrading( int slot, const char *str );
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -437,19 +437,6 @@ static const char *choose( const char *first, ... )
 	return ret;
 }
 
-
-/*
-=================
-CG_FileExists
-
-Test if a specific file exists or not
-=================
-*/
-bool CG_FileExists( const char *filename )
-{
-	return trap_FS_FOpenFile( filename, nullptr, fsMode_t::FS_READ );
-}
-
 static void CG_UpdateMediaFraction( float fraction )
 {
 	cg.mediaLoadingFraction = fraction;

--- a/src/cgame/cg_particles.cpp
+++ b/src/cgame/cg_particles.cpp
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // cg_particles.c -- the particle system
 
+#include "common/FileSystem.h"
 #include "cg_local.h"
 
 static baseParticleSystem_t  baseParticleSystems[ MAX_BASEPARTICLE_SYSTEMS ];
@@ -1738,34 +1739,20 @@ static bool CG_ParseParticleFile( const char *fileName )
 {
 	const char         *text_p;
 	int          i;
-	int          len;
 	char         *token;
-	char         text[ 32000 ];
 	char         psName[ MAX_QPATH ];
 	bool     psNameSet = false;
-	fileHandle_t f;
 
-	// load the file
-	len = trap_FS_FOpenFile( fileName, &f, fsMode_t::FS_READ );
-
-	if ( len < 0 )
+	std::error_code err;
+	std::string text = FS::PakPath::ReadFile( fileName, err );
+	if ( err )
 	{
+		Log::Warn( "couldn't read particle file '%s': %s", fileName, err.message() );
 		return false;
 	}
-
-	if ( len == 0 || len + 1 >= (int) sizeof( text ) )
-	{
-		trap_FS_FCloseFile( f );
-		Log::Warn( len ? "particle file %s is too long" : "particle file %s is empty", fileName );
-		return false;
-	}
-
-	trap_FS_Read( text, len, f );
-	text[ len ] = 0;
-	trap_FS_FCloseFile( f );
 
 	// parse the text
-	text_p = text;
+	text_p = text.c_str();
 
 	// read optional parameters
 	while ( 1 )

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // cg_players.c -- handle the media and animation for player entities
 
+#include "common/FileSystem.h"
 #include "cg_local.h"
 #include "cg_animdelta.h"
 #include "cg_segmented_skeleton.h"
@@ -806,14 +807,14 @@ static bool CG_RegisterClientModelname( clientInfo_t *ci, const char *modelName,
 	char filename[ MAX_QPATH ];
 
 	Com_sprintf( filename, sizeof( filename ), "models/players/%s/%s.iqm", modelName, modelName );
-	if ( CG_FileExists( filename ) )
+	if ( FS::PakPath::FileExists( filename ) )
 	{
 		ci->bodyModel = trap_R_RegisterModel( filename );
 	}
 
 	if ( ! ci->bodyModel ) {
 		Com_sprintf( filename, sizeof( filename ), "models/players/%s/body.md5mesh", modelName );
-		if ( CG_FileExists(filename) )
+		if ( FS::PakPath::FileExists(filename) )
 		{
 			ci->bodyModel = trap_R_RegisterModel( filename );
 		}

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -112,33 +112,19 @@ models/players/visor/character.cfg, etc
 static bool CG_ParseCharacterFile( const char *filename, clientInfo_t *ci )
 {
 	const char         *text_p;
-	int          len;
 	int          i;
 	char         *token;
-	char         text[ 20000 ];
-	fileHandle_t f;
 
-	// load the file
-	len = trap_FS_FOpenFile( filename, &f, fsMode_t::FS_READ );
-
-	if ( len <= 0 )
+	std::error_code err;
+	std::string text = FS::PakPath::ReadFile( filename, err );
+	if ( err )
 	{
+		Log::Warn( "couldn't read player model file '%s': %s", filename, err.message() );
 		return false;
 	}
-
-	if ( len + 1 >= (int) sizeof( text ) )
-	{
-		Log::Warn( "File %s is too long", filename );
-		trap_FS_FCloseFile( f );
-		return false;
-	}
-
-	trap_FS_Read( text, len, f );
-	text[ len ] = 0;
-	trap_FS_FCloseFile( f );
 
 	// parse the text
-	text_p = text;
+	text_p = text.c_str();
 
 	ci->footsteps = FOOTSTEP_GENERAL;
 	VectorClear( ci->headOffset );
@@ -382,38 +368,24 @@ Read a configuration file containing animation counts and rates
 static bool CG_ParseAnimationFile( const char *filename, clientInfo_t *ci )
 {
 	const char         *text_p, *prev;
-	int          len;
 	int          i;
 	char         *token;
 	float        fps;
 	int          skip;
-	char         text[ 20000 ];
-	fileHandle_t f;
 	animation_t  *animations;
 
 	animations = ci->animations;
 
-	// load the file
-	len = trap_FS_FOpenFile( filename, &f, fsMode_t::FS_READ );
-
-	if ( len < 0 )
+	std::error_code err;
+	std::string text = FS::PakPath::ReadFile( filename, err );
+	if ( err )
 	{
+		Log::Warn( "couldn't read player animation file '%s': %s", filename, err.message() );
 		return false;
 	}
-
-	if ( len == 0 || len + 1 >= (int) sizeof( text ) )
-	{
-		Log::Warn( len == 0 ? "File %s is empty" : "File %s is too long", filename );
-		trap_FS_FCloseFile( f );
-		return false;
-	}
-
-	trap_FS_Read( text, len, f );
-	text[ len ] = 0;
-	trap_FS_FCloseFile( f );
 
 	// parse the text
-	text_p = text;
+	text_p = text.c_str();
 	skip = 0; // quite the compiler warning
 
 	ci->footsteps = FOOTSTEP_GENERAL;

--- a/src/cgame/cg_rocket.cpp
+++ b/src/cgame/cg_rocket.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/FileSystem.h"
 #include "cg_local.h"
 
 rocketInfo_t rocketInfo;
@@ -43,10 +44,8 @@ static connstate_t oldConnState;
 
 void CG_Rocket_Init( glconfig_t gl )
 {
-	int len;
 	const char *token, *text_p;
 	char text[ 20000 ];
-	fileHandle_t f;
 
 	oldConnState = connstate_t::CA_UNINITIALIZED;
 	cgs.glconfig = gl;
@@ -77,23 +76,9 @@ void CG_Rocket_Init( glconfig_t gl )
 	Rocket_RegisterProperty( "locked-marker-color", "red", false, false, "color" );
 
 	// Preload all the menu files...
-	len = trap_FS_FOpenFile( rocket_menuFile.Get().c_str(), &f, fsMode_t::FS_READ );
+	std::string content = FS::PakPath::ReadFile( rocket_menuFile.Get() );
 
-	if ( len <= 0 )
-	{
-		Sys::Drop( "Unable to load %s. No rocket menus loaded.", rocket_menuFile.Get() );
-	}
-
-	if ( len >= (int) sizeof( text ) - 1 )
-	{
-		trap_FS_FCloseFile( f );
-		Sys::Drop( "File %s too long.", rocket_menuFile.Get() );
-	}
-
-	trap_FS_Read( text, len, f );
-	text[ len ] = 0;
-	text_p = text;
-	trap_FS_FCloseFile( f );
+	text_p = content.c_str();
 
 	// Parse files to load...
 	while ( 1 )
@@ -265,29 +250,12 @@ void CG_Rocket_Init( glconfig_t gl )
 
 void CG_Rocket_LoadHuds()
 {
-	int i, len;
+	int i;
 	const char *token, *text_p;
-	char text[ 20000 ];
-	fileHandle_t f;
 
 	// Preload all the menu files...
-	len = trap_FS_FOpenFile( rocket_hudFile.Get().c_str(), &f, fsMode_t::FS_READ );
-
-	if ( len <= 0 )
-	{
-		Sys::Drop( "Unable to load %s. No rocket menus loaded.", rocket_menuFile.Get() );
-	}
-
-	if ( len >= (int) sizeof( text ) - 1 )
-	{
-		trap_FS_FCloseFile( f );
-		Sys::Drop( "File %s too long.", rocket_hudFile.Get() );
-	}
-
-	trap_FS_Read( text, len, f );
-	text[ len ] = 0;
-	text_p = text;
-	trap_FS_FCloseFile( f );
+	std::string text = FS::PakPath::ReadFile( rocket_hudFile.Get() );
+	text_p = text.c_str();
 
 	Rocket_InitializeHuds( WP_NUM_WEAPONS );
 

--- a/src/cgame/cg_trails.cpp
+++ b/src/cgame/cg_trails.cpp
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // cg_trails.c -- the trail system
 
+#include "common/FileSystem.h"
 #include "cg_local.h"
 
 static Log::Logger logs = Log::Logger("cgame.trails", "[Trail Systems]");
@@ -1206,34 +1207,20 @@ static bool CG_ParseTrailFile( const char *fileName )
 {
 	const char         *text_p;
 	int          i;
-	int          len;
 	char         *token;
-	char         text[ 32000 ];
 	char         tsName[ MAX_QPATH ];
 	bool     tsNameSet = false;
-	fileHandle_t f;
 
-	// load the file
-	len = trap_FS_FOpenFile( fileName, &f, fsMode_t::FS_READ );
-
-	if ( len <= 0 )
+	std::error_code err;
+	std::string text = FS::PakPath::ReadFile( fileName, err );
+	if ( err )
 	{
+		Log::Warn( "couldn't read trail system file '%s': %s", fileName, err.message() );
 		return false;
 	}
-
-	if ( len == 0 || len + 1 >= (int) sizeof( text ) )
-	{
-		trap_FS_FCloseFile( f );
-		logs.Warn( len ? "trail file %s is too long" : "trail file %s is empty", fileName );
-		return false;
-	}
-
-	trap_FS_Read( text, len, f );
-	text[ len ] = 0;
-	trap_FS_FCloseFile( f );
 
 	// parse the text
-	text_p = text;
+	text_p = text.c_str();
 
 	// read optional parameters
 	while ( 1 )

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -85,31 +85,23 @@ Load custom crosshairs specified by the user
 static void CG_LoadCustomCrosshairs()
 {
 	const char         *text_p, *token;
-	char         text[ 20000 ];
-	int          len;
-	fileHandle_t f;
 	weapon_t     weapon;
 
-	len = trap_FS_FOpenFile( cg_crosshairFile.Get().c_str(), &f, fsMode_t::FS_READ );
-
-	if ( len < 0 )
+	std::string filename = cg_crosshairFile.Get();
+	if ( filename.empty() )
 	{
 		return;
 	}
-
-	if ( len == 0 || len + 1 >= (int) sizeof( text ) )
+	std::error_code err;
+	std::string text = FS::PakPath::ReadFile( filename, err );
+	if ( err )
 	{
-		Log::Warn( len == 0 ? "File %s is empty" : "File %s is too long", cg_crosshairFile.Get() );
-		trap_FS_FCloseFile( f );
+		Log::Warn( "couldn't read custom crosshair file '%s': %s", filename, err.message() );
 		return;
 	}
-
-	trap_FS_Read( text, len, f );
-	text[ len ] = 0;
-	trap_FS_FCloseFile( f );
 
 	// parse the text
-	text_p = text;
+	text_p = text.c_str();
 
 	while ( 1 )
 	{
@@ -230,37 +222,28 @@ Reads the animation.cfg for weapons
 static bool CG_ParseWeaponAnimationFile( const char *filename, weaponInfo_t *wi )
 {
 	const char         *text_p;
-	int          len;
 	int          i;
 	char         *token;
 	float        fps;
-	char         text[ 20000 ];
-	fileHandle_t f;
 	animation_t  *animations;
 
 	animations = wi->animations;
 
-	// load the file
-	len = trap_FS_FOpenFile( filename, &f, fsMode_t::FS_READ );
-
-	if ( len < 0 )
+	std::error_code err;
+	std::string text = FS::PakPath::ReadFile( filename, err );
+	if ( err )
 	{
+		const std::error_code notFound(Util::ordinal(FS::filesystem_error::no_such_file), FS::filesystem_category());
+		// Some weapons e.g. dretch attack actually don't have animations
+		if ( err != notFound )
+		{
+			Log::Warn( "couldn't read weapon animation file '%s': %s", filename, err.message() );
+		}
 		return false;
 	}
-
-	if ( len == 0 || len + 1 >= (int) sizeof( text ) )
-	{
-		Log::Warn( len == 0 ? "File %s is empty" : "File %s is too long", filename );
-		trap_FS_FCloseFile( f );
-		return false;
-	}
-
-	trap_FS_Read( text, len, f );
-	text[ len ] = 0;
-	trap_FS_FCloseFile( f );
 
 	// parse the text
-	text_p = text;
+	text_p = text.c_str();
 
 	for ( i = WANIM_NONE + 1; i < MAX_WEAPON_ANIMATIONS; i++ )
 	{
@@ -618,37 +601,23 @@ Parses a configuration file describing a weapon
 static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *wi )
 {
 	const char         *text_p;
-	int          len;
 	char         *token;
-	char         text[ 20000 ];
-	fileHandle_t f;
 	weaponMode_t weaponMode = WPM_NONE;
 	char         token2[ MAX_QPATH ];
 	int          i;
 
-	// load the file
-	len = trap_FS_FOpenFile( filename, &f, fsMode_t::FS_READ );
-
-	if ( len < 0 )
+	std::error_code err;
+	std::string text = FS::PakPath::ReadFile( filename, err );
+	if ( err )
 	{
+		Log::Warn( "couldn't read weapon configuration file '%s': %s", filename, err.message() );
 		return false;
 	}
-
-	if ( len == 0 || len + 1 >= (int) sizeof( text ) )
-	{
-		trap_FS_FCloseFile( f );
-		Log::Warn( len == 0 ? "File %s is empty" : "File %s is too long", filename );
-		return false;
-	}
-
-	trap_FS_Read( text, len, f );
-	text[ len ] = 0;
-	trap_FS_FCloseFile( f );
-
-	wi->scale = 1.0f;
 
 	// parse the text
-	text_p = text;
+	text_p = text.c_str();
+
+	wi->scale = 1.0f;
 
 	// read optional parameters
 	while ( 1 )

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // cg_weapons.c -- events and effects dealing with weapons
 
+#include "common/FileSystem.h"
 #include "cg_local.h"
 
 static refSkeleton_t gunSkeleton;
@@ -705,7 +706,7 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 
 			COM_StripExtension( token, token2 );
 
-			if ( CG_FileExists( va( "%s_view.iqm", token2 ) ) &&
+			if ( FS::PakPath::FileExists( va( "%s_view.iqm", token2 ) ) &&
 			     ( wi->weaponModel = trap_R_RegisterModel( va( "%s_view.iqm", token2 ) ) ) )
 			{
 				wi->md5 = true;
@@ -790,7 +791,7 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 						break;
 				}
 			}
-			else if ( CG_FileExists( va( "%s_view.md5mesh", token2 ) ) &&
+			else if ( FS::PakPath::FileExists( va( "%s_view.md5mesh", token2 ) ) &&
 			          ( wi->weaponModel = trap_R_RegisterModel( va( "%s_view.md5mesh", token2 ) ) ) )
 			{
 				wi->md5 = true;
@@ -887,21 +888,21 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 
 			COM_StripExtension( token, path );
 			strcat( path, "_flash.md3" );
-			if ( CG_FileExists( path ) )
+			if ( FS::PakPath::FileExists( path ) )
 			{
 				wi->flashModel = trap_R_RegisterModel( path );
 			}
 
 			COM_StripExtension( token, path );
 			strcat( path, "_barrel.md3" );
-			if ( CG_FileExists( path ) )
+			if ( FS::PakPath::FileExists( path ) )
 			{
 				wi->barrelModel = trap_R_RegisterModel( path );
 			}
 
 			COM_StripExtension( token, path );
 			strcat( path, "_hand.md3" );
-			if ( CG_FileExists( path ) )
+			if ( FS::PakPath::FileExists( path ) )
 			{
 				wi->handsModel = trap_R_RegisterModel( path );
 			}
@@ -929,14 +930,14 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 
 			COM_StripExtension( token, path );
 			strcat( path, "_flash.md3" );
-			if ( CG_FileExists( path ) )
+			if ( FS::PakPath::FileExists( path ) )
 			{
 				wi->flashModel3rdPerson = trap_R_RegisterModel( path );
 			}
 
 			COM_StripExtension( token, path );
 			strcat( path, "_barrel.md3" );
-			if ( CG_FileExists( path ) )
+			if ( FS::PakPath::FileExists( path ) )
 			{
 			    wi->barrelModel3rdPerson = trap_R_RegisterModel( path );
 			}

--- a/src/cgame/rocket/rocket.cpp
+++ b/src/cgame/rocket/rocket.cpp
@@ -76,7 +76,7 @@ public:
 	Rocket::Core::FileHandle Open( const Rocket::Core::String &filePath )
 	{
 		fileHandle_t fileHandle;
-		trap_FS_FOpenFile( filePath.CString(), &fileHandle, fsMode_t::FS_READ );
+		trap_FS_OpenPakFile( filePath.CString(), fileHandle );
 		return ( Rocket::Core::FileHandle )fileHandle;
 	}
 

--- a/src/cgame/rocket/rocket.cpp
+++ b/src/cgame/rocket/rocket.cpp
@@ -34,6 +34,7 @@ Maryland 20850 USA.
 
 // The basic interfaces for libRocket
 
+#include "common/Common.h"
 #include "rocket.h"
 #include <Rocket/Core/FileInterface.h>
 #include <Rocket/Core/SystemInterface.h>

--- a/src/cgame/translation.cpp
+++ b/src/cgame/translation.cpp
@@ -75,7 +75,7 @@ public:
 		end = buffer + BUFFER_SIZE - putBack;
 		setg( end, end, end );
 
-		trap_FS_FOpenFile( filename.c_str(), &fileHandle, fsMode_t::FS_READ );
+		trap_FS_OpenPakFile( filename.c_str(), fileHandle );
 	}
 
 	~DaemonInputbuf()

--- a/src/sgame/botlib/bot_load.cpp
+++ b/src/sgame/botlib/bot_load.cpp
@@ -69,11 +69,6 @@ void BotInit()
 #endif
 }
 
-#define FS_Read trap_FS_Read
-#define FS_Write trap_FS_Write
-#define FS_FCloseFile trap_FS_FCloseFile
-#define FS_FOpenFileRead(name, handle) trap_FS_FOpenFile((name), (handle), fsMode_t::FS_READ)
-
 void BotSaveOffMeshConnections( NavData_t *nav )
 {
 	char filePath[ MAX_QPATH ];
@@ -92,40 +87,40 @@ void BotSaveOffMeshConnections( NavData_t *nav )
 	OffMeshConnectionHeader header;
 	header.version = LittleLong( NAVMESHCON_VERSION );
 	header.numConnections = LittleLong( conCount );
-	FS_Write( &header, sizeof( header ), f );
+	trap_FS_Write( &header, sizeof( header ), f );
 
 	size_t size = sizeof( float ) * 6 * conCount;
 	float *verts = ( float * ) dtAlloc( size, DT_ALLOC_TEMP );
 	memcpy( verts, nav->process.con.verts, size );
 	SwapArray( verts, conCount * 6 );
-	FS_Write( verts, size, f );
+	trap_FS_Write( verts, size, f );
 	dtFree( verts );
 
 	size = sizeof( float ) * conCount;
 	float *rad = ( float * ) dtAlloc( size, DT_ALLOC_TEMP );
 	memcpy( rad, nav->process.con.rad, size );
 	SwapArray( rad, conCount );
-	FS_Write( rad, size, f );
+	trap_FS_Write( rad, size, f );
 	dtFree( rad );
 
 	size = sizeof( unsigned short ) * conCount;
 	unsigned short *flags = ( unsigned short * ) dtAlloc( size, DT_ALLOC_TEMP );
 	memcpy( flags, nav->process.con.flags, size );
 	SwapArray( flags, conCount );
-	FS_Write( flags, size, f );
+	trap_FS_Write( flags, size, f );
 	dtFree( flags );
 
-	FS_Write( nav->process.con.areas, sizeof( unsigned char ) * conCount, f );
-	FS_Write( nav->process.con.dirs, sizeof( unsigned char ) * conCount, f );
+	trap_FS_Write( nav->process.con.areas, sizeof( unsigned char ) * conCount, f );
+	trap_FS_Write( nav->process.con.dirs, sizeof( unsigned char ) * conCount, f );
 
 	size = sizeof( unsigned int ) * conCount;
 	unsigned int *userids = ( unsigned int * ) dtAlloc( size, DT_ALLOC_TEMP );
 	memcpy( userids, nav->process.con.userids, size );
 	SwapArray( userids, conCount );
-	FS_Write( userids, size, f );
+	trap_FS_Write( userids, size, f );
 	dtFree( userids );
 
-	FS_FCloseFile( f );
+	trap_FS_FCloseFile( f );
 }
 
 void BotLoadOffMeshConnections( const char *filename, NavData_t *nav )
@@ -135,7 +130,7 @@ void BotLoadOffMeshConnections( const char *filename, NavData_t *nav )
 
 	std::string mapname = Cvar::GetValue("mapname");
 	Com_sprintf( filePath, sizeof( filePath ), "maps/%s-%s.navcon", mapname.c_str(), filename );
-	FS_FOpenFileRead( filePath, &f );
+	trap_FS_FOpenFile( filePath, &f, fsMode_t::FS_READ );
 
 	if ( !f )
 	{
@@ -143,14 +138,14 @@ void BotLoadOffMeshConnections( const char *filename, NavData_t *nav )
 	}
 
 	OffMeshConnectionHeader header;
-	FS_Read( &header, sizeof( header ), f );
+	trap_FS_Read( &header, sizeof( header ), f );
 
 	header.version = LittleLong( header.version );
 	header.numConnections = LittleLong( header.numConnections );
 
 	if ( header.version != NAVMESHCON_VERSION )
 	{
-		FS_FCloseFile( f );
+		trap_FS_FCloseFile( f );
 		return;
 	}
 
@@ -158,28 +153,28 @@ void BotLoadOffMeshConnections( const char *filename, NavData_t *nav )
 
 	if ( conCount > nav->process.con.MAX_CON )
 	{
-		FS_FCloseFile( f );
+		trap_FS_FCloseFile( f );
 		return;
 	}
 
 	nav->process.con.offMeshConCount = conCount;
 
-	FS_Read( nav->process.con.verts, sizeof( float ) * 6 * conCount, f );
+	trap_FS_Read( nav->process.con.verts, sizeof( float ) * 6 * conCount, f );
 	SwapArray( nav->process.con.verts, conCount * 6 );
 
-	FS_Read( nav->process.con.rad, sizeof( float ) * conCount, f );
+	trap_FS_Read( nav->process.con.rad, sizeof( float ) * conCount, f );
 	SwapArray( nav->process.con.rad, conCount );
 
-	FS_Read( nav->process.con.flags, sizeof( unsigned short ) * conCount, f );
+	trap_FS_Read( nav->process.con.flags, sizeof( unsigned short ) * conCount, f );
 	SwapArray( nav->process.con.flags, conCount );
 
-	FS_Read( nav->process.con.areas, sizeof( unsigned char ) * conCount, f );
-	FS_Read( nav->process.con.dirs, sizeof( unsigned char ) * conCount, f );
+	trap_FS_Read( nav->process.con.areas, sizeof( unsigned char ) * conCount, f );
+	trap_FS_Read( nav->process.con.dirs, sizeof( unsigned char ) * conCount, f );
 
-	FS_Read( nav->process.con.userids, sizeof( unsigned int ) * conCount, f );
+	trap_FS_Read( nav->process.con.userids, sizeof( unsigned int ) * conCount, f );
 	SwapArray( nav->process.con.userids, conCount );
 
-	FS_FCloseFile( f );
+	trap_FS_FCloseFile( f );
 }
 
 static bool BotLoadNavMesh( const char *filename, NavData_t &nav )
@@ -193,7 +188,7 @@ static bool BotLoadNavMesh( const char *filename, NavData_t &nav )
 	Com_sprintf( filePath, sizeof( filePath ), "maps/%s-%s.navMesh", mapname.c_str(), filename );
 	Log::Notice( " loading navigation mesh file '%s'...", filePath );
 
-	int len = FS_FOpenFileRead( filePath, &f );
+	int len = trap_FS_FOpenFile( filePath, &f, fsMode_t::FS_READ );
 
 	if ( !f )
 	{
@@ -209,21 +204,21 @@ static bool BotLoadNavMesh( const char *filename, NavData_t &nav )
 
 	NavMeshSetHeader header;
 	
-	FS_Read( &header, sizeof( header ), f );
+	trap_FS_Read( &header, sizeof( header ), f );
 
 	SwapNavMeshSetHeader( header );
 
 	if ( header.magic != NAVMESHSET_MAGIC )
 	{
 		Log::Warn("File is wrong magic" );
-		FS_FCloseFile( f );
+		trap_FS_FCloseFile( f );
 		return false;
 	}
 
 	if ( header.version != NAVMESHSET_VERSION )
 	{
 		Log::Warn("File is wrong version found: %d want: %d", header.version, NAVMESHSET_VERSION );
-		FS_FCloseFile( f );
+		trap_FS_FCloseFile( f );
 		return false;
 	}
 
@@ -232,7 +227,7 @@ static bool BotLoadNavMesh( const char *filename, NavData_t &nav )
 	if ( !nav.mesh )
 	{
 		Log::Warn("Unable to allocate nav mesh" );
-		FS_FCloseFile( f );
+		trap_FS_FCloseFile( f );
 		return false;
 	}
 
@@ -243,7 +238,7 @@ static bool BotLoadNavMesh( const char *filename, NavData_t &nav )
 		Log::Warn("Could not init navmesh" );
 		dtFreeNavMesh( nav.mesh );
 		nav.mesh = nullptr;
-		FS_FCloseFile( f );
+		trap_FS_FCloseFile( f );
 		return false;
 	}
 
@@ -254,7 +249,7 @@ static bool BotLoadNavMesh( const char *filename, NavData_t &nav )
 		Log::Warn("Could not allocate tile cache" );
 		dtFreeNavMesh( nav.mesh );
 		nav.mesh = nullptr;
-		FS_FCloseFile( f );
+		trap_FS_FCloseFile( f );
 		return false;
 	}
 
@@ -267,7 +262,7 @@ static bool BotLoadNavMesh( const char *filename, NavData_t &nav )
 		dtFreeTileCache( nav.cache );
 		nav.mesh = nullptr;
 		nav.cache = nullptr;
-		FS_FCloseFile( f );
+		trap_FS_FCloseFile( f );
 		return false;
 	}
 
@@ -275,7 +270,7 @@ static bool BotLoadNavMesh( const char *filename, NavData_t &nav )
 	{
 		NavMeshTileHeader tileHeader;
 
-		FS_Read( &tileHeader, sizeof( tileHeader ), f );
+		trap_FS_Read( &tileHeader, sizeof( tileHeader ), f );
 
 		SwapNavMeshTileHeader( tileHeader );
 
@@ -286,7 +281,7 @@ static bool BotLoadNavMesh( const char *filename, NavData_t &nav )
 			dtFreeTileCache( nav.cache );
 			nav.cache = nullptr;
 			nav.mesh = nullptr;
-			FS_FCloseFile( f );
+			trap_FS_FCloseFile( f );
 			return false;
 		}
 
@@ -299,13 +294,13 @@ static bool BotLoadNavMesh( const char *filename, NavData_t &nav )
 			dtFreeTileCache( nav.cache );
 			nav.cache = nullptr;
 			nav.mesh = nullptr;
-			FS_FCloseFile( f );
+			trap_FS_FCloseFile( f );
 			return false;
 		}
 
 		memset( data, 0, tileHeader.dataSize );
 
-		FS_Read( data, tileHeader.dataSize, f );
+		trap_FS_Read( data, tileHeader.dataSize, f );
 
 		if ( LittleLong( 1 ) != 1 )
 		{
@@ -323,7 +318,7 @@ static bool BotLoadNavMesh( const char *filename, NavData_t &nav )
 			dtFreeNavMesh( nav.mesh );
 			nav.cache = nullptr;
 			nav.mesh = nullptr;
-			FS_FCloseFile( f );
+			trap_FS_FCloseFile( f );
 			return false;
 		}
 
@@ -333,7 +328,7 @@ static bool BotLoadNavMesh( const char *filename, NavData_t &nav )
 		}
 	}
 
-	FS_FCloseFile( f );
+	trap_FS_FCloseFile( f );
 	return true;
 }
 

--- a/src/sgame/botlib/bot_load.cpp
+++ b/src/sgame/botlib/bot_load.cpp
@@ -130,7 +130,7 @@ void BotLoadOffMeshConnections( const char *filename, NavData_t *nav )
 
 	std::string mapname = Cvar::GetValue("mapname");
 	Com_sprintf( filePath, sizeof( filePath ), "maps/%s-%s.navcon", mapname.c_str(), filename );
-	trap_FS_FOpenFile( filePath, &f, fsMode_t::FS_READ );
+	G_FOpenGameOrPakPath( filePath, f );
 
 	if ( !f )
 	{
@@ -188,7 +188,7 @@ static bool BotLoadNavMesh( const char *filename, NavData_t &nav )
 	Com_sprintf( filePath, sizeof( filePath ), "maps/%s-%s.navMesh", mapname.c_str(), filename );
 	Log::Notice( " loading navigation mesh file '%s'...", filePath );
 
-	int len = trap_FS_FOpenFile( filePath, &f, fsMode_t::FS_READ );
+	int len = G_FOpenGameOrPakPath( filePath, f );
 
 	if ( !f )
 	{

--- a/src/sgame/botlib/bot_nav_edit.cpp
+++ b/src/sgame/botlib/bot_nav_edit.cpp
@@ -191,34 +191,31 @@ static bool CheckHost( gentity_t *ent )
 	return false;
 }
 
-#define Cmd_Argc trap_Argc
-#define Cmd_Argv(i) (trap_Args().Argv(i).c_str())
-
 void Cmd_NavEdit( gentity_t *ent )
 {
 	if ( !CheckHost( ent ) ) return;
-	int argc = Cmd_Argc();
+	const Cmd::Args& args = trap_Args();
 	const char *arg = nullptr;
 	const char usage[] = "Usage: navedit enable/disable/save <navmesh>";
 
-	if ( argc < 2 )
+	if ( args.Argc() < 2 )
 	{
 		Log::Notice( usage );
 		return;
 	}
 
-	arg = Cmd_Argv( 1 );
+	arg = args.Argv( 1 ).c_str();
 
 	if ( !Q_stricmp( arg, "enable" ) )
 	{
 		int i;
-		if ( argc < 3 )
+		if ( args.Argc() < 3 )
 		{
 			Log::Notice( usage );
 			return;
 		}
 
-		arg = Cmd_Argv( 2 );
+		arg = args.Argv( 2 ).c_str();
 		for ( i = 0; i < numNavData; i++ )
 		{
 			if ( !Q_stricmp( BotNavData[ i ].name, arg ) )
@@ -266,15 +263,15 @@ void Cmd_AddConnection( gentity_t *ent )
 	const char usage[] = "Usage: addcon start <dir> (radius)\n"
 	                     " addcon end";
 	const char *arg = nullptr;
-	int argc = Cmd_Argc();
+	const Cmd::Args& args = trap_Args();
 
-	if ( argc < 2 )
+	if ( args.Argc() < 2 )
 	{
 		Log::Notice( usage );
 		return;
 	}
 
-	arg = Cmd_Argv( 1 );
+	arg = args.Argv( 1 ).c_str();
 
 	if ( !Q_stricmp( arg, "start" ) )
 	{
@@ -283,13 +280,13 @@ void Cmd_AddConnection( gentity_t *ent )
 			return;
 		}
 
-		if ( argc < 3 )
+		if ( args.Argc() < 3 )
 		{
 			Log::Notice( usage );
 			return;
 		}
 
-		arg = Cmd_Argv( 2 );
+		arg = args.Argv( 2 ).c_str();
 
 		if ( !Q_stricmp( arg, "oneway" ) )
 		{
@@ -311,9 +308,9 @@ void Cmd_AddConnection( gentity_t *ent )
 			cmd.pc.flag = POLYFLAGS_WALK;
 			cmd.pc.userid = 0;
 
-			if ( argc == 4 )
+			if ( args.Argc() == 4 )
 			{
-				cmd.pc.radius = std::max( atoi( Cmd_Argv( 3 ) ), 10 );
+				cmd.pc.radius = std::max( atoi( args.Argv( 3 ).c_str() ), 10 );
 			}
 			else
 			{
@@ -368,8 +365,7 @@ void Cmd_NavTest( gentity_t *ent )
 {
 	if ( !CheckHost( ent ) ) return;
 	const char usage[] = "Usage: navtest shownodes/hidenodes/showportals/hideportals/startpath/endpath";
-	const char *arg = nullptr;
-	int argc = Cmd_Argc();
+	const Cmd::Args& args = trap_Args();
 
 	if ( !cmd.enabled )
 	{
@@ -377,13 +373,13 @@ void Cmd_NavTest( gentity_t *ent )
 		return;
 	}
 
-	if ( argc < 2 )
+	if ( args.Argc() < 2 )
 	{
 		Log::Notice( usage );
 		return;
 	}
 
-	arg = Cmd_Argv( 1 );
+	const char* arg = args.Argv( 1 ).c_str();
 
 	if ( !Q_stricmp( arg, "shownodes" ) )
 	{

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -3273,8 +3273,7 @@ bool G_admin_changemap( gentity_t *ent )
 		trap_Argv( 2, layout, sizeof( layout ) );
 
 		if ( !Q_stricmp( layout, S_BUILTIN_LAYOUT ) ||
-		     trap_FS_FOpenFile( va( "layouts/%s/%s.dat", map, layout ),
-		                        nullptr, fsMode_t::FS_READ ) > 0 )
+		     G_LayoutExists( map, layout ) )
 		{
 			// nothing to do
 		}
@@ -4328,7 +4327,7 @@ bool G_admin_restart( gentity_t *ent )
 	// check that the layout's available
 	builtin = !*layout || !Q_stricmp( layout, S_BUILTIN_LAYOUT );
 
-	if ( !builtin && !trap_FS_FOpenFile( va( "layouts/%s/%s.dat", map, layout ), nullptr, fsMode_t::FS_READ ) )
+	if ( !builtin && !G_LayoutExists( map, layout ) )
 	{
 		ADMP( va( "%s %s", QQ( N_("^3restart:^* layout '$1$' does not exist") ), layout ) );
 		return false;

--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -1343,7 +1343,7 @@ AIBehaviorTree_t *ReadBehaviorTree( const char *name, AITreeList_t *list )
 
 	Q_strncpyz( treefilename, va( "bots/%s.bt", name ), sizeof( treefilename ) );
 
-	handle = Parse_LoadSourceHandle( treefilename );
+	handle = Parse_LoadSourceHandle( treefilename, G_FOpenGameOrPakPath );
 	if ( !handle )
 	{
 		Log::Warn( "Cannot load behavior tree %s: File not found", treefilename );

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -1952,7 +1952,7 @@ void Cmd_CallVote_f( gentity_t *ent )
 			trap_Cvar_VariableStringBuffer( "mapname", map, sizeof( map ) );
 
 			if ( Q_stricmp( arg, S_BUILTIN_LAYOUT ) &&
-			     !trap_FS_FOpenFile( va( "layouts/%s/%s.dat", map, arg ), nullptr, fsMode_t::FS_READ ) )
+			     !G_LayoutExists( map, arg ) )
 			{
 				trap_SendServerCommand( ent - g_entities, va( "print_tr %s %s", QQ( N_("callvote: "
 				                        "layout '$1$' could not be found on the server") ), Quote( arg ) ) );

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -756,7 +756,7 @@ void G_InitDamageLocations()
 		modelName = BG_ClassModelConfig( i )->modelName;
 		Com_sprintf( filename, sizeof( filename ), "configs/classes/%s.locdamage.cfg", modelName );
 
-		len = trap_FS_FOpenFile( filename, &fileHandle, fsMode_t::FS_READ );
+		len = G_FOpenGameOrPakPath( filename, fileHandle );
 
 		if ( !fileHandle )
 		{

--- a/src/sgame/sg_maprotation.cpp
+++ b/src/sgame/sg_maprotation.cpp
@@ -126,8 +126,8 @@ Check if a map exists
 */
 bool G_MapExists( const char *name )
 {
-	// Due to filesystem changes, this is no longer the correct way to check if a map exists
-	//return trap_FS_FOpenFile( va( "maps/%s.bsp", name ), nullptr, FS_READ );
+	// Due to filesystem changes, checking whether "maps/$name.bsp" exists in the
+	// VFS is no longer the correct way to check whether a map exists
 	return trap_FindPak( va( "map-%s", name ) );
 }
 
@@ -527,10 +527,11 @@ static bool G_ParseMapRotationFile( const char *fileName )
 	fileHandle_t f;
 
 	// load the file
-	len = trap_FS_FOpenFile( fileName, &f, fsMode_t::FS_READ );
+	len = G_FOpenGameOrPakPath( fileName, f );
 
 	if ( len < 0 )
 	{
+		Log::Warn( "file '%s' not found", fileName );
 		return false;
 	}
 
@@ -1471,17 +1472,9 @@ Load a maprotation file if it exists
 */
 void G_LoadMaprotation( const char *fileName )
 {
-	// Load the file if it exists
-	if ( trap_FS_FOpenFile( fileName, nullptr, fsMode_t::FS_READ ) )
+	if ( !G_ParseMapRotationFile( fileName ) )
 	{
-		if ( !G_ParseMapRotationFile( fileName ) )
-		{
-			Log::Warn("failed to parse %s file", fileName );
-		}
-	}
-	else
-	{
-		Log::Warn( "%s file not found.", fileName );
+		Log::Warn( "failed to load map rotation '%s'", fileName );
 	}
 }
 

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -93,6 +93,7 @@ void              G_SetIdleBuildableAnim(gentity_t *ent, buildableAnimNumber_t a
 void              G_SpawnBuildable(gentity_t *ent, buildable_t buildable);
 void              G_LayoutSave( const char *name );
 int               G_LayoutList( const char *map, char *list, int len );
+bool G_LayoutExists( Str::StringRef map, Str::StringRef layout );
 void              G_LayoutSelect();
 void              G_LayoutLoad();
 void              G_BaseSelfDestruct( team_t team );

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -316,6 +316,7 @@ bool              G_IsPlayableTeam( int team );
 team_t            G_IterateTeams( team_t team );
 float             G_Distance( gentity_t *ent1, gentity_t *ent2 );
 float G_DistanceToBBox( const vec3_t origin, gentity_t* ent );
+int G_FOpenGameOrPakPath( Str::StringRef filename, fileHandle_t &handle );
 
 // sg_weapon.c
 void              G_ForceWeaponChange( gentity_t *ent, weapon_t weapon );

--- a/src/sgame/sg_trapcalls.h
+++ b/src/sgame/sg_trapcalls.h
@@ -37,6 +37,7 @@ int              trap_FS_FOpenFile( const char *qpath, fileHandle_t *f, fsMode_t
 int              trap_FS_Read( void *buffer, int len, fileHandle_t f );
 int              trap_FS_Write( const void *buffer, int len, fileHandle_t f );
 void             trap_FS_FCloseFile( fileHandle_t f );
+// TODO: in many cases we want only VFS (pakpath) files, not VFS + gamepath which this gives
 int              trap_FS_GetFileList( const char *path, const char *extension, char *listbuf, int bufsize );
 void             trap_LocateGameData( int numGEntities, int sizeofGEntity_t, int sizeofGClient );
 void             trap_DropClient( int clientNum, const char *reason );

--- a/src/sgame/sg_trapcalls.h
+++ b/src/sgame/sg_trapcalls.h
@@ -36,7 +36,6 @@ void             trap_SendConsoleCommand( const char *text );
 int              trap_FS_FOpenFile( const char *qpath, fileHandle_t *f, fsMode_t mode );
 int              trap_FS_Read( void *buffer, int len, fileHandle_t f );
 int              trap_FS_Write( const void *buffer, int len, fileHandle_t f );
-void             trap_FS_Rename( const char *from, const char *to );
 void             trap_FS_FCloseFile( fileHandle_t f );
 int              trap_FS_GetFileList( const char *path, const char *extension, char *listbuf, int bufsize );
 void             trap_LocateGameData( int numGEntities, int sizeofGEntity_t, int sizeofGClient );

--- a/src/sgame/sg_utils.cpp
+++ b/src/sgame/sg_utils.cpp
@@ -901,3 +901,16 @@ float G_DistanceToBBox( const vec3_t origin, gentity_t* ent )
 	}
 	return sqrtf( distanceSquared );
 }
+
+// The intention of this is to look for a file in <homepath>/game/ first, and then
+// in the VFS if it is not found there. This is good if you want to allow server-side
+// overrides of pak files which do not need to be downloaded by clients. For example, bot behaviors.
+//
+// DOES NOT WORK as of 0.52. This looks in the VFS first, and the gamepath second. With the current
+// API, it is impossible to read from a path in the homepath that also exists in the VFS (unless
+// you are willing to copy or rename the file to achieve this).
+// TODO(0.53): Use new APIs to make it work.
+int G_FOpenGameOrPakPath( Str::StringRef filename, fileHandle_t &handle )
+{
+	return trap_FS_FOpenFile( filename.c_str(), &handle, fsMode_t::FS_READ );
+}

--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -35,12 +35,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // delayed translation - these strings may be passed to Trans_Gettext() later
 #define N_(x) x
 
-int                                trap_FS_FOpenFile( const char *qpath, fileHandle_t *f, fsMode_t mode );
-int                                trap_FS_Read( void *buffer, int len, fileHandle_t f );
-int                                trap_FS_Write( const void *buffer, int len, fileHandle_t f );
-void                               trap_FS_FCloseFile( fileHandle_t f );
-void                               trap_FS_Seek( fileHandle_t f, long offset, fsOrigin_t origin );  // fsOrigin_t
-int                                trap_FS_GetFileList( const char *path, const char *extension, char *listbuf, int bufsize );
 void                               trap_QuoteString( const char *, char *, int );
 
 struct buildableName_t

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -1537,7 +1537,7 @@ void                      BG_InitAllConfigs();
 void                      BG_UnloadAllConfigs();
 
 // Parsers
-bool                  BG_ReadWholeFile( const char *filename, char *buffer, int size);
+bool                  BG_ReadWholeFile( const char *filename, char *buffer, size_t size);
 bool                  BG_CheckConfigVars();
 bool                  BG_NonSegModel( const char *filename );
 void                      BG_ParseBuildableAttributeFile( const char *filename, buildableAttributes_t *ba );

--- a/src/shared/bg_voice.cpp
+++ b/src/shared/bg_voice.cpp
@@ -427,7 +427,7 @@ static voiceCmd_t *BG_VoiceParse( const char *name )
 	bool   parsingCmd = false;
 	int        handle;
 
-	handle = Parse_LoadSourceHandle( va( "voice/%s.voice", name ) );
+	handle = Parse_LoadSourceHandle( va( "voice/%s.voice", name ), trap_FS_OpenPakFile );
 
 	if ( !handle )
 	{

--- a/src/shared/bg_voice.cpp
+++ b/src/shared/bg_voice.cpp
@@ -26,13 +26,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 // bg_voice.c -- both games voice functions
+#include "common/FileSystem.h"
 #include "engine/qcommon/q_shared.h"
 #include "shared/parse.h"
 #include "bg_public.h"
 #include "bg_local.h"
 
-int         trap_FS_FOpenFile( const char *qpath, fileHandle_t *f, fsMode_t mode );
 int         trap_FS_GetFileList( const char *path, const char *extension, char *listbuf, int bufsize );
+int trap_FS_OpenPakFile( Str::StringRef path, fileHandle_t &f );
 
 #ifdef BUILD_CGAME
 sfxHandle_t trap_S_RegisterSound( const char *sample, bool compressed );
@@ -78,7 +79,7 @@ static voice_t *BG_VoiceList()
 
 	// special case for default.voice.  this file is REQUIRED and will
 	// always be loaded first in the event of overflow of voice definitions
-	if ( !trap_FS_FOpenFile( "voice/default.voice", nullptr, fsMode_t::FS_READ ) )
+	if ( !FS::PakPath::FileExists( "voice/default.voice" ) )
 	{
 		Log::Notice( "voice/default.voice missing, voice system disabled.\n" );
 		return nullptr;
@@ -112,7 +113,7 @@ static voice_t *BG_VoiceList()
 		}
 
 		// trap_FS_GetFileList() buffer has overflowed
-		if ( !trap_FS_FOpenFile( va( "voice/%s", filePtr ), nullptr, fsMode_t::FS_READ ) )
+		if ( !FS::PakPath::FileExists( va( "voice/%s", filePtr ) ) )
 		{
 			Log::Warn( "BG_VoiceList(): detected "
 			            "an invalid .voice file \"%s\" in directory listing.  You have "

--- a/src/shared/parse.h
+++ b/src/shared/parse.h
@@ -49,7 +49,7 @@ struct pc_token_t {
 };
 
 int Parse_AddGlobalDefine(const char *string);
-int Parse_LoadSourceHandle(const char *filename);
+int Parse_LoadSourceHandle(const char *filename, int (*openFunc)(Str::StringRef, fileHandle_t &));
 int Parse_FreeSourceHandle(int handle);
 bool Parse_ReadTokenHandle(int handle, pc_token_t *pc_token);
 int Parse_SourceFileAndLine(int handle, char (&filename)[MAX_QPATH], int *line);


### PR DESCRIPTION
Currently there is only a single syscall, `FSFOpenFileMsg`, for reading files both in the pakpath and in the homepath (it checks the pakpath first). This is not a good situation; often you only want one or the other, and if you want to check both, you want the reverse order.

After this PR it will be like this:
- `FS::PathPak::ReadFile` or `trap_FS_OpenPakFile` (requires https://github.com/DaemonEngine/Daemon/pull/549) for pakpath-only reading
- `trap_FS_FOpenFile` for homepath-only access
- `G_FOpenGameOrPakPath` for homepath first and pathpak second reading

Pakpath-only access can already be emulated by checking the file's existence beforehand. Homepath-only read access will have to wait for 0.53.

Inspired by @bmorel 's report about the navmesh files in https://github.com/DaemonEngine/Daemon/issues/547.