### PR TITLE
Exec map configs before map_restart when possible

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -3288,6 +3288,7 @@ bool G_admin_changemap( gentity_t *ent )
 	admin_log( map );
 	admin_log( layout );
 
+	G_MapConfigs( map );
 	trap_SendConsoleCommand( va( "map %s %s", Quote( map ), Quote( layout ) ) );
 
 	level.restarted = true;

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -1928,7 +1928,7 @@ void Cmd_CallVote_f( gentity_t *ent )
 		if ( *reason ) // layout?
 		{
 			Com_sprintf( level.team[ team ].voteString, sizeof( level.team[ team ].voteString ),
-			             "map %s %s", Quote( arg ), Quote( reason ) );
+			             "changemap %s %s", Quote( arg ), Quote( reason ) );
 			Com_sprintf( level.team[ team ].voteDisplayString,
 			             sizeof( level.team[ team ].voteDisplayString ),
 			             "Change to map '%s' layout '%s'", arg, reason );
@@ -1936,7 +1936,7 @@ void Cmd_CallVote_f( gentity_t *ent )
 		else
 		{
 			Com_sprintf( level.team[ team ].voteString, sizeof( level.team[ team ].voteString ),
-			             "map %s", Quote( arg ) );
+			             "changemap %s", Quote( arg ) );
 			Com_sprintf( level.team[ team ].voteDisplayString,
 			             sizeof( level.team[ team ].voteDisplayString ),
 			             "Change to map '%s'", arg );

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -371,6 +371,15 @@ void G_InitSetEntities()
 /*
 =================
 G_MapConfigs
+
+If a map is started by a map/devmap command from the user, map configs are executed at the beginning
+of the new game. If a map is selected by the map rotation, a vote, or the changemap command, then
+map configs are executed at the end of the previous game. g_mapConfigsLoaded book-keeps this so they
+aren't executed twice.
+
+Clearly this is a janky situation. Why not always execute the configs at the beginning? Well,
+executing configs at the end of the previous game might be useful for setting fs_extrapaks or other
+things that only work prior to a restart.
 =================
 */
 void G_MapConfigs( const char *mapname )
@@ -1394,10 +1403,12 @@ void ExitLevel()
 	if ( !Q_stricmp( currentMapName, g_nextMap.Get().c_str() ) )
 	{
 		g_layouts.Set( g_nextMapLayouts.Get() );
+		G_MapConfigs( currentMapName );
 		trap_SendConsoleCommand( "map_restart" );
 	}
 	else if ( G_MapExists( g_nextMap.Get().c_str() ) )
 	{
+		G_MapConfigs( g_nextMap.Get().c_str() );
 		trap_SendConsoleCommand( va( "map %s %s", Quote( g_nextMap.Get().c_str() ), Quote( g_nextMapLayouts.Get().c_str() ) ) );
 	}
 	else if ( G_MapRotationActive() )
@@ -1406,6 +1417,7 @@ void ExitLevel()
 	}
 	else
 	{
+		G_MapConfigs( currentMapName );
 		trap_SendConsoleCommand( "map_restart" );
 	}
 

--- a/src/sgame/sg_maprotation.cpp
+++ b/src/sgame/sg_maprotation.cpp
@@ -1078,6 +1078,14 @@ static void G_IssueMapChange( int index, int rotation )
 
 	trap_Cvar_VariableStringBuffer( "mapname", currentMapName, sizeof( currentMapName ) );
 
+	if ( strlen( map->postCommand ) > 0 )
+	{
+		trap_SendConsoleCommand( map->postCommand );
+	}
+
+	// Load up map defaults if g_mapConfigs is set
+	G_MapConfigs( map->name );
+
 	// Restart if map is the same
 	if ( !Q_stricmp( currentMapName, map->name ) )
 	{
@@ -1088,8 +1096,6 @@ static void G_IssueMapChange( int index, int rotation )
 		}
 
 		trap_SendConsoleCommand( "map_restart" );
-
-
 	}
 	// Load new map if different
 	else
@@ -1103,14 +1109,6 @@ static void G_IssueMapChange( int index, int rotation )
 		{
 			trap_SendConsoleCommand( va( "map %s\n", Quote( map->name ) ) );
 		}
-	}
-
-	// Load up map defaults if g_mapConfigs is set
-	G_MapConfigs( map->name );
-
-	if ( strlen( map->postCommand ) > 0 )
-	{
-		trap_SendConsoleCommand( map->postCommand );
 	}
 }
 


### PR DESCRIPTION
@bmorel This makes it possible to load "mods" on a per-map basis. You can configure the server with `set g_mapConfigs map` and write `set fs_extrapaks <whatever>` in `config/map/<mapname>.cfg`. And then if you want the mods to be off for other maps, `set fs_extrapaks ""` in `config/map/default.cfg`.