### PR TITLE
make bot default skill in Cvars

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -5716,7 +5716,7 @@ static bool BotAddCmd( gentity_t* ent, const Cmd::Args& args )
 	}
 	else
 	{
-		skill = BOT_DEFAULT_SKILL;
+		skill = g_bot_default_skill.Get();
 	}
 
 	const char* behavior = args.Argc() >= 6 ? args[5].data() : BOT_DEFAULT_BEHAVIOR;
@@ -5752,7 +5752,7 @@ static bool BotFillCmd( gentity_t *ent, const Cmd::Args& args )
 	{
 		teams = { team_t::TEAM_ALIENS, team_t::TEAM_HUMANS };
 	}
-	int skill = args.Argc() >= 5 ? BotSkillFromString(ent, args[4].data()) : BOT_DEFAULT_SKILL;
+	int skill = args.Argc() >= 5 ? BotSkillFromString(ent, args[4].data()) : g_bot_default_skill.Get();
 
 	for (team_t team : teams)
 	{

--- a/src/sgame/sg_bot_public.h
+++ b/src/sgame/sg_bot_public.h
@@ -67,7 +67,6 @@ void G_BotAddObstacle( const vec3_t mins, const vec3_t maxs, qhandle_t *handle )
 void G_BotRemoveObstacle( qhandle_t handle );
 void G_BotUpdateObstacles();
 
-constexpr int BOT_DEFAULT_SKILL = 5;
 const char BOT_DEFAULT_BEHAVIOR[] = "default";
 const char BOT_NAME_FROM_LIST[] = "*";
 

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -199,6 +199,9 @@ extern Cvar::Cvar<bool> g_bot_level3;
 extern Cvar::Cvar<bool> g_bot_level3upg;
 extern Cvar::Cvar<bool> g_bot_level4;
 
+// bot default configurations
+extern Cvar::Range<Cvar::Cvar<int>> g_bot_default_skill;
+
 // misc bot cvars
 extern Cvar::Cvar<bool> g_bot_attackStruct;
 extern Cvar::Cvar<float> g_bot_fov;

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -254,6 +254,9 @@ Cvar::Cvar<bool> g_bot_level3("g_bot_level3", "whether bots use non-advanced Dra
 Cvar::Cvar<bool> g_bot_level3upg("g_bot_level3upg", "whether bots use Advanced Dragoon", Cvar::NONE, true);
 Cvar::Cvar<bool> g_bot_level4("g_bot_level4", "whether bots use Tyrant", Cvar::NONE, true);
 
+// bot default configurations
+Cvar::Range<Cvar::Cvar<int>> g_bot_default_skill( "g_bot_default_skill", "Default skill value bots will have when added", Cvar::NONE, 5, 1, 9 );
+
 // misc bot cvars
 Cvar::Cvar<bool> g_bot_attackStruct("g_bot_attackStruct", "whether bots target buildables", Cvar::NONE, true);
 Cvar::Cvar<float> g_bot_fov("g_bot_fov", "bots' \"field of view\"", Cvar::NONE, 125);


### PR DESCRIPTION
This allows for more generic configurations, notably, if the rotation makes a different number of bots depending on the map, a single `bot fill X` is enough, while currently it requires one line per team.
The 2 other ones are because why not. I see no con at having things less hard-coded.

Originally, all were in a single commit, I've split it just in case.