### PR TITLE
make bot say where they suicide

### DIFF
--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1047,6 +1047,10 @@ AINodeStatus_t BotActionHeal( gentity_t *self, AIGenericNode_t *node )
 
 AINodeStatus_t BotActionSuicide( gentity_t *self, AIGenericNode_t* )
 {
+	//hopefully this is enough digits for all maps.
+	char str[] = "I'm stuck at x=0123456789 y=0123456789 z=0123456789 !?!";
+	snprintf( str, sizeof( str ), "I'm stuck at x=%-.0f y=%-.0f z=%-.0f !?!", self->s.origin[0], self->s.origin[1], self->s.origin[2] );
+	G_Say( self, SAY_TEAM, str );
 	Entities::Kill( self, MOD_SUICIDE );
 	return AINodeStatus_t::STATUS_SUCCESS;
 }


### PR DESCRIPTION
This is a bit hackish, but should be safe, and could be handy when there will be a way to know a player's position.
Multiple improvements on this can be imagined though, such as placing beacons, which would be more handy, so that teammate would be able to  check the cause, in case theres a building preventing the moves.