### PR TITLE
start rotation immediately by default

### DIFF
--- a/dist/configs/config/server.cfg
+++ b/dist/configs/config/server.cfg
@@ -77,3 +77,6 @@ set g_initialMapRotation rotation1
 // start this map first, usually the last of the rotation
 // since rotation will start from the first one after that
 map yocto
+// uncomment to have rotation starting immediately, so that rotation's
+// specific commands are run
+// nextmap


### PR DESCRIPTION
Workaround to improve on https://github.com/DaemonEngine/Daemon/issues/552 (servers should just run maprotation instead of forcing a specific map).

The intent is to have an example configuration file which is less surprising, that is, starting immediately with the maprotation.