### PR TITLE
cleanup

### DIFF
--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -330,30 +330,21 @@ public:
 		int           value;
 		playerState_t *ps = &cg.snap->ps;
 
-		switch ( BG_PrimaryWeapon( ps->stats ) )
+		if ( BG_Weapon( BG_PrimaryWeapon( ps->stats ) )->infiniteAmmo )
 		{
-			case WP_NONE:
-			case WP_BLASTER:
-			case WP_ABUILD:
-			case WP_ABUILD2:
-			case WP_HBUILD:
-				if ( clips != -1 )
-				{
-					SetText( "" );
-				}
-				clips = -1;
-				return;
+			if ( clips != -1 )
+			{
+				SetText( "" );
+			}
+			clips = -1;
+			return;
+		}
+		value = ps->clips;
 
-			default:
-				value = ps->clips;
-
-				if ( value > -1 && value != clips )
-				{
-					SetText( va( "%d", value ) );
-					clips = value;
-				}
-
-				break;
+		if ( value > -1 && value != clips )
+		{
+			SetText( va( "%d", value ) );
+			clips = value;
 		}
 	}
 


### PR DESCRIPTION
The only change this does is to remove the number of clips for painsaw, which have very little use considering it has infinite ammo (and thus, no clips).

Should probably just *not* show the hud element for infinite ammo weapons or weapon with a single clip (flamer, luci, chaingun, lasgun).