### PR TITLE
allow giving momentum to specific team without joining

### DIFF
--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -593,7 +593,7 @@ void Cmd_Give_f( gentity_t *ent )
 	char     *name;
 	bool give_all = false;
 	float    amount;
-	team_t team = static_cast<team_t>( ent->client->pers.team );
+	team_t team = G_Team( ent );
 
 	if ( trap_Argc() < 2 )
 	{
@@ -644,13 +644,16 @@ void Cmd_Give_f( gentity_t *ent )
 		{
 			++end;
 			team = BG_PlayableTeamFromString( end );
-		}
-		if ( team == team_t::TEAM_NONE )
-		{
-			team = static_cast<team_t>( ent->client->pers.team );
+			if ( team != TEAM_NONE )
+			{
+				team = G_Team( ent );
+			}
 		}
 
-		G_AddMomentumGeneric( team, amount );
+		if ( team != TEAM_NONE )
+		{
+			G_AddMomentumGeneric( team, amount );
+		}
 	}
 
 	if ( team != TEAM_NONE && Q_strnicmp( name, "bp", strlen("bp") ) == 0 )

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -593,6 +593,7 @@ void Cmd_Give_f( gentity_t *ent )
 	char     *name;
 	bool give_all = false;
 	float    amount;
+	team_t team = static_cast<team_t>( ent->client->pers.team );
 
 	if ( trap_Argc() < 2 )
 	{
@@ -639,7 +640,6 @@ void Cmd_Give_f( gentity_t *ent )
 			amount = strtof( name + strlen( "momentum" ), &end );
 		}
 
-		team_t team = team_t::TEAM_NONE;
 		if ( trap_Argc() >= 4 && *end != '\0' )
 		{
 			++end;
@@ -653,7 +653,7 @@ void Cmd_Give_f( gentity_t *ent )
 		G_AddMomentumGeneric( team, amount );
 	}
 
-	if ( Q_strnicmp( name, "bp", strlen("bp") ) == 0 )
+	if ( team != TEAM_NONE && Q_strnicmp( name, "bp", strlen("bp") ) == 0 )
 	{
 		float bp = trap_Argc() < 3 ? 300.0f : atof( name + strlen("bp") );
 		level.team[ent->client->pers.team].totalBudget += bp;
@@ -664,7 +664,7 @@ void Cmd_Give_f( gentity_t *ent )
 		return;
 	}
 
-	if ( give_all || Q_strnicmp( name, "health", strlen("health") ) == 0 )
+	if ( team != TEAM_NONE && ( give_all || Q_strnicmp( name, "health", strlen("health") ) == 0 ) )
 	{
 		if ( give_all || trap_Argc() < 3 )
 		{
@@ -685,17 +685,17 @@ void Cmd_Give_f( gentity_t *ent )
 		}
 	}
 
-	if ( give_all || Q_stricmp( name, "stamina" ) == 0 )
+	if ( team != TEAM_NONE && ( give_all || Q_stricmp( name, "stamina" ) == 0 ) )
 	{
 		ent->client->ps.stats[ STAT_STAMINA ] = STAMINA_MAX;
 	}
 
-	if ( give_all || Q_stricmp( name, "fuel" ) == 0 )
+	if ( team != TEAM_NONE && ( give_all || Q_stricmp( name, "fuel" ) == 0 ) )
 	{
 		G_RefillFuel(ent, false);
 	}
 
-	if ( Q_stricmp( name, "poison" ) == 0 )
+	if ( team != TEAM_NONE && ( Q_stricmp( name, "poison" ) == 0 ) )
 	{
 		if ( ent->client->pers.team == TEAM_HUMANS )
 		{
@@ -710,7 +710,7 @@ void Cmd_Give_f( gentity_t *ent )
 		}
 	}
 
-	if ( give_all || Q_stricmp( name, "ammo" ) == 0 )
+	if ( team != TEAM_NONE && ( give_all || Q_stricmp( name, "ammo" ) == 0 ) )
 	{
 		G_RefillAmmo( ent, false );
 	}

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -598,7 +598,7 @@ void Cmd_Give_f( gentity_t *ent )
 	{
 		ADMP( QQ( N_( "usage: give [what]" ) ) );
 		ADMP( QQ( N_( "usage: valid choices are: all, health [amount], funds [amount], "
-		              "bp [amount], momentum [amount], stamina, poison, fuel, ammo" ) ) );
+		              "bp [amount], momentum [amount] [team], stamina, poison, fuel, ammo" ) ) );
 		return;
 	}
 
@@ -629,16 +629,28 @@ void Cmd_Give_f( gentity_t *ent )
 	// give momentum
 	if ( Q_strnicmp( name, "momentum", strlen("momentum") ) == 0 )
 	{
+		char* end;
 		if ( trap_Argc() < 3 )
 		{
 			amount = 300.0f;
 		}
 		else
 		{
-			amount = atof( name + strlen("momentum") );
+			amount = strtof( name + strlen( "momentum" ), &end );
 		}
 
-		G_AddMomentumGeneric( (team_t) ent->client->pers.team, amount );
+		team_t team = team_t::TEAM_NONE;
+		if ( trap_Argc() >= 4 && *end != '\0' )
+		{
+			++end;
+			team = BG_PlayableTeamFromString( end );
+		}
+		if ( team == team_t::TEAM_NONE )
+		{
+			team = static_cast<team_t>( ent->client->pers.team );
+		}
+
+		G_AddMomentumGeneric( team, amount );
 	}
 
 	if ( Q_strnicmp( name, "bp", strlen("bp") ) == 0 )
@@ -4427,7 +4439,7 @@ static const commands_t cmds[] =
 	{ "follow",          CMD_SPEC,                            Cmd_Follow_f           },
 	{ "follownext",      CMD_SPEC,                            Cmd_FollowCycle_f      },
 	{ "followprev",      CMD_SPEC,                            Cmd_FollowCycle_f      },
-	{ "give",            CMD_CHEAT | CMD_TEAM,                Cmd_Give_f             },
+	{ "give",            CMD_CHEAT,                           Cmd_Give_f             },
 	{ "god",             CMD_CHEAT,                           Cmd_God_f              },
 	{ "ignite",          CMD_CHEAT | CMD_TEAM | CMD_ALIVE,    Cmd_Ignite_f           },
 	{ "ignore",          0,                                   Cmd_Ignore_f           },

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -629,7 +629,7 @@ void Cmd_Give_f( gentity_t *ent )
 	// give momentum
 	if ( Q_strnicmp( name, "momentum", strlen("momentum") ) == 0 )
 	{
-		char* end;
+		char* end = nullptr;
 		if ( trap_Argc() < 3 )
 		{
 			amount = 300.0f;


### PR DESCRIPTION
This is not the cleaner implementation, but it works. I think it's not *much* of a problem if a cheat command is not cleanly implemented, and overall this whole file should probably be done the same way sg_cmds.cpp is done, as said in #538.
Still, this patch is useful as it reduces a lot the pain when doing tests (checking if events bound to momentum or if a specific change in AI works correctly, notably, I don't really see other reasons to use that).