### PR TITLE
Navmesh generation in gamelogic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,13 @@ if (BUILD_SGAME)
                         ${LIB_DIR}/recastnavigation/DetourTileCache/Include
                         ${LIB_DIR}/recastnavigation/DebugUtils/Include
                         ${LIB_DIR}/recastnavigation/DetourCrowd/Include)
+
+    # Recast
+    add_library(srclibs-recast EXCLUDE_FROM_ALL ${RECASTLIST})
+    set_target_properties(srclibs-recast PROPERTIES POSITION_INDEPENDENT_CODE 1 FOLDER "libs")
+    include_directories(
+        ${LIB_DIR}/recastnavigation/Recast/Include
+        ${LIB_DIR}/recastnavigation/RecastDemo/Include)
 endif()
 
 add_library(srclibs-tinygettext EXCLUDE_FROM_ALL ${TINYGETTEXTLIST})
@@ -152,6 +159,7 @@ if (BUILD_SGAME)
             ${sgame_GENERATED_CBSE}
         LIBS
             srclibs-detour
+            srclibs-recast
             srclibs-fastlz
     )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ if (BUILD_CGAME AND (BUILD_GAME_NATIVE_DLL OR BUILD_GAME_NATIVE_EXE OR NACL))
     include_directories(${ROCKET_INCLUDE_DIRS})
 endif()
 
-if (BUILD_SGAME)
+if (BUILD_SGAME OR BUILD_CGAME)
     # Fastlz
     add_library(srclibs-fastlz EXCLUDE_FROM_ALL ${FASTLZLIST})
     set_target_properties(srclibs-fastlz PROPERTIES POSITION_INDEPENDENT_CODE 1 FOLDER "libs")
@@ -178,5 +178,8 @@ if (BUILD_CGAME)
         ${FREETYPE_LIBRARIES}
         ${LUA_LIBRARY}
         srclibs-tinygettext
+        srclibs-detour
+        srclibs-recast
+        srclibs-fastlz
   )
 endif()

--- a/src.cmake
+++ b/src.cmake
@@ -78,6 +78,10 @@ set(GAMESHAREDLIST
     ${GAMELOGIC_DIR}/shared/parse.cpp
     ${GAMELOGIC_DIR}/shared/parse.h
     ${GAMELOGIC_DIR}/shared/Clustering.h
+
+    ${GAMELOGIC_DIR}/shared/navgen/brush.cpp
+    ${GAMELOGIC_DIR}/shared/navgen/nav.cpp
+    ${GAMELOGIC_DIR}/shared/navgen/navgen.h
 )
 
 set(CGAMELIST
@@ -245,10 +249,6 @@ set(SGAMELIST
     ${GAMELOGIC_DIR}/sgame/botlib/bot_nav_edit.cpp
     ${GAMELOGIC_DIR}/sgame/botlib/bot_navdraw.h
     ${GAMELOGIC_DIR}/sgame/botlib/bot_types.h
-
-    ${GAMELOGIC_DIR}/shared/navgen/brush.cpp
-    ${GAMELOGIC_DIR}/shared/navgen/nav.cpp
-    ${GAMELOGIC_DIR}/shared/navgen/navgen.h
 
     ${GAMELOGIC_DIR}/sgame/components/AcidTubeComponent.cpp
     ${GAMELOGIC_DIR}/sgame/components/AcidTubeComponent.h

--- a/src.cmake
+++ b/src.cmake
@@ -74,6 +74,7 @@ set(GAMESHAREDLIST
     ${GAMELOGIC_DIR}/shared/bg_teamprogress.cpp
     ${GAMELOGIC_DIR}/shared/bg_utilities.cpp
     ${GAMELOGIC_DIR}/shared/bg_voice.cpp
+    ${GAMELOGIC_DIR}/shared/bot_nav_shared.h
     ${GAMELOGIC_DIR}/shared/parse.cpp
     ${GAMELOGIC_DIR}/shared/parse.h
     ${GAMELOGIC_DIR}/shared/Clustering.h
@@ -244,7 +245,6 @@ set(SGAMELIST
     ${GAMELOGIC_DIR}/sgame/botlib/bot_nav_edit.cpp
     ${GAMELOGIC_DIR}/sgame/botlib/bot_navdraw.h
     ${GAMELOGIC_DIR}/sgame/botlib/bot_types.h
-    ${GAMELOGIC_DIR}/sgame/botlib/nav.h
 
     ${GAMELOGIC_DIR}/shared/navgen/brush.cpp
     ${GAMELOGIC_DIR}/shared/navgen/nav.cpp

--- a/src.cmake
+++ b/src.cmake
@@ -16,6 +16,27 @@ set(DETOURLIST
     ${LIB_DIR}/recastnavigation/DetourTileCache/Source/DetourTileCacheBuilder.cpp
 )
 
+# Note that this includes some "demo" code not part of the library proper
+set(RECASTLIST
+    ${LIB_DIR}/recastnavigation/Recast/Source/RecastAlloc.cpp
+    ${LIB_DIR}/recastnavigation/Recast/Include/RecastAlloc.h
+    ${LIB_DIR}/recastnavigation/Recast/Source/RecastArea.cpp
+    ${LIB_DIR}/recastnavigation/Recast/Source/RecastAssert.cpp
+    ${LIB_DIR}/recastnavigation/Recast/Include/RecastAssert.h
+    ${LIB_DIR}/recastnavigation/Recast/Source/RecastContour.cpp
+    ${LIB_DIR}/recastnavigation/Recast/Source/Recast.cpp
+    ${LIB_DIR}/recastnavigation/Recast/Include/Recast.h
+    ${LIB_DIR}/recastnavigation/Recast/Source/RecastFilter.cpp
+    ${LIB_DIR}/recastnavigation/Recast/Source/RecastLayers.cpp
+    ${LIB_DIR}/recastnavigation/Recast/Source/RecastMesh.cpp
+    ${LIB_DIR}/recastnavigation/Recast/Source/RecastMeshDetail.cpp
+    ${LIB_DIR}/recastnavigation/Recast/Source/RecastRasterization.cpp
+    ${LIB_DIR}/recastnavigation/Recast/Source/RecastRegion.cpp
+
+    ${LIB_DIR}/recastnavigation/RecastDemo/Source/ChunkyTriMesh.cpp
+    ${LIB_DIR}/recastnavigation/RecastDemo/Include/ChunkyTriMesh.h
+)
+
 set(FASTLZLIST
     ${LIB_DIR}/fastlz/fastlz.c
 )
@@ -224,6 +245,10 @@ set(SGAMELIST
     ${GAMELOGIC_DIR}/sgame/botlib/bot_navdraw.h
     ${GAMELOGIC_DIR}/sgame/botlib/bot_types.h
     ${GAMELOGIC_DIR}/sgame/botlib/nav.h
+
+    ${GAMELOGIC_DIR}/shared/navgen/brush.cpp
+    ${GAMELOGIC_DIR}/shared/navgen/nav.cpp
+    ${GAMELOGIC_DIR}/shared/navgen/navgen.h
 
     ${GAMELOGIC_DIR}/sgame/components/AcidTubeComponent.cpp
     ${GAMELOGIC_DIR}/sgame/components/AcidTubeComponent.h

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1225,6 +1225,8 @@ struct cg_t
 	float                   mediaLoadingFraction;
 	float                   buildableLoadingFraction;
 	float                   characterLoadingFraction;
+	float navmeshLoadingFraction;
+	bool loadingNavmesh;
 
 	int                     lastBuildAttempt;
 	int                     lastEvolveAttempt;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -29,6 +29,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "cg_local.h"
 #include "cg_key_name.h"
 #include "shared/parse.h"
+#include "shared/navgen/navgen.h"
 
 cg_t            cg;
 cgs_t           cgs;
@@ -145,6 +146,10 @@ Cvar::Cvar<float> cg_animBlend("cg_animblend", "I don't know", Cvar::NONE, 5.0);
 Cvar::Cvar<float> cg_motionblur("cg_motionblur", "strength of motion blur", Cvar::NONE, 0.05);
 Cvar::Cvar<float> cg_motionblurMinSpeed("cg_motionblurMinSpeed", "minimum speed to trigger motion blur", Cvar::NONE, 600);
 Cvar::Cvar<bool> cg_spawnEffects("cg_spawnEffects", "desaturate world view when dead or spawning", Cvar::NONE, true);
+
+// TODO(0.53): turn this on by default. Not turning on right away because the filesystem stuff is still
+// a bit broken in 0.52 (a homepath file can't override a VFS file).
+static Cvar::Cvar<bool> cg_navgenOnLoad("cg_navgenOnLoad", "generate navmeshes when starting a local game", Cvar::NONE, false);
 
 // search 'fovCvar' to find usage of these (names come from config files)
 // 0 means use global FOV setting
@@ -458,6 +463,7 @@ enum cgLoadingStep_t {
 	LOAD_CLIENTS,
 	LOAD_HUDS,
 	LOAD_GLSL,
+	LOAD_CHECK_NAVMESH, // only checking for existence, not generation
 	LOAD_DONE
 };
 
@@ -538,6 +544,10 @@ static void CG_UpdateLoadingStep( cgLoadingStep_t step )
 
 		case LOAD_GLSL:
 			CG_UpdateLoadingProgress( step, "GLSL shaders", choose(_("Compiling GLSL shaders (please be patient)…"), nullptr) );
+			break;
+
+		case LOAD_CHECK_NAVMESH:
+			CG_UpdateLoadingProgress( step, "Navmesh existence", choose(_("Surveying the map…"), nullptr) );
 			break;
 
 		case LOAD_DONE:
@@ -1086,6 +1096,78 @@ bool CG_ClientIsReady( int clientNum )
 	return Com_ClientListContains( &ready, clientNum );
 }
 
+// Generate a navmesh file for each class that doesn't already have
+// an existing and (according to the header) up-to-date navmesh.
+// Navmesh generation uses a separate progress bar counter from the main loading bar.
+// Generating navmeshes in the cgame is kind of stupid, but the engine
+// is not set up to handle long loading times in the sgame.
+static void GenerateNavmeshes()
+{
+	std::string mapName = Cvar::GetValue( "mapname" );
+	std::vector<class_t> missing;
+	for ( int species = PCL_NONE; ++species < PCL_NUM_CLASSES; )
+	{
+		if ( species == PCL_ALIEN_BUILDER0 || BG_ClassModelConfig( species )->navMeshClass )
+		{
+			continue; // uses another class's navmesh, or granger which bots can't use
+		}
+		fileHandle_t f;
+		std::string filename = Str::Format(
+			"maps/%s-%s.navMesh", mapName, BG_Class( species )->name );
+		// TODO(0.53): match new behavior of G_FOpenGameOrPakPath
+		if ( trap_FS_FOpenFile( filename.c_str(), &f, fsMode_t::FS_READ ) < 0)
+		{
+			missing.push_back( static_cast<class_t>(species) );
+			continue;
+		}
+		NavMeshSetHeader header;
+		std::string error = GetNavmeshHeader( f, header );
+		if ( !error.empty() )
+		{
+			Log::Notice( "Existing navmesh file %s can't be used: %s", filename, error );
+			missing.push_back( static_cast<class_t>(species) );
+		}
+		trap_FS_FCloseFile( f );
+	}
+	if ( missing.empty() )
+	{
+		return;
+	}
+
+	const char* message = _("Generating bot navigation meshes");
+	cg.navmeshLoadingFraction = 0;
+	cg.loadingNavmesh = true;
+	Q_strncpyz( cg.loadingText, message, sizeof(cg.loadingText) );
+	trap_UpdateScreen();
+
+	NavmeshGenerator navgen;
+	navgen.Init( mapName );
+	float classesCompleted = 0.3; // Assume that Init() is 0.3 times as much work as generating 1 species
+	// and assume that each species takes the same amount of time, which is actually completely wrong:
+	// smaller ones take much longer
+	float classesTotal = classesCompleted + missing.size();
+	for ( class_t species : missing )
+	{
+		std::string message2 = Str::Format( "%s — %s", message, BG_ClassModelConfig( species )->humanName );
+		Q_strncpyz( cg.loadingText, message2.c_str(), sizeof(cg.loadingText) );
+		cg.loadingFraction = classesCompleted / classesTotal;
+		trap_UpdateScreen();
+
+		navgen.StartGeneration( species );
+		do
+		{
+			float fraction = ( classesCompleted + navgen.SpeciesFractionCompleted() ) / classesTotal;
+			if ( fraction - cg.navmeshLoadingFraction > 0.01 )
+			{
+				cg.navmeshLoadingFraction = fraction;
+				trap_UpdateScreen();
+			}
+		} while ( !navgen.Step() );
+		++classesCompleted;
+	}
+	cg.loadingNavmesh = false;
+}
+
 /*
 =================
 CG_Init
@@ -1222,6 +1304,12 @@ void CG_Init( int serverMessageNum, int clientNum, const glconfig_t& gl, const G
 
 	CG_UpdateLoadingStep( LOAD_GLSL );
 	trap_S_EndRegistration();
+
+	if ( cg_navgenOnLoad.Get() && Cvar::GetValue( "sv_running" ) == "1" )
+	{
+		CG_UpdateLoadingStep( LOAD_CHECK_NAVMESH );
+		GenerateNavmeshes();
+	}
 
 	CG_UpdateLoadingStep( LOAD_DONE );
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1105,19 +1105,15 @@ static void GenerateNavmeshes()
 {
 	std::string mapName = Cvar::GetValue( "mapname" );
 	std::vector<class_t> missing;
-	for ( int species = PCL_NONE; ++species < PCL_NUM_CLASSES; )
+	for ( class_t species : RequiredNavmeshes() )
 	{
-		if ( species == PCL_ALIEN_BUILDER0 || BG_ClassModelConfig( species )->navMeshClass )
-		{
-			continue; // uses another class's navmesh, or granger which bots can't use
-		}
 		fileHandle_t f;
 		std::string filename = Str::Format(
 			"maps/%s-%s.navMesh", mapName, BG_Class( species )->name );
 		// TODO(0.53): match new behavior of G_FOpenGameOrPakPath
 		if ( trap_FS_FOpenFile( filename.c_str(), &f, fsMode_t::FS_READ ) < 0)
 		{
-			missing.push_back( static_cast<class_t>(species) );
+			missing.push_back( species );
 			continue;
 		}
 		NavMeshSetHeader header;
@@ -1125,7 +1121,7 @@ static void GenerateNavmeshes()
 		if ( !error.empty() )
 		{
 			Log::Notice( "Existing navmesh file %s can't be used: %s", filename, error );
-			missing.push_back( static_cast<class_t>(species) );
+			missing.push_back( species );
 		}
 		trap_FS_FCloseFile( f );
 	}

--- a/src/cgame/cg_rocket_progressbar.cpp
+++ b/src/cgame/cg_rocket_progressbar.cpp
@@ -36,6 +36,11 @@ Maryland 20850 USA.
 
 static float CG_Rocket_GetLoadProgress()
 {
+	if ( cg.loadingNavmesh )
+	{
+		return cg.navmeshLoadingFraction;
+	}
+
 	return (
 		cg.loadingFraction
 		+ cg.mediaLoadingFraction

--- a/src/sgame/botlib/bot_debug.cpp
+++ b/src/sgame/botlib/bot_debug.cpp
@@ -43,7 +43,6 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 #pragma GCC diagnostic pop
 #endif
 #include "bot_local.h"
-#include "nav.h"
 #include "engine/botlib/bot_debug.h"
 #include "bot_navdraw.h"
 

--- a/src/sgame/botlib/bot_load.cpp
+++ b/src/sgame/botlib/bot_load.cpp
@@ -37,7 +37,6 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 
 #include "sgame/sg_local.h"
 #include "bot_local.h"
-#include "nav.h"
 
 static Cvar::Range<Cvar::Cvar<int>> maxNavNodes(
 	"bot_maxNavNodes", "maximum number of nodes in navmesh", Cvar::NONE, 4096, 0, 65535);

--- a/src/sgame/botlib/bot_load.cpp
+++ b/src/sgame/botlib/bot_load.cpp
@@ -202,21 +202,10 @@ static bool BotLoadNavMesh( const char *filename, NavData_t &nav )
 	}
 
 	NavMeshSetHeader header;
-	
-	trap_FS_Read( &header, sizeof( header ), f );
-
-	SwapNavMeshSetHeader( header );
-
-	if ( header.magic != NAVMESHSET_MAGIC )
+	std::string error = GetNavmeshHeader( f, header );
+	if ( !error.empty() )
 	{
-		Log::Warn("File is wrong magic" );
-		trap_FS_FCloseFile( f );
-		return false;
-	}
-
-	if ( header.version != NAVMESHSET_VERSION )
-	{
-		Log::Warn("File is wrong version found: %d want: %d", header.version, NAVMESHSET_VERSION );
+		Log::Warn( "Loading navmesh %s failed: %s", filePath, error );
 		trap_FS_FCloseFile( f );
 		return false;
 	}

--- a/src/sgame/botlib/bot_load.cpp
+++ b/src/sgame/botlib/bot_load.cpp
@@ -191,7 +191,7 @@ static bool BotLoadNavMesh( const char *filename, NavData_t &nav )
 
 	if ( !f )
 	{
-		Log::Warn("Cannot open Navigation Mesh file" );
+		Log::Warn("Cannot open Navigation Mesh file '%s'", filePath);
 		return false;
 	}
 

--- a/src/sgame/botlib/bot_load.cpp
+++ b/src/sgame/botlib/bot_load.cpp
@@ -209,6 +209,16 @@ static bool BotLoadNavMesh( const char *filename, NavData_t &nav )
 		trap_FS_FCloseFile( f );
 		return false;
 	}
+	else if ( header.params.tileHeight == PERMANENT_NAVGEN_ERROR )
+	{
+		NavMeshTileHeader ignored;
+		trap_FS_Read( &ignored, sizeof(ignored), f );
+		char error[256] = {};
+		trap_FS_Read( error, sizeof(error) - 1, f );
+		Log::Warn( "Can't load %s: Cached navmesh generation failure (%s)", filename, error );
+		trap_FS_FCloseFile( f );
+		return false;
+	}
 
 	nav.mesh = dtAllocNavMesh();
 

--- a/src/sgame/botlib/bot_local.h
+++ b/src/sgame/botlib/bot_local.h
@@ -45,7 +45,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 
 #include "bot_types.h"
 #include "bot_api.h"
-#include "nav.h"
+#include "shared/bot_nav_shared.h"
 #include "bot_convert.h"
 
 const int MAX_NAV_DATA = 16;

--- a/src/sgame/botlib/bot_local.h
+++ b/src/sgame/botlib/bot_local.h
@@ -65,13 +65,32 @@ struct dtRouteResult
 	bool      invalid;
 };
 
+struct NavconMeshProcess : public BasicMeshProcess
+{
+	OffMeshConnections con;
+
+	void process( struct dtNavMeshCreateParams *params, unsigned char *polyAreas, unsigned short *polyFlags ) override
+	{
+		// Update poly flags from areas.
+		BasicMeshProcess::process( params, polyAreas, polyFlags );
+
+		params->offMeshConVerts = con.verts;
+		params->offMeshConRad = con.rad;
+		params->offMeshConCount = con.offMeshConCount;
+		params->offMeshConAreas = con.areas;
+		params->offMeshConDir = con.dirs;
+		params->offMeshConFlags = con.flags;
+		params->offMeshConUserID = con.userids;
+	}
+};
+
 struct NavData_t
 {
 	dtTileCache      *cache;
 	dtNavMesh        *mesh;
 	dtNavMeshQuery   *query;
 	dtQueryFilter    filter;
-	MeshProcess      process;
+	NavconMeshProcess process;
 	char             name[ 64 ];
 };
 

--- a/src/sgame/botlib/bot_local.h
+++ b/src/sgame/botlib/bot_local.h
@@ -65,6 +65,93 @@ struct dtRouteResult
 	bool      invalid;
 };
 
+static const int NAVMESHCON_VERSION = 2;
+struct OffMeshConnectionHeader
+{
+	int version;
+	int numConnections;
+};
+
+struct OffMeshConnection
+{
+	rVec  start;
+	rVec  end;
+	float radius;
+	unsigned short flag;
+	unsigned char area;
+	unsigned char dir;
+	unsigned int userid;
+};
+
+struct OffMeshConnections
+{
+	static CONSTEXPR int MAX_CON = 128;
+	float  verts[ MAX_CON * 6 ]; // dtOffMeshConnection::pos
+	float  rad[ MAX_CON ]; // dtOffMeshConnection::rad
+	unsigned short flags[ MAX_CON ]; // dtOffMeshConnection::poly
+	unsigned char areas[ MAX_CON ]; // dtOffMeshConnection::flags
+	unsigned char dirs[ MAX_CON ]; // likely dtOffMeshConnection::side
+	unsigned int userids[ MAX_CON ]; // dtOffMeshConnection::userId
+	int      offMeshConCount;
+
+	OffMeshConnections() : offMeshConCount( 0 ) { }
+
+	void reset()
+	{
+		offMeshConCount = 0;
+	}
+
+	void delConnection( int index )
+	{
+		if ( index < 0 || index >= offMeshConCount )
+		{
+			return;
+		}
+
+		for ( int i = index * 6; i < offMeshConCount * 6 - 1; i++ )
+		{
+			verts[ i ] = verts[ i + 1 ];
+		}
+
+		for ( int i = index; i < offMeshConCount - 1; i++ )
+		{
+			rad[ i ] = rad[ i + 1 ];
+			flags[ i ] = flags[ i + 1 ];
+			areas[ i ] = areas[ i + 1 ];
+			dirs[ i ] = dirs[ i + 1 ];
+			userids[ i ] = userids[ i + 1 ];
+		}
+		offMeshConCount--;
+	}
+
+	bool addConnection( const OffMeshConnection &c )
+	{
+		if ( offMeshConCount == MAX_CON )
+		{
+			return false;
+		}
+
+		float *start = &verts[ offMeshConCount * 6 ];
+		float *end = start + 3;
+
+		start[ 0 ] = c.start[ 0 ];
+		start[ 1 ] = c.start[ 1 ];
+		start[ 2 ] = c.start[ 2 ];
+		end[ 0 ] = c.end[ 0 ];
+		end[ 1 ] = c.end[ 1 ];
+		end[ 2 ] = c.end[ 2 ];
+
+		rad[ offMeshConCount ] = c.radius;
+		flags[ offMeshConCount ] = c.flag;
+		areas[ offMeshConCount ] = c.area;
+		dirs[ offMeshConCount ] = c.dir;
+		userids[ offMeshConCount ] = c.userid;
+
+		offMeshConCount++;
+		return true;
+	}
+};
+
 struct NavconMeshProcess : public BasicMeshProcess
 {
 	OffMeshConnections con;

--- a/src/sgame/botlib/bot_nav_edit.cpp
+++ b/src/sgame/botlib/bot_nav_edit.cpp
@@ -43,7 +43,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 #pragma GCC diagnostic pop
 #endif
 #include "bot_navdraw.h"
-#include "nav.h"
+#include "shared/bot_nav_shared.h"
 
 static const int DEFAULT_CONNECTION_SIZE = 50;
 

--- a/src/sgame/botlib/bot_types.h
+++ b/src/sgame/botlib/bot_types.h
@@ -78,32 +78,6 @@ struct botRouteTarget_t
 	float polyExtents[ 3 ];
 };
 
-enum navPolyFlags
-{
-	POLYFLAGS_DISABLED = 0,
-	POLYFLAGS_WALK     = 1 << 0,
-	POLYFLAGS_JUMP     = 1 << 1,
-	POLYFLAGS_POUNCE   = 1 << 2,
-	POLYFLAGS_WALLWALK = 1 << 3,
-	POLYFLAGS_LADDER   = 1 << 4,
-	POLYFLAGS_DROPDOWN = 1 << 5,
-	POLYFLAGS_DOOR     = 1 << 6,
-	POLYFLAGS_TELEPORT = 1 << 7,
-	POLYFLAGS_CROUCH   = 1 << 8,
-	POLYFLAGS_SWIM     = 1 << 9,
-	POLYFLAGS_ALL      = 0xffff, // All abilities.
-};
-
-enum navPolyAreas
-{
-	POLYAREA_GROUND     = 1 << 0,
-	POLYAREA_LADDER     = 1 << 1,
-	POLYAREA_WATER      = 1 << 2,
-	POLYAREA_DOOR       = 1 << 3,
-	POLYAREA_JUMPPAD    = 1 << 4,
-	POLYAREA_TELEPORTER = 1 << 5,
-};
-
 //route status flags
 #define ROUTE_FAILED  ( 1u << 31 )
 #define	ROUTE_SUCCEED ( 1u << 30 )

--- a/src/sgame/botlib/nav.h
+++ b/src/sgame/botlib/nav.h
@@ -196,11 +196,11 @@ struct FastLZCompressor : public dtTileCacheCompressor
 	}
 };
 
-struct MeshProcess : public dtTileCacheMeshProcess
-{
-	OffMeshConnections con;
 
-	virtual void process( struct dtNavMeshCreateParams *params, unsigned char *polyAreas, unsigned short *polyFlags )
+
+struct BasicMeshProcess : public dtTileCacheMeshProcess
+{
+	void process( struct dtNavMeshCreateParams *params, unsigned char *polyAreas, unsigned short *polyFlags ) override
 	{
 		// Update poly flags from areas.
 		for ( int i = 0; i < params->polyCount; ++i )
@@ -219,14 +219,6 @@ struct MeshProcess : public dtTileCacheMeshProcess
 				polyFlags[ i ] = navPolyFlags::POLYFLAGS_WALK | navPolyFlags::POLYFLAGS_DOOR;
 			}
 		}
-
-		params->offMeshConVerts = con.verts;
-		params->offMeshConRad = con.rad;
-		params->offMeshConCount = con.offMeshConCount;
-		params->offMeshConAreas = con.areas;
-		params->offMeshConDir = con.dirs;
-		params->offMeshConFlags = con.flags;
-		params->offMeshConUserID = con.userids;
 	}
 };
 

--- a/src/sgame/botlib/nav.h
+++ b/src/sgame/botlib/nav.h
@@ -35,9 +35,12 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 #ifndef BOTLIB_NAV_H_
 #define BOTLIB_NAV_H_
 
-#include "bot_types.h"
+#include "DetourCommon.h"
+#include "DetourNavMesh.h"
+#include "DetourNavMeshBuilder.h"
+#include "DetourTileCache.h"
+#include "DetourTileCacheBuilder.h"
 #include "fastlz/fastlz.h"
-#include "bot_convert.h"
 
 // should be the same as in rest of engine
 #define STEPSIZE 18
@@ -45,6 +48,32 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 
 static const int NAVMESHSET_MAGIC = 'M'<<24 | 'S'<<16 | 'E'<<8 | 'T'; //'MSET';
 static const int NAVMESHSET_VERSION = 3;
+
+enum navPolyFlags
+{
+	POLYFLAGS_DISABLED = 0,
+	POLYFLAGS_WALK     = 1 << 0,
+	POLYFLAGS_JUMP     = 1 << 1,
+	POLYFLAGS_POUNCE   = 1 << 2,
+	POLYFLAGS_WALLWALK = 1 << 3,
+	POLYFLAGS_LADDER   = 1 << 4,
+	POLYFLAGS_DROPDOWN = 1 << 5,
+	POLYFLAGS_DOOR     = 1 << 6,
+	POLYFLAGS_TELEPORT = 1 << 7,
+	POLYFLAGS_CROUCH   = 1 << 8,
+	POLYFLAGS_SWIM     = 1 << 9,
+	POLYFLAGS_ALL      = 0xffff, // All abilities.
+};
+
+enum navPolyAreas
+{
+	POLYAREA_GROUND     = 1 << 0,
+	POLYAREA_LADDER     = 1 << 1,
+	POLYAREA_WATER      = 1 << 2,
+	POLYAREA_DOOR       = 1 << 3,
+	POLYAREA_JUMPPAD    = 1 << 4,
+	POLYAREA_TELEPORTER = 1 << 5,
+};
 
 struct NavMeshSetHeader
 {
@@ -85,93 +114,6 @@ static inline void SwapNavMeshTileHeader( NavMeshTileHeader &header )
 		dtSwapEndian( &header.tileRef );
 	}
 }
-
-static const int NAVMESHCON_VERSION = 2;
-struct OffMeshConnectionHeader
-{
-	int version;
-	int numConnections;
-};
-
-struct OffMeshConnection
-{
-	rVec  start;
-	rVec  end;
-	float radius;
-	unsigned short flag;
-	unsigned char area;
-	unsigned char dir;
-	unsigned int userid;
-};
-
-struct OffMeshConnections
-{
-	static CONSTEXPR int MAX_CON = 128;
-	float  verts[ MAX_CON * 6 ]; // dtOffMeshConnection::pos
-	float  rad[ MAX_CON ]; // dtOffMeshConnection::rad
-	unsigned short flags[ MAX_CON ]; // dtOffMeshConnection::poly
-	unsigned char areas[ MAX_CON ]; // dtOffMeshConnection::flags
-	unsigned char dirs[ MAX_CON ]; // likely dtOffMeshConnection::side
-	unsigned int userids[ MAX_CON ]; // dtOffMeshConnection::userId
-	int      offMeshConCount;
-
-	OffMeshConnections() : offMeshConCount( 0 ) { }
-
-	void reset()
-	{
-		offMeshConCount = 0;
-	}
-
-	void delConnection( int index )
-	{
-		if ( index < 0 || index >= offMeshConCount )
-		{
-			return;
-		}
-
-		for ( int i = index * 6; i < offMeshConCount * 6 - 1; i++ )
-		{
-			verts[ i ] = verts[ i + 1 ];
-		}
-
-		for ( int i = index; i < offMeshConCount - 1; i++ )
-		{
-			rad[ i ] = rad[ i + 1 ];
-			flags[ i ] = flags[ i + 1 ];
-			areas[ i ] = areas[ i + 1 ];
-			dirs[ i ] = dirs[ i + 1 ];
-			userids[ i ] = userids[ i + 1 ];
-		}
-		offMeshConCount--;
-	}
-
-	bool addConnection( const OffMeshConnection &c )
-	{
-		if ( offMeshConCount == MAX_CON )
-		{
-			return false;
-		}
-
-		float *start = &verts[ offMeshConCount * 6 ];
-		float *end = start + 3;
-
-		start[ 0 ] = c.start[ 0 ];
-		start[ 1 ] = c.start[ 1 ];
-		start[ 2 ] = c.start[ 2 ];
-		end[ 0 ] = c.end[ 0 ];
-		end[ 1 ] = c.end[ 1 ];
-		end[ 2 ] = c.end[ 2 ];
-
-		rad[ offMeshConCount ] = c.radius;
-		flags[ offMeshConCount ] = c.flag;
-		areas[ offMeshConCount ] = c.area;
-		dirs[ offMeshConCount ] = c.dir;
-		userids[ offMeshConCount ] = c.userid;
-
-		offMeshConCount++;
-		return true;
-	}
-};
 
 struct FastLZCompressor : public dtTileCacheCompressor
 {

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -311,6 +311,12 @@ static const g_admin_cmd_t     g_admin_cmds[] =
 	},
 
 	{
+		"navgen",       G_admin_navgen,      false, "navgen",
+		N_("request bot navmesh generation"),
+		"<class>..."
+	},
+
+	{
 		"nextmap",      G_admin_nextmap,     false, "nextmap",
 		N_("go to the next map in the cycle"),
 		""
@@ -5760,6 +5766,22 @@ static bool BotFillCmd( gentity_t *ent, const Cmd::Args& args )
 	}
 
 	G_BotFill(true);
+	return true;
+}
+
+void GenerateNavmesh( Str::StringRef species );
+bool G_admin_navgen( gentity_t* ent )
+{
+	const Cmd::Args& args = trap_Args();
+	if ( args.Argc() < 2 )
+	{
+		ADMP( QQ("^3navgen:^* usage: navgen <class>...") );
+		return false;
+	}
+	for ( int i = 1; i < args.Argc(); i++ )
+	{
+		GenerateNavmesh( args.Argv( i ) );
+	}
 	return true;
 }
 

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -5727,6 +5727,12 @@ static bool BotAddCmd( gentity_t* ent, const Cmd::Args& args )
 
 	const char* behavior = args.Argc() >= 6 ? args[5].data() : BOT_DEFAULT_BEHAVIOR;
 
+	if ( !G_BotInit() )
+	{
+		ADMP( QQ( N_( "Navigation mesh files unavailable for this map" ) ) );
+		return false;
+	}
+
 	bool result = G_BotAdd( name, team, skill, behavior );
 	if ( !result )
 	{
@@ -5760,6 +5766,12 @@ static bool BotFillCmd( gentity_t *ent, const Cmd::Args& args )
 	}
 	int skill = args.Argc() >= 5 ? BotSkillFromString(ent, args[4].data()) : g_bot_default_skill.Get();
 
+	if ( !G_BotInit() )
+	{
+		ADMP( QQ( N_( "Navigation mesh files unavailable for this map" ) ) );
+		return false;
+	}
+
 	for (team_t team : teams)
 	{
 		level.team[team].botFillTeamSize = count;
@@ -5770,6 +5782,8 @@ static bool BotFillCmd( gentity_t *ent, const Cmd::Args& args )
 	return true;
 }
 
+// This command does NOT load the navmesh that it creates.
+// However the mesh will be used if you run /navgen before the first bot fill/add command.
 bool G_admin_navgen( gentity_t* ent )
 {
 	static NavmeshGenerator navgen;

--- a/src/sgame/sg_admin.h
+++ b/src/sgame/sg_admin.h
@@ -168,6 +168,7 @@ bool        G_admin_l1( gentity_t *ent );  // AA-QVM 1.2
 bool        G_admin_register( gentity_t *ent );  // AA-QVM 1.2
 bool        G_admin_unregister( gentity_t *ent );  // AA-QVM 1.2
 bool        G_admin_bot( gentity_t *ent );
+bool        G_admin_navgen( gentity_t *ent );
 
 void            G_admin_print( gentity_t *ent, Str::StringRef m );
 void            G_admin_print_plural( gentity_t *ent, Str::StringRef m, int number );

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -275,11 +275,7 @@ bool G_BotAdd( const char *name, team_t team, int skill, const char *behavior, b
 	bool autoname = false;
 	bool okay;
 
-	if ( !navMeshLoaded )
-	{
-		Log::Warn( "No Navigation Mesh file is available for this map" );
-		return false;
-	}
+	ASSERT( navMeshLoaded );
 
 	// find what clientNum to use for bot
 	clientNum = trap_BotAllocateClient();
@@ -560,13 +556,23 @@ void G_BotIntermissionThink( gclient_t *client )
 	client->readyToExit = true;
 }
 
-void G_BotInit()
+// Initialization happens whenever someone first tries to add a bot.
+// This incurs some delay (a few tenths of a second), but on servers bots
+// are normally added at the beginning of the round so it shouldn't be noticeable.
+bool G_BotInit()
 {
-	G_BotNavInit( );
 	if ( treeList.maxTrees == 0 )
 	{
 		InitTreeList( &treeList );
 	}
+
+	if ( !G_BotNavInit() )
+	{
+		Log::Notice( "Failed to load navmeshes" );
+		G_BotNavCleanup();
+		return false;
+	}
+	return true;
 }
 
 void G_BotCleanup()

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -38,14 +38,23 @@ Navigation Mesh Loading
 */
 
 // FIXME: use nav handle instead of classes
-void G_BotNavInit()
+bool G_BotNavInit()
 {
+	if ( navMeshLoaded )
+	{
+		return true;
+	}
+
 	int i;
 
-	Log::Notice( "==== Bot Navigation Initialization ==== \n" );
+	Log::Notice( "==== Bot Navigation Initialization ====" );
 
 	for ( i = PCL_NONE + 1; i < PCL_NUM_CLASSES; i++ )
 	{
+		if ( i == PCL_ALIEN_BUILDER0 )
+		{
+			continue;
+		}
 		classModelConfig_t *model;
 		botClass_t bot;
 		bot.polyFlagsInclude = POLYFLAGS_WALK;
@@ -58,7 +67,7 @@ void G_BotNavInit()
 			{
 				Log::Warn( "class '%s': navmesh reference target class '%s' must have its own navmesh",
 				            BG_Class( i )->name, BG_Class( model->navMeshClass )->name );
-				return;
+				return false;
 			}
 
 			continue;
@@ -68,10 +77,11 @@ void G_BotNavInit()
 
 		if ( !G_BotSetupNav( &bot, &model->navHandle ) )
 		{
-			return;
+			return false;
 		}
 	}
 	navMeshLoaded = true;
+	return true;
 }
 
 void G_BotNavCleanup()

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "sg_bot_util.h"
 #include "botlib/bot_types.h"
 #include "botlib/bot_api.h"
-#include "botlib/nav.h"
+#include "shared/bot_nav_shared.h"
 
 //tells if all navmeshes loaded successfully
 bool navMeshLoaded = false;

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "sg_bot_util.h"
 #include "botlib/bot_types.h"
 #include "botlib/bot_api.h"
+#include "botlib/nav.h"
 
 //tells if all navmeshes loaded successfully
 bool navMeshLoaded = false;
@@ -381,7 +382,6 @@ void BotWalk( gentity_t *self, bool enable )
 	}
 }
 
-#define STEPSIZE 18.0f
 gentity_t* BotGetPathBlocker( gentity_t *self, const vec3_t dir )
 {
 	vec3_t playerMins, playerMaxs;

--- a/src/sgame/sg_bot_public.h
+++ b/src/sgame/sg_bot_public.h
@@ -60,7 +60,7 @@ void G_BotEnableArea( vec3_t origin, vec3_t mins, vec3_t maxs );
 void G_BotAddObstacle( const vec3_t mins, const vec3_t maxs, qhandle_t *handle );
 void G_BotRemoveObstacle( qhandle_t handle );
 void G_BotUpdateObstacles();
-void G_BotInit();
+bool G_BotInit();
 void G_BotCleanup();
 void G_BotFill( bool immediately );
 void G_BotAddObstacle( const vec3_t mins, const vec3_t maxs, qhandle_t *handle );

--- a/src/sgame/sg_bot_util.h
+++ b/src/sgame/sg_bot_util.h
@@ -113,7 +113,7 @@ enum botMoveDir_t
 // global navigation
 extern bool navMeshLoaded;
 
-void         G_BotNavInit();
+bool         G_BotNavInit();
 void         G_BotNavCleanup();
 bool     FindRouteToTarget( gentity_t *self, botTarget_t target, bool allowPartial );
 void         BotMoveToGoal( gentity_t *self );

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -550,9 +550,6 @@ void G_InitGame( int levelTime, int randomSeed, bool inClient )
 	// load up a custom building layout if there is one
 	G_LayoutLoad();
 
-	// setup bot code
-	G_BotInit();
-
 	// Initialize item locking state
 	BG_InitUnlockackables();
 

--- a/src/sgame/sg_trapcalls.h
+++ b/src/sgame/sg_trapcalls.h
@@ -25,6 +25,8 @@ along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>
 #ifndef SG_TRAPCALLS_H_
 #define SG_TRAPCALLS_H_
 
+struct gentity_t;
+
 int              trap_Milliseconds();
 void             trap_Cvar_Set( const char *var_name, const char *value );
 int              trap_Cvar_VariableIntegerValue( const char *var_name );

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -49,7 +49,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 #define MIN_WALK_NORMAL 0.7f
 
 static const int NAVMESHSET_MAGIC = 'M'<<24 | 'S'<<16 | 'E'<<8 | 'T'; //'MSET';
-static const int NAVMESHSET_VERSION = 3;
+static const int NAVMESHSET_VERSION = 3; // Increment when navgen algorithm or data format changes
 
 enum navPolyFlags
 {
@@ -75,6 +75,17 @@ enum navPolyAreas
 	POLYAREA_DOOR       = 1 << 3,
 	POLYAREA_JUMPPAD    = 1 << 4,
 	POLYAREA_TELEPORTER = 1 << 5,
+};
+
+// Will be part of header which must contain 4-byte members only
+struct NavgenConfig {
+	float cellHeight;
+	float stepSize;
+	int excludeCaulk; // boolean - exclude caulk surfaces
+	int excludeSky; // boolean - exclude surfaces with surfaceparm sky from navmesh generation
+	int filterGaps; // boolean - add new walkable spans so bots can walk over small gaps
+
+	static NavgenConfig Default() { return { 2.0f, STEPSIZE, 1, 1, 1 }; }
 };
 
 struct NavMeshSetHeader

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -41,6 +41,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 #include "DetourNavMeshBuilder.h"
 #include "DetourTileCache.h"
 #include "DetourTileCacheBuilder.h"
+#include "shared/bg_public.h"
 #include "fastlz/fastlz.h"
 
 // should be the same as in rest of engine
@@ -241,5 +242,20 @@ struct LinearAllocator : public dtTileCacheAlloc
 	void free( void* /*ptr*/ ) override { }
 	size_t getHighSize() { return high; }
 };
+
+inline std::vector<class_t> RequiredNavmeshes()
+{
+	return {
+		PCL_ALIEN_LEVEL0,
+		PCL_ALIEN_LEVEL1,
+		PCL_ALIEN_LEVEL2,
+		PCL_ALIEN_LEVEL2_UPG,
+		PCL_ALIEN_LEVEL3,
+		PCL_ALIEN_LEVEL3_UPG,
+		PCL_ALIEN_LEVEL4,
+		PCL_HUMAN_NAKED,
+		PCL_HUMAN_BSUIT,
+	};
+}
 
 #endif // SHARED_BOT_NAV_SHARED_H_

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -31,9 +31,10 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 ===========================================================================
 */
 
-// nav.h -- navigation mesh definitions
-#ifndef BOTLIB_NAV_H_
-#define BOTLIB_NAV_H_
+// Definitions used by both the code that *generates* navmeshes and the code that *uses* them
+
+#ifndef SHARED_BOT_NAV_SHARED_H_
+#define SHARED_BOT_NAV_SHARED_H_
 
 #include "DetourCommon.h"
 #include "DetourNavMesh.h"
@@ -219,4 +220,4 @@ struct LinearAllocator : public dtTileCacheAlloc
 	size_t getHighSize() { return high; }
 };
 
-#endif
+#endif // SHARED_BOT_NAV_SHARED_H_

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -96,6 +96,7 @@ struct NavMeshSetHeader
 	dtNavMeshParams params;
 	dtTileCacheParams cacheParams;
 };
+constexpr int PERMANENT_NAVGEN_ERROR = -789; // as value of header.params.tileHeight
 
 struct NavMeshTileHeader
 {

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -116,6 +116,28 @@ static inline void SwapNavMeshTileHeader( NavMeshTileHeader &header )
 	}
 }
 
+// Returns a non-empty string on error
+inline std::string GetNavmeshHeader( fileHandle_t f, NavMeshSetHeader& header )
+{
+	if ( sizeof(header) != trap_FS_Read( &header, sizeof( header ), f ) )
+	{
+		return "File too small";
+	}
+	SwapNavMeshSetHeader( header );
+
+	if ( header.magic != NAVMESHSET_MAGIC )
+	{
+		return "File is wrong magic";
+	}
+
+	if ( header.version != NAVMESHSET_VERSION )
+	{
+		return Str::Format( "File is wrong version (found %d, want %d)", header.version, NAVMESHSET_VERSION );
+	}
+
+	return "";
+}
+
 struct FastLZCompressor : public dtTileCacheCompressor
 {
 	virtual int maxCompressedSize( const int bufferSize )

--- a/src/shared/navgen/brush.cpp
+++ b/src/shared/navgen/brush.cpp
@@ -1,0 +1,156 @@
+/* -------------------------------------------------------------------------------
+
+   Copyright (C) 1999-2007 id Software, Inc. and contributors.
+   For a list of contributors, see the accompanying CONTRIBUTORS file.
+
+   This file is part of GtkRadiant.
+
+   GtkRadiant is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 2 of the License, or
+   (at your option) any later version.
+
+   GtkRadiant is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with GtkRadiant; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+   ----------------------------------------------------------------------------------
+
+   This code has been altered significantly from its original form, to support
+   several games based on the Quake III Arena engine, in the form of "Q3Map2."
+
+   ------------------------------------------------------------------------------- */
+
+
+
+/* marker */
+#define BRUSH_C
+
+
+
+/* dependencies */
+#include "q3map2.h"
+
+
+
+/* -------------------------------------------------------------------------------
+
+   functions
+
+   ------------------------------------------------------------------------------- */
+
+/*
+   SnapWeldVector() - ydnar
+   welds two vec3_t's into a third, taking into account nearest-to-integer
+   instead of averaging
+ */
+
+#define SNAP_EPSILON    0.01
+
+void SnapWeldVector( vec3_t a, vec3_t b, vec3_t out ){
+	int i;
+	vec_t ai, bi, outi;
+
+
+	/* dummy check */
+	if ( a == NULL || b == NULL || out == NULL ) {
+		return;
+	}
+
+	/* do each element */
+	for ( i = 0; i < 3; i++ )
+	{
+		/* round to integer */
+		ai = Q_rint( a[ i ] );
+		bi = Q_rint( b[ i ] );
+
+		/* prefer exact integer */
+		if ( ai == a[ i ] ) {
+			out[ i ] = a[ i ];
+		}
+		else if ( bi == b[ i ] ) {
+			out[ i ] = b[ i ];
+		}
+
+		/* use nearest */
+		else if ( fabs( ai - a[ i ] ) < fabs( bi - b[ i ] ) ) {
+			out[ i ] = a[ i ];
+		}
+		else{
+			out[ i ] = b[ i ];
+		}
+
+		/* snap */
+		outi = Q_rint( out[ i ] );
+		if ( fabs( outi - out[ i ] ) <= SNAP_EPSILON ) {
+			out[ i ] = outi;
+		}
+	}
+}
+
+
+
+/*
+   FixWinding() - ydnar
+   removes degenerate edges from a winding
+   returns qtrue if the winding is valid
+ */
+
+#define DEGENERATE_EPSILON  0.1
+
+qboolean FixWinding( winding_t *w ){
+	qboolean valid = qtrue;
+	int i, j, k;
+	vec3_t vec;
+	float dist;
+
+
+	/* dummy check */
+	if ( !w ) {
+		return qfalse;
+	}
+
+	/* check all verts */
+	for ( i = 0; i < w->numpoints; i++ )
+	{
+		/* don't remove points if winding is a triangle */
+		if ( w->numpoints == 3 ) {
+			return valid;
+		}
+
+		/* get second point index */
+		j = ( i + 1 ) % w->numpoints;
+
+		/* degenerate edge? */
+		VectorSubtract( w->p[ i ], w->p[ j ], vec );
+		dist = VectorLength( vec );
+		if ( dist < DEGENERATE_EPSILON ) {
+			valid = qfalse;
+			//Sys_FPrintf( SYS_VRB, "WARNING: Degenerate winding edge found, fixing...\n" );
+
+			/* create an average point (ydnar 2002-01-26: using nearest-integer weld preference) */
+			SnapWeldVector( w->p[ i ], w->p[ j ], vec );
+			VectorCopy( vec, w->p[ i ] );
+			//VectorAdd( w->p[ i ], w->p[ j ], vec );
+			//VectorScale( vec, 0.5, w->p[ i ] );
+
+			/* move the remaining verts */
+			for ( k = i + 2; k < w->numpoints; k++ )
+			{
+				VectorCopy( w->p[ k ], w->p[ k - 1 ] );
+			}
+			w->numpoints--;
+		}
+	}
+
+	/* one last check and return */
+	if ( w->numpoints < 3 ) {
+		valid = qfalse;
+	}
+	return valid;
+}

--- a/src/shared/navgen/brush.cpp
+++ b/src/shared/navgen/brush.cpp
@@ -34,7 +34,9 @@
 
 
 /* dependencies */
-#include "q3map2.h"
+#include <math.h>
+#include "engine/qcommon/qcommon.h"
+#include "common/cm/cm_polylib.h"
 
 
 
@@ -66,8 +68,8 @@ void SnapWeldVector( vec3_t a, vec3_t b, vec3_t out ){
 	for ( i = 0; i < 3; i++ )
 	{
 		/* round to integer */
-		ai = Q_rint( a[ i ] );
-		bi = Q_rint( b[ i ] );
+		ai = roundf( a[ i ] );
+		bi = roundf( b[ i ] );
 
 		/* prefer exact integer */
 		if ( ai == a[ i ] ) {
@@ -86,7 +88,7 @@ void SnapWeldVector( vec3_t a, vec3_t b, vec3_t out ){
 		}
 
 		/* snap */
-		outi = Q_rint( out[ i ] );
+		outi = roundf( out[ i ] );
 		if ( fabs( outi - out[ i ] ) <= SNAP_EPSILON ) {
 			out[ i ] = outi;
 		}
@@ -103,8 +105,8 @@ void SnapWeldVector( vec3_t a, vec3_t b, vec3_t out ){
 
 #define DEGENERATE_EPSILON  0.1
 
-qboolean FixWinding( winding_t *w ){
-	qboolean valid = qtrue;
+bool FixWinding( winding_t *w ){
+	bool valid = true;
 	int i, j, k;
 	vec3_t vec;
 	float dist;
@@ -112,7 +114,7 @@ qboolean FixWinding( winding_t *w ){
 
 	/* dummy check */
 	if ( !w ) {
-		return qfalse;
+		return false;
 	}
 
 	/* check all verts */
@@ -130,7 +132,7 @@ qboolean FixWinding( winding_t *w ){
 		VectorSubtract( w->p[ i ], w->p[ j ], vec );
 		dist = VectorLength( vec );
 		if ( dist < DEGENERATE_EPSILON ) {
-			valid = qfalse;
+			valid = false;
 			//Sys_FPrintf( SYS_VRB, "WARNING: Degenerate winding edge found, fixing...\n" );
 
 			/* create an average point (ydnar 2002-01-26: using nearest-integer weld preference) */
@@ -150,7 +152,7 @@ qboolean FixWinding( winding_t *w ){
 
 	/* one last check and return */
 	if ( w->numpoints < 3 ) {
-		valid = qfalse;
+		valid = false;
 	}
 	return valid;
 }

--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -29,6 +29,7 @@
 #include "common/cm/cm_polylib.h"
 #include "common/FileSystem.h"
 #include "navgen.h"
+#include "sgame/botlib/bot_convert.h"
 #include "sgame/sg_trapcalls.h"
 
 static Log::Logger LOG("sgame.navgen", "");

--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -40,7 +40,7 @@
 #include "common/FileSystem.h"
 #include "navgen.h"
 
-static Log::Logger LOG( VM_STRING_PREFIX "navgen", "");
+static Log::Logger LOG( VM_STRING_PREFIX "navgen", "", Log::Level::NOTICE );
 
 void UnvContext::doLog(const rcLogCategory /*category*/, const char* msg, const int /*len*/)
 {
@@ -1005,7 +1005,7 @@ bool NavmeshGenerator::Step()
 	{
 		if ( d_->status.code == NavgenStatus::OK )
 		{
-			LOG.Notice( "Finished generating navmesh for %s", BG_ClassModelConfig( d_->species )->humanName );
+			LOG.Verbose( "Finished generating navmesh for %s", BG_ClassModelConfig( d_->species )->humanName );
 		}
 		else
 		{
@@ -1084,8 +1084,8 @@ void NavmeshGenerator::Init(Str::StringRef mapName)
 			return;
 		}
 
-		LOG.Notice( "Previous cell height: %f", prevCellHeight );
-		LOG.Notice( "New cell height: %f", config_.cellHeight );
+		LOG.Verbose( "Previous cell height: %f", prevCellHeight );
+		LOG.Verbose( "New cell height: %f", config_.cellHeight );
 	}
 }
 

--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -21,17 +21,26 @@
  */
 // nav.cpp -- navigation mesh generator interface
 
+#include "common/Common.h"
+
 #include <iostream>
 #include <vector>
 #include <queue>
+
+// Filesystem APIs are stupidly declared in different headers
+#ifdef BUILD_CGAME
+#include "engine/client/cg_api.h"
+#else
+#include "sgame/sg_trapcalls.h"
+#endif
+
 #include "engine/qcommon/qcommon.h"
 #include "common/cm/cm_patch.h"
 #include "common/cm/cm_polylib.h"
 #include "common/FileSystem.h"
 #include "navgen.h"
-#include "sgame/sg_trapcalls.h"
 
-static Log::Logger LOG("sgame.navgen", "");
+static Log::Logger LOG( VM_STRING_PREFIX "navgen", "");
 
 void UnvContext::doLog(const rcLogCategory /*category*/, const char* msg, const int /*len*/)
 {
@@ -1023,4 +1032,10 @@ void NavmeshGenerator::Init(Str::StringRef mapName)
 		LOG.Notice( "Previous cell height: %f", prevCellHeight );
 		LOG.Notice( "New cell height: %f", cellHeight );
 	}
+}
+
+float NavmeshGenerator::SpeciesFractionCompleted() const
+{
+	// Assume that writing the file at the end is 10%
+	return 0.9f * float(d_->y * d_->tw + d_->x) / float(d_->tw * d_->th);
 }

--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -1,0 +1,1111 @@
+/*
+   ===========================================================================
+   Copyright (C) 2012 Unvanquished Developers
+
+   This file is part of Daemon source code.
+
+   Daemon source code is free software; you can redistribute it
+   and/or modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation; either version 2 of the License,
+   or (at your option) any later version.
+
+   Daemon source code is distributed in the hope that it will be
+   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Daemon source code; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+   ===========================================================================
+ */
+// nav.cpp -- navigation mesh generator interface
+
+#include "q3map2.h"
+#include <iostream>
+#include <vector>
+#include <queue>
+#include "cm_patch.h"
+#include "navgen.h"
+
+class UnvContext : public rcContext
+{
+	/// Clears all log entries.
+	void doResetLog() override
+	{
+	}
+
+	/// Logs a message.
+	///  @param[in]   category  The category of the message.
+	///  @param[in]   msg     The formatted message.
+	///  @param[in]   len     The length of the formatted message.
+	void doLog(const rcLogCategory /*category*/, const char* msg, const int /*len*/) override
+	{
+		if( m_logEnabled )
+		{
+			fprintf( stderr, "\n%s\n", msg );
+		}
+	}
+
+	/// Clears all timers. (Resets all to unused.)
+	void doResetTimers() override
+	{
+	}
+
+	/// Starts the specified performance timer.
+	///  @param[in]   label The category of timer.
+	void doStartTimer(const rcTimerLabel /*label*/) override
+	{
+	}
+
+	/// Stops the specified performance timer.
+	///  @param[in]   label The category of the timer.
+	void doStopTimer(const rcTimerLabel /*label*/) override
+	{
+	}
+
+	/// Returns the total accumulated time of the specified performance timer.
+	///  @param[in]   label The category of the timer.
+	///  @return The accumulated time of the timer, or -1 if timers are disabled or the timer has never been started.
+	int doGetAccumulatedTime(const rcTimerLabel /*label*/) const override
+	{
+		return -1;
+	}
+};
+
+Geometry geo;
+
+float cellHeight = 2.0f;
+float stepSize = STEPSIZE;
+int tileSize = 64;
+
+struct Character
+{
+	const char *name;   //appended to filename
+	float radius; //radius of agents (BBox maxs[0] or BBox maxs[1])
+	float height; //height of agents (BBox maxs[2] - BBox mins[2])
+};
+
+static const Character characterArray[] = {
+	{ "builder",     20, 40 },
+	{ "human_naked", 15, 56 },
+	{ "human_bsuit", 15, 76 },
+	{ "level0",      15, 30 },
+	{ "level1",      15, 30 },
+	{ "level2",      23, 36 },
+	{ "level2upg",   25, 40 },
+	{ "level3",      26, 55 },
+	{ "level3upg",   29, 66 },
+	{ "level4",      32, 92 }
+};
+
+//flag for excluding caulk surfaces
+static qboolean excludeCaulk = qtrue;
+
+//flag for excluding surfaces with surfaceparm sky from navmesh generation
+static qboolean excludeSky = qtrue;
+
+//flag for adding new walkable spans so bots can walk over small gaps
+static qboolean filterGaps = qtrue;
+
+static void WriteNavMeshFile( const char* agentname, const dtTileCache *tileCache, const dtNavMeshParams *params ) {
+	int numTiles = 0;
+	FILE *file = NULL;
+	char filename[ 1024 ];
+	char filenameWithoutExt[ 1024 ];
+	NavMeshSetHeader header;
+	const int maxTiles = tileCache->getTileCount();
+
+	for ( int i = 0; i < maxTiles; i++ )
+	{
+		const dtCompressedTile *tile = tileCache->getTile( i );
+		if ( !tile || !tile->header || !tile->dataSize ) {
+			continue;
+		}
+		numTiles++;
+	}
+
+	header.magic = NAVMESHSET_MAGIC;
+	header.version = NAVMESHSET_VERSION;
+	header.numTiles = numTiles;
+	header.cacheParams = *tileCache->getParams();
+	header.params = *params;
+
+	SwapNavMeshSetHeader( header );
+
+	strcpy( filenameWithoutExt, source );
+	StripExtension( filenameWithoutExt );
+
+	if ( snprintf( filename, sizeof( filename ), "%s-%s", filenameWithoutExt, agentname ) < 0 )
+	{
+		Error( "Filename too long for agent: %s\n", agentname );
+	}
+
+	DefaultExtension( filename, ".navMesh" );
+	file = fopen( filename, "wb" );
+
+	if ( !file ) {
+		Error( "Error opening %s: %s\n", filename, strerror( errno ) );
+	}
+
+	fwrite( &header, sizeof( header ), 1, file );
+
+	for ( int i = 0; i < maxTiles; i++ )
+	{
+		const dtCompressedTile *tile = tileCache->getTile( i );
+
+		if ( !tile || !tile->header || !tile->dataSize ) {
+			continue;
+		}
+
+		NavMeshTileHeader tileHeader;
+		tileHeader.tileRef = tileCache->getTileRef( tile );
+		tileHeader.dataSize = tile->dataSize;
+
+		SwapNavMeshTileHeader( tileHeader );
+		fwrite( &tileHeader, sizeof( tileHeader ), 1, file );
+
+		unsigned char* data = ( unsigned char * ) malloc( tile->dataSize );
+
+		memcpy( data, tile->data, tile->dataSize );
+		if ( LittleLong( 1 ) != 1 ) {
+			dtTileCacheHeaderSwapEndian( data, tile->dataSize );
+		}
+
+		fwrite( data, tile->dataSize, 1, file );
+
+		free( data );
+	}
+	fclose( file );
+}
+
+//need this to get the windings for brushes
+extern "C" qboolean FixWinding( winding_t* w );
+
+static void AddVert( std::vector<float> &verts, std::vector<int> &tris, vec3_t vert ) {
+	vec3_t recastVert;
+	VectorCopy( vert, recastVert );
+	quake2recast( recastVert );
+	int index = 0;
+	for ( int i = 0; i < 3; i++ ) {
+		verts.push_back( recastVert[i] );
+	}
+	index = ( verts.size() - 3 ) / 3;
+	tris.push_back( index );
+}
+
+static void AddTri( std::vector<float> &verts, std::vector<int> &tris, vec3_t v1, vec3_t v2, vec3_t v3 ) {
+	AddVert( verts, tris, v1 );
+	AddVert( verts, tris, v2 );
+	AddVert( verts, tris, v3 );
+}
+
+static void LoadBrushTris( std::vector<float> &verts, std::vector<int> &tris ) {
+	int j;
+
+	int solidFlags = 0;
+	int temp = 0;
+	int surfaceSkip = 0;
+
+	char surfaceparm[16];
+
+	strcpy( surfaceparm, "default" );
+	ApplySurfaceParm( surfaceparm, &solidFlags, NULL, NULL );
+
+	strcpy( surfaceparm, "playerclip" );
+	ApplySurfaceParm( surfaceparm, &temp, NULL, NULL );
+	solidFlags |= temp;
+
+	if ( excludeSky ) {
+		strcpy( surfaceparm, "sky" );
+		ApplySurfaceParm( surfaceparm, NULL, &surfaceSkip, NULL );
+	}
+
+	/* get model, index 0 is worldspawn entity */
+	bspModel_t *model = &bspModels[0];
+
+	if ( model->numBSPBrushes <= 0 ) {
+		std::cerr << "No brushes found. Aborting." << std::endl;
+		exit( 2 );
+	}
+
+	//go through the brushes
+	for ( int i = model->firstBSPBrush,m = 0; m < model->numBSPBrushes; i++,m++ ) {
+		int numSides = bspBrushes[i].numSides;
+		int firstSide = bspBrushes[i].firstSide;
+		bspShader_t *brushShader = &bspShaders[bspBrushes[i].shaderNum];
+
+		if ( !( brushShader->contentFlags & solidFlags ) ) {
+			continue;
+		}
+		/* walk the list of brush sides */
+		for ( int p = 0; p < numSides; p++ )
+		{
+			/* get side and plane */
+			bspBrushSide_t *side = &bspBrushSides[p + firstSide];
+			bspPlane_t *plane = &bspPlanes[side->planeNum];
+			bspShader_t *shader = &bspShaders[side->shaderNum];
+
+			if ( shader->surfaceFlags & surfaceSkip ) {
+				continue;
+			}
+
+			if ( excludeCaulk && !Q_stricmp( shader->shader, "textures/common/caulk" ) ) {
+				continue;
+			}
+
+			/* make huge winding */
+			winding_t *w = BaseWindingForPlane( plane->normal, plane->dist );
+
+			/* walk the list of brush sides */
+			for ( j = 0; j < numSides && w != NULL; j++ )
+			{
+				bspBrushSide_t *chopSide = &bspBrushSides[j + firstSide];
+				if ( chopSide == side ) {
+					continue;
+				}
+				if ( chopSide->planeNum == ( side->planeNum ^ 1 ) ) {
+					continue;       /* back side clipaway */
+
+				}
+				bspPlane_t *chopPlane = &bspPlanes[chopSide->planeNum ^ 1];
+
+				ChopWindingInPlace( &w, chopPlane->normal, chopPlane->dist, 0 );
+
+				/* ydnar: fix broken windings that would generate trifans */
+				FixWinding( w );
+			}
+
+			if ( w ) {
+				for ( int j = 2; j < w->numpoints; j++ ) {
+					AddTri( verts, tris, w->p[0], w->p[j - 1], w->p[j] );
+				}
+				FreeWinding( w );
+			}
+		}
+	}
+}
+
+static qboolean BoundsIntersect( const vec3_t mins, const vec3_t maxs, const vec3_t mins2, const vec3_t maxs2 ){
+	if ( maxs[ 0 ] < mins2[ 0 ] ||
+		 maxs[ 1 ] < mins2[ 1 ] || maxs[ 2 ] < mins2[ 2 ] || mins[ 0 ] > maxs2[ 0 ] || mins[ 1 ] > maxs2[ 1 ] || mins[ 2 ] > maxs2[ 2 ] ) {
+		return qfalse;
+	}
+
+	return qtrue;
+}
+
+static void LoadPatchTris( std::vector<float> &verts, std::vector<int> &tris ) {
+
+	vec3_t mins, maxs;
+	int solidFlags = 0;
+	int temp = 0;
+
+	char surfaceparm[16];
+
+	strcpy( surfaceparm, "default" );
+	ApplySurfaceParm( surfaceparm, &solidFlags, NULL, NULL );
+
+	strcpy( surfaceparm, "playerclip" );
+	ApplySurfaceParm( surfaceparm, &temp, NULL, NULL );
+	solidFlags |= temp;
+
+	/*
+	    Patches are not used during the bsp building process where
+	    the generated portals are flooded through from all entity positions
+	    if even one entity reaches the void, the map will not be compiled
+	    Therefore, we can assume that any patch which lies outside the collective
+	    bounds of the brushes cannot be reached by entitys
+	 */
+
+	// calculate bounds of all verts
+	rcCalcBounds( &verts[ 0 ], verts.size() / 3, mins, maxs );
+
+	// convert from recast to quake3 coordinates
+	recast2quake( mins );
+	recast2quake( maxs );
+
+	vec3_t tmin, tmax;
+
+	// need to recalculate mins and maxs because they no longer represent
+	// the minimum and maximum vector components respectively
+	ClearBounds( tmin, tmax );
+
+	AddPointToBounds( mins, tmin, tmax );
+	AddPointToBounds( maxs, tmin, tmax );
+
+	VectorCopy( tmin, mins );
+	VectorCopy( tmax, maxs );
+
+	/* get model, index 0 is worldspawn entity */
+	const bspModel_t *model = &bspModels[0];
+	for ( int k = model->firstBSPSurface, n = 0; n < model->numBSPSurfaces; k++,n++ )
+	{
+		const bspDrawSurface_t *surface = &bspDrawSurfaces[k];
+
+		if ( !( bspShaders[surface->shaderNum].contentFlags & solidFlags ) ) {
+			continue;
+		}
+
+		if ( surface->surfaceType != MST_PATCH ) {
+			continue;
+		}
+
+		if ( !surface->patchWidth ) {
+			continue;
+		}
+
+		cGrid_t grid;
+		grid.width = surface->patchWidth;
+		grid.height = surface->patchHeight;
+		grid.wrapHeight = qfalse;
+		grid.wrapWidth = qfalse;
+
+		bspDrawVert_t *curveVerts = &bspDrawVerts[surface->firstVert];
+
+		// make sure the patch intersects the bounds of the brushes
+		ClearBounds( tmin, tmax );
+
+		for ( int x = 0; x < grid.width; x++ )
+		{
+			for ( int y = 0; y < grid.height; y++ )
+			{
+				AddPointToBounds( curveVerts[ y * grid.width + x ].xyz, tmin, tmax );
+			}
+		}
+
+		if ( !BoundsIntersect( tmin, tmax, mins, maxs ) ) {
+			// we can safely ignore this patch surface
+			continue;
+		}
+
+		for ( int x = 0; x < grid.width; x++ )
+		{
+			for ( int y = 0; y < grid.height; y++ )
+			{
+				VectorCopy( curveVerts[ y * grid.width + x ].xyz, grid.points[ x ][ y ] );
+			}
+		}
+
+		// subdivide the grid
+		CM_SetGridWrapWidth( &grid );
+		CM_SubdivideGridColumns( &grid );
+		CM_RemoveDegenerateColumns( &grid );
+
+		CM_TransposeGrid( &grid );
+
+		CM_SetGridWrapWidth( &grid );
+		CM_SubdivideGridColumns( &grid );
+		CM_RemoveDegenerateColumns( &grid );
+
+		for ( int x = 0; x < ( grid.width - 1 ); x++ )
+		{
+			for ( int y = 0; y < ( grid.height - 1 ); y++ )
+			{
+				/* set indexes */
+				float *p1 = grid.points[ x ][ y ];
+				float *p2 = grid.points[ x + 1 ][ y ];
+				float *p3 = grid.points[ x + 1 ][ y + 1 ];
+				AddTri( verts, tris, p1, p2, p3 );
+
+				p1 = grid.points[ x + 1 ][ y + 1 ];
+				p2 = grid.points[ x ][ y + 1 ];
+				p3 = grid.points[ x ][ y ];
+				AddTri( verts, tris, p1, p2, p3 );
+			}
+		}
+	}
+}
+
+static void LoadGeometry(){
+	std::vector<float> verts;
+	std::vector<int> tris;
+
+	Sys_Printf( "loading geometry...\n" );
+	int numVerts, numTris;
+
+	//count surfaces
+	LoadBrushTris( verts, tris );
+	LoadPatchTris( verts, tris );
+
+	numTris = tris.size() / 3;
+	numVerts = verts.size() / 3;
+
+	Sys_Printf( "Using %d triangles\n", numTris );
+	Sys_Printf( "Using %d vertices\n", numVerts );
+
+	geo.init( &verts[ 0 ], numVerts, &tris[ 0 ], numTris );
+
+	const float *mins = geo.getMins();
+	const float *maxs = geo.getMaxs();
+
+	Sys_Printf( "set recast world bounds to\n" );
+	Sys_Printf( "min: %f %f %f\n", mins[0], mins[1], mins[2] );
+	Sys_Printf( "max: %f %f %f\n", maxs[0], maxs[1], maxs[2] );
+}
+
+// Modified version of Recast's rcErodeWalkableArea that uses an AABB instead of a cylindrical radius
+static bool rcErodeWalkableAreaByBox( rcContext* ctx, int boxRadius, rcCompactHeightfield& chf ){
+	rcAssert( ctx );
+
+	const int w = chf.width;
+	const int h = chf.height;
+
+	ctx->startTimer( RC_TIMER_ERODE_AREA );
+
+	unsigned char* dist = (unsigned char*)rcAlloc( sizeof( unsigned char ) * chf.spanCount, RC_ALLOC_TEMP );
+	if ( !dist ) {
+		ctx->log( RC_LOG_ERROR, "erodeWalkableArea: Out of memory 'dist' (%d).", chf.spanCount );
+		return false;
+	}
+
+	// Init distance.
+	memset( dist, 0xff, sizeof( unsigned char ) * chf.spanCount );
+
+	// Mark boundary cells.
+	for ( int y = 0; y < h; ++y )
+	{
+		for ( int x = 0; x < w; ++x )
+		{
+			const rcCompactCell& c = chf.cells[x + y * w];
+			for ( int i = (int)c.index, ni = (int)( c.index + c.count ); i < ni; ++i )
+			{
+				if ( chf.areas[i] == RC_NULL_AREA ) {
+					dist[i] = 0;
+				}
+				else
+				{
+					const rcCompactSpan& s = chf.spans[i];
+					int nc = 0;
+					for ( int dir = 0; dir < 4; ++dir )
+					{
+						if ( rcGetCon( s, dir ) != RC_NOT_CONNECTED ) {
+							const int nx = x + rcGetDirOffsetX( dir );
+							const int ny = y + rcGetDirOffsetY( dir );
+							const int nidx = (int)chf.cells[nx + ny * w].index + rcGetCon( s, dir );
+							if ( chf.areas[nidx] != RC_NULL_AREA ) {
+								nc++;
+							}
+						}
+					}
+					// At least one missing neighbour.
+					if ( nc != 4 ) {
+						dist[i] = 0;
+					}
+				}
+			}
+		}
+	}
+
+	unsigned char nd;
+
+	// Pass 1
+	for ( int y = 0; y < h; ++y )
+	{
+		for ( int x = 0; x < w; ++x )
+		{
+			const rcCompactCell& c = chf.cells[x + y * w];
+			for ( int i = (int)c.index, ni = (int)( c.index + c.count ); i < ni; ++i )
+			{
+				const rcCompactSpan& s = chf.spans[i];
+
+				if ( rcGetCon( s, 0 ) != RC_NOT_CONNECTED ) {
+					// (-1,0)
+					const int ax = x + rcGetDirOffsetX( 0 );
+					const int ay = y + rcGetDirOffsetY( 0 );
+					const int ai = (int)chf.cells[ax + ay * w].index + rcGetCon( s, 0 );
+					const rcCompactSpan& as = chf.spans[ai];
+					nd = (unsigned char)rcMin( (int)dist[ai] + 2, 255 );
+					if ( nd < dist[i] ) {
+						dist[i] = nd;
+					}
+
+					// (-1,-1)
+					if ( rcGetCon( as, 3 ) != RC_NOT_CONNECTED ) {
+						const int aax = ax + rcGetDirOffsetX( 3 );
+						const int aay = ay + rcGetDirOffsetY( 3 );
+						const int aai = (int)chf.cells[aax + aay * w].index + rcGetCon( as, 3 );
+						nd = (unsigned char)rcMin( (int)dist[aai] + 2, 255 );
+						if ( nd < dist[i] ) {
+							dist[i] = nd;
+						}
+					}
+				}
+				if ( rcGetCon( s, 3 ) != RC_NOT_CONNECTED ) {
+					// (0,-1)
+					const int ax = x + rcGetDirOffsetX( 3 );
+					const int ay = y + rcGetDirOffsetY( 3 );
+					const int ai = (int)chf.cells[ax + ay * w].index + rcGetCon( s, 3 );
+					const rcCompactSpan& as = chf.spans[ai];
+					nd = (unsigned char)rcMin( (int)dist[ai] + 2, 255 );
+					if ( nd < dist[i] ) {
+						dist[i] = nd;
+					}
+
+					// (1,-1)
+					if ( rcGetCon( as, 2 ) != RC_NOT_CONNECTED ) {
+						const int aax = ax + rcGetDirOffsetX( 2 );
+						const int aay = ay + rcGetDirOffsetY( 2 );
+						const int aai = (int)chf.cells[aax + aay * w].index + rcGetCon( as, 2 );
+						nd = (unsigned char)rcMin( (int)dist[aai] + 2, 255 );
+						if ( nd < dist[i] ) {
+							dist[i] = nd;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Pass 2
+	for ( int y = h - 1; y >= 0; --y )
+	{
+		for ( int x = w - 1; x >= 0; --x )
+		{
+			const rcCompactCell& c = chf.cells[x + y * w];
+			for ( int i = (int)c.index, ni = (int)( c.index + c.count ); i < ni; ++i )
+			{
+				const rcCompactSpan& s = chf.spans[i];
+
+				if ( rcGetCon( s, 2 ) != RC_NOT_CONNECTED ) {
+					// (1,0)
+					const int ax = x + rcGetDirOffsetX( 2 );
+					const int ay = y + rcGetDirOffsetY( 2 );
+					const int ai = (int)chf.cells[ax + ay * w].index + rcGetCon( s, 2 );
+					const rcCompactSpan& as = chf.spans[ai];
+					nd = (unsigned char)rcMin( (int)dist[ai] + 2, 255 );
+					if ( nd < dist[i] ) {
+						dist[i] = nd;
+					}
+
+					// (1,1)
+					if ( rcGetCon( as, 1 ) != RC_NOT_CONNECTED ) {
+						const int aax = ax + rcGetDirOffsetX( 1 );
+						const int aay = ay + rcGetDirOffsetY( 1 );
+						const int aai = (int)chf.cells[aax + aay * w].index + rcGetCon( as, 1 );
+						nd = (unsigned char)rcMin( (int)dist[aai] + 2, 255 );
+						if ( nd < dist[i] ) {
+							dist[i] = nd;
+						}
+					}
+				}
+				if ( rcGetCon( s, 1 ) != RC_NOT_CONNECTED ) {
+					// (0,1)
+					const int ax = x + rcGetDirOffsetX( 1 );
+					const int ay = y + rcGetDirOffsetY( 1 );
+					const int ai = (int)chf.cells[ax + ay * w].index + rcGetCon( s, 1 );
+					const rcCompactSpan& as = chf.spans[ai];
+					nd = (unsigned char)rcMin( (int)dist[ai] + 2, 255 );
+					if ( nd < dist[i] ) {
+						dist[i] = nd;
+					}
+
+					// (-1,1)
+					if ( rcGetCon( as, 0 ) != RC_NOT_CONNECTED ) {
+						const int aax = ax + rcGetDirOffsetX( 0 );
+						const int aay = ay + rcGetDirOffsetY( 0 );
+						const int aai = (int)chf.cells[aax + aay * w].index + rcGetCon( as, 0 );
+						nd = (unsigned char)rcMin( (int)dist[aai] + 2, 255 );
+						if ( nd < dist[i] ) {
+							dist[i] = nd;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	const unsigned char thr = (unsigned char)( boxRadius * 2 );
+	for ( int i = 0; i < chf.spanCount; ++i ) {
+		if ( dist[i] < thr ) {
+			chf.areas[i] = RC_NULL_AREA;
+		}
+	}
+
+	rcFree( dist );
+
+	ctx->stopTimer( RC_TIMER_ERODE_AREA );
+
+	return true;
+}
+
+/*
+   rcFilterGaps
+
+   Does a super simple sampling of ledges to detect and fix
+   any "gaps" in the heightfield that are narrow enough for us to walk over
+   because of our AABB based collision system
+ */
+static void rcFilterGaps( rcContext *ctx, int walkableRadius, int walkableClimb, int walkableHeight, rcHeightfield &solid ) {
+	const int h = solid.height;
+	const int w = solid.width;
+	const int MAX_HEIGHT = 0xffff;
+	std::vector<int> spanData;
+	spanData.reserve( 500 * 3 );
+	std::vector<int> data;
+	data.reserve( ( walkableRadius * 2 - 1 ) * 3 );
+
+	//for every span in the heightfield
+	for ( int y = 0; y < h; ++y ) {
+		for ( int x = 0; x < w; ++x ) {
+			//check each span in the column
+			for ( rcSpan *s = solid.spans[x + y * w]; s; s = s->next ) {
+				//bottom and top of the "base" span
+				const int sbot = s->smax;
+				const int stop = ( s->next ) ? ( s->next->smin ) : MAX_HEIGHT;
+
+				//if the span is walkable
+				if ( s->area != RC_NULL_AREA ) {
+					//check all neighbor connections
+					for ( int dir = 0; dir < 4; dir++ ) {
+						const int dirx = rcGetDirOffsetX( dir );
+						const int diry = rcGetDirOffsetY( dir );
+						int dx = x;
+						int dy = y;
+						bool freeSpace = false;
+						bool stop = false;
+
+						if ( dx < 0 || dy < 0 || dx >= w || dy >= h ) {
+							continue;
+						}
+
+						//keep going the direction for walkableRadius * 2 - 1 spans
+						//because we can walk as long as at least part of our bbox is on a solid surface
+						for ( int i = 1; i < walkableRadius * 2; i++ ) {
+							dx = dx + dirx;
+							dy = dy + diry;
+							if ( dx < 0 || dy < 0 || dx >= w || dy >= h ) {
+								i--;
+								freeSpace = false;
+								stop = false;
+								break;
+							}
+
+							//tells if there is space here for us to stand
+							freeSpace = false;
+
+							//go through the column
+							for ( rcSpan *ns = solid.spans[dx + dy * w]; ns; ns = ns->next ) {
+								int nsbot = ns->smax;
+								int nstop = ( ns->next ) ? ( ns->next->smin ) : MAX_HEIGHT;
+
+								//if there is a span within walkableClimb of the base span, we have reached the end of the gap (if any)
+								if ( rcAbs( sbot - nsbot ) <= walkableClimb && ns->area != RC_NULL_AREA ) {
+									//set flag telling us to stop
+									stop = true;
+
+									//only add spans if we have gone for more than 1 iteration
+									//if we stop at the first iteration, it means there was no gap to begin with
+									if ( i > 1 ) {
+										freeSpace = true;
+									}
+									break;
+								}
+
+								if ( nsbot < sbot && nstop >= sbot + walkableHeight ) {
+									//tell that we found walkable space within reach of the previous span
+									freeSpace = true;
+									//add this span to a temporary storage location
+									data.push_back( dx );
+									data.push_back( dy );
+									data.push_back( sbot );
+									break;
+								}
+							}
+
+							//stop if there is no more freespace, or we have reached end of gap
+							if ( stop || !freeSpace ) {
+								break;
+							}
+						}
+						//move the spans from the temp location to the storage
+						//we check freeSpace to make sure we don't add a
+						//span when we stop at the first iteration (because there is no gap)
+						//checking stop tells us if there was a span to complete the "bridge"
+						if ( freeSpace && stop ) {
+							const int N = data.size();
+							for ( int i = 0; i < N; i++ )
+								spanData.push_back( data[i] );
+						}
+						data.clear();
+					}
+				}
+			}
+		}
+	}
+
+	//add the new spans
+	//we cant do this in the loop, because the loop would then iterate over those added spans
+	for ( std::vector<int>::size_type i = 0; i < spanData.size(); i += 3 ) {
+		rcAddSpan( ctx, solid, spanData[i], spanData[i + 1], spanData[i + 2] - 1, spanData[i + 2], RC_WALKABLE_AREA, walkableClimb );
+	}
+}
+
+static int rasterizeTileLayers( rcContext &context, int tx, int ty, const rcConfig &mcfg, TileCacheData *data, int maxLayers ){
+	rcConfig cfg;
+
+	FastLZCompressor comp;
+	RasterizationContext rc;
+
+	const float tcs = mcfg.tileSize * mcfg.cs;
+
+	memcpy( &cfg, &mcfg, sizeof( cfg ) );
+
+	// find tile bounds
+	// easy optimisation here: avoid recalculating things Y * X times
+	cfg.bmin[ 0 ] = mcfg.bmin[ 0 ] + tx * tcs;
+	cfg.bmin[ 1 ] = mcfg.bmin[ 1 ];
+	cfg.bmin[ 2 ] = mcfg.bmin[ 2 ] + ty * tcs;
+
+	cfg.bmax[ 0 ] = mcfg.bmin[ 0 ] + ( tx + 1 ) * tcs;
+	cfg.bmax[ 1 ] = mcfg.bmax[ 1 ];
+	cfg.bmax[ 2 ] = mcfg.bmin[ 2 ] + ( ty + 1 ) * tcs;
+
+	// expand bounds by border size
+	// easy optimisation here: borderSize and cs (cs: The xz-plane cell size to use for fields)
+	// are constants (coming directly from mcfg, previously named cfg, you follow?).
+	cfg.bmin[ 0 ] -= cfg.borderSize * cfg.cs;
+	cfg.bmin[ 2 ] -= cfg.borderSize * cfg.cs;
+
+	cfg.bmax[ 0 ] += cfg.borderSize * cfg.cs;
+	cfg.bmax[ 2 ] += cfg.borderSize * cfg.cs;
+
+	rc.solid = rcAllocHeightfield();
+
+	if ( !rcCreateHeightfield( &context, *rc.solid, cfg.width, cfg.height, cfg.bmin, cfg.bmax, cfg.cs, cfg.ch ) ) {
+		Error( "Failed to create heightfield for navigation mesh.\n" );
+	}
+
+	//I understand that using std::vector prevents NiH's proudness.
+	const float *verts = geo.getVerts();
+	const int nverts = geo.getNumVerts();
+	const rcChunkyTriMesh *chunkyMesh = geo.getChunkyMesh();
+
+	rc.triareas = new unsigned char[ chunkyMesh->maxTrisPerChunk ];
+	//you know what? This will never be reached, because new throws exceptions, by default.
+	//really, should just use STL or C, not raw C++ with C's bugs.
+	if ( !rc.triareas ) {
+		Error( "Out of memory rc.triareas\n" );
+	}
+
+	float tbmin[ 2 ], tbmax[ 2 ];
+
+	tbmin[ 0 ] = cfg.bmin[ 0 ];
+	tbmin[ 1 ] = cfg.bmin[ 2 ];
+	tbmax[ 0 ] = cfg.bmax[ 0 ];
+	tbmax[ 1 ] = cfg.bmax[ 2 ];
+
+	int *cid = new int[ chunkyMesh->nnodes ];
+
+	//do not search for this in libraries, you won't find it. It's in RecastDemo's code.
+	//It " Creates partitioned triangle mesh (AABB tree), where each node contains at max trisPerChunk triangles."
+	//why? No idea.
+	const int ncid = rcGetChunksOverlappingRect( chunkyMesh, tbmin, tbmax, cid, chunkyMesh->nnodes );
+	if ( !ncid ) {
+		delete[] cid;
+		return 0;
+	}
+
+	for ( int i = 0; i < ncid; i++ )
+	{
+		const rcChunkyTriMeshNode &node = chunkyMesh->nodes[ cid[ i ] ];
+		const int *tris = &chunkyMesh->tris[ node.i * 3 ];
+		const int ntris = node.n;
+
+		memset( rc.triareas, 0, ntris * sizeof( unsigned char ) );
+
+		rcMarkWalkableTriangles( &context, cfg.walkableSlopeAngle, verts, nverts, tris, ntris, rc.triareas );
+		rcRasterizeTriangles( &context, verts, nverts, tris, rc.triareas, ntris, *rc.solid, cfg.walkableClimb );
+	}
+
+	delete[] cid;
+
+	//makes them walkable (unlike the other filters, would probably kill some people to write meaningful code)
+	rcFilterLowHangingWalkableObstacles( &context, cfg.walkableClimb, *rc.solid );
+
+	//dont filter ledge spans since characters CAN walk on ledges due to using a bbox for movement collision
+	//makes them un-walkable
+	//rcFilterLedgeSpans (&context, cfg.walkableHeight, cfg.walkableClimb, *rc.solid);
+
+	//makes them un-walkable
+	rcFilterWalkableLowHeightSpans( &context, cfg.walkableHeight, *rc.solid );
+
+	//by default, make gaps walkable (because using a BBox system makes agents cubes). In theory a great idea, but
+	//it does not work correctly.
+	if ( filterGaps ) {
+		rcFilterGaps( &context, cfg.walkableRadius, cfg.walkableClimb, cfg.walkableHeight, *rc.solid );
+	}
+
+	rc.chf = rcAllocCompactHeightfield();
+
+	if ( !rcBuildCompactHeightfield( &context, cfg.walkableHeight, cfg.walkableClimb, *rc.solid, *rc.chf ) ) {
+		Error( "Failed to create compact heightfield for navigation mesh.\n" );
+	}
+
+	if ( !rcErodeWalkableAreaByBox( &context, cfg.walkableRadius, *rc.chf ) ) {
+		Error( "Unable to erode walkable surfaces.\n" );
+	}
+
+	rc.lset = rcAllocHeightfieldLayerSet();
+
+	if ( !rc.lset ) {
+		Error( "Out of memory heightfield layer set\n" );
+	}
+
+	if ( !rcBuildHeightfieldLayers( &context, *rc.chf, cfg.borderSize, cfg.walkableHeight, *rc.lset ) ) {
+		Error( "Could not build heightfield layers\n" );
+	}
+
+	rc.ntiles = 0;
+
+	for ( int i = 0; i < rcMin( rc.lset->nlayers, MAX_LAYERS ); i++ )
+	{
+		TileCacheData *tile = &rc.tiles[ rc.ntiles++ ];
+		const rcHeightfieldLayer *layer = &rc.lset->layers[ i ];
+
+		dtTileCacheLayerHeader header;
+		header.magic = DT_TILECACHE_MAGIC;
+		header.version = DT_TILECACHE_VERSION;
+
+		header.tx = tx;
+		header.ty = ty;
+		header.tlayer = i;
+		dtVcopy( header.bmin, layer->bmin );
+		dtVcopy( header.bmax, layer->bmax );
+
+		header.width = ( unsigned char ) layer->width;
+		header.height = ( unsigned char ) layer->height;
+		header.minx = ( unsigned char ) layer->minx;
+		header.maxx = ( unsigned char ) layer->maxx;
+		header.miny = ( unsigned char ) layer->miny;
+		header.maxy = ( unsigned char ) layer->maxy;
+		header.hmin = ( unsigned short ) layer->hmin;
+		header.hmax = ( unsigned short ) layer->hmax;
+
+		dtStatus status = dtBuildTileCacheLayer( &comp, &header, layer->heights, layer->areas, layer->cons, &tile->data, &tile->dataSize );
+
+		if ( dtStatusFailed( status ) ) {
+			return 0;
+		}
+	}
+
+	// transfer tile data over to caller
+	int n = 0;
+	for ( int i = 0; i < rcMin( rc.ntiles, maxLayers ); i++ )
+	{
+		data[ n++ ] = rc.tiles[ i ];
+		rc.tiles[ i ].data = 0;
+		rc.tiles[ i ].dataSize = 0;
+	}
+
+	return n;
+}
+
+static void BuildNavMesh( int characterNum ){
+	const Character &agent = characterArray[ characterNum ];
+
+	dtTileCache *tileCache;
+	const float *bmin = geo.getMins();
+	const float *bmax = geo.getMaxs();
+	int gw = 0, gh = 0;
+	const float cellSize = agent.radius / 4.0f;
+
+	rcCalcGridSize( bmin, bmax, cellSize, &gw, &gh );
+
+	const int ts = tileSize;
+	const int tw = ( gw + ts - 1 ) / ts;
+	const int th = ( gh + ts - 1 ) / ts;
+
+	rcConfig cfg;
+	memset( &cfg, 0, sizeof( cfg ) );
+
+	cfg.cs = cellSize;
+	cfg.ch = cellHeight;
+	cfg.walkableSlopeAngle = RAD2DEG( acosf( MIN_WALK_NORMAL ) );
+	cfg.walkableHeight = ( int ) ceilf( agent.height / cfg.ch );
+	cfg.walkableClimb = ( int ) floorf( stepSize / cfg.ch );
+	cfg.walkableRadius = ( int ) ceilf( agent.radius / cfg.cs );
+	cfg.maxEdgeLen = 0;
+	cfg.maxSimplificationError = 1.3f;
+	cfg.minRegionArea = rcSqr( 25 );
+	cfg.mergeRegionArea = rcSqr( 50 );
+	cfg.maxVertsPerPoly = 6;
+	cfg.tileSize = ts;
+	cfg.borderSize = cfg.walkableRadius * 2;
+	cfg.width = cfg.tileSize + cfg.borderSize * 2;
+	cfg.height = cfg.tileSize + cfg.borderSize * 2;
+	cfg.detailSampleDist = cfg.cs * 6.0f;
+	cfg.detailSampleMaxError = cfg.ch * 1.0f;
+
+	rcVcopy( cfg.bmin, bmin );
+	rcVcopy( cfg.bmax, bmax );
+
+	dtTileCacheParams tcparams;
+	memset( &tcparams, 0, sizeof( tcparams ) );
+	rcVcopy( tcparams.orig, bmin );
+	tcparams.cs = cellSize;
+	tcparams.ch = cellHeight;
+	tcparams.width = ts;
+	tcparams.height = ts;
+	tcparams.walkableHeight = agent.height;
+	tcparams.walkableRadius = agent.radius;
+	tcparams.walkableClimb = stepSize;
+	tcparams.maxSimplificationError = 1.3;
+	tcparams.maxTiles = tw * th * EXPECTED_LAYERS_PER_TILE;
+	tcparams.maxObstacles = 256;
+
+	tileCache = dtAllocTileCache();
+
+	if ( !tileCache ) {
+		Error( "Could not allocate tile cache\n" );
+	}
+
+	LinearAllocator alloc( 32000 );
+	FastLZCompressor comp;
+	MeshProcess proc;
+
+	dtStatus status = tileCache->init( &tcparams, &alloc, &comp, &proc );
+
+	if ( dtStatusFailed( status ) ) {
+		if ( dtStatusDetail( status, DT_INVALID_PARAM ) ) {
+			Error( "Could not init tile cache: Invalid parameter\n" );
+		}
+		else
+		{
+			Error( "Could not init tile cache\n" );
+		}
+	}
+
+	UnvContext context;
+	context.enableLog( true );
+
+	//iterate over all tiles (number is determined by rcCalcGridSize)
+	for ( int y = 0; y < th; y++ )
+	{
+		for ( int x = 0; x < tw; x++ )
+		{
+			TileCacheData tiles[ MAX_LAYERS ];
+			memset( tiles, 0, sizeof( tiles ) );
+
+			int ntiles = rasterizeTileLayers( context, x, y, cfg, tiles, MAX_LAYERS );
+
+			for ( int i = 0; i < ntiles; i++ )
+			{
+				TileCacheData *tile = &tiles[ i ];
+				status = tileCache->addTile( tile->data, tile->dataSize, DT_COMPRESSEDTILE_FREE_DATA, 0 );
+				if ( dtStatusFailed( status ) ) {
+					dtFree( tile->data );
+					tile->data = 0;
+					continue;
+				}
+			}
+		}
+	}
+
+	// there are 22 bits to store a tile and its polys
+	int tileBits = rcMin( ( int ) dtIlog2( dtNextPow2( tcparams.maxTiles ) ), 14 );
+	int polyBits = 22 - tileBits;
+
+	dtNavMeshParams params;
+	dtVcopy( params.orig, tcparams.orig );
+	params.tileHeight = ts * cfg.cs;
+	params.tileWidth = ts * cfg.cs;
+	params.maxTiles = 1 << tileBits;
+	params.maxPolys = 1 << polyBits;
+
+	WriteNavMeshFile( agent.name, tileCache, &params );
+	dtFreeTileCache( tileCache );
+}
+
+/*
+   ===========
+   NavMain
+   ===========
+ */
+extern "C" int NavMain( int argc, char **argv ){
+	float temp;
+	int i;
+
+	if ( argc < 2 ) {
+		Sys_Printf( "Usage: daemonmap -nav [-cellheight f] [-stepsize f] [-includecaulk] [-includesky] [-nogapfilter] <filename.bsp>\n" );
+		return 0;
+	}
+
+	/* note it */
+	Sys_Printf( "--- Nav ---\n" );
+
+	/* process arguments */
+	for ( i = 1; i < ( argc - 1 ); i++ )
+	{
+		if ( !Q_stricmp( argv[i],"-cellheight" ) ) {
+			i++;
+			if ( i < ( argc - 1 ) ) {
+				temp = atof( argv[i] );
+				if ( temp > 0 ) {
+					cellHeight = temp;
+				}
+			}
+		}
+		else if ( !Q_stricmp( argv[i], "-stepsize" ) ) {
+			i++;
+			if ( i < ( argc - 1 ) ) {
+				temp = atof( argv[i] );
+				if ( temp > 0 ) {
+					stepSize = temp;
+				}
+			}
+		}
+		else if ( !Q_stricmp( argv[i], "-includecaulk" ) ) {
+			excludeCaulk = qfalse;
+		}
+		else if ( !Q_stricmp( argv[i], "-includesky" ) ) {
+			excludeSky = qfalse;
+		}
+		else if ( !Q_stricmp( argv[i], "-nogapfilter" ) ) {
+			filterGaps = qfalse;
+		}
+		else {
+			Sys_Printf( "WARNING: Unknown option \"%s\"\n", argv[i] );
+		}
+	}
+
+	/* load the bsp */
+	sprintf( source, "%s%s", inbase, ExpandArg( argv[i] ) );
+	StripExtension( source );
+	strcat( source, ".bsp" );
+	//LoadShaderInfo();
+
+	Sys_Printf( "Loading %s\n", source );
+
+	LoadBSPFile( source );
+
+	ParseEntities();
+
+	LoadGeometry();
+
+	float height = rcAbs( geo.getMaxs()[1] ) + rcAbs( geo.getMins()[1] );
+	if ( height / cellHeight > RC_SPAN_MAX_HEIGHT ) {
+		Sys_Printf( "WARNING: Map geometry is too tall for specified cell height. Increasing cell height to compensate. This may cause a less accurate navmesh.\n" );
+		float prevCellHeight = cellHeight;
+		float minCellHeight = height / RC_SPAN_MAX_HEIGHT;
+
+		int divisor = ( int ) stepSize;
+
+		while ( divisor && cellHeight < minCellHeight )
+		{
+			cellHeight = stepSize / divisor;
+			divisor--;
+		}
+
+		if ( !divisor ) {
+			Error( "ERROR: Map is too tall to generate a navigation mesh\n" );
+		}
+
+		Sys_Printf( "Previous cell height: %f\n", prevCellHeight );
+		Sys_Printf( "New cell height: %f\n", cellHeight );
+	}
+
+	RunThreadsOnIndividual( sizeof( characterArray ) / sizeof( characterArray[ 0 ] ), qtrue, BuildNavMesh );
+
+	return 0;
+}

--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -29,7 +29,6 @@
 #include "common/cm/cm_polylib.h"
 #include "common/FileSystem.h"
 #include "navgen.h"
-#include "sgame/botlib/bot_convert.h"
 #include "sgame/sg_trapcalls.h"
 
 static Log::Logger LOG("sgame.navgen", "");
@@ -153,7 +152,7 @@ bool FixWinding( winding_t* w );
 static void AddVert( std::vector<float> &verts, std::vector<int> &tris, vec3_t vert ) {
 	vec3_t recastVert;
 	VectorCopy( vert, recastVert );
-	quake2recast( recastVert );
+	std::swap( recastVert[1], recastVert[2] ); // convert Quake to Recast coordinates
 	int index = 0;
 	for ( int i = 0; i < 3; i++ ) {
 		verts.push_back( recastVert[i] );

--- a/src/shared/navgen/navgen.h
+++ b/src/shared/navgen/navgen.h
@@ -1,0 +1,104 @@
+/*
+   ===========================================================================
+   Copyright (C) 2012 Unvanquished Developers
+
+   This file is part of Daemon source code.
+
+   Daemon source code is free software; you can redistribute it
+   and/or modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation; either version 2 of the License,
+   or (at your option) any later version.
+
+   Daemon source code is distributed in the hope that it will be
+   useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Daemon source code; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+   ===========================================================================
+ */
+
+#include "Compiler.h"
+#include "Recast.h"
+#include "RecastAlloc.h"
+#include "RecastAssert.h"
+#include "ChunkyTriMesh.h"
+#include "DetourCommon.h"
+#include "DetourNavMesh.h"
+#include "DetourNavMeshBuilder.h"
+#include "DetourTileCache.h"
+#include "DetourTileCacheBuilder.h"
+#include "nav.h"
+
+static const int MAX_LAYERS = 32;
+static const int EXPECTED_LAYERS_PER_TILE = 4;
+
+struct TileCacheData
+{
+	unsigned char* data;
+	int dataSize;
+};
+
+struct RasterizationContext
+{
+	rcHeightfield* solid;
+	unsigned char* triareas;
+	rcHeightfieldLayerSet* lset;
+	rcCompactHeightfield* chf;
+	TileCacheData tiles[MAX_LAYERS];
+	int ntiles;
+
+	RasterizationContext() :
+		solid( 0 ),
+		triareas( 0 ),
+		lset( 0 ),
+		chf( 0 ),
+		ntiles( 0 ){
+		memset( tiles, 0, sizeof( TileCacheData ) * MAX_LAYERS );
+	}
+
+	~RasterizationContext(){
+		rcFreeHeightField( solid );
+		delete[] triareas;
+		rcFreeHeightfieldLayerSet( lset );
+		rcFreeCompactHeightfield( chf );
+		for ( int i = 0; i < MAX_LAYERS; ++i )
+		{
+			dtFree( tiles[i].data );
+			tiles[i].data = 0;
+		}
+	}
+};
+
+class Geometry
+{
+private:
+float mins[ 3 ];
+float maxs[ 3 ];
+float           *verts;
+int nverts;
+rcChunkyTriMesh mesh;
+
+public:
+Geometry() : verts( 0 ), nverts( 0 ) {}
+~Geometry() { delete[] verts; }
+
+void init( const float *v, int nv, const int *tris, int ntris ){
+	verts = new float[ nv * 3 ];
+	memcpy( verts, v, sizeof( float ) * nv * 3 );
+
+	nverts = nv;
+
+	rcCreateChunkyTriMesh( verts, tris, ntris, 1024, &mesh );
+
+	rcCalcBounds( verts, nverts, mins, maxs );
+}
+
+const float           *getMins(){ return mins; }
+const float           *getMaxs() { return maxs; }
+const float           *getVerts() { return verts; }
+int                    getNumVerts() { return nverts; }
+const rcChunkyTriMesh *getChunkyMesh() { return &mesh; }
+};

--- a/src/shared/navgen/navgen.h
+++ b/src/shared/navgen/navgen.h
@@ -109,6 +109,7 @@ class UnvContext : public rcContext
 	void doLog(const rcLogCategory /*category*/, const char* msg, const int /*len*/) override;
 };
 
+// Public interface to navgen. Rest of this file is internal details
 class NavmeshGenerator {
 private:
 	struct PerClassData {
@@ -126,6 +127,7 @@ private:
 	};
 
 	UnvContext recastContext_;
+	NavgenConfig config_;
 	// Map data
 	std::string mapName_;
 	std::string mapData_;

--- a/src/shared/navgen/navgen.h
+++ b/src/shared/navgen/navgen.h
@@ -109,6 +109,17 @@ class UnvContext : public rcContext
 	void doLog(const rcLogCategory /*category*/, const char* msg, const int /*len*/) override;
 };
 
+struct NavgenStatus
+{
+	enum Code {
+		OK,
+		TRANSIENT_FAILURE, // e.g. memory allocation failure
+		PERMANENT_FAILURE,
+	};
+	Code code;
+	std::string message;
+};
+
 // Public interface to navgen. Rest of this file is internal details
 class NavmeshGenerator {
 private:
@@ -124,6 +135,7 @@ private:
 		int th;
 		int x = 0;
 		int y = 0;
+		NavgenStatus status;
 	};
 
 	UnvContext recastContext_;
@@ -132,6 +144,7 @@ private:
 	std::string mapName_;
 	std::string mapData_;
 	Geometry geo_;
+	NavgenStatus initStatus_;
 	// Data for generating current class
 	std::unique_ptr<PerClassData> d_;
 

--- a/src/shared/navgen/navgen.h
+++ b/src/shared/navgen/navgen.h
@@ -144,5 +144,9 @@ public:
 	void Init(Str::StringRef mapName);
 
 	void StartGeneration(class_t species);
+
+	float SpeciesFractionCompleted() const;
+
+	// Returns true when finished
 	bool Step();
 };

--- a/src/shared/navgen/navgen.h
+++ b/src/shared/navgen/navgen.h
@@ -30,7 +30,7 @@
 #include "DetourNavMeshBuilder.h"
 #include "DetourTileCache.h"
 #include "DetourTileCacheBuilder.h"
-#include "sgame/botlib/nav.h"
+#include "shared/bot_nav_shared.h"
 #include "shared/bg_public.h"
 
 static const int MAX_LAYERS = 32;

--- a/src/shared/navgen/navgen.h
+++ b/src/shared/navgen/navgen.h
@@ -20,7 +20,6 @@
    ===========================================================================
  */
 
-#include "Compiler.h"
 #include "Recast.h"
 #include "RecastAlloc.h"
 #include "RecastAssert.h"
@@ -30,7 +29,7 @@
 #include "DetourNavMeshBuilder.h"
 #include "DetourTileCache.h"
 #include "DetourTileCacheBuilder.h"
-#include "nav.h"
+#include "sgame/botlib/nav.h"
 
 static const int MAX_LAYERS = 32;
 static const int EXPECTED_LAYERS_PER_TILE = 4;

--- a/src/shared/navgen/navgen.h
+++ b/src/shared/navgen/navgen.h
@@ -118,7 +118,7 @@ private:
 		std::unique_ptr<dtTileCache> tileCache;
 		LinearAllocator alloc = LinearAllocator(32000);
 		FastLZCompressor comp;
-		MeshProcess proc;
+		BasicMeshProcess proc;
 		int tw;
 		int th;
 		int x = 0;


### PR DESCRIPTION
Import navmesh generation code from daemonmap. The gamelogic can now write navmeshes to `game/maps/` in the homepath. There are two entry points to the code:
- In the cgame during the load screen, if `cg_navgenOnLoad` is enabled and there is a local server. It restarts the progressbar and updates it with the navgen progress.
- In the sgame with the `navgen` command.

TODO before merging:
- Add command variants `navgen all`, and `navgen missing` (to generate only non-cached ones). The latter is especially needed for the server-side generation to be usable.
- Rename `src/sgame/navgen` -> `src/shared/navgen`
- More cache invalidation. E.g. detect that new navmesh is needed if the bbox changes
- Make errors in navmesh generation not abort the game