### PR TITLE
Fix crash on cg_shadows modification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,6 @@ if (BUILD_SGAME)
     # Fastlz
     add_library(srclibs-fastlz EXCLUDE_FROM_ALL ${FASTLZLIST})
     set_target_properties(srclibs-fastlz PROPERTIES POSITION_INDEPENDENT_CODE 1 FOLDER "libs")
-    set(LIBS_ENGINE ${LIBS_ENGINE} srclibs-fastlz)
 
     # Detour
     add_library(srclibs-detour EXCLUDE_FROM_ALL ${DETOURLIST})

--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -2241,7 +2241,7 @@ void CG_Buildable( centity_t *cent )
 	}
 
 	// add inverse shadow map
-	if ( cg_shadows.Get() > Util::ordinal(shadowingMode_t::SHADOWING_BLOB) && cg_buildableShadows.Get() )
+	if ( cg_shadows > shadowingMode_t::SHADOWING_BLOB && cg_buildableShadows.Get() )
 	{
 		CG_StartShadowCaster( ent.lightingOrigin, mins, maxs );
 	}
@@ -2523,7 +2523,7 @@ void CG_Buildable( centity_t *cent )
 		}
 	}
 
-	if ( cg_shadows.Get() > Util::ordinal(shadowingMode_t::SHADOWING_BLOB) && cg_buildableShadows.Get() )
+	if ( cg_shadows > shadowingMode_t::SHADOWING_BLOB && cg_buildableShadows.Get() )
 	{
 		CG_EndShadowCaster( );
 	}

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1734,7 +1734,7 @@ extern Cvar::Cvar<int> cg_teslaTrailTime;
 extern Cvar::Cvar<float> cg_runpitch;
 extern Cvar::Cvar<float> cg_runroll;
 extern Cvar::Cvar<float> cg_swingSpeed;
-extern Cvar::Range<Cvar::Cvar<int>> cg_shadows;
+extern shadowingMode_t cg_shadows;
 extern Cvar::Cvar<bool> cg_playerShadows;
 extern Cvar::Cvar<bool> cg_buildableShadows;
 extern Cvar::Cvar<bool> cg_drawTimer;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -43,7 +43,7 @@ Cvar::Cvar<int> cg_teslaTrailTime("cg_teslaTrailTime", "time (ms) to show reacto
 Cvar::Cvar<float> cg_runpitch("cg_runpitch", "pitch angle change magnitude when running", Cvar::NONE, 0.002);
 Cvar::Cvar<float> cg_runroll("cg_runroll", "roll angle magnitude change when running", Cvar::NONE, 0.005);
 Cvar::Cvar<float> cg_swingSpeed("cg_swingSpeed", "something about view angles", Cvar::CHEAT, 0.3);
-Cvar::Range<Cvar::Cvar<int>> cg_shadows("cg_shadows", "type of shadows to draw", Cvar::LATCH, 1, 0, 6);
+shadowingMode_t cg_shadows;
 Cvar::Cvar<bool> cg_playerShadows("cg_playerShadows", "draw shadows of players", Cvar::NONE, true);
 Cvar::Cvar<bool> cg_buildableShadows("cg_buildableShadows", "draw shadows of buildables", Cvar::NONE, false);
 Cvar::Cvar<bool> cg_drawTimer("cg_drawTimer", "show game time", Cvar::NONE, true);
@@ -1116,6 +1116,8 @@ void CG_Init( int serverMessageNum, int clientNum, const glconfig_t& gl, const G
 	cgs.screenYScale = cgs.glconfig.vidHeight / 480.0f;
 	cgs.aspectScale = ( ( 640.0f * cgs.glconfig.vidHeight ) /
 	( 480.0f * cgs.glconfig.vidWidth ) );
+	// cg_shadows is latched so we can get it once at the beginning
+	cg_shadows = Util::enum_cast<shadowingMode_t>( trap_Cvar_VariableIntegerValue( "cg_shadows" ) );
 
 	// load a few needed things before we do any screen updates
 	trap_R_SetAltShaderTokens( "unpowered,destroyed,idle,idle2" );

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -2612,7 +2612,7 @@ static bool CG_PlayerShadow( centity_t *cent, class_t class_ )
 		}
 	}
 
-	if ( cg_shadows.Get() == Util::ordinal(shadowingMode_t::SHADOWING_NONE))
+	if ( cg_shadows == shadowingMode_t::SHADOWING_NONE)
 	{
 		return false;
 	}
@@ -2629,7 +2629,7 @@ static bool CG_PlayerShadow( centity_t *cent, class_t class_ )
 		return false;
 	}
 
-	if ( cg_shadows.Get() > Util::ordinal(shadowingMode_t::SHADOWING_BLOB) &&
+	if ( cg_shadows > shadowingMode_t::SHADOWING_BLOB &&
 	     cg_playerShadows.Get() ) {
 		// add inverse shadow map
 		{
@@ -2637,7 +2637,7 @@ static bool CG_PlayerShadow( centity_t *cent, class_t class_ )
 		}
 	}
 
-	if ( cg_shadows.Get() != Util::ordinal(shadowingMode_t::SHADOWING_BLOB)) // no mark for stencil or projection shadows
+	if ( cg_shadows != shadowingMode_t::SHADOWING_BLOB) // no mark for stencil or projection shadows
 	{
 		return true;
 	}
@@ -2656,12 +2656,12 @@ static bool CG_PlayerShadow( centity_t *cent, class_t class_ )
 
 static void CG_PlayerShadowEnd()
 {
-	if ( cg_shadows.Get() == Util::ordinal(shadowingMode_t::SHADOWING_NONE))
+	if ( cg_shadows == shadowingMode_t::SHADOWING_NONE)
 	{
 		return;
 	}
 
-	if ( cg_shadows.Get() > Util::ordinal(shadowingMode_t::SHADOWING_BLOB) &&
+	if ( cg_shadows > shadowingMode_t::SHADOWING_BLOB &&
 	     cg_playerShadows.Get() ) {
 		CG_EndShadowCaster( );
 	}
@@ -2681,7 +2681,7 @@ static void CG_PlayerSplash( centity_t *cent, class_t class_ )
 	trace_t trace;
 	int     contents;
 
-	if ( cg_shadows.Get() == Util::ordinal(shadowingMode_t::SHADOWING_NONE))
+	if ( cg_shadows == shadowingMode_t::SHADOWING_NONE)
 	{
 		return;
 	}

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -163,7 +163,7 @@ Cvar::Cvar<std::string> g_nextMapLayouts("g_nextMapLayouts", "list of layouts (o
 Cvar::Cvar<std::string> g_initialMapRotation("g_initialMapRotation", "map rotation to use on server startup", Cvar::NONE, "rotation1");
 Cvar::Cvar<std::string> g_mapLog("g_mapLog", "contains results of recent games", Cvar::NONE, "");
 Cvar::Cvar<std::string> g_mapStartupMessage("g_mapStartupMessage", "message sent to players on connection (reset after game)", Cvar::NONE, "");
-Cvar::Cvar<int> g_mapStartupMessageDelay("g_mapStartupMessageDelay", "show g_mapStartupMessage x milliseconds after connection", Cvar::LATCH, 5000);
+Cvar::Cvar<int> g_mapStartupMessageDelay("g_mapStartupMessageDelay", "show g_mapStartupMessage x milliseconds after connection", Cvar::NONE, 5000);
 
 Cvar::Cvar<bool> g_debugVoices("g_debugVoices", "print sgame's list of vsays on startup", Cvar::NONE, false);
 Cvar::Cvar<bool> g_enableVsays("g_voiceChats", "allow vsays (prerecorded audio messages)", Cvar::NONE, true);
@@ -177,8 +177,8 @@ Cvar::Cvar<float> g_sayAreaRange("g_sayAreaRange", "distance for area chat messa
 Cvar::Cvar<int> g_floodMaxDemerits("g_floodMaxDemerits", "client message rate control (lower = stricter)", Cvar::NONE, 5000);
 Cvar::Cvar<int> g_floodMinTime("g_floodMinTime", "mute period after flooding, in milliseconds", Cvar::NONE, 2000);
 
-Cvar::Cvar<std::string> g_defaultLayouts("g_defaultLayouts", "layouts to pick randomly from each map", Cvar::LATCH, "");
-Cvar::Cvar<std::string> g_layouts("g_layouts", "layouts for next map (cleared after use)", Cvar::LATCH, "");
+Cvar::Cvar<std::string> g_defaultLayouts("g_defaultLayouts", "layouts to pick randomly from each map", Cvar::NONE, "");
+Cvar::Cvar<std::string> g_layouts("g_layouts", "layouts for next map (cleared after use)", Cvar::NONE, "");
 Cvar::Cvar<bool> g_layoutAuto("g_layoutAuto", "pick arbitrary layout instead of builtin", Cvar::NONE, false);
 
 Cvar::Cvar<bool> g_emoticonsAllowedInNames("g_emoticonsAllowedInNames", "allow [emoticon]s in player names", Cvar::NONE, true);


### PR DESCRIPTION
Fix cvar-related crashes on changing cg_shadows.

This doesn't fix crashes related to uninitialized shaders with certain cg_shadows values.

I have a WIP branch for allowing multiple cvar proxies on one variable (so that multiple modules can observe changes), so I will make sure to fix the underlying cvar system bug with that branch.