### PR TITLE
show balloon over head of chatting players

### DIFF
--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -2571,10 +2571,13 @@ Float sprites over the player's head
 */
 static void CG_PlayerSprites( centity_t *cent )
 {
+	if ( cent->currentState.eFlags & EF_TALKING )
+	{
+		CG_PlayerFloatSprite( cent, cgs.media.balloonShader );
+	}
 	if ( cent->currentState.eFlags & EF_CONNECTION )
 	{
 		CG_PlayerFloatSprite( cent, cgs.media.connectionShader );
-		return;
 	}
 }
 

--- a/src/shared/bg_pmove.cpp
+++ b/src/shared/bg_pmove.cpp
@@ -4825,6 +4825,7 @@ void PmoveSingle( pmove_t *pmove )
 	{
 		usercmdClearButtons( pmove->cmd.buttons );
 		usercmdPressButton( pmove->cmd.buttons, BTN_TALK );
+		pm->ps->eFlags |= EF_TALKING;
 		pmove->cmd.forwardmove = 0;
 		pmove->cmd.rightmove = 0;
 
@@ -4832,6 +4833,10 @@ void PmoveSingle( pmove_t *pmove )
 		{
 			pmove->cmd.upmove = 0;
 		}
+	}
+	else
+	{
+		pm->ps->eFlags &= ~EF_TALKING;
 	}
 
 	// clear all pmove local vars

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -455,7 +455,7 @@ enum persEnum_t
 #define EF_FIRING2          0x0400 // alt fire
 #define EF_FIRING3          0x0800 // third fire
 #define EF_MOVER_STOP       0x1000 // will push otherwise
-#define EF_UNUSED_2         0x2000 // UNUSED
+#define EF_TALKING          0x2000 // draw a chat balloon above head
 #define EF_CONNECTION       0x4000 // draw a connection trouble sprite
 #define EF_BLOBLOCKED       0x8000 // caught by a trapper
 


### PR DESCRIPTION
The idea is to use a state bit to communicate about the chat "state" of players, and for players which are chatting, to display an icon over their head, same way as when they seems disconnected.

[This](https://github.com/UnvanquishedAssets/unvanquished_src.dpkdir/blob/9a7bc181205bc2c4470f531dd7c233213dc800bf/gfx/feedback/chatballoon.png) is the icon which will be used, if all works correctly.

This is a draft because I could never test it, it seems that I'd need building complete dpk and all the stuff: I'm not in the mood right now.