### PR TITLE
improve blocker situation

### DIFF
--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -439,7 +439,10 @@ void G_BotThink( gentity_t *self )
 		//BotClampPos( self );
 	}
 
-	self->botMind->willSprint( false ); //let the BT decide that
+	// let the BT decide what kind of moves to do
+	self->botMind->willSprint( false );
+	self->botMind->willCrouch( false );
+
 	self->botMind->behaviorTree->run( self, ( AIGenericNode_t * ) self->botMind->behaviorTree );
 
 	// if we were nudged...
@@ -632,4 +635,17 @@ void botMemory_t::doSprint( int jumpCost, int stamina, usercmd_t& cmd )
 	}
 
 	exhausted = exhausted && stamina <= jumpCost * 2;
+}
+
+void botMemory_t::willCrouch( bool enable )
+{
+	wantCrouch = enable;
+}
+
+void botMemory_t::doCrouch( usercmd_t& cmd )
+{
+	if ( wantCrouch )
+	{
+		cmd.upmove = -127;
+	}
 }

--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -101,6 +101,9 @@ struct botMemory_t
 	botTarget_t goal;
 	void willSprint( bool enable );
 	void doSprint( int jumpCost, int stamina, usercmd_t& cmd );
+	void willCrouch( bool enable );
+	void doCrouch( usercmd_t& cmd );
+
 	usercmd_t   cmdBuffer;
 
 	botSkill_t botSkill;
@@ -126,6 +129,7 @@ struct botMemory_t
 	//avoid relying on buttons to remember what AI was doing
 	bool wantSprinting = false;
 	bool exhausted = false;
+	bool wantCrouch = false;
 };
 
 bool G_BotSetupNav( const botClass_t *botClass, qhandle_t *navHandle );

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -387,11 +387,11 @@ gentity_t* BotGetPathBlocker( gentity_t *self, const vec3_t dir )
 		blockers[i] = &g_entities[trace.entityNum];
 	}
 
-	for ( int i = -1; i != 1; ++i )
+	for ( gentity_t* ent : blockers )
 	{
-		if ( blockers[i] )
+		if ( ent )
 		{
-			return blockers[i];
+			return ent;
 		}
 	}
 

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -409,12 +409,6 @@ bool BotShouldJump( gentity_t *self, gentity_t *blocker, const vec3_t dir )
 	const int TRACE_LENGTH = BOT_OBSTACLE_AVOID_RANGE;
 	vec3_t end;
 
-	//blocker is not on our team, so ignore
-	if ( G_Team( self ) != G_Team( blocker ) )
-	{
-		return false;
-	}
-
 	//already normalized
 
 	BG_ClassBoundingBox( ( class_t ) self->client->ps.stats[STAT_CLASS], playerMins, playerMaxs, nullptr, nullptr, nullptr );
@@ -446,7 +440,7 @@ bool BotShouldJump( gentity_t *self, gentity_t *blocker, const vec3_t dir )
 
 	//if we can jump over it, then jump
 	//note that we also test for a blocking barricade because barricades will collapse to let us through
-	return blocker->s.modelindex == BA_A_BARRICADE || trace.fraction == 1.0f;
+	return ( G_Team( self ) == G_Team( blocker ) && blocker->s.modelindex == BA_A_BARRICADE ) || trace.fraction == 1.0f;
 }
 
 // try to find a path around the obstacle by projecting 5


### PR DESCRIPTION
This basically allows "big bots" (humans, dragoons, tyrants) to navigate better in the map if the proper navmesh is generated, *and* to not be stopped when a human jumps over their defenses.

Proper navmesh means, the climbHeight value should be `std::min( STEPSIZE + ( JumpMagnitude * JumpMagnitude ) / ( gravity * 2 ), maxs[2] - mins[2] - 1)`.

My previous (not published because buggy) attempt at doing that was not capped, and thus had navigation problems when maps had bridges.

[edit]
I merged this with #1701 since they really participate to the same thing: make bots less stuck.
I'm copying here that other PR's text for convenience:

> This improves on #1493 by allowing bots to move on flat or on downward
tight corridors.
The code is a quick workaround, as explained in the commit, a correct
fix would require a complete rewrite of the obstacle management code,
and would even require better engine API to give bots a usable "vision".
>
The "if" block was kept as close to original on purpose, to make it more
obvious that this improves a situation while not fixing all problems.