### PR TITLE
Partial revert of #1532

### DIFF
--- a/src/sgame/sg_bot_util.h
+++ b/src/sgame/sg_bot_util.h
@@ -46,9 +46,6 @@ gentity_t* BotFindBuilding( gentity_t *self, int buildingType, int range );
 bool   BotTeamateHasWeapon( gentity_t *self, int weapon );
 void       BotSearchForEnemy( gentity_t *self );
 void       BotPain( gentity_t *self, gentity_t *attacker, int damage );
-botEntityAndDistance_t BotGetClosestBuildingAmongTypes(
-		gentity_t *self, const std::initializer_list<buildable_t> buildables );
-const gentity_t *BotGetHealTarget( gentity_t *self );
 
 // aiming
 void  BotGetIdealAimLocation( gentity_t *self, botTarget_t target, vec3_t aimLocation );


### PR DESCRIPTION
Fix #1588

This fix 2 problems introduced in said PR:

* alien bots trying to heal with buildings on ceiling happening much more often (because overmind is no longer the highest priority target after booster, and booster is usually placed in easy to access locations)
* alien bots try to heal on very stupid places, like between barricades and enemies, keeping doors blocked by barricades open, or on open grounds because there's a leech. Eggs and boosters are usually placed in rather easy to defend spots, or even defended by actual defenses, which is obviously untrue for almost all other buildings.