### PR TITLE
Deduplicate navmesh file path building

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1108,8 +1108,7 @@ static void GenerateNavmeshes()
 	for ( class_t species : RequiredNavmeshes() )
 	{
 		fileHandle_t f;
-		std::string filename = Str::Format(
-			"maps/%s-%s.navMesh", mapName, BG_Class( species )->name );
+		std::string filename = NavmeshFilename( mapName, BG_Class( species )->name );
 		// TODO(0.53): match new behavior of G_FOpenGameOrPakPath
 		if ( trap_FS_FOpenFile( filename.c_str(), &f, fsMode_t::FS_READ ) < 0)
 		{

--- a/src/sgame/botlib/bot_load.cpp
+++ b/src/sgame/botlib/bot_load.cpp
@@ -178,13 +178,12 @@ void BotLoadOffMeshConnections( const char *filename, NavData_t *nav )
 
 static bool BotLoadNavMesh( const char *filename, NavData_t &nav )
 {
-	char filePath[ MAX_QPATH ];
 	fileHandle_t f = 0;
 
 	BotLoadOffMeshConnections( filename, &nav );
 
 	std::string mapname = Cvar::GetValue("mapname");
-	Com_sprintf( filePath, sizeof( filePath ), "maps/%s-%s.navMesh", mapname.c_str(), filename );
+	std::string filePath = NavmeshFilename( mapname, filename );
 	Log::Notice( " loading navigation mesh file '%s'...", filePath );
 
 	int len = G_FOpenGameOrPakPath( filePath, f );

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -270,4 +270,9 @@ inline std::vector<class_t> RequiredNavmeshes()
 	};
 }
 
+inline std::string NavmeshFilename(Str::StringRef mapName, Str::StringRef species)
+{
+	return Str::Format("maps/%s-%s.navMesh", mapName, species);
+}
+
 #endif // SHARED_BOT_NAV_SHARED_H_

--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -78,7 +78,7 @@ void NavmeshGenerator::WriteFile() {
 	params.maxTiles = 1 << tileBits;
 	params.maxPolys = 1 << polyBits;
 
-	std::string filename = Str::Format("maps/%s-%s.navMesh", mapName_, BG_Class(d_->species)->name);
+	std::string filename = NavmeshFilename( mapName_, BG_Class( d_->species )->name );
 
 	NavMeshSetHeader header;
 	int maxTiles;


### PR DESCRIPTION
@bmorel Have a look at this. When this is merged, you could make a 1-line change in your mod in the `NavmeshFilename` function to use a different path scheme for the navmesh files. Then the ones in map paks will no longer be used and you'll be free to use navmeshes stored in the homepath.