### PR TITLE
make creepslow modifier a class attribute

### DIFF
--- a/src/shared/bg_gameplay.h
+++ b/src/shared/bg_gameplay.h
@@ -124,8 +124,6 @@ extern int   LEVEL4_TRAMPLE_REPEAT;
 
 #define CREEP_BASESIZE          700
 #define CREEP_TIMEOUT           1000
-#define CREEP_MODIFIER          0.5f
-#define CREEP_ARMOUR_MODIFIER   0.75f
 #define CREEP_SCALEDOWN_TIME    3000
 
 #define BARRICADE_SHRINKPROP    0.25f

--- a/src/shared/bg_parse.cpp
+++ b/src/shared/bg_parse.cpp
@@ -997,7 +997,8 @@ void BG_ParseClassAttributeFile( const char *filename, classAttributes_t *ca )
 		STAMINASPRINTCOST  = 1 << 21,
 		STAMINAJOGRESTORE  = 1 << 22,
 		STAMINAWALKRESTORE = 1 << 23,
-		STAMINASTOPRESTORE = 1 << 24
+		STAMINASTOPRESTORE = 1 << 24,
+		CREEPMODIFIER      = 1 << 25,
 	};
 
 	if( !BG_ReadWholeFile( filename, text_buffer, sizeof(text_buffer) ) )
@@ -1230,6 +1231,12 @@ void BG_ParseClassAttributeFile( const char *filename, classAttributes_t *ca )
 			ca->staminaStopRestore = atoi( token );
 			defined |= STAMINASTOPRESTORE;
 		}
+		else if ( !Q_stricmp( token, "creepModifier" ) )
+		{
+			PARSE( text, token );
+			ca->creepModifier = atof( token );
+			defined |= CREEPMODIFIER;
+		}
 		else
 		{
 			Log::Warn( "%s: unknown token '%s'", filename, token );
@@ -1277,6 +1284,37 @@ void BG_ParseClassAttributeFile( const char *filename, classAttributes_t *ca )
 		{
 			Log::Warn( "%s (mandatory for human team) not defined in %s",
 			            token, filename );
+		}
+	}
+
+	// TODO(0.53) move the values into config files
+	if ( !( defined & CREEPMODIFIER ) )
+	{
+		Log::Warn( "creepModifier not defined in %s (using previously hard-coded values)", filename );
+		switch( ca->number )
+		{
+			case PCL_ALIEN_BUILDER0:
+			case PCL_ALIEN_BUILDER0_UPG:
+			case PCL_ALIEN_LEVEL0:
+			case PCL_ALIEN_LEVEL1:
+			case PCL_ALIEN_LEVEL2:
+			case PCL_ALIEN_LEVEL2_UPG:
+			case PCL_ALIEN_LEVEL3:
+			case PCL_ALIEN_LEVEL3_UPG:
+			case PCL_ALIEN_LEVEL4:
+				ca->creepModifier = 1.f;
+				break;
+			case PCL_HUMAN_NAKED:
+				ca->creepModifier = 0.5f;
+				break;
+			case PCL_HUMAN_LIGHT:
+			case PCL_HUMAN_MEDIUM:
+			case PCL_HUMAN_BSUIT:
+				ca->creepModifier = 0.75f;
+				break;
+			case PCL_NONE:
+			case PCL_NUM_CLASSES:
+				ASSERT_UNREACHABLE();
 		}
 	}
 }

--- a/src/shared/bg_parse.cpp
+++ b/src/shared/bg_parse.cpp
@@ -1312,7 +1312,6 @@ void BG_ParseClassAttributeFile( const char *filename, classAttributes_t *ca )
 			case PCL_HUMAN_BSUIT:
 				ca->creepModifier = 0.75f;
 				break;
-			case PCL_NONE:
 			case PCL_NUM_CLASSES:
 				ASSERT_UNREACHABLE();
 		}

--- a/src/shared/bg_parse.cpp
+++ b/src/shared/bg_parse.cpp
@@ -1293,6 +1293,7 @@ void BG_ParseClassAttributeFile( const char *filename, classAttributes_t *ca )
 		Log::Warn( "creepModifier not defined in %s (using previously hard-coded values)", filename );
 		switch( ca->number )
 		{
+			case PCL_NONE:
 			case PCL_ALIEN_BUILDER0:
 			case PCL_ALIEN_BUILDER0_UPG:
 			case PCL_ALIEN_LEVEL0:

--- a/src/shared/bg_pmove.cpp
+++ b/src/shared/bg_pmove.cpp
@@ -543,16 +543,7 @@ static float PM_CmdScale( usercmd_t *cmd, bool zFlight )
 		// TODO: Move modifer into upgrade/class config files of armour items/classes
 		if ( pm->ps->stats[ STAT_STATE ] & SS_CREEPSLOWED )
 		{
-			if ( BG_InventoryContainsUpgrade( UP_LIGHTARMOUR, pm->ps->stats ) ||
-			     BG_InventoryContainsUpgrade( UP_MEDIUMARMOUR, pm->ps->stats ) ||
-			     BG_InventoryContainsUpgrade( UP_BATTLESUIT,  pm->ps->stats ) )
-			{
-				modifier *= CREEP_ARMOUR_MODIFIER;
-			}
-			else
-			{
-				modifier *= CREEP_MODIFIER;
-			}
+			modifier *= BG_Class( pm->ps->stats[ STAT_CLASS ] )->creepModifier;
 		}
 
 		// Apply level1 slow modifier

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -1252,6 +1252,7 @@ struct classAttributes_t
 	float    friction;
 	float    stopSpeed;
 	float    jumpMagnitude;
+	float    creepModifier;
 	int      mass;
 
 	// stamina (human only)


### PR DESCRIPTION
This includes default values matching the ones in 0.52.1 if nothing is found in configuration, to avoid breaking compat.

Note that alien classes are also checked, because I thought that it might be interesting to give aliens a speed boost when in their base. Can easily be removed and the option made humans-only.