### PR TITLE
in BT: toggling of upgrades can fail

### DIFF
--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -577,11 +577,17 @@ AINodeStatus_t BotActionActivateUpgrade( gentity_t *self, AIGenericNode_t *node 
 	AIActionNode_t *action = ( AIActionNode_t * ) node;
 	upgrade_t u = ( upgrade_t ) AIUnBoxInt( action->params[ 0 ] );
 
-	if ( !BG_UpgradeIsActive( u, self->client->ps.stats ) &&
-		BG_InventoryContainsUpgrade( u, self->client->ps.stats ) )
+	if ( !BG_InventoryContainsUpgrade( u, self->client->ps.stats ) )
 	{
-		BG_ActivateUpgrade( u, self->client->ps.stats );
+		return STATUS_FAILURE;
 	}
+
+	if ( BG_UpgradeIsActive( u, self->client->ps.stats ) )
+	{
+		return STATUS_FAILURE;
+	}
+
+	BG_ActivateUpgrade( u, self->client->ps.stats );
 	return STATUS_SUCCESS;
 }
 
@@ -590,11 +596,17 @@ AINodeStatus_t BotActionDeactivateUpgrade( gentity_t *self, AIGenericNode_t *nod
 	AIActionNode_t *action = ( AIActionNode_t * ) node;
 	upgrade_t u = ( upgrade_t ) AIUnBoxInt( action->params[ 0 ] );
 
-	if ( BG_UpgradeIsActive( u, self->client->ps.stats ) &&
-		BG_InventoryContainsUpgrade( u, self->client->ps.stats ) )
+	if ( !BG_InventoryContainsUpgrade( u, self->client->ps.stats ) )
 	{
-		BG_DeactivateUpgrade( u, self->client->ps.stats );
+		return STATUS_FAILURE;
 	}
+
+	if ( !BG_UpgradeIsActive( u, self->client->ps.stats ) )
+	{
+		return STATUS_FAILURE;
+	}
+
+	BG_DeactivateUpgrade( u, self->client->ps.stats );
 	return STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
This PR fixes a "regression" introduced in [this commit](https://github.com/UnvanquishedAssets/unvanquished_src.dpkdir/commit/b3107f469986c77dd490f8d7b96ecbf72b557025) which made human bots act weird (freezing, usually) in presence of alien buildings.

This could likely be further improved by making the API to upgrade/disable upgrades return a boolean instead of nothing, but I think the fix I'm proposing is the least intrusive one while still fixing the actual problem.

How to reproduce the faulty behavior is rather simple:

* /devmap plat23
* /bot add * h 9
* allow bots to cheat
* go in alien base and look at main entrance: bot will destroy a 1st tube then freeze.