### PR TITLE
use real mass to shove, not health

### DIFF
--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -246,7 +246,7 @@ static void ClientShove( gentity_t *ent, gentity_t *victim )
 	}
 
 	force = g_shove.Get() * entMass / vicMass;
-	force = Math::Clamp( force, 0.f, 150.f );
+	force = Math::Clamp( force, 0.f, g_shoveMaxForce.Get() );
 
 	// Give the victim some shove velocity
 	VectorSubtract( victim->r.currentOrigin, ent->r.currentOrigin, dir );
@@ -259,7 +259,7 @@ static void ClientShove( gentity_t *ent, gentity_t *victim )
 	if ( !victim->client->ps.pm_time )
 	{
 		int time = force * 2 + 0.5f;
-		time = Math::Clamp( time, 50, 200 );
+		time = Math::Clamp( time, 50, 50 + static_cast<int>( g_shoveMaxForce.Get() ) );
 
 		victim->client->ps.pm_time = time;
 		victim->client->ps.pm_flags |= PMF_TIME_KNOCKBACK;

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -342,14 +342,13 @@ void ClientImpacts( gentity_t *ent, pmove_t *pm )
 			ClientShove( ent, other );
 
 			//bot should get pushed out the way
-			if( (other->r.svFlags & SVF_BOT) && ent->client->pers.team == other->client->pers.team)
+			if( ( other->r.svFlags & SVF_BOT ) && G_OnSameTeam( ent, other ) )
 			{
 				PushBot(ent, other);
 			}
 
 			// if we are standing on their head, then we should be pushed also
-			if( (ent->r.svFlags & SVF_BOT) && ent->s.groundEntityNum == other->s.number &&
-			    other->client && ent->client->pers.team == other->client->pers.team)
+			if( ( ent->r.svFlags & SVF_BOT ) && G_OnSameTeam( ent, other ) && ent->s.groundEntityNum == other->s.number && other->client )
 			{
 				PushBot(other, ent);
 			}

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -231,8 +231,7 @@ static void ClientShove( gentity_t *ent, gentity_t *victim )
 	}
 
 	// Cannot push enemy players unless they are walking on the player
-	if ( !G_OnSameTeam( ent, victim ) &&
-	     victim->client->ps.groundEntityNum != ent - g_entities )
+	if ( !G_OnSameTeam( ent, victim ) && ent->s.groundEntityNum != victim->s.number )
 	{
 		return;
 	}

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -247,16 +247,7 @@ static void ClientShove( gentity_t *ent, gentity_t *victim )
 	}
 
 	force = g_shove.Get() * entMass / vicMass;
-
-	if ( force < 0 )
-	{
-		force = 0;
-	}
-
-	if ( force > 150 )
-	{
-		force = 150;
-	}
+	force = Math::Clamp( force, 0.f, 150.f );
 
 	// Give the victim some shove velocity
 	VectorSubtract( victim->r.currentOrigin, ent->r.currentOrigin, dir );
@@ -268,19 +259,8 @@ static void ClientShove( gentity_t *ent, gentity_t *victim )
 	// out the movement immediately
 	if ( !victim->client->ps.pm_time )
 	{
-		int time;
-
-		time = force * 2 + 0.5f;
-
-		if ( time < 50 )
-		{
-			time = 50;
-		}
-
-		if ( time > 200 )
-		{
-			time = 200;
-		}
+		int time = force * 2 + 0.5f;
+		time = Math::Clamp( time, 50, 200 );
 
 		victim->client->ps.pm_time = time;
 		victim->client->ps.pm_flags |= PMF_TIME_KNOCKBACK;

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -212,38 +212,6 @@ void G_SetClientSound( gentity_t *ent )
 	}
 }
 
-//==============================================================
-
-/*
-==============
-GetClientMass
-
-TODO: Define player class masses in config files
-==============
-*/
-static int GetClientMass( gentity_t *ent )
-{
-	int entMass = 100;
-
-	if ( ent->client->pers.team == TEAM_ALIENS )
-	{
-		entMass = BG_Class( ent->client->pers.classSelection )->health;
-	}
-	else if ( ent->client->pers.team == TEAM_HUMANS )
-	{
-		if ( BG_InventoryContainsUpgrade( UP_BATTLESUIT, ent->client->ps.stats ) )
-		{
-			entMass *= 2;
-		}
-	}
-	else
-	{
-		return 0;
-	}
-
-	return entMass;
-}
-
 /*
 ==============
 ClientShove
@@ -270,8 +238,8 @@ static void ClientShove( gentity_t *ent, gentity_t *victim )
 	}
 
 	// Shove force is scaled by relative mass
-	entMass = GetClientMass( ent );
-	vicMass = GetClientMass( victim );
+	entMass = BG_Class( ent->client->ps.stats[ STAT_CLASS ] )->mass;
+	vicMass = BG_Class( victim->client->ps.stats[ STAT_CLASS ] )->mass;
 
 	if ( vicMass <= 0 || entMass <= 0 )
 	{

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -231,7 +231,7 @@ static void ClientShove( gentity_t *ent, gentity_t *victim )
 	}
 
 	// Cannot push enemy players unless they are walking on the player
-	if ( !G_OnSameTeam( ent, victim ) && ent->s.groundEntityNum != victim->s.number )
+	if ( !( G_OnSameTeam( ent, victim ) || g_shoveEnemies.Get() ) && ent->s.groundEntityNum != victim->s.number )
 	{
 		return;
 	}

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -129,6 +129,7 @@ extern Cvar::Cvar<int> g_floodMinTime;
 
 extern Cvar::Cvar<float> g_shove;
 extern Cvar::Cvar<bool> g_shoveEnemies;
+extern Cvar::Cvar<float> g_shoveMaxForce;
 extern Cvar::Cvar<bool> g_antiSpawnBlock;
 
 extern Cvar::Cvar<std::string> g_mapConfigs;

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -128,6 +128,7 @@ extern Cvar::Cvar<int> g_floodMaxDemerits;
 extern Cvar::Cvar<int> g_floodMinTime;
 
 extern Cvar::Cvar<float> g_shove;
+extern Cvar::Cvar<bool> g_shoveEnemies;
 extern Cvar::Cvar<bool> g_antiSpawnBlock;
 
 extern Cvar::Cvar<std::string> g_mapConfigs;

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -170,6 +170,7 @@ Cvar::Cvar<bool> g_enableVsays("g_voiceChats", "allow vsays (prerecorded audio m
 
 Cvar::Cvar<float> g_shove("g_shove", "force multiplier when pushing players", Cvar::NONE, 0.0);
 Cvar::Cvar<bool> g_shoveEnemies("g_shoveEnemies", "Allow shoving enemies", Cvar::NONE, false);
+Cvar::Cvar<float> g_shoveMaxForce("g_shoveMaxForce", "changes the maximum shove limit", Cvar::NONE, 150.f);
 Cvar::Cvar<bool> g_antiSpawnBlock("g_antiSpawnBlock", "push away players who block their spawns", Cvar::NONE, false);
 
 Cvar::Cvar<std::string> g_mapConfigs("g_mapConfigs", "map config directory, relative to <homepath>/config/", Cvar::NONE, "");

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -169,6 +169,7 @@ Cvar::Cvar<bool> g_debugVoices("g_debugVoices", "print sgame's list of vsays on 
 Cvar::Cvar<bool> g_enableVsays("g_voiceChats", "allow vsays (prerecorded audio messages)", Cvar::NONE, true);
 
 Cvar::Cvar<float> g_shove("g_shove", "force multiplier when pushing players", Cvar::NONE, 0.0);
+Cvar::Cvar<bool> g_shoveEnemies("g_shoveEnemies", "Allow shoving enemies", Cvar::NONE, false);
 Cvar::Cvar<bool> g_antiSpawnBlock("g_antiSpawnBlock", "push away players who block their spawns", Cvar::NONE, false);
 
 Cvar::Cvar<std::string> g_mapConfigs("g_mapConfigs", "map config directory, relative to <homepath>/config/", Cvar::NONE, "");


### PR DESCRIPTION
Removes old code using the actual health to know someone's mass in order to shove them out of the way.
This might improve situation of aliens being blocked by smaller one when fleeing (because hurt, hence less life)