### PR TITLE
bots do not lag, so do not call G_UnlaggedOn

### DIFF
--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -290,6 +290,7 @@ bool G_BotAdd( const char *name, team_t team, int skill, const char *behavior, b
 
 	// register user information
 	userinfo[0] = '\0';
+	Info_SetValueForKey( userinfo, "cg_unlagged", "0", false ); // bots do not lag
 	Info_SetValueForKey( userinfo, "name", name ? name : "", false ); // allow defaulting
 	Info_SetValueForKey( userinfo, "rate", "25000", false );
 	Info_SetValueForKey( userinfo, "snaps", "20", false );


### PR DESCRIPTION
According to a comment found, G_UnlaggedOn might be rather costly and is
only useful for clients, not stuff running in server.
Bots do run in server, so this patch prevents them to enable Unlagged
mode *in sg_weapon*.
In my opinion, the best thing to do would be to do the check in the
G_UnlaggedOn() and G_UnlaggedOff() calls, but this would take a bit more
time and I'm not even certain it is a good idea to do so, hence doing it
the quick'n dirty way