### PR TITLE
Map list: lazily load levelshots; ignore .arena

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1283,7 +1283,6 @@ struct rocketMenu_t
 #define MAX_OUTPUTS 16
 #define MAX_MODS 64
 #define MAX_DEMOS 256
-#define MAX_MAPS 128
 
 struct server_t
 {
@@ -1323,8 +1322,7 @@ struct modInfo_t
 
 struct mapInfo_t
 {
-	char *mapName;
-	char *mapLoadName;
+	std::string mapLoadName;
 };
 
 struct rocketDataSource_t
@@ -1359,8 +1357,7 @@ struct rocketDataSource_t
 	int demoCount;
 	int demoIndex;
 
-	mapInfo_t mapList[ MAX_MAPS ];
-	int mapCount;
+	std::vector<mapInfo_t> mapList;
 	int mapIndex;
 
 	int selectedTeamIndex;

--- a/src/cgame/cg_rocket_dataformatter.cpp
+++ b/src/cgame/cg_rocket_dataformatter.cpp
@@ -110,10 +110,19 @@ static void CG_Rocket_DFVotePlayer( int handle, const char *data )
 
 static void CG_Rocket_DFVoteMap( int handle, const char *data )
 {
-	int mapIndex = atoi( Info_ValueForKey( data, "1" ) );
-	if ( mapIndex < rocketInfo.data.mapCount )
+	size_t mapIndex = atoi( Info_ValueForKey( data, "1" ) );
+	if ( mapIndex < rocketInfo.data.mapList.size() )
 	{
-		Rocket_DataFormatterFormattedData( handle, va("<button onClick=\"Events.pushevent('exec set ui_dialogCvar1 %s;hide maps;exec rocket ui/dialogs/mapdialog.rml load; exec rocket mapdialog show', event)\" class=\"maps\"><div class=\"levelname\">%s</div> <img class=\"levelshot\"src='/meta/%s/%s'/><div class=\"hovertext\">Start Vote</div> </button>", rocketInfo.data.mapList[ mapIndex ].mapLoadName, CG_Rocket_QuakeToRML( rocketInfo.data.mapList[ mapIndex ].mapName ), rocketInfo.data.mapList[ mapIndex ].mapLoadName, rocketInfo.data.mapList[ mapIndex ].mapLoadName ) , false );
+		Rocket_DataFormatterFormattedData(
+			handle,
+			va( "<button onClick=\"Events.pushevent('exec set ui_dialogCvar1 %s;hide maps;"
+			    "exec rocket ui/dialogs/mapdialog.rml load; exec rocket mapdialog show', event)\" class=\"maps\">"
+			    "<div class=\"levelname\">%s</div> <img class=\"levelshot\"src='/meta/%s/%s'/><div class=\"hovertext\">Start Vote</div> </button>",
+			    rocketInfo.data.mapList[ mapIndex ].mapLoadName.c_str(),
+			    CG_Rocket_QuakeToRML( rocketInfo.data.mapList[ mapIndex ].mapLoadName.c_str() ),
+			    rocketInfo.data.mapList[ mapIndex ].mapLoadName.c_str(),
+			    rocketInfo.data.mapList[ mapIndex ].mapLoadName.c_str() ),
+			false );
 	}
 }
 

--- a/src/cgame/cg_rocket_datasource.cpp
+++ b/src/cgame/cg_rocket_datasource.cpp
@@ -1117,18 +1117,15 @@ void CG_Rocket_SortPlayerList( const char*, const char *sortBy )
 
 void CG_Rocket_BuildMapList( const char* )
 {
-	int i;
-
 	Rocket_DSClearTable( "mapList", "default" );
-	trap_FS_LoadAllMapMetadata();
 	CG_LoadArenas();
 
-	for ( i = 0; i < rocketInfo.data.mapCount; ++i )
+	for ( size_t i = 0; i < rocketInfo.data.mapList.size(); ++i )
 	{
 		char buf[ MAX_INFO_STRING ] = { 0 };
 		Info_SetValueForKey( buf, "num", va( "%d", i ), false );
-		Info_SetValueForKey( buf, "mapName", rocketInfo.data.mapList[ i ].mapName, false );
-		Info_SetValueForKey( buf, "mapLoadName", rocketInfo.data.mapList[ i ].mapLoadName, false );
+		Info_SetValueForKey( buf, "mapName", rocketInfo.data.mapList[ i ].mapLoadName.c_str(), false );
+		Info_SetValueForKey( buf, "mapLoadName", rocketInfo.data.mapList[ i ].mapLoadName.c_str(), false );
 
 		Rocket_DSAddRow( "mapList", "default", buf );
 	}
@@ -1137,15 +1134,6 @@ void CG_Rocket_BuildMapList( const char* )
 
 void CG_Rocket_CleanUpMapList( const char* )
 {
-	int i;
-
-	for ( i = 0; i < rocketInfo.data.mapCount; ++i )
-	{
-		BG_Free( rocketInfo.data.mapList[ i ].mapLoadName );
-		BG_Free( rocketInfo.data.mapList[ i ].mapName );
-	}
-
-	rocketInfo.data.mapCount = 0;
 }
 
 void CG_Rocket_SetMapListIndex( const char*, int index )

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/FileSystem.h"
 #include "cg_local.h"
 #include "cg_key_name.h"
 #include "rocket/rocket.h"
@@ -1710,7 +1711,8 @@ public:
 
 	void DoOnUpdate() override
 	{
-		if ( ( rocketInfo.data.mapIndex < 0 || rocketInfo.data.mapIndex >= rocketInfo.data.mapCount ) )
+		if ( rocketInfo.data.mapIndex < 0 ||
+		     static_cast<size_t>( rocketInfo.data.mapIndex ) >= rocketInfo.data.mapList.size() )
 		{
 			Clear();
 			return;
@@ -1719,9 +1721,11 @@ public:
 		if ( mapIndex != rocketInfo.data.mapIndex )
 		{
 			mapIndex = rocketInfo.data.mapIndex;
-			SetInnerRML( va( "<img class='levelshot' src='/meta/%s/%s' />",
-							 rocketInfo.data.mapList[ mapIndex ].mapLoadName,
-					rocketInfo.data.mapList[ mapIndex ].mapLoadName ) );
+			std::error_code ignored;
+			const std::string& mapName = rocketInfo.data.mapList[ mapIndex ].mapLoadName;
+			FS::PakPath::LoadPakPrefix(
+				*FS::FindPak( "map-" + mapName ), Str::Format( "meta/%s/", mapName ), ignored );
+			SetInnerRML( Str::Format( "<img class='levelshot' src='/meta/%s/%s' />", mapName, mapName ) );
 		}
 	}
 


### PR DESCRIPTION
Companion: https://github.com/DaemonEngine/Daemon/pull/601

See https://github.com/DaemonEngine/Daemon/issues/557.

Before: When the map list is opened, all paks with the map- prefix are
opened and files with the meta/ prefix are opened. Arena files are
parsed. The map's name is displayed in the list according to the
'longname' key in the .arena.

After: The map list is built based on pak names that begin with "map-".
The meta/ prefix is loaded for a given pak only when you click on it in
the list. The pak name (excluding the prefix) is used as the name of the
map in the list. Arena files are not used.