### PR TITLE
Fix bug with spawning inside another player

### DIFF
--- a/src/sgame/components/SpawnerComponent.cpp
+++ b/src/sgame/components/SpawnerComponent.cpp
@@ -155,8 +155,8 @@ Entity* SpawnerComponent::CheckSpawnPointHelper(
 	} else {
 		// Check whether a spawned client has space.
 		trap_Trace(
-			&tr, spawnPoint.Data(), clientMins.Data(), clientMaxs.Data(), spawnPoint.Data(), 0,
-			MASK_PLAYERSOLID, 0
+			&tr, spawnPoint.Data(), clientMins.Data(), clientMaxs.Data(), spawnPoint.Data(),
+			ENTITYNUM_NONE, MASK_PLAYERSOLID, 0
 		);
 
 		if (tr.entityNum != ENTITYNUM_NONE) {

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -288,10 +288,11 @@ gentity_t *G_SelectUnvanquishedSpawnPoint( team_t team, vec3_t preference, vec3_
 	}
 
 	// Get spawn point for selected spawner.
-	Entity* blocker = nullptr;
+	Entity* blocker;
 	Vec3    spawnPoint;
 
 	spot->entity->CheckSpawnPoint(blocker, spawnPoint);
+	ASSERT_EQ(blocker, nullptr); // TODO: CheckSpawnPoint is already called in G_SelectSpawnBuildable
 	spawnPoint.Store(origin);
 
 	VectorCopy( spot->s.angles, angles );


### PR DESCRIPTION
The trap_Trace call was putting 0 as the passEntityNum, which means that
the trace ignored the player in slot 0.

Fixes #1368.