### PR TITLE
sg_admin.cpp: more default permissions for lvl4 admin (written into file admin.dat)

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -1078,7 +1078,7 @@ static void admin_default_levels()
 	Q_strncpyz( l->name, "^3Senior Admin", sizeof( l->name ) );
 	Q_strncpyz( l->flags,
 	            "listplayers admintest adminhelp time putteam spec999 warn kick mute showbans ban "
-	            "namelog buildlog ADMINCHAT register unregister l0 l1",
+	            "namelog buildlog ADMINCHAT register unregister l0 l1 pause revert",
 	            sizeof( l->flags ) );
 
 	l = l->next = (g_admin_level_t*) BG_Alloc( sizeof( g_admin_level_t ) );


### PR DESCRIPTION
Level 4 admins are the highest level below what is called "server operator". By default, they should be able to pause the game and revert the buildables to a previous state. As far as I know, this is the best response to evil players vandalizing a game.