### PR TITLE
fix try again in 0s

### DIFF
--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -870,7 +870,7 @@ void Cmd_Team_f( gentity_t *ent )
 	     Entities::IsAlive( ent ) &&
 	     ent->client->lastCombatTime + g_combatCooldown.Get() * 1000 > level.time )
 	{
-		float remaining = ( ( ent->client->lastCombatTime + g_combatCooldown.Get() * 1000 ) - level.time ) / 1000;
+		float remaining = ceil( ( ( ent->client->lastCombatTime + g_combatCooldown.Get() * 1000 ) - level.time ) / 1000 );
 
 		trap_SendServerCommand( ent - g_entities,
 		    va( "print_tr %s %i %.0f", QQ( N_("You cannot leave your team until $1$ after combat. Try again in $2$s.") ),


### PR DESCRIPTION
When fighting and willing to change team, game will sometimes ask the player to "try again in 0s" which makes no sense.