### PR TITLE
improve use_entity_range mecanism for armory

### DIFF
--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -1075,9 +1075,23 @@ public:
 
 		const entityState_t &es = cg_entities[ trace.entityNum ].currentState;
 
+		vec3_t originMins, originMaxs;
+		BG_ClassBoundingBox( cg.predictedPlayerState.stats[STAT_CLASS]
+				, originMins, originMaxs, nullptr, nullptr, nullptr );
+
+		//TODO: do not hard-code ARMORY here.
+		//While we're listing stuff to do: check that target is
+		//a usable *before* doing any maths.
+		vec3_t targetMins, targetMaxs;
+		BG_BuildableBoundingBox( BA_H_ARMOURY, originMins, originMaxs );
+
+		float distance = Distance( cg.predictedPlayerState.origin, es.origin )
+			- RadiusFromBounds( originMins, originMaxs )
+			- RadiusFromBounds( targetMins, targetMaxs );
+
 		if ( es.eType == entityType_t::ET_BUILDABLE
 				&& es.modelindex == BA_H_ARMOURY
-				&& Distance(cg.predictedPlayerState.origin, es.origin) < ENTITY_USE_RANGE - 0.2f // use an epsilon to account for rounding errors
+				&& distance < ENTITY_USE_RANGE - 0.2f // use an epsilon to account for rounding errors
 				&& CG_IsOnMyTeam(es) )
 		{
 			if ( !IsVisible() )

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -2186,8 +2186,7 @@ void ClientThink_real( gentity_t *self )
 
 		if ( ent && ent->use &&
 		     ( !ent->buildableTeam   || ent->buildableTeam   == client->pers.team ) &&
-		     ( !ent->conditions.team || ent->conditions.team == client->pers.team ) &&
-		     Distance( self->s.origin, ent->s.origin ) < ENTITY_USE_RANGE )
+		     ( !ent->conditions.team || ent->conditions.team == client->pers.team ) )
 		{
 			if ( g_debugEntities.Get() > 1 )
 			{
@@ -2196,28 +2195,9 @@ void ClientThink_real( gentity_t *self )
 
 			ent->use( ent, self, self ); // other and activator are the same in this context
 		}
-		else
+		else if ( client->pers.team == TEAM_ALIENS )
 		{
-			// no entity in front of player - do a small area search
-			for ( ent = nullptr; ( ent = G_IterateEntitiesWithinRadius( ent, client->ps.origin, ENTITY_USE_RANGE ) ); )
-			{
-				if ( ent && ent->use && ent->buildableTeam == client->pers.team)
-				{
-					if ( g_debugEntities.Get() > 1 )
-					{
-						Log::Debug("Calling entity->use after an area-search for %s", etos(ent));
-					}
-
-					ent->use( ent, self, self ); // other and activator are the same in this context
-
-					break;
-				}
-			}
-
-			if ( !ent && client->pers.team == TEAM_ALIENS )
-			{
-				G_TriggerMenu( client->ps.clientNum, MN_A_INFEST );
-			}
+			G_TriggerMenu( client->ps.clientNum, MN_A_INFEST );
 		}
 	}
 

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -2153,7 +2153,7 @@ void BotSellWeapons( gentity_t *self )
 	int i;
 
 	//no armoury nearby
-	if ( !G_BuildableInRange( self->client->ps.origin, ENTITY_USE_RANGE, BA_H_ARMOURY ) )
+	if ( !G_InUseRange( self->client->ps, BA_H_ARMOURY ) )
 	{
 		return;
 	}
@@ -2193,7 +2193,7 @@ void BotSellUpgrades( gentity_t *self )
 	int i;
 
 	//no armoury nearby
-	if ( !G_BuildableInRange( self->client->ps.origin, ENTITY_USE_RANGE, BA_H_ARMOURY ) )
+	if ( !G_InUseRange( self->client->ps, BA_H_ARMOURY ) )
 	{
 		return;
 	}

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -2115,6 +2115,7 @@ bool BotBuyUpgrade( gentity_t *self, upgrade_t upgrade )
 	}
 
 	vec3_t newOrigin;
+	//FIXME: duplicated code in sg_cmds.cpp
 	struct
 	{
 		upgrade_t upg;

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -2701,3 +2701,17 @@ void G_BuildLogRevert( int id )
 
 	G_AddMomentumEnd();
 }
+
+// verifies if armory is in range.
+// ENTITY_USE_RANGE is the distance between player and armory's
+// BBoxes.
+bool G_InUseRange( const playerState_t &ps, buildable_t target )
+{
+	//no armoury nearby
+	vec3_t startMins, startMaxs;
+	BG_ClassBoundingBox( ps.stats[ STAT_CLASS ], startMins, startMaxs
+			, nullptr, nullptr, nullptr );
+	// NOT doing the same with buildable's size, since G_BuildableInRange() does it
+	float radius = ENTITY_USE_RANGE + RadiusFromBounds( startMins, startMaxs );
+	return G_BuildableInRange( ps.origin, radius, target );
+}

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -900,7 +900,7 @@ void G_BuildableTouchTriggers( gentity_t *ent )
 /**
  * @return Whether origin is within a distance of radius of a buildable of the given type.
  */
-bool G_BuildableInRange( vec3_t origin, float radius, buildable_t buildable )
+bool G_BuildableInRange( const vec3_t origin, float radius, buildable_t buildable )
 {
 	gentity_t *neighbor = nullptr;
 

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -2975,7 +2975,14 @@ static bool Cmd_Sell_internal( gentity_t *ent, const char *s )
 	upgrade_t upgrade;
 
 	//no armoury nearby
-	if ( !G_BuildableInRange( ent->client->ps.origin, ENTITY_USE_RANGE, BA_H_ARMOURY ) )
+	//TODO duplicated code Cmd_Sell_internal/Cmd_Buy_internal
+	vec3_t startMins, startMaxs;
+	BG_ClassBoundingBox( ent->client->ps.stats[ STAT_CLASS ], startMins, startMaxs
+			, nullptr, nullptr, nullptr );
+	// NOT doing the same with buildable's size, since G_BuildableInRange() does it
+	float radius = ENTITY_USE_RANGE + RadiusFromBounds( startMins, startMaxs );
+
+	if ( !G_BuildableInRange( ent->client->ps.origin, radius, BA_H_ARMOURY ) )
 	{
 		G_TriggerMenu( ent->client->ps.clientNum, MN_H_NOARMOURYHERE );
 		return false;
@@ -3129,7 +3136,14 @@ static bool Cmd_Buy_internal( gentity_t *ent, const char *s, bool sellConflictin
 	upgrade = BG_UpgradeByName( s )->number;
 
 	// check if armoury is in reach
-	if ( !G_BuildableInRange( ent->client->ps.origin, ENTITY_USE_RANGE, BA_H_ARMOURY ) )
+	//TODO duplicated code Cmd_Sell_internal/Cmd_Buy_internal
+	vec3_t startMins, startMaxs;
+	BG_ClassBoundingBox( ent->client->ps.stats[ STAT_CLASS ], startMins, startMaxs
+			, nullptr, nullptr, nullptr );
+	// NOT doing the same with buildable's size, since G_BuildableInRange() does it
+	float radius = ENTITY_USE_RANGE + RadiusFromBounds( startMins, startMaxs );
+
+	if ( !G_BuildableInRange( ent->client->ps.origin, radius, BA_H_ARMOURY ) )
 	{
 		G_TriggerMenu( ent->client->ps.clientNum, MN_H_NOARMOURYHERE );
 

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -2969,24 +2969,10 @@ static bool Cmd_Sell_armour( gentity_t *ent )
 	       Cmd_Sell_upgradeItem( ent, UP_RADAR );
 }
 
-// verifies if armory is in range.
-// ENTITY_USE_RANGE is the distance between player and armory's
-// BBoxes.
-static bool InUseRange( const playerState_t &ps, buildable_t target )
-{
-	//no armoury nearby
-	vec3_t startMins, startMaxs;
-	BG_ClassBoundingBox( ps.stats[ STAT_CLASS ], startMins, startMaxs
-			, nullptr, nullptr, nullptr );
-	// NOT doing the same with buildable's size, since G_BuildableInRange() does it
-	float radius = ENTITY_USE_RANGE + RadiusFromBounds( startMins, startMaxs );
-	return G_BuildableInRange( ps.origin, radius, target );
-}
-
 static bool Cmd_Sell_internal( gentity_t *ent, const char *s )
 {
 	//no armoury nearby
-	if ( !InUseRange( ent->client->ps, BA_H_ARMOURY ) )
+	if ( !G_InUseRange( ent->client->ps, BA_H_ARMOURY ) )
 	{
 		G_TriggerMenu( ent->client->ps.clientNum, MN_H_NOARMOURYHERE );
 		return false;
@@ -3139,7 +3125,7 @@ static bool Cmd_Buy_internal( gentity_t *ent, const char *s, bool sellConflictin
 	upgrade_t upgrade = BG_UpgradeByName( s )->number;
 
 	//no armoury nearby
-	if ( !InUseRange( ent->client->ps, BA_H_ARMOURY ) )
+	if ( !G_InUseRange( ent->client->ps, BA_H_ARMOURY ) )
 	{
 		G_TriggerMenu( ent->client->ps.clientNum, MN_H_NOARMOURYHERE );
 		return false;

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -81,7 +81,7 @@ float             G_DistanceToBase(gentity_t *self);
 bool              G_InsideBase(gentity_t *self);
 bool              G_DretchCanDamageEntity( const gentity_t *self, const gentity_t *other );
 gentity_t         *G_Build( gentity_t *builder, buildable_t buildable, const vec3_t origin, const vec3_t normal, const vec3_t angles, int groundEntityNum );
-bool              G_BuildableInRange( vec3_t origin, float radius, buildable_t buildable );
+bool              G_BuildableInRange( const vec3_t origin, float radius, buildable_t buildable );
 gentity_t         *G_GetDeconstructibleBuildable( gentity_t *ent );
 bool              G_DeconstructDead( gentity_t *buildable );
 void              G_DeconstructUnprotected( gentity_t *buildable, gentity_t *ent );

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -82,6 +82,7 @@ bool              G_InsideBase(gentity_t *self);
 bool              G_DretchCanDamageEntity( const gentity_t *self, const gentity_t *other );
 gentity_t         *G_Build( gentity_t *builder, buildable_t buildable, const vec3_t origin, const vec3_t normal, const vec3_t angles, int groundEntityNum );
 bool              G_BuildableInRange( const vec3_t origin, float radius, buildable_t buildable );
+bool G_InUseRange( const playerState_t &ps, buildable_t type );
 gentity_t         *G_GetDeconstructibleBuildable( gentity_t *ent );
 bool              G_DeconstructDead( gentity_t *buildable );
 void              G_DeconstructUnprotected( gentity_t *buildable, gentity_t *ent );

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -232,8 +232,15 @@ bool G_FindAmmo( gentity_t *self )
 		return false;
 	}
 
+	//TODO duplicated from sg_cmds.cpp Cmd_Sell_internal/Cmd_Buy_internal
+	vec3_t startMins, startMaxs;
+	BG_ClassBoundingBox( self->client->ps.stats[ STAT_CLASS ], startMins, startMaxs
+			, nullptr, nullptr, nullptr );
+	// NOT doing the same with buildable's size, since G_BuildableInRange() does it
+	float radius = ENTITY_USE_RANGE + RadiusFromBounds( startMins, startMaxs );
+
 	// search for ammo source
-	while ( ( neighbor = G_IterateEntitiesWithinRadius( neighbor, self->s.origin, ENTITY_USE_RANGE ) ) )
+	while ( ( neighbor = G_IterateEntitiesWithinRadius( neighbor, self->s.origin, radius ) ) )
 	{
 		// only friendly, living and powered buildables provide ammo
 		if ( neighbor->s.eType != entityType_t::ET_BUILDABLE || !G_OnSameTeam( self, neighbor ) ||

--- a/src/shared/bg_gameplay.h
+++ b/src/shared/bg_gameplay.h
@@ -305,7 +305,7 @@ extern int   MEDKIT_STARTUP_SPEED;
 
 #define QU_TO_METER                        0.03125 // in m/qu
 
-#define ENTITY_USE_RANGE                   128.0f
+#define ENTITY_USE_RANGE                   64.0f
 
 // fire
 #define FIRE_MIN_DISTANCE                  20.0f


### PR DESCRIPTION
fix #1720

The way it works is by applying the player's sizes before searching for armories in range on sgame.
On cgame, both player's and armory's sizes are considered. There, Reactor is not handled, not sure if that's because I could not find where it is handled though or if it's handled a different way.

Note that this means the current value for ENTITY_USE_RANGE is likely way too big, and that it should probably be back at 64, but this should be done *after* testing.