### PR TITLE
fix trigger_class and trigger_equipement

### DIFF
--- a/src/sgame/sg_spawn_sensor.cpp
+++ b/src/sgame/sg_spawn_sensor.cpp
@@ -473,7 +473,8 @@ void sensor_player_touch( gentity_t *self, gentity_t *activator, trace_t* )
 	if ( self->conditions.team && ( activator->client->pers.team != self->conditions.team ) )
 		return;
 
-	// handle legacy maps with trigger_class and trigger_equip
+	// handle legacy `trigger_class` and `trigger_equip` entities
+	// by only checking for class on aliens, and equipment on humans
 	if ( self->conditions.isClassSensor && G_Team( activator ) != TEAM_ALIENS )
 	{
 		return;

--- a/src/sgame/sg_spawn_sensor.cpp
+++ b/src/sgame/sg_spawn_sensor.cpp
@@ -473,6 +473,16 @@ void sensor_player_touch( gentity_t *self, gentity_t *activator, trace_t* )
 	if ( self->conditions.team && ( activator->client->pers.team != self->conditions.team ) )
 		return;
 
+	// handle legacy maps with trigger_class and trigger_equip
+	if ( self->conditions.isClassSensor && G_Team( activator ) != TEAM_ALIENS )
+	{
+		return;
+	}
+	if ( self->conditions.isEquipSensor && G_Team( activator ) != TEAM_HUMANS )
+	{
+		return;
+	}
+
 	if ( ( !self->conditions.upgrades.empty() || !self->conditions.weapons.empty() ) && activator->client->pers.team == TEAM_HUMANS )
 	{
 		shouldFire = sensor_equipment_match( self, activator );
@@ -509,6 +519,14 @@ void SP_sensor_player( gentity_t *self )
 		self->reset = sensor_reset;
 	}
 
+	if(!Q_stricmp(self->classname, "trigger_class"))
+	{
+		self->conditions.isClassSensor = true;
+	}
+	if(!Q_stricmp(self->classname, "trigger_equipment"))
+	{
+		self->conditions.isEquipSensor = true;
+	}
 	InitBrushSensor( self );
 }
 

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -80,6 +80,8 @@ struct gentityConditions_t
 	BoundedVector<buildable_t, BA_NUM_BUILDABLES> buildables;
 
 	bool negated;
+	bool isClassSensor = false;
+	bool isEquipSensor = false;
 };
 
 /**


### PR DESCRIPTION
Those triggers were broken compared to tremulous, where they could be
used notably to test for a team (if list is empty).
There is no clue at all that the non-deprecated trigger works, and no
clue that it is actually used, this patch only fixes stuff which is
used in practice.
Some actual examples of usage are:
* tremship (used to detect team, but also for some easter eggs I
  believe)
* unvanquished's 0.52 parpax (used to implement a joke "achievement" in
  vents)