### PR TITLE
Perf improvements

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -4987,7 +4987,7 @@ bool G_admin_flag( gentity_t *ent )
 
 bool G_admin_builder( gentity_t *ent )
 {
-	vec3_t     forward, right, up;
+	vec3_t     forward;
 	vec3_t     start, end, dist;
 	trace_t    tr;
 	gentity_t  *traceEnt;
@@ -5005,12 +5005,12 @@ bool G_admin_builder( gentity_t *ent )
 
 	buildlog = G_admin_permission( ent, "buildlog" );
 
-	AngleVectors( ent->client->ps.viewangles, forward, right, up );
+	AngleVectors( ent->client->ps.viewangles, forward, nullptr, nullptr );
 
 	if ( ent->client->pers.team != TEAM_NONE &&
 	     ent->client->sess.spectatorState == SPECTATOR_NOT )
 	{
-		G_CalcMuzzlePoint( ent, forward, right, up, start );
+		G_CalcMuzzlePoint( ent, forward, start );
 	}
 	else
 	{

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1296,6 +1296,11 @@ bool BotTargetIsVisible( const gentity_t *self, botTarget_t target, int mask )
 	G_CalcMuzzlePoint( self, forward, muzzle );
 	target.getPos( targetPos );
 
+	if ( BotAimAngle( self, targetPos ) > g_bot_fov.Get() / 2 )
+	{
+		return false;
+	}
+
 	if ( !trap_InPVS( muzzle, targetPos ) )
 	{
 		return false;
@@ -1489,7 +1494,7 @@ void BotSlowAim( gentity_t *self, vec3_t target, float slowAmount )
 	VectorMA( viewBase, length, skilledVec, target );
 }
 
-float BotAimAngle( gentity_t *self, vec3_t pos )
+float BotAimAngle( const gentity_t *self, vec3_t pos )
 {
 	vec3_t viewPos;
 	vec3_t forward;

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1097,7 +1097,7 @@ bool BotTargetInAttackRange( const gentity_t *self, botTarget_t target )
 	float width = 0, height = 0;
 
 	AngleVectors( self->client->ps.viewangles, forward, right, up );
-	G_CalcMuzzlePoint( self, forward, right, up , muzzle );
+	G_CalcMuzzlePoint( self, forward, muzzle );
 	target.getPos( targetPos );
 	switch ( self->client->ps.weapon )
 	{
@@ -1290,10 +1290,10 @@ bool BotTargetIsVisible( const gentity_t *self, botTarget_t target, int mask )
 
 	trace_t trace;
 	vec3_t  muzzle, targetPos;
-	vec3_t  forward, right, up;
+	vec3_t  forward;
 
-	AngleVectors( self->client->ps.viewangles, forward, right, up );
-	G_CalcMuzzlePoint( self, forward, right, up, muzzle );
+	AngleVectors( self->client->ps.viewangles, forward, nullptr, nullptr );
+	G_CalcMuzzlePoint( self, forward, muzzle );
 	target.getPos( targetPos );
 
 	if ( !trap_InPVS( muzzle, targetPos ) )
@@ -1714,15 +1714,15 @@ float CalcAimPitch( gentity_t *self, vec3_t targetPos, vec_t launchSpeed )
 {
 	vec3_t startPos;
 	float initialHeight;
-	vec3_t forward, right, up;
+	vec3_t forward;
 	vec3_t muzzle;
 	float distance2D;
 	float x, y, v, g;
 	float check;
 	float angle1, angle2, angle;
 
-	AngleVectors( self->s.origin, forward, right, up );
-	G_CalcMuzzlePoint( self, forward, right, up, muzzle );
+	AngleVectors( self->s.origin, forward, nullptr, nullptr );
+	G_CalcMuzzlePoint( self, forward, muzzle );
 	VectorCopy( muzzle, startPos );
 
 	//project everything onto a 2D plane with initial position at (0,0)
@@ -1783,13 +1783,13 @@ void BotFireWeaponAI( gentity_t *self )
 {
 	float distance;
 	vec3_t targetPos;
-	vec3_t forward, right, up;
+	vec3_t forward;
 	vec3_t muzzle;
 	trace_t trace;
 	usercmd_t *botCmdBuffer = &self->botMind->cmdBuffer;
 
-	AngleVectors( self->client->ps.viewangles, forward, right, up );
-	G_CalcMuzzlePoint( self, forward, right, up, muzzle );
+	AngleVectors( self->client->ps.viewangles, forward, nullptr, nullptr );
+	G_CalcMuzzlePoint( self, forward, muzzle );
 	BotGetIdealAimLocation( self, self->botMind->goal, targetPos );
 
 	trap_Trace( &trace, muzzle, nullptr, nullptr, targetPos, ENTITYNUM_NONE, MASK_SHOT, 0 );

--- a/src/sgame/sg_bot_util.h
+++ b/src/sgame/sg_bot_util.h
@@ -52,7 +52,7 @@ void  BotGetIdealAimLocation( gentity_t *self, botTarget_t target, vec3_t aimLoc
 void  BotAimAtEnemy( gentity_t *self );
 void  BotSlowAim( gentity_t *self, vec3_t target, float slow );
 void  BotAimAtLocation( gentity_t *self, vec3_t target );
-float BotAimAngle( gentity_t *self, vec3_t pos );
+float BotAimAngle( const gentity_t *self, vec3_t pos );
 
 // targets
 bool BotEntityIsValidTarget( const gentity_t *ent );

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -327,7 +327,7 @@ bool          G_RefillAmmo( gentity_t *self, bool triggerEvent );
 bool          G_RefillFuel( gentity_t *self, bool triggerEvent );
 bool          G_FindAmmo( gentity_t *self );
 bool          G_FindFuel( gentity_t *self );
-void              G_CalcMuzzlePoint( const gentity_t *self, const vec3_t forward, const vec3_t right, const vec3_t up, vec3_t muzzlePoint );
+void              G_CalcMuzzlePoint( const gentity_t *self, const vec3_t forward, vec3_t muzzlePoint );
 void              G_SnapVectorTowards( vec3_t v, vec3_t to );
 bool              G_CheckDretchAttack( gentity_t *self );
 bool              G_CheckPounceAttack( gentity_t *self );

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -1060,7 +1060,7 @@ bool G_CheckDretchAttack( gentity_t *self )
 
 	// Calculate muzzle point
 	AngleVectors( self->client->ps.viewangles, forward, right, up );
-	G_CalcMuzzlePoint( self, forward, right, up, muzzle );
+	G_CalcMuzzlePoint( self, forward, muzzle );
 
 	G_WideTrace( &tr, self, LEVEL0_BITE_RANGE, LEVEL0_BITE_WIDTH, LEVEL0_BITE_WIDTH, &traceEnt );
 
@@ -1332,7 +1332,7 @@ bool G_CheckPounceAttack( gentity_t *self )
 
 	// Calculate muzzle point
 	AngleVectors( self->client->ps.viewangles, forward, right, up );
-	G_CalcMuzzlePoint( self, forward, right, up, muzzle );
+	G_CalcMuzzlePoint( self, forward, muzzle );
 
 	// Trace from muzzle to see what we hit
 	pounceRange = self->client->ps.weapon == WP_ALEVEL3 ? LEVEL3_POUNCE_RANGE :
@@ -1536,7 +1536,7 @@ void G_WeightAttack( gentity_t *self, gentity_t *victim )
 Set muzzle location relative to pivoting eye.
 ===============
 */
-void G_CalcMuzzlePoint( const gentity_t *self, const vec3_t forward, const vec3_t, const vec3_t, vec3_t muzzlePoint )
+void G_CalcMuzzlePoint( const gentity_t *self, const vec3_t forward, vec3_t muzzlePoint )
 {
 	vec3_t normal;
 
@@ -1554,7 +1554,7 @@ void G_FireWeapon( gentity_t *self, weapon_t weapon, weaponMode_t weaponMode )
 	if ( self->client )
 	{
 		AngleVectors( self->client->ps.viewangles, forward, right, up );
-		G_CalcMuzzlePoint( self, forward, right, up, muzzle );
+		G_CalcMuzzlePoint( self, forward, muzzle );
 	}
 	else
 	{
@@ -1783,7 +1783,7 @@ void G_FireUpgrade( gentity_t *self, upgrade_t upgrade )
 	}
 
 	AngleVectors( self->client->ps.viewangles, forward, right, up );
-	G_CalcMuzzlePoint( self, forward, right, up, muzzle );
+	G_CalcMuzzlePoint( self, forward, muzzle );
 
 	switch ( upgrade )
 	{


### PR DESCRIPTION
1st commit  avoid doing useless calculations.
2nd commit prevent doing a trace when target is not in front of bot: checking for angles is faster than doing a trace.

There's likely more places in which this could be useful, but... what should actually be done is reuse the information calculated by BotSearchForEnemy() instead, since there's already calculations of distance and visibility check done.
This should still save few cycles, though.