### PR TITLE
bg_misc: Fix off-by-one in BG_WeaponByName.

### DIFF
--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -610,7 +610,7 @@ const weaponAttributes_t *BG_WeaponByName( const char *name )
 
 	if ( weapon )
 	{
-		return &bg_weapons[ weapon ];
+		return &bg_weapons[ weapon - 1 ];
 	}
 	else
 	{


### PR DESCRIPTION
We don't include WP_NONE in bg_weapons, so subtract one. Also see
BG_Weapon() where we do the same.