### PR TITLE
0.52/navigational fixes

### DIFF
--- a/src/sgame/botlib/bot_types.h
+++ b/src/sgame/botlib/bot_types.h
@@ -55,9 +55,9 @@ struct botTrace_t
 // if they are followed exactly, the bot will not go off the nav mesh
 struct botNavCmd_t
 {
-	float    pos[ 3 ];
-	float    tpos[ 3 ];
-	float    dir[ 3 ];
+	float    pos[ 3 ]; // self position (with a height diff though)
+	float    tpos[ 3 ]; // position of the target (as for pos, with a height diff I guess)
+	float    dir[ 3 ]; // normalized direction of the target
 	int      directPathToGoal;
 	int      havePath;
 };

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -636,8 +636,11 @@ AINodeStatus_t BotActionAimAtGoal( gentity_t *self, AIGenericNode_t* )
 
 AINodeStatus_t BotActionMoveToGoal( gentity_t *self, AIGenericNode_t* )
 {
-	BotMoveToGoal( self );
-	return STATUS_RUNNING;
+	if ( GoalInRange( self, BotGetGoalRadius( self ) ) )
+	{
+		return STATUS_SUCCESS;
+	}
+	return BotMoveToGoal( self ) ? STATUS_RUNNING : STATUS_FAILURE;
 }
 
 AINodeStatus_t BotActionMoveInDir( gentity_t *self, AIGenericNode_t *node )
@@ -918,13 +921,11 @@ AINodeStatus_t BotActionRoamInRadius( gentity_t *self, AIGenericNode_t *node )
 		self->botMind->currentNode = node;
 	}
 
-	if ( self->botMind->nav.directPathToGoal && GoalInRange( self, 70 ) )
+	if ( GoalInRange( self, BotGetGoalRadius( self ) ) )
 	{
 		return STATUS_SUCCESS;
 	}
-	BotMoveToGoal( self );
-
-	return STATUS_RUNNING;
+	return BotMoveToGoal( self ) ? STATUS_RUNNING : STATUS_FAILURE;
 }
 
 AINodeStatus_t BotActionRoam( gentity_t *self, AIGenericNode_t *node )
@@ -940,15 +941,11 @@ AINodeStatus_t BotActionRoam( gentity_t *self, AIGenericNode_t *node )
 		self->botMind->currentNode = node;
 	}
 
-	if ( self->botMind->nav.directPathToGoal && GoalInRange( self, 70 ) )
+	if ( GoalInRange( self, BotGetGoalRadius( self ) ) )
 	{
 		return STATUS_SUCCESS;
 	}
-	else
-	{
-		BotMoveToGoal( self );
-	}
-	return STATUS_RUNNING;
+	return BotMoveToGoal( self ) ? STATUS_RUNNING : STATUS_FAILURE;
 }
 
 botTarget_t BotGetMoveToTarget( gentity_t *self, AIEntity_t e )
@@ -988,19 +985,16 @@ AINodeStatus_t BotActionMoveTo( gentity_t *self, AIGenericNode_t *node )
 		return STATUS_FAILURE;
 	}
 
-	BotMoveToGoal( self );
-
 	if ( radius == 0 )
 	{
 		radius = BotGetGoalRadius( self );
 	}
 
-	if ( DistanceToGoal2DSquared( self ) <= Square( radius ) && self->botMind->nav.directPathToGoal )
+	if ( GoalInRange( self, radius ) )
 	{
 		return STATUS_SUCCESS;
 	}
-
-	return STATUS_RUNNING;
+	return BotMoveToGoal( self ) ? STATUS_RUNNING : STATUS_FAILURE;
 }
 
 AINodeStatus_t BotActionRush( gentity_t *self, AIGenericNode_t *node )
@@ -1023,11 +1017,11 @@ AINodeStatus_t BotActionRush( gentity_t *self, AIGenericNode_t *node )
 		return STATUS_FAILURE;
 	}
 
-	if ( !GoalInRange( self, 100 ) )
+	if ( GoalInRange( self, BotGetGoalRadius( self ) ) )
 	{
-		BotMoveToGoal( self );
+		return STATUS_SUCCESS;
 	}
-	return STATUS_RUNNING;
+	return BotMoveToGoal( self ) ? STATUS_RUNNING : STATUS_FAILURE;
 }
 
 AINodeStatus_t BotActionHealA( gentity_t *self, AIGenericNode_t *node );

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -595,6 +595,10 @@ Global Bot Navigation
 =========================
 */
 
+// This function makes the bot move and aim at it's goal, trying
+// to move faster if the skill is high enough, depending on it's
+// class.
+// Returns false on failure.
 bool BotMoveToGoal( gentity_t *self )
 {
 	vec3_t dir;

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -519,24 +519,8 @@ bool BotAvoidObstacles( gentity_t *self, vec3_t dir )
 
 	if ( BotFindSteerTarget( self, dir ) )
 	{
-		return true;
+		return false;
 	}
-
-	vec3_t angles;
-	vec3_t right;
-	vectoangles( dir, angles );
-	AngleVectors( angles, dir, right, nullptr );
-
-	if ( ( self->client->time10000 % 2000 ) < 1000 )
-	{
-		VectorCopy( right, dir );
-	}
-	else
-	{
-		VectorNegate( right, dir );
-	}
-	dir[ 2 ] = 0;
-	VectorNormalize( dir );
 	return true;
 }
 

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -339,7 +339,7 @@ void BotWalk( gentity_t *self, bool enable )
 }
 
 // search for obstacle forward, and return pointer on it if any
-gentity_t* BotGetPathBlocker( gentity_t *self, const vec3_t dir )
+const gentity_t* BotGetPathBlocker( gentity_t *self, const vec3_t dir )
 {
 	vec3_t playerMins, playerMaxs;
 	vec3_t end;
@@ -369,7 +369,7 @@ gentity_t* BotGetPathBlocker( gentity_t *self, const vec3_t dir )
 
 // checks if jumping would get rid of blocker
 // return true if yes
-bool BotShouldJump( gentity_t *self, gentity_t *blocker, const vec3_t dir )
+bool BotShouldJump( gentity_t *self, const gentity_t *blocker, const vec3_t dir )
 {
 	vec3_t playerMins;
 	vec3_t playerMaxs;
@@ -504,9 +504,7 @@ bool BotFindSteerTarget( gentity_t *self, vec3_t dir )
 //return true on error
 bool BotAvoidObstacles( gentity_t *self, vec3_t dir )
 {
-	gentity_t *blocker;
-
-	blocker = BotGetPathBlocker( self, dir );
+	gentity_t const *blocker = BotGetPathBlocker( self, dir );
 
 	if ( !blocker )
 	{
@@ -617,13 +615,6 @@ void BotMoveToGoal( gentity_t *self )
 {
 	vec3_t dir;
 	VectorCopy( self->botMind->nav.dir, dir );
-	const playerState_t& ps  = self->client->ps;
-
-	if ( dir[ 2 ] < 0 )
-	{
-		dir[ 2 ] = 0;
-		VectorNormalize( dir );
-	}
 
 	BotAvoidObstacles( self, dir );
 	BotSeek( self, dir );
@@ -650,6 +641,7 @@ void BotMoveToGoal( gentity_t *self )
 	usercmd_t &botCmdBuffer = self->botMind->cmdBuffer;
 	weaponMode_t wpm = WPM_NONE;
 	int magnitude = 0;
+	const playerState_t& ps  = self->client->ps;
 	switch ( ps.stats [ STAT_CLASS ] )
 	{
 		case PCL_HUMAN_NAKED:

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -112,7 +112,7 @@ float BotGetGoalRadius( const gentity_t *self )
 	if ( t.targetsCoordinates() )
 	{
 		// we check the coord to be (almost) in our bounding box
-		return RadiusFromBounds2D( self->r.mins, self->r.maxs );
+		return RadiusFromBounds2D( self->r.mins, self->r.maxs ) + BOT_OBSTACLE_AVOID_RANGE;
 	}
 	else
 	{
@@ -127,7 +127,7 @@ float BotGetGoalRadius( const gentity_t *self )
 		}
 		else
 		{
-			return RadiusFromBounds2D( target->r.mins, target->r.maxs ) + RadiusFromBounds2D( self->r.mins, self->r.maxs );
+			return RadiusFromBounds2D( target->r.mins, target->r.maxs ) + RadiusFromBounds2D( self->r.mins, self->r.maxs ) + BOT_OBSTACLE_AVOID_RANGE;
 		}
 	}
 }

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -611,18 +611,21 @@ Global Bot Navigation
 =========================
 */
 
-void BotMoveToGoal( gentity_t *self )
+bool BotMoveToGoal( gentity_t *self )
 {
 	vec3_t dir;
 	VectorCopy( self->botMind->nav.dir, dir );
 
-	BotAvoidObstacles( self, dir );
+	if ( BotAvoidObstacles( self, dir ) )
+	{
+		return false;
+	}
 	BotSeek( self, dir );
 
 	// dumb bots don't know how to be efficient
 	if( self->botMind->botSkill.level < 5 )
 	{
-		return;
+		return true;
 	}
 
 	team_t targetTeam = TEAM_NONE;
@@ -635,7 +638,7 @@ void BotMoveToGoal( gentity_t *self )
 	// when available (still need to implement wall walking, but that will be more complex)
 	if ( G_Team( self ) != targetTeam )
 	{
-		return;
+		return true;
 	}
 
 	usercmd_t &botCmdBuffer = self->botMind->cmdBuffer;
@@ -696,6 +699,7 @@ void BotMoveToGoal( gentity_t *self )
 		}
 		BotFireWeapon( wpm, &botCmdBuffer );
 	}
+	return true;
 }
 
 bool FindRouteToTarget( gentity_t *self, botTarget_t target, bool allowPartial )

--- a/src/sgame/sg_bot_util.h
+++ b/src/sgame/sg_bot_util.h
@@ -113,7 +113,7 @@ extern bool navMeshLoaded;
 bool         G_BotNavInit();
 void         G_BotNavCleanup();
 bool     FindRouteToTarget( gentity_t *self, botTarget_t target, bool allowPartial );
-void         BotMoveToGoal( gentity_t *self );
+bool         BotMoveToGoal( gentity_t *self );
 void         BotSetNavmesh( gentity_t  *ent, class_t newClass );
 
 // local navigation


### PR DESCRIPTION
This PR prepares the ground for bigger navigational changes which will happen between 0.53 and 0.54, namely:

* fixing the obstacle management (there's several bugs with it, like #1493)
* replacement of complex actions (flee, heal, repair, fight, buy...) by several simpler ones ( most of those can be implemented as `sequence { changeGoal FOOBAR; moveToGoal }` for most of the stuff )
* multiple-goal support, which will start by allowing bots to move in a different direction than the direction they aim at, without moving outside of their navmesh

The reason I do this now is to reduce the risk of code conflicts in the upcoming months. Those changes are also likely to fix currently open issues such as #1620 , #1577 .