### PR TITLE
Fix the second evo rounding bug

### DIFF
--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -889,20 +889,26 @@ public:
 	void DoOnUpdate()
 	{
 		playerState_t *ps = &cg.snap->ps;
-		float value = ps->persistant[ PERS_CREDIT ];;
 
-		value /= ( float ) CREDITS_PER_EVO;
+		// display the value rounded down
+		//
+		// we use integer division to avoid rounding errors, those are
+		// multiplications and divisions by 10 because humans count in
+		// base 10.
+
+		int value = ps->persistant[ PERS_CREDIT ];;
+		// value is in tenth of evo points
+		value = value * 10 / CREDITS_PER_EVO;
 
 		if ( evos != value )
 		{
 			evos = value;
-			// display it rounded down
-			SetText( va( "%1.1f", floorf(evos*10)/10 ) );
+			SetText( va( "%i.%i", value/10, value%10 ) );
 		}
 	}
 
 private:
-	float evos;
+	int evos;
 };
 
 class StaminaValueElement : public TextHudElement


### PR DESCRIPTION
Because while 7.99 shouldn't be 8 ([first bug](https://github.com/Unvanquished/Unvanquished/pull/1248/commits/dcf5b0a566403c6102be35a8603ee438396ac9c8)),  20.0 shoudn't be 19.9 either.