### PR TITLE
Don't protect immortals against damage when suiciding

### DIFF
--- a/src/sgame/components/HealthComponent.cpp
+++ b/src/sgame/components/HealthComponent.cpp
@@ -55,7 +55,7 @@ Util::optional<Vec3> direction, int flags, meansOfDeath_t meansOfDeath) {
 	gclient_t *client = entity.oldEnt->client;
 
 	// Check for immunity.
-	if (entity.oldEnt->flags & FL_GODMODE) return;
+	if (entity.oldEnt->flags & FL_GODMODE && meansOfDeath != MOD_SUICIDE) return;
 	if (client) {
 		if (client->noclip) return;
 		if (client->sess.spectatorState != SPECTATOR_NOT) return;


### PR DESCRIPTION
If something really wants to die, it should be allowed to do it even if it usually doesn't take damage

This is used in the juggernaut mod, which also defines `g_indestructibleBuildables` (see https://github.com/Unvanquished/Unvanquished/pull/1915)