### PR TITLE
add Cvar g_bot_ignore_momentum to allow bots to cheat even more

### DIFF
--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -68,7 +68,7 @@ struct equipment_t
 	bool allowed( void ) const;
 	bool canBuyNow( void ) const
 	{
-		return allowed() && unlocked();
+		return allowed() && ( g_bot_infiniteMomentum.Get() || unlocked() );
 	}
 	int slots( void ) const;
 	bool operator==( T other ) const
@@ -489,12 +489,15 @@ float BotGetEnemyPriority( gentity_t *self, gentity_t *ent )
 
 bool BotCanEvolveToClass( const gentity_t *self, class_t newClass )
 {
+	equipment_t<class_t>* cl = std::find( std::begin( classes ), std::end( classes ), newClass );
+
 	int fromClass = self->client->ps.stats[STAT_CLASS];
 	evolveInfo_t info = BG_ClassEvolveInfoFromTo( fromClass, newClass );
 
 	// TODO: one might be willing to allow switching to same cost classes,
 	// notably, from dretch to advanced granger when base in on fire.
-	return info.classIsUnlocked && info.evolveCost > 0 // no devolving
+
+	return cl->canBuyNow() && info.evolveCost > 0 // no devolving
 		&& self->client->ps.persistant[PERS_CREDIT] >= info.evolveCost;
 }
 

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -206,5 +206,6 @@ extern Cvar::Cvar<float> g_bot_fov;
 extern Cvar::Cvar<int> g_bot_chasetime;
 extern Cvar::Cvar<int> g_bot_reactiontime;
 extern Cvar::Cvar<bool> g_bot_infinite_funds;
+extern Cvar::Cvar<bool> g_bot_infiniteMomentum;
 
 #endif // SG_EXTERN_H_

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -261,6 +261,7 @@ Cvar::Cvar<float> g_bot_fov("g_bot_fov", "bots' \"field of view\"", Cvar::NONE, 
 Cvar::Cvar<int> g_bot_chasetime("g_bot_chasetime", "bots stop chasing after x ms out of sight", Cvar::NONE, 5000);
 Cvar::Cvar<int> g_bot_reactiontime("g_bot_reactiontime", "bots' reaction time to enemies (milliseconds)", Cvar::NONE, 500);
 Cvar::Cvar<bool> g_bot_infinite_funds("g_bot_infinite_funds", "give bots unlimited funds", Cvar::NONE, false);
+Cvar::Cvar<bool> g_bot_infiniteMomentum("g_bot_infiniteMomentum", "allow bots to ignore momentum, but not other restrictions", Cvar::NONE, false);
 
 //</bot stuff>
 


### PR DESCRIPTION
fix #1801


This is worth a line in a changelog, as it increases control over bots. Also, requires a GUI option.