### PR TITLE
use trace distance instead of origin distance

### DIFF
--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -2184,10 +2184,11 @@ void ClientThink_real( gentity_t *self )
 
 		ent = &g_entities[ trace.entityNum ];
 
-		if ( ent && ent->use &&
-		     ( !ent->buildableTeam   || ent->buildableTeam   == client->pers.team ) &&
-		     ( !ent->conditions.team || ent->conditions.team == client->pers.team ) &&
-		     Distance( self->s.origin, ent->s.origin ) < ENTITY_USE_RANGE )
+		if ( ent && ent->use
+		     && ( !ent->buildableTeam   || ent->buildableTeam   == client->pers.team )
+		     && ( !ent->conditions.team || ent->conditions.team == client->pers.team )
+		     && trace.fraction < 1.0f
+		   )
 		{
 			if ( g_debugEntities.Get() > 1 )
 			{

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -2188,6 +2188,7 @@ void ClientThink_real( gentity_t *self )
 		     && ( !ent->buildableTeam   || ent->buildableTeam   == client->pers.team )
 		     && ( !ent->conditions.team || ent->conditions.team == client->pers.team )
 		     && trace.fraction < 1.0f
+				 && !( entityType == eType_t::BUILDABLE && Distance( self->s.origin, ent->s.origin ) >= ENTITY_USE_RANGE )
 		   )
 		{
 			if ( g_debugEntities.Get() > 1 )


### PR DESCRIPTION
No real bug is fixed with that, as far as I know, but it should make things better for later. This also avoid calculating a distance between 2 origins, when there is already such distance information in the shape of a trace.