### PR TITLE
Trem compat

### DIFF
--- a/src/sgame/sg_spawn.cpp
+++ b/src/sgame/sg_spawn.cpp
@@ -579,11 +579,7 @@ bool G_CallSpawnFunction( gentity_t *spawnedEntity )
 		 *  to allow each spawn function to test and handle for itself,
 		 *  we handle it automatically *after* the spawn (but before it's use/reset)
 		 */
-		if(!G_HandleEntityVersions( spawnedClass, spawnedEntity ))
-			return false;
-
-
-		return true;
+		return G_HandleEntityVersions( spawnedClass, spawnedEntity );
 	}
 
 	//don't even warn about spawning-errors with -2 (maps might still work at least partly if we ignore these willingly)

--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -60,6 +60,7 @@ static const buildableName_t bg_buildableNameList[] =
 	{ BA_H_MEDISTAT,  "medistat",  "team_human_medistat"  },
  	{ BA_H_DRILL,     "drill",     "team_human_drill"     },
 	{ BA_H_REACTOR,   "reactor",   "team_human_reactor"   },
+	{ BA_H_DRILL,     "repeater",  "team_human_repeater"  },
 };
 
 static const size_t bg_numBuildables = ARRAY_LEN( bg_buildableNameList );
@@ -2272,7 +2273,16 @@ BoundedVector<buildable_t, BA_NUM_BUILDABLES>
 		}
 		else
 		{
-			Log::Warn( "unknown buildable %s", *i );
+			// tremulous' repeater was replaced by drill
+			if ( strcmp( "repeater", *i ) )
+			{
+				results.append( BA_H_DRILL );
+				Log::Warn( "Deprecated %s was replaced by a drill", *i );
+			}
+			else
+			{
+				Log::Warn( "unknown buildable %s", *i );
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR aims to automatically replace repeaters from trem maps by a drill, since they have the same role and very close mechanics:

* can't (or rather should avoid, for drill) be too close from other ones
* refuel energy weapons
* help with building more