### PR TITLE
sgame: Stop running entity frames after the game ends.

### DIFF
--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -267,7 +267,7 @@ Cvar::Cvar<bool> g_bot_infinite_funds("g_bot_infinite_funds", "give bots unlimit
 static Cvar::Cvar<std::string> gamename("gamename", "game/mod identifier", Cvar::SERVERINFO | Cvar::ROM, GAME_VERSION);
 static Cvar::Cvar<std::string> gamedate("gamedate", "date the sgame was compiled", Cvar::ROM, __DATE__);
 
-void               CheckExitRules();
+bool               CheckExitRules();
 static void        G_LogGameplayStats( int state );
 
 // state field of G_LogGameplayStats
@@ -1774,7 +1774,7 @@ If one or more players have not acknowledged the continue, the game will
 wait 10 seconds before going on.
 =================
 */
-static void CheckIntermissionExit()
+static bool CheckIntermissionExit()
 {
 	int          ready, notReady;
 	int          i;
@@ -1786,7 +1786,7 @@ static void CheckIntermissionExit()
 	if ( level.numConnectedClients == 0 && !voting)
 	{
 		ExitLevel();
-		return;
+		return true;
 	}
 
 	// see which players are ready
@@ -1825,28 +1825,28 @@ static void CheckIntermissionExit()
 	// never exit in less than five seconds or if there's an ongoing vote
 	if ( voting || level.time < level.intermissiontime + 5000 )
 	{
-		return;
+		return false;
 	}
 
 	// never let intermission go on for over 1 minute
 	if ( level.time > level.intermissiontime + 60000 )
 	{
 		ExitLevel();
-		return;
+		return true;
 	}
 
 	// if nobody wants to go, clear timer
 	if ( ready == 0 && notReady > 0 )
 	{
 		level.readyToExit = false;
-		return;
+		return false;
 	}
 
 	// if everyone wants to go, go now
 	if ( notReady == 0 )
 	{
 		ExitLevel();
-		return;
+		return true;
 	}
 
 	// the first person to ready starts the thirty second timeout
@@ -1860,10 +1860,11 @@ static void CheckIntermissionExit()
 	// wanted to exit, go ahead
 	if ( level.time < level.exitTime + 30000 )
 	{
-		return;
+		return false;
 	}
 
 	ExitLevel();
+	return true;
 }
 
 /*
@@ -1875,18 +1876,17 @@ and the time everyone is moved to the intermission spot, so you
 can see the last frag.
 =================
 */
-void CheckExitRules()
+bool CheckExitRules()
 {
 	if ( g_cheats && g_neverEnd.Get() ) {
-		return;
+		return false;
 	}
 
 	// if at the intermission, wait for all non-bots to
 	// signal ready, then go to next level
 	if ( level.intermissiontime )
 	{
-		CheckIntermissionExit();
-		return;
+		return CheckIntermissionExit();
 	}
 
 	if ( level.intermissionQueued )
@@ -1897,7 +1897,7 @@ void CheckExitRules()
 			BeginIntermission();
 		}
 
-		return;
+		return true;
 	}
 
 	if ( level.timelimit )
@@ -1910,7 +1910,7 @@ void CheckExitRules()
 			G_notify_sensor_end( TEAM_NONE );
 			LogExit( "Timelimit hit." );
 			G_MapLog_Result( 't' );
-			return;
+			return true;
 		}
 		else if ( level.matchTime >= ( level.timelimit - 5 ) * 60000 &&
 		          level.timelimitWarning < TW_IMMINENT )
@@ -1939,6 +1939,7 @@ void CheckExitRules()
 		G_notify_sensor_end( TEAM_HUMANS );
 		LogExit( "Humans win." );
 		G_MapLog_Result( 'h' );
+		return true;
 	}
 	else if ( level.unconditionalWin == TEAM_ALIENS ||
 	          ( level.unconditionalWin != TEAM_HUMANS &&
@@ -1953,6 +1954,7 @@ void CheckExitRules()
 		G_notify_sensor_end( TEAM_ALIENS );
 		LogExit( "Aliens win." );
 		G_MapLog_Result( 'a' );
+		return true;
 	}
 	else if ( g_emptyTeamsSkipMapTime.Get() &&
 		( level.time - level.startTime ) / 60000 >=
@@ -1965,7 +1967,9 @@ void CheckExitRules()
 		trap_SetConfigstring( CS_WINNER, "Stalemate" );
 		LogExit( "Timelimit hit." );
 		G_MapLog_Result( 't' );
+		return true;
 	}
+	return false;
 }
 
 /*
@@ -2359,6 +2363,18 @@ void G_RunFrame( int levelTime )
 	// now we are done spawning
 	level.spawning = false;
 
+	// cancel vote if timed out
+	for ( i = 0; i < NUM_TEAMS; i++ )
+	{
+		G_CheckVote( (team_t) i );
+	}
+
+	// see if it is time to end the level
+	if (CheckExitRules())
+	{
+		return;
+	}
+
 	G_CheckPmoveParamChanges();
 
 	// go through all allocated objects
@@ -2487,20 +2503,10 @@ void G_RunFrame( int levelTime )
 	// log gameplay statistics
 	G_LogGameplayStats( LOG_GAMEPLAY_STATS_BODY );
 
-	// see if it is time to end the level
-	CheckExitRules();
-
 	G_BotFill( false );
 
 	// update to team status?
 	CheckTeamStatus();
-
-	// cancel vote if timed out
-	for ( i = 0; i < NUM_TEAMS; i++ )
-	{
-		G_CheckVote( (team_t) i );
-	}
-
 	BotDebugDrawMesh();
 	G_BotUpdateObstacles();
 	level.frameMsec = trap_Milliseconds();


### PR DESCRIPTION
Before, even after the game ended, we would still update clients and
such. This can lead to potentially bad states leading to a segfault if
something calls and entity method after the entity is cleared as in #1939.