### PR TITLE
sgame: Allow running per-layout configs.

### DIFF
--- a/dist/configs/config/server.cfg
+++ b/dist/configs/config/server.cfg
@@ -67,9 +67,11 @@ set g_teamForceBalance 2
 //set g_warmup 20
 
 // load per map config file from this subdirectory
-// it will load map/<mapname>.cfg like map/plat23.cfg
-// or fallback on map/default.cfg
-// map config files can be used to fill game with bots
+// it will load all the configs specified:
+//   - map/default.cfg (for every map)
+//   - map/plat23.cfg (for plat23, regardless of the layout)
+//   - map/plat23/layout.cfg (for plat23 and layout "layout")
+// map config files can be used to fill game with bots and set other useful configs.
 set g_mapConfigs "map"
 
 // following the first map, start this rotation

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -41,7 +41,7 @@ const char        *G_admin_name( gentity_t *ent );
 const char        *G_quoted_admin_name( gentity_t *ent );
 
 // Beacon.cpp
-namespace Beacon 
+namespace Beacon
 {
 	void Frame();
 	void Move( gentity_t *ent, const vec3_t origin );
@@ -209,7 +209,7 @@ int               G_GetPosInSpawnQueue( spawnQueue_t *sq, int clientNum );
 void              G_PrintSpawnQueue( spawnQueue_t *sq );
 void              BeginIntermission();
 void              MoveClientToIntermission( gentity_t *client );
-void              G_MapConfigs( const char *mapname );
+void              G_MapConfigs( Str::StringRef mapname, Str::StringRef layout );
 void              CalculateRanks();
 void              FindIntermissionPoint();
 void              G_RunThink( gentity_t *ent );


### PR DESCRIPTION
This changes the directory structure based on the comments in #1795.

It executes default.cfg for all maps, mapname.cfg, mapname/default.cfg,
and mapname/layout.cfg.

Fixes #1871