### PR TITLE
Revert "make slowblob for advgrangers lockblob"

### DIFF
--- a/src/sgame/sg_missile.cpp
+++ b/src/sgame/sg_missile.cpp
@@ -252,7 +252,6 @@ static int ImpactSlowblob( gentity_t *ent, trace_t *trace, gentity_t *hitEnt )
 {
 	int       impactFlags = MIB_IMPACT;
 	gentity_t *attacker = &g_entities[ ent->r.ownerNum ];
-	vec3_t dir;
 	int reward = 0;
 
 	// put out fires on direct hit
@@ -284,19 +283,8 @@ static int ImpactSlowblob( gentity_t *ent, trace_t *trace, gentity_t *hitEnt )
 
 	if ( hitEnt->client && hitEnt->client->pers.team == TEAM_HUMANS )
 	{
-		if( !ABUILDER_BLOB_LOCK_TIME || hitEnt->client->pers.classSelection == PCL_HUMAN_BSUIT )
-		{
-			hitEnt->client->ps.stats[ STAT_STATE ] |= SS_SLOWLOCKED;
-			hitEnt->client->lastSlowTime = level.time;
-		}
-		else if ( attacker->client->pers.classSelection == PCL_ALIEN_BUILDER0_UPG )
-		{
-			hitEnt->client->ps.stats[ STAT_STATE ] |= SS_BLOBLOCKED;
-			hitEnt->client->lastLockTime = level.time - LOCKBLOB_LOCKTIME + ABUILDER_BLOB_LOCK_TIME;
-			AngleVectors( hitEnt->client->ps.viewangles, dir, nullptr, nullptr );
-			hitEnt->client->ps.stats[ STAT_VIEWLOCK ] = DirToByte( dir );
-		}
-
+		hitEnt->client->ps.stats[ STAT_STATE ] |= SS_SLOWLOCKED;
+		hitEnt->client->lastSlowTime = level.time;
 	}
 	else if ( hitEnt->s.eType == entityType_t::ET_BUILDABLE && hitEnt->buildableTeam == TEAM_ALIENS )
 	{

--- a/src/shared/bg_gameplay.h
+++ b/src/shared/bg_gameplay.h
@@ -44,7 +44,6 @@ extern float ABUILDER_CLAW_RANGE;
 extern float ABUILDER_CLAW_WIDTH;
 extern float ABUILDER_BLOB_SPEED;
 extern float ABUILDER_BLOB_SPEED_MOD;
-extern int   ABUILDER_BLOB_LOCK_TIME;
 extern int   ABUILDER_BLOB_TIME;
 
 extern int   LEVEL0_BITE_DMG;

--- a/src/shared/bg_parse.cpp
+++ b/src/shared/bg_parse.cpp
@@ -66,7 +66,6 @@ float ABUILDER_CLAW_WIDTH;
 float ABUILDER_BLOB_SPEED;
 float ABUILDER_BLOB_SPEED_MOD;
 int   ABUILDER_BLOB_TIME;
-int		ABUILDER_BLOB_LOCK_TIME;
 
 int   LEVEL0_BITE_DMG;
 float LEVEL0_BITE_RANGE;
@@ -178,7 +177,6 @@ static configVar_t bg_configVars[] =
 	{"u_medkit_startupSpeed", INTEGER, false, &MEDKIT_STARTUP_SPEED},
 	{"u_medkit_startupTime", INTEGER, false, &MEDKIT_STARTUP_TIME},
 
-	{"w_abuild_blobLockTime", INTEGER, false, &ABUILDER_BLOB_LOCK_TIME},
 	{"w_abuild_blobSlowTime", INTEGER, false, &ABUILDER_BLOB_TIME},
 	{"w_abuild_blobSpeed", FLOAT, false, &ABUILDER_BLOB_SPEED},
 	{"w_abuild_blobSpeedMod", FLOAT, false, &ABUILDER_BLOB_SPEED_MOD},


### PR DESCRIPTION
This reverts the absurd decision to change granger spit from slowblobs into lockblobs. This gameplay mechanic is **_broken_** and imo should never have been approved in the first place.