### PR TITLE
welcome: Fix showing welcome window on connection.

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1275,6 +1275,16 @@ struct cg_t
 	Filter<WeaponOffsets>   weaponOffsetsFilter;
 };
 
+enum rocketElementType_t
+{
+	ELEMENT_ALL,
+	ELEMENT_GAME,
+	ELEMENT_LOADING,
+	ELEMENT_HUMANS,
+	ELEMENT_ALIENS,
+	ELEMENT_BOTH,
+};
+
 enum class rocketVarType_t {
 	ROCKET_STRING,
 	ROCKET_FLOAT,
@@ -1298,6 +1308,7 @@ enum rocketMenuType_t {
 	ROCKETMENU_CHAT,
 	ROCKETMENU_BEACONS,
 	ROCKETMENU_ERROR,
+	ROCKETMENU_WELCOME,
 	ROCKETMENU_NUM_TYPES
 };
 
@@ -1728,16 +1739,6 @@ enum rangeMarker_t
 	RM_SPHERE,
 	RM_SPHERICAL_CONE_64,
 	RM_SPHERICAL_CONE_240,
-};
-
-enum rocketElementType_t
-{
-	ELEMENT_ALL,
-	ELEMENT_GAME,
-	ELEMENT_LOADING,
-	ELEMENT_HUMANS,
-	ELEMENT_ALIENS,
-	ELEMENT_BOTH,
 };
 
 enum altShader_t

--- a/src/cgame/cg_rocket.cpp
+++ b/src/cgame/cg_rocket.cpp
@@ -509,12 +509,12 @@ void CG_Rocket_Frame( cgClientState_t state )
 				Rocket_DocumentAction( rocketInfo.menu[ ROCKETMENU_DOWNLOADING ].id, "show" );
 				break;
 			case connstate_t::CA_LOADING:
-			case connstate_t::CA_PRIMED:
 				Rocket_DocumentAction( rocketInfo.menu[ ROCKETMENU_LOADING ].id, "show" );
 				break;
-
-			case connstate_t::CA_ACTIVE:
+			case connstate_t::CA_PRIMED:
 				Rocket_DocumentAction( "", "blurall" );
+				break;
+			case connstate_t::CA_ACTIVE:
 				break;
 
 			default:

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -415,6 +415,7 @@ static void CG_Menu( int menuType, int arg )
 	switch ( menuType )
 	{
 		case MN_WELCOME:
+			menu = ROCKETMENU_WELCOME;
 			break;
 
 		case MN_TEAM:

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -1364,15 +1364,15 @@ void ClientBegin( int clientNum )
 		// 0 - don't show
 		// 1 - always show to all
 		// 2 - show only to unregistered
-		switch ( g_showHelpOnConnection.Get() )
+		if ( g_showWelcome.Get() == 0 )
 		{
-		case 0:
-			if (0)
-		default:
-			if ( !client->pers.admin )
-		case 1:
-			G_TriggerMenu( client->ps.clientNum, MN_WELCOME );
+			return;
 		}
+		else if ( g_showWelcome.Get() == 2 && client->pers.admin )
+		{
+			return;
+		}
+		G_TriggerMenu( client->ps.clientNum, MN_WELCOME );
 	}
 }
 

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -52,7 +52,7 @@ extern Cvar::Cvar<bool> g_lockTeamsAtStart;
 extern Cvar::Cvar<float> g_minNameChangePeriod;
 extern Cvar::Cvar<int> g_maxNameChanges;
 
-extern Cvar::Range<Cvar::Cvar<int>> g_showHelpOnConnection;
+extern Cvar::Range<Cvar::Cvar<int>> g_showWelcome;
 extern Cvar::Cvar<int> g_timelimit;
 extern Cvar::Cvar<bool> g_dretchPunt;
 extern Cvar::Callback<Cvar::Cvar<std::string>> g_password;

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -39,7 +39,7 @@ level_locals_t level;
 gentity_t          *g_entities;
 gclient_t          *g_clients;
 
-Cvar::Range<Cvar::Cvar<int>> g_showHelpOnConnection("g_showHelpOnConnection", "show MN_WELCOME on connect (1 = all, 2 = unregistered)", Cvar::NONE, 1, 0, 2);
+Cvar::Range<Cvar::Cvar<int>> g_showWelcome("g_showWelcome", "show MN_WELCOME on connect (0 = none, 1 = all, 2 = unregistered)", Cvar::NONE, 0, 0, 2);
 
 Cvar::Range<Cvar::Cvar<int>> g_gravity(
 		"g_gravity",


### PR DESCRIPTION
This used to be g_showHelpOnConnection, but that cvar is too long, so just call it g_showWelcome. Also, with the old code, it would come at the same frame that we go to CA_ACTIVE, which meant that rmlui would hide all the windows. However, since, PRIMED happens just before we get the first data from the server, it makes sense to hide all the menus then so we don't hide any commands we receive from the server.