### PR TITLE
sg_admin: Don't register commands for the local client. 

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -529,6 +529,14 @@ void G_admin_cmdlist( gentity_t *ent )
 	char out[ MAX_STRING_CHARS ] = "";
 	unsigned len, outlen;
 
+	// If this is the local client, no need to send them commands.
+	// The local client will get their commands registered in
+	// G_admin_register_cmds.
+	if ( level.inClient && ent->client->ps.clientNum == 0 )
+	{
+		return;
+	}
+
 	outlen = 0;
 
 	for ( unsigned i = 0; i < adminNumCmds; i++ )


### PR DESCRIPTION
These commands are only added to this array so we can have command
completion for them. There is no need to register them because they will
be registered when the sgame tells the cgame to register them.