### PR TITLE
g_maxMiners: better error messages

### DIFF
--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -596,6 +596,11 @@ static void CG_Menu( int menuType, int arg )
 			shortMsg = _("There can only be one Reactor");
 			break;
 
+		case MN_H_NOMOREDRILLS:
+			longMsg = nullptr;
+			shortMsg = _("Your team cannot have any more drills");
+			break;
+
 		case MN_H_NOSLOTS:
 			longMsg = _("You have no room to carry this. Please sell any conflicting "
 			          "upgrades before purchasing this item.");
@@ -658,6 +663,11 @@ static void CG_Menu( int menuType, int arg )
 			longMsg = _("There can only be one Overmind. Deconstruct the existing one if you "
 			          "wish to move it.");
 			shortMsg = _("There can only be one Overmind");
+			break;
+
+		case MN_A_NOMORELEECHES:
+			longMsg = nullptr;
+			shortMsg = _("Your team cannot have any more leeches");
 			break;
 
 		case MN_A_NOBP:

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -1716,7 +1716,7 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 		if ( miners >= max_miners )
 		{
 			//TODO 0.54: make this a more appropriate error message, or remove g_maxMiners completely
-			return ent->client->pers.team == TEAM_HUMANS ? IBE_NOHUMANBP : IBE_NOALIENBP;
+			return ent->client->pers.team == TEAM_HUMANS ? IBE_NOMOREDRILLS : IBE_NOMORELEECHES;
 		}
 	}
 		
@@ -2106,6 +2106,10 @@ bool G_BuildIfValid( gentity_t *ent, buildable_t buildable )
 			G_TriggerMenu( ent->client->ps.clientNum, MN_A_ONEOVERMIND );
 			return false;
 
+		case IBE_NOMORELEECHES:
+			G_TriggerMenu( ent->client->ps.clientNum, MN_A_NOMORELEECHES );
+			return false;
+
 		case IBE_NORMAL:
 			G_TriggerMenu( ent->client->ps.clientNum, MN_B_NORMAL );
 			return false;
@@ -2124,6 +2128,10 @@ bool G_BuildIfValid( gentity_t *ent, buildable_t buildable )
 
 		case IBE_NOREACTOR:
 			G_TriggerMenu( ent->client->ps.clientNum, MN_H_NOREACTOR );
+			return false;
+
+		case IBE_NOMOREDRILLS:
+			G_TriggerMenu( ent->client->ps.clientNum, MN_H_NOMOREDRILLS );
 			return false;
 
 		case IBE_NOROOM:

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -1715,7 +1715,6 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 		});
 		if ( miners >= max_miners )
 		{
-			//TODO 0.54: make this a more appropriate error message, or remove g_maxMiners completely
 			return ent->client->pers.team == TEAM_HUMANS ? IBE_NOMOREDRILLS : IBE_NOMORELEECHES;
 		}
 	}

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -390,10 +390,12 @@ enum itemBuildError_t
   IBE_NOOVERMIND,       // no overmind present
   IBE_ONEOVERMIND,      // may not build two overminds
   IBE_NOALIENBP,        // not enough build points (aliens)
+  IBE_NOMORELEECHES,    // no more leeches allowed
 
   IBE_NOREACTOR,        // not enough power in this area and no reactor present
   IBE_ONEREACTOR,       // may not build two reactors
   IBE_NOHUMANBP,        // not enough build points (humans)
+  IBE_NOMOREDRILLS,     // no more drills allowed
 
   IBE_NORMAL,           // surface is too steep
   IBE_NOROOM,           // no room
@@ -798,6 +800,7 @@ enum dynMenu_t
   MN_A_ONEOVERMIND,
   MN_A_NOBP,
   MN_A_NOOVMND,
+  MN_A_NOMORELEECHES,
 
   //human stuff
   MN_H_SPAWN,
@@ -818,7 +821,8 @@ enum dynMenu_t
   MN_H_NOREACTOR,
   MN_H_NOBP,
   MN_H_NOTPOWERED,
-  MN_H_ONEREACTOR
+  MN_H_ONEREACTOR,
+  MN_H_NOMOREDRILLS
 };
 
 // animations


### PR DESCRIPTION
This adds more understandable error messages for the case that g_maxMiners is enabled (it is disabled by default). From my own experiments I conclude that g_maxMiners can solve some of the problems described in https://github.com/Unvanquished/gameplay/issues/23. So having proper error messages seems to be in order.

I'd prefer have to have `longMsg` too, but that would be overlaid by the window informing the builder about build points.