### PR TITLE
Introduce g_persistDevmap

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -3392,7 +3392,7 @@ bool G_admin_changemap( gentity_t *ent )
 	admin_log( map );
 	admin_log( layout );
 
-	trap_SendConsoleCommand( Str::Format( "map %s %s", Cmd::Escape( map ), Cmd::Escape( layout ) ).c_str() );
+	trap_SendConsoleCommand( Str::Format( "%s %s %s", G_NextMapCommand(), Cmd::Escape( map ), Cmd::Escape( layout ) ).c_str() );
 
 	level.restarted = true;
 	G_MapLog_Result( 'M' );

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -1950,7 +1950,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 		if ( *reason ) // layout?
 		{
 			Com_sprintf( level.team[ team ].voteString, sizeof( level.team[ team ].voteString ),
-			             "map %s %s", Cmd::Escape( arg ).c_str(), Cmd::Escape( reason ).c_str() );
+			             "%s %s %s", G_NextMapCommand(), Cmd::Escape( arg ).c_str(), Cmd::Escape( reason ).c_str() );
 			Com_sprintf( level.team[ team ].voteDisplayString,
 			             sizeof( level.team[ team ].voteDisplayString ),
 			             "Change to map '%s' layout '%s'", arg, reason );
@@ -1958,7 +1958,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 		else
 		{
 			Com_sprintf( level.team[ team ].voteString, sizeof( level.team[ team ].voteString ),
-			             "map %s", Cmd::Escape( arg ).c_str() );
+			             "%s %s", G_NextMapCommand(), Cmd::Escape( arg ).c_str() );
 			Com_sprintf( level.team[ team ].voteDisplayString,
 			             sizeof( level.team[ team ].voteDisplayString ),
 			             "Change to map '%s'", arg );

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -163,6 +163,7 @@ Cvar::Cvar<std::string> g_mapRotationStack("g_mapRotationStack", "FOR INTERNAL U
 Cvar::Cvar<std::string> g_nextMap("g_nextMap", "map to load next (cleared after use)", Cvar::NONE, "");
 Cvar::Cvar<std::string> g_nextMapLayouts("g_nextMapLayouts", "list of layouts (one's chosen randomly) to go with g_nextMap", Cvar::NONE, "");
 Cvar::Cvar<std::string> g_initialMapRotation("g_initialMapRotation", "map rotation to use on server startup", Cvar::NONE, "rotation1");
+static Cvar::Cvar<bool> g_persistDevmap("g_persistDevmap", "allow cheats next map if allowed now", Cvar::NONE, false);
 Cvar::Cvar<std::string> g_mapLog("g_mapLog", "contains results of recent games", Cvar::NONE, "");
 Cvar::Cvar<std::string> g_mapStartupMessage("g_mapStartupMessage", "message sent to players on connection (reset after game)", Cvar::NONE, "");
 Cvar::Cvar<int> g_mapStartupMessageDelay("g_mapStartupMessageDelay", "show g_mapStartupMessage x milliseconds after connection", Cvar::NONE, 5000);
@@ -1411,7 +1412,7 @@ static void ExitLevel()
 	}
 	else if ( G_MapExists( g_nextMap.Get().c_str() ) )
 	{
-		trap_SendConsoleCommand( va( "map %s %s", Cmd::Escape( g_nextMap.Get() ).c_str(), Cmd::Escape( g_nextMapLayouts.Get() ).c_str() ) );
+		trap_SendConsoleCommand( va( "%s %s %s", G_NextMapCommand(), Cmd::Escape( g_nextMap.Get() ).c_str(), Cmd::Escape( g_nextMapLayouts.Get() ).c_str() ) );
 	}
 	else if ( G_MapRotationActive() )
 	{
@@ -2542,4 +2543,14 @@ void G_PrepareEntityNetCode() {
 	ForEntities<SpectatorComponent>([&](Entity& entity, SpectatorComponent&){
 		entity.PrepareNetCode();
 	});
+}
+
+Str::StringRef G_NextMapCommand()
+{
+	if ( g_cheats && g_persistDevmap.Get() )
+	{
+		return "devmap";
+	}
+
+	return "map";
 }

--- a/src/sgame/sg_maprotation.cpp
+++ b/src/sgame/sg_maprotation.cpp
@@ -1103,11 +1103,11 @@ static void G_IssueMapChange( int index, int rotation )
 		// allow a manually defined g_layouts setting to override the maprotation
 		if ( g_layouts.Get().empty() && map->layouts[ 0 ] )
 		{
-			trap_SendConsoleCommand( Str::Format( "map %s %s", Cmd::Escape( map->name ), Cmd::Escape( map->layouts ) ).c_str() );
+			trap_SendConsoleCommand( Str::Format( "%s %s %s", G_NextMapCommand(), Cmd::Escape( map->name ), Cmd::Escape( map->layouts ) ).c_str() );
 		}
 		else
 		{
-			trap_SendConsoleCommand( Str::Format( "map %s", Cmd::Escape( map->name ) ).c_str() );
+			trap_SendConsoleCommand( Str::Format( "%s %s", G_NextMapCommand(), Cmd::Escape( map->name ) ).c_str() );
 		}
 	}
 }

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -227,6 +227,7 @@ void              G_ShutdownGame( int restart );
 void              G_CheckPmoveParamChanges();
 void              G_SendClientPmoveParams(int client);
 void              G_PrepareEntityNetCode();
+Str::StringRef G_NextMapCommand();
 
 // sg_maprotation.c
 void              G_PrintRotations();


### PR DESCRIPTION
Make it so that dev mode can continue to be enabled after map changes.
Useful for development scenarios which need to last beyond the end of a
map.