### PR TITLE
Set g_mapConfigs to "map" by default

### DIFF
--- a/dist/configs/config/map/default.cfg
+++ b/dist/configs/config/map/default.cfg
@@ -1,3 +1,8 @@
+// This file (config/map/default.cfg) is executed each time a new map is loaded.
+// In addition, map- and layout-specific configs will be executed if present:
+// - config/map/plat23.cfg (for map plat23)
+// - config/map/plat23/eggspam.cfg (for map plat23 and layout "eggspam")
+
 // define some bot names
 bot names clear
 bot names humans "^9[bot]^4 Clodomir" "^9[bot]^4 Alaric" "^9[bot]^4 Baudry" "^9[bot]^4 Adelin" "^9[bot]^4 Ferdinand" "^9[bot]^4 Brieux" "^9[bot]^4 Audran" "^9[bot]^4 Alistair" "^9[bot]^4 Renan" "^9[bot]^4 Malo"

--- a/dist/configs/config/server.cfg
+++ b/dist/configs/config/server.cfg
@@ -68,14 +68,6 @@ set g_teamForceBalance 2
 
 set g_bot_defaultFill 3
 
-// load per map config file from this subdirectory
-// it will load all the configs specified:
-//   - map/default.cfg (for every map)
-//   - map/plat23.cfg (for plat23, regardless of the layout)
-//   - map/plat23/layout.cfg (for plat23 and layout "layout")
-// map config files can be used to fill game with bots and set other useful configs.
-set g_mapConfigs "map"
-
 // following the first map, start this rotation
 // rotation is described in game/maprotation.cfg
 set g_initialMapRotation rotation1

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -173,7 +173,7 @@ Cvar::Cvar<bool> g_enableVsays("g_voiceChats", "allow vsays (prerecorded audio m
 Cvar::Cvar<float> g_shove("g_shove", "force multiplier when pushing players", Cvar::NONE, 0.0);
 Cvar::Cvar<bool> g_antiSpawnBlock("g_antiSpawnBlock", "push away players who block their spawns", Cvar::NONE, false);
 
-Cvar::Cvar<std::string> g_mapConfigs("g_mapConfigs", "map config directory, relative to <homepath>/config/", Cvar::NONE, "");
+Cvar::Cvar<std::string> g_mapConfigs("g_mapConfigs", "map config directory, relative to <homepath>/config/", Cvar::NONE, "map");
 Cvar::Cvar<float> g_sayAreaRange("g_sayAreaRange", "distance for area chat messages", Cvar::NONE, 1000);
 
 Cvar::Cvar<int> g_floodMaxDemerits("g_floodMaxDemerits", "client message rate control (lower = stricter)", Cvar::NONE, 5000);


### PR DESCRIPTION
Get rid of an unnecessary extra step when setting up a server.