### PR TITLE
improve listrotation display

### DIFF
--- a/src/sgame/sg_maprotation.cpp
+++ b/src/sgame/sg_maprotation.cpp
@@ -845,24 +845,24 @@ void G_PrintCurrentRotation( gentity_t *ent )
 			}
 		}
 
-		ADMBP( va( "^7%s%3i %s%s\n",
+		ADMBP( va( "^7%s%3i %s%s",
 		           ( currentMap && currentShown && !override ) ? MAP_CURRENT_MARKER : " ",
 		           i, colour, G_RotationNode_ToString( node ) ) );
 
 		while ( node->type == NT_CONDITION )
 		{
 			node = node->u.condition.target;
-			ADMBP( va( "%*s%s%s\n", indentation, "", colour, G_RotationNode_ToString( node ) ) );
+			ADMBP( va( "%*s%s%s", indentation, "", colour, G_RotationNode_ToString( node ) ) );
 			indentation += 2;
 		}
 
 		if ( override )
 		{
-			ADMBP( va( MAP_DEFAULT MAP_CURRENT_MARKER "    " MAP_CURRENT "%s\n", currentMapName ) ); // use current map colour here
+			ADMBP( va( MAP_DEFAULT MAP_CURRENT_MARKER "    " MAP_CURRENT "%s", currentMapName ) ); // use current map colour here
 		}
 		if ( currentMap && currentShown && G_MapExists( g_nextMap.Get().c_str() ) )
 		{
-			ADMBP( va( MAP_DEFAULT "     %s\n", g_nextMap.Get().c_str() ) );
+			ADMBP( va( MAP_DEFAULT "     %s", g_nextMap.Get().c_str() ) );
 			currentMap = false;
 		}
 	}
@@ -871,11 +871,11 @@ void G_PrintCurrentRotation( gentity_t *ent )
 	// (e.g. server just started up) and that entry is not for a map
 	if ( !currentShown )
 	{
-		ADMBP( va( MAP_DEFAULT MAP_CURRENT_MARKER "    " MAP_CURRENT "%s\n", currentMapName ) ); // use current map colour here
+		ADMBP( va( MAP_DEFAULT MAP_CURRENT_MARKER "    " MAP_CURRENT "%s", currentMapName ) ); // use current map colour here
 
 		if ( G_MapExists( g_nextMap.Get().c_str() ) )
 		{
-			ADMBP( va( MAP_DEFAULT "     %s\n", g_nextMap.Get().c_str() ) );
+			ADMBP( va( MAP_DEFAULT "     %s", g_nextMap.Get().c_str() ) );
 		}
 	}
 


### PR DESCRIPTION
Before:

![2022-08-30-194410_1366x768_scrot](https://user-images.githubusercontent.com/1316300/187507559-4dc29aed-a529-4238-bcdc-9b72f28ff55e.png)

After:

![2022-08-30-194502_1366x768_scrot](https://user-images.githubusercontent.com/1316300/187507566-91f6d739-a82f-4bfe-8c09-11792ccbcf21.png)

@cu-kai I know it does not fix much, but it's still a bit better when rotation have maaaaany maps :)