### PR TITLE
g_bot_defaultFill should default to 0

### DIFF
--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -266,7 +266,7 @@ Cvar::Cvar<bool> g_bot_attackStruct("g_bot_attackStruct", "whether bots target b
 Cvar::Cvar<float> g_bot_fov("g_bot_fov", "bots' \"field of view\"", Cvar::NONE, 125);
 Cvar::Cvar<int> g_bot_chasetime("g_bot_chasetime", "bots stop chasing after x ms out of sight", Cvar::NONE, 5000);
 Cvar::Cvar<int> g_bot_reactiontime("g_bot_reactiontime", "bots' reaction time to enemies (milliseconds)", Cvar::NONE, 500);
-Cvar::Callback<Cvar::Cvar<int>> g_bot_defaultFill("g_bot_defaultFill", "fills both teams with that number of bots at start of game", Cvar::NONE, 3, G_SetBotFill);
+Cvar::Callback<Cvar::Cvar<int>> g_bot_defaultFill("g_bot_defaultFill", "fills both teams with that number of bots at start of game", Cvar::NONE, 0, G_SetBotFill);
 Cvar::Cvar<bool> g_bot_infinite_funds("g_bot_infinite_funds", "give bots unlimited funds", Cvar::NONE, false);
 Cvar::Cvar<bool> g_bot_infiniteMomentum("g_bot_infiniteMomentum", "allow bots to ignore momentum, but not other restrictions", Cvar::NONE, false);
 


### PR DESCRIPTION
As discussed on IRC, we now use g_bot_defaultFill in the sample configs (`dist/configs/config/server.cfg`), but we don't want bots to be added by default for a server with no config.

```
<perturbed> that's the *example* config though
<perturbed> you shouldn't just have bots automatically if you start a server without any commands
<freem> good point. Guess it needs a PR to address that then
<illwieckz> we can add the autofill cvar in sample server.cfg but this cvar set to 0 by default
<illwieckz> so as a developer you do devmap, no bot
<illwieckz> you're a server owner, you download the sample, done
<freem> yes, so this needs a PR to change that
```