### PR TITLE
rmlui: Fix copypasta error in the <numSpawns/> element.

### DIFF
--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -2423,7 +2423,7 @@ public:
 			return;
 		}
 		spawns_ = newSpawns;
-		if ( spawns_ == 1 )
+		if ( spawns_ == 0 )
 		{
 			SetText( _( "There are no spawns remaining" ) );
 		}


### PR DESCRIPTION
The element would report no spawns remaining when there was one.