### PR TITLE
graphics: avoid ET_LEV2_ZAP_CHAIN undefined behavior

### DIFF
--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -1108,7 +1108,7 @@ static void CG_CEntityPVSLeave( centity_t *cent )
 	switch ( es->eType )
 	{
 		case entityType_t::ET_LEV2_ZAP_CHAIN:
-			for ( i = 0; i <= LEVEL2_AREAZAP_MAX_TARGETS; i++ )
+			for ( i = 0; i < LEVEL2_AREAZAP_MAX_TARGETS; i++ )
 			{
 				if ( CG_IsTrailSystemValid( &cent->level2ZapTS[ i ] ) )
 				{


### PR DESCRIPTION
Found by gcc:

```
/build/source/src/cgame/cg_trails.cpp:1514:14: warning: iteration 5 invokes undefined behavior
 1514 |         if ( *ts == nullptr || ( *ts && !( *ts )->valid ) )
      |              ^
/build/source/src/cgame/cg_ents.cpp:1111:40: note: within this loop
 1111 |                         for ( i = 0; i <= LEVEL2_AREAZAP_MAX_TARGETS; i++ )
      |                                        ^
```

(using https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Waggressive-loop-optimizations-Waggressive-loop-optimizations)

level2ZapTS has size LEVEL2_AREAZAP_MAX_TARGETS, and not one more.