### PR TITLE
check that bots are allowed to evolve/buy in ::allowed()

### DIFF
--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -127,19 +127,19 @@ bool equipment_t<weapon_t>::unlocked( void ) const
 template <>
 bool equipment_t<class_t>::allowed( void ) const
 {
-	return authorized.Get() && !BG_ClassDisabled( item );
+	return authorized.Get() && g_bot_evolve.Get() && !BG_ClassDisabled( item );
 }
 
 template <>
 bool equipment_t<upgrade_t>::allowed( void ) const
 {
-	return authorized.Get() && !BG_UpgradeDisabled( item );
+	return authorized.Get() && g_bot_buy.Get() && !BG_UpgradeDisabled( item );
 }
 
 template <>
 bool equipment_t<weapon_t>::allowed( void ) const
 {
-	return authorized.Get() && !BG_WeaponDisabled( item );
+	return authorized.Get() && g_bot_buy.Get() && !BG_WeaponDisabled( item );
 }
 
 // slots

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -134,6 +134,7 @@ bool equipment_t<class_t>::allowed( void ) const
 template <>
 bool equipment_t<upgrade_t>::allowed( void ) const
 {
+// HACK: only humans can buy equipment, so this should be fine for now.
 	return authorized.Get() && g_bot_buy.Get() && !BG_UpgradeDisabled( item );
 }
 

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -141,6 +141,7 @@ bool equipment_t<upgrade_t>::allowed( void ) const
 template <>
 bool equipment_t<weapon_t>::allowed( void ) const
 {
+// HACK: only humans can buy equipment, so this should be fine for now.
 	return authorized.Get() && g_bot_buy.Get() && !BG_WeaponDisabled( item );
 }
 

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -127,6 +127,7 @@ bool equipment_t<weapon_t>::unlocked( void ) const
 template <>
 bool equipment_t<class_t>::allowed( void ) const
 {
+// HACK: only aliens can "buy" classes, aka evolve, so this should work, for now.
 	return authorized.Get() && g_bot_evolve.Get() && !BG_ClassDisabled( item );
 }
 


### PR DESCRIPTION
This complements a change in #2190 while not conflicting.
Notably, this removes the need for https://github.com/Unvanquished/Unvanquished/pull/2190/commits/e34f6cd8e9c4f5ffdf379237552e5cc53314f4b3#diff-7efa7a4eedeb7b61fdb165d5390858216282e89de0c7009041d7004243d50303R507 to still check for `g_bot_evolve.Get()` as it makes little sense that the sg_bot_util.cpp functions do not do it already.

cc @necessarily-equal 