### PR TITLE
Fix spacing in name on chasing screen

### DIFF
--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -2907,8 +2907,8 @@ static void CG_Rocket_DrawMinimap()
 	}
 }
 
-#define FOLLOWING_STRING "following^7 "
-#define CHASING_STRING   "chasing^7 "
+#define FOLLOWING_STRING "following ^7"
+#define CHASING_STRING   "chasing ^7"
 static void CG_Rocket_DrawFollow()
 {
 	if ( cg.snap && cg.snap->ps.pm_flags & PMF_FOLLOW )


### PR DESCRIPTION
Look at the "Following $x" message in the middle bottom

| Before | After |
| --- | --- |
| ![Screenshot from 2022-09-11 15-49-20](https://user-images.githubusercontent.com/59283660/189531235-2c7d7355-64cb-4e73-b6be-67128d9ef1f4.png) | ![Screenshot from 2022-09-11 15-48-30](https://user-images.githubusercontent.com/59283660/189531251-f403f13a-529b-4e4f-add5-8a7fb36a6807.png) |

Fixup https://github.com/Unvanquished/Unvanquished/pull/2172