### PR TITLE
Fix bot pounce aim

### DIFF
--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1731,16 +1731,13 @@ void BotClassMovement( gentity_t *self, bool inAttackRange )
 
 float CalcAimPitch( gentity_t *self, glm::vec3 &targetPos, float launchSpeed )
 {
-	glm::vec3 startPos;
-	glm::vec3 forward, right, up;
-	glm::vec3 muzzle;
-
 	float g = self->client->ps.gravity;
 	float v = launchSpeed;
 
-	AngleVectors( VEC2GLM( self->s.origin ), &forward, &right, &up );
-	muzzle = G_CalcMuzzlePoint( self, forward );
-	startPos = muzzle;
+	glm::vec3 forward;
+	AngleVectors( VEC2GLM( self->client->ps.viewangles ), &forward, nullptr, nullptr );
+	const glm::vec3 muzzle = G_CalcMuzzlePoint( self, forward );
+	const glm::vec3 &startPos = muzzle;
 
 	// Project everything onto a 2D plane with initial position at (0,0)
 	// dz (Δz) is the difference in height and dr (Δr) the distance forward

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1766,6 +1766,15 @@ float CalcAimPitch( gentity_t *self, glm::vec3 &targetPos, float launchSpeed )
 float CalcPounceAimPitch( gentity_t *self, glm::vec3 &targetPos )
 {
 	vec_t speed = ( self->client->ps.stats[STAT_CLASS] == PCL_ALIEN_LEVEL3 ) ? LEVEL3_POUNCE_JUMP_MAG : LEVEL3_POUNCE_JUMP_MAG_UPG;
+
+	// Aim a bit higher to account for
+	// 1. enemies moving (often backwards when fighting)
+	// 2. bbox "mins" differences
+	// 3. and last but not least, to make it more likely that you pounce
+	//    *on them*, actually dealing damage
+	// This does still hit the enemy if it moves towards you
+	targetPos[2] += 32.0f; // aim 1m higher
+
 	return CalcAimPitch( self, targetPos, speed );
 
 	//in usrcmd angles, a positive angle is down, so multiply angle by -1


### PR DESCRIPTION
This is the spiritual successor to https://github.com/Unvanquished/Unvanquished/pull/2162.

This PR aim to improve offensive goon pounce, fixing half of https://github.com/Unvanquished/Unvanquished/issues/2151. It also fixes a bug that affects all pounce and barbs, addressing https://github.com/Unvanquished/Unvanquished/pull/2162#issuecomment-1237517027 too.