### PR TITLE
Ignore nobuild

### DIFF
--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -1598,7 +1598,7 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 
 		// Check surface permissions
 		bool invalid = (tr1.contents & (CUSTOM_CONTENTS_NOALIENBUILD | CUSTOM_CONTENTS_NOBUILD)) || (contents & (CUSTOM_CONTENTS_NOALIENBUILD | CUSTOM_CONTENTS_NOBUILD));
-		if ( invalid && !g_cheatIgnoreNobuild.Get() )
+		if ( invalid && !( g_cheats && g_cheatIgnoreNobuild.Get() ) )
 		{
 			reason = IBE_SURFACE;
 		}
@@ -1622,7 +1622,7 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 
 		// Check permissions
 		bool invalid = (tr1.contents & (CUSTOM_CONTENTS_NOHUMANBUILD | CUSTOM_CONTENTS_NOBUILD)) || (contents & (CUSTOM_CONTENTS_NOHUMANBUILD | CUSTOM_CONTENTS_NOBUILD));
-		if ( invalid && !g_cheatIgnoreNobuild.Get() )
+		if ( invalid && !( g_cheats && g_cheatIgnoreNobuild.Get() ) )
 		{
 			reason = IBE_SURFACE;
 		}

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -1598,7 +1598,7 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 
 		// Check surface permissions
 		bool invalid = (tr1.contents & (CUSTOM_CONTENTS_NOALIENBUILD | CUSTOM_CONTENTS_NOBUILD)) || (contents & (CUSTOM_CONTENTS_NOALIENBUILD | CUSTOM_CONTENTS_NOBUILD));
-		if ( invalid && !( g_cheats && g_cheatIgnoreNobuild.Get() ) )
+		if ( invalid && !g_cheatIgnoreNobuild.Get() )
 		{
 			reason = IBE_SURFACE;
 		}
@@ -1622,7 +1622,7 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 
 		// Check permissions
 		bool invalid = (tr1.contents & (CUSTOM_CONTENTS_NOHUMANBUILD | CUSTOM_CONTENTS_NOBUILD)) || (contents & (CUSTOM_CONTENTS_NOHUMANBUILD | CUSTOM_CONTENTS_NOBUILD));
-		if ( invalid && !( g_cheats && g_cheatIgnoreNobuild.Get() ) )
+		if ( invalid && !g_cheatIgnoreNobuild.Get() )
 		{
 			reason = IBE_SURFACE;
 		}

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -1598,7 +1598,7 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 
 		// Check surface permissions
 		bool invalid = (tr1.contents & (CUSTOM_CONTENTS_NOALIENBUILD | CUSTOM_CONTENTS_NOBUILD)) || (contents & (CUSTOM_CONTENTS_NOALIENBUILD | CUSTOM_CONTENTS_NOBUILD));
-		if ( invalid && !g_cheatIgnoreNobuild.Get() )
+		if ( invalid && !g_ignoreNobuild.Get() )
 		{
 			reason = IBE_SURFACE;
 		}
@@ -1622,7 +1622,7 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 
 		// Check permissions
 		bool invalid = (tr1.contents & (CUSTOM_CONTENTS_NOHUMANBUILD | CUSTOM_CONTENTS_NOBUILD)) || (contents & (CUSTOM_CONTENTS_NOHUMANBUILD | CUSTOM_CONTENTS_NOBUILD));
-		if ( invalid && !g_cheatIgnoreNobuild.Get() )
+		if ( invalid && !g_ignoreNobuild.Get() )
 		{
 			reason = IBE_SURFACE;
 		}

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -1597,8 +1597,8 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 		}
 
 		// Check surface permissions
-		if ( (tr1.contents & (CUSTOM_CONTENTS_NOALIENBUILD | CUSTOM_CONTENTS_NOBUILD))
-			|| (contents & (CUSTOM_CONTENTS_NOALIENBUILD | CUSTOM_CONTENTS_NOBUILD)) )
+		bool invalid = (tr1.contents & (CUSTOM_CONTENTS_NOALIENBUILD | CUSTOM_CONTENTS_NOBUILD)) || (contents & (CUSTOM_CONTENTS_NOALIENBUILD | CUSTOM_CONTENTS_NOBUILD));
+		if ( invalid && !g_cheatIgnoreNobuild.Get() )
 		{
 			reason = IBE_SURFACE;
 		}
@@ -1621,8 +1621,8 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 		}
 
 		// Check permissions
-		if ( (tr1.contents & (CUSTOM_CONTENTS_NOHUMANBUILD | CUSTOM_CONTENTS_NOBUILD))
-			|| (contents & (CUSTOM_CONTENTS_NOHUMANBUILD | CUSTOM_CONTENTS_NOBUILD)) )
+		bool invalid = (tr1.contents & (CUSTOM_CONTENTS_NOHUMANBUILD | CUSTOM_CONTENTS_NOBUILD)) || (contents & (CUSTOM_CONTENTS_NOHUMANBUILD | CUSTOM_CONTENTS_NOBUILD));
+		if ( invalid && !g_cheatIgnoreNobuild.Get() )
 		{
 			reason = IBE_SURFACE;
 		}

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -163,7 +163,7 @@ extern Cvar::Cvar<int> g_combatCooldown;
 extern Cvar::Range<Cvar::Cvar<int>> g_debugEntities;
 
 extern Cvar::Cvar<bool> g_instantBuilding;
-extern Cvar::Cvar<bool> g_cheatIgnoreNobuild;
+extern Cvar::Cvar<bool> g_ignoreNobuild;
 
 extern  Cvar::Cvar<float> g_evolveAroundHumans;
 extern  Cvar::Cvar<float> g_devolveMaxBaseDistance;

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -168,6 +168,7 @@ extern  Cvar::Cvar<float> g_evolveAroundHumans;
 extern  Cvar::Cvar<float> g_devolveMaxBaseDistance;
 
 extern Cvar::Cvar<int> g_maxMiners;
+extern Cvar::Cvar<bool> g_cheatIgnoreNobuild;
 
 // bots: buying weapons cvars
 extern Cvar::Cvar<bool> g_bot_buy;

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -163,12 +163,12 @@ extern Cvar::Cvar<int> g_combatCooldown;
 extern Cvar::Range<Cvar::Cvar<int>> g_debugEntities;
 
 extern Cvar::Cvar<bool> g_instantBuilding;
+extern Cvar::Cvar<bool> g_cheatIgnoreNobuild;
 
 extern  Cvar::Cvar<float> g_evolveAroundHumans;
 extern  Cvar::Cvar<float> g_devolveMaxBaseDistance;
 
 extern Cvar::Cvar<int> g_maxMiners;
-extern Cvar::Cvar<bool> g_cheatIgnoreNobuild;
 
 // bots: buying weapons cvars
 extern Cvar::Cvar<bool> g_bot_buy;

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -221,6 +221,7 @@ Cvar::Cvar<float>  g_devolveMaxBaseDistance("g_devolveMaxBaseDistance", "Max Ove
 Cvar::Cvar<bool>   g_autoPause("g_autoPause", "pause empty server", Cvar::NONE, false);
 
 Cvar::Cvar<int> g_maxMiners("g_maxMiners", "set maximum number of miners per team. -1 = disabled.", Cvar::NONE, -1);
+Cvar::Cvar<bool> g_cheatIgnoreNobuild("g_cheatIgnoreNobuild", "ignore nobuild area", Cvar::NONE, false);
 
 // <bot stuff>
 

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -210,6 +210,7 @@ Cvar::Cvar<int> g_combatCooldown("g_combatCooldown", "team change disallowed unt
 Cvar::Range<Cvar::Cvar<int>> g_debugEntities("g_debugEntities", "entity debug level", Cvar::NONE, 0, -2, 3);
 
 Cvar::Cvar<bool> g_instantBuilding("g_instantBuilding", "cheat mode for building", Cvar::NONE, false);
+Cvar::Cvar<bool> g_cheatIgnoreNobuild("g_cheatIgnoreNobuild", "ignore nobuild area", Cvar::NONE, false);
 
 Cvar::Cvar<int> g_emptyTeamsSkipMapTime("g_emptyTeamsSkipMapTime", "end game over x minutes if no real players", Cvar::NONE, 0);
 
@@ -221,7 +222,6 @@ Cvar::Cvar<float>  g_devolveMaxBaseDistance("g_devolveMaxBaseDistance", "Max Ove
 Cvar::Cvar<bool>   g_autoPause("g_autoPause", "pause empty server", Cvar::NONE, false);
 
 Cvar::Cvar<int> g_maxMiners("g_maxMiners", "set maximum number of miners per team. -1 = disabled.", Cvar::NONE, -1);
-Cvar::Cvar<bool> g_cheatIgnoreNobuild("g_cheatIgnoreNobuild", "ignore nobuild area", Cvar::NONE, false);
 
 // <bot stuff>
 

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -210,7 +210,7 @@ Cvar::Cvar<int> g_combatCooldown("g_combatCooldown", "team change disallowed unt
 Cvar::Range<Cvar::Cvar<int>> g_debugEntities("g_debugEntities", "entity debug level", Cvar::NONE, 0, -2, 3);
 
 Cvar::Cvar<bool> g_instantBuilding("g_instantBuilding", "cheat mode for building", Cvar::NONE, false);
-Cvar::Cvar<bool> g_cheatIgnoreNobuild("g_cheatIgnoreNobuild", "ignore nobuild area", Cvar::NONE, false);
+Cvar::Cvar<bool> g_cheatIgnoreNobuild("g_cheatIgnoreNobuild", "ignore nobuild area", Cvar::CHEAT, false);
 
 Cvar::Cvar<int> g_emptyTeamsSkipMapTime("g_emptyTeamsSkipMapTime", "end game over x minutes if no real players", Cvar::NONE, 0);
 

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -210,7 +210,7 @@ Cvar::Cvar<int> g_combatCooldown("g_combatCooldown", "team change disallowed unt
 Cvar::Range<Cvar::Cvar<int>> g_debugEntities("g_debugEntities", "entity debug level", Cvar::NONE, 0, -2, 3);
 
 Cvar::Cvar<bool> g_instantBuilding("g_instantBuilding", "cheat mode for building", Cvar::NONE, false);
-Cvar::Cvar<bool> g_cheatIgnoreNobuild("g_cheatIgnoreNobuild", "ignore nobuild area", Cvar::CHEAT, false);
+Cvar::Cvar<bool> g_ignoreNobuild("g_ignoreNobuild", "ignore nobuild area", Cvar::NONE, false);
 
 Cvar::Cvar<int> g_emptyTeamsSkipMapTime("g_emptyTeamsSkipMapTime", "end game over x minutes if no real players", Cvar::NONE, 0);
 


### PR DESCRIPTION
A cvar to ignore nobuild areas in maps, usable only when the map was loaded by /devmap.

Edit:
The cvar is called `g_cheatIgnoreNobuild`. Should it be called `g_cheat_ignoreNobuild` instead?