### PR TITLE
sgame: Send pmove_params on ClientBegin

### DIFF
--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -1188,8 +1188,6 @@ const char *ClientConnect( int clientNum, bool firstTime )
 	             client->pers.netname,
 	             client->pers.netname );
 
-	G_SendClientPmoveParams(clientNum);
-
 	// don't do the "xxx connected" messages if they were caried over from previous level
 	if ( firstTime )
 	{
@@ -1313,6 +1311,7 @@ void ClientBegin( int clientNum )
 		trap_UnlinkEntity( ent );
 	}
 
+	G_SendClientPmoveParams(clientNum);
 	G_InitGentity( ent );
 
 	// Create a basic client entity, will be replaced by a more specific one later.


### PR DESCRIPTION
Before they were being sent on ClientConnect. This is bad because the client doesn't actually process server commands at this time, so they get queued. They get queued with other potentially stale commands, so we don't want to carry them forward to the next game. Moving pmove_params here allows us to drop early commands which can load to bugs like the stuck scoreboard in #1102