### PR TITLE
chat: Show a chat bubble when players are typing.

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -808,7 +808,7 @@ static void CG_RegisterGraphics()
 	cgs.media.redCgrade = trap_R_RegisterShader("gfx/cgrading/red-only", (RegisterShaderFlags_t) ( RSF_NOMIP | RSF_NOLIGHTSCALE ) );
 	cgs.media.tealCgrade = trap_R_RegisterShader("gfx/cgrading/teal-only", (RegisterShaderFlags_t) ( RSF_NOMIP | RSF_NOLIGHTSCALE ) );
 
-	cgs.media.balloonShader = trap_R_RegisterShader("gfx/feedback/chatballoon", (RegisterShaderFlags_t) ( RSF_SPRITE | RSF_NOMIP ) );
+	cgs.media.balloonShader = trap_R_RegisterShader("gfx/feedback/chatballoon", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
 	cgs.media.disconnectPS = CG_RegisterParticleSystem( "particles/feedback/disconnect" );
 

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -2574,7 +2574,10 @@ static void CG_PlayerSprites( centity_t *cent )
 	if ( cent->currentState.eFlags & EF_CONNECTION )
 	{
 		CG_PlayerFloatSprite( cent, cgs.media.connectionShader );
-		return;
+	}
+	else if ( cent->currentState.eFlags & EF_TYPING )
+	{
+		CG_PlayerFloatSprite( cent, cgs.media.balloonShader );
 	}
 }
 

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -1880,7 +1880,8 @@ void CG_DrawActiveFrame( int serverTime, bool demoPlayback )
 	}
 
 	// let the client system know what our weapon and zoom settings are
-	trap_SetUserCmdValue( cg.weaponSelect, 0, cg.zoomSensitivity );
+	// also notify about our typing status.
+	trap_SetUserCmdValue( cg.weaponSelect, trap_Key_GetCatcher() ? UF_TYPING : 0x0, cg.zoomSensitivity );
 
 	if ( cg.clientFrame == 0 )
 	{

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -2249,6 +2249,14 @@ void ClientThink( int clientNum )
 
 	ent = g_entities + clientNum;
 	trap_GetUsercmd( clientNum, &ent->client->pers.cmd );
+	if ( ent->client->pers.cmd.flags & UF_TYPING )
+	{
+		ent->client->ps.eFlags |= EF_TYPING;
+	}
+	else
+	{
+		ent->client->ps.eFlags &= ~EF_TYPING;
+	}
 
 	// mark the time we got info, so we can display the phone jack if we don't get any for a while
 	ent->client->lastCmdTime = level.time;

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -472,7 +472,7 @@ enum persEnum_t
 #define EF_FIRING2          0x0400 // alt fire
 #define EF_FIRING3          0x0800 // third fire
 #define EF_MOVER_STOP       0x1000 // will push otherwise
-#define EF_UNUSED_2         0x2000 // UNUSED
+#define EF_TYPING           0x2000 // client is typing
 #define EF_CONNECTION       0x4000 // draw a connection trouble sprite
 #define EF_BLOBLOCKED       0x8000 // caught by a trapper
 
@@ -488,6 +488,9 @@ enum persEnum_t
 
 #define EF_BC_TAG_RELEVANT  (EF_BC_ENEMY|EF_BC_TAG_PLAYER)   // relevant flags for tags
 #define EF_BC_BASE_RELEVANT (EF_BC_ENEMY|EF_BC_BASE_OUTPOST) // relevant flags for bases
+
+// For usercmd_t flags
+#define UF_TYPING           BIT(0) // player is typing
 
 enum weaponMode_t
 {


### PR DESCRIPTION
This uses the usercmd flags which relate to input to note whether the game has input. Currently, AFAICT this field is unused, so we use it to transmit whether the client is typing. WE need to remove the RSF_SPRITE from the chatBubble thing because for some reason the chat bubble doesn't show with it.

Fixes #2217

![](https://i.imgur.com/QR4egg2.jpg)