### PR TITLE
Load information from `.arena` file on map load to display it on map loading screen

### DIFF
--- a/src/cgame/cg_gameinfo.cpp
+++ b/src/cgame/cg_gameinfo.cpp
@@ -42,7 +42,7 @@ static char *cg_arenaInfos[ MAX_ARENAS ];
 CG_ParseInfos
 ===============
 */
-int CG_ParseInfos( const char *buf, int max, char *infos[] )
+static int CG_ParseInfos( const char *buf, int max, char *infos[] )
 {
 	char *token;
 	int  count = 0;
@@ -120,7 +120,7 @@ CG_LoadArenasFromFile
 TODO: consider deleting, unless we want to display 'longname' somewhere
 ===============
 */
-void CG_LoadArenasFromFile( char *filename )
+static void CG_LoadArenasFromFile( char *filename )
 {
 	std::error_code err;
 	std::string text = FS::PakPath::ReadFile( filename, err );

--- a/src/cgame/cg_gameinfo.cpp
+++ b/src/cgame/cg_gameinfo.cpp
@@ -41,9 +41,10 @@ static std::vector<arenaInfo_t> arenaList;
 CG_ParseInfos
 ===============
 */
-static void CG_ParseInfos( const char *buf )
+static void CG_ParseInfos( Str::StringRef text )
 {
-	char *token;
+	const char *buf = text.c_str();
+	const char *token;
 	char key[ MAX_TOKEN_CHARS ];
 
 	while ( true )
@@ -84,7 +85,7 @@ static void CG_ParseInfos( const char *buf )
 
 			if ( !token[ 0 ] )
 			{
-				strcpy( token, "<NULL>" );
+				token = "<NULL>";
 			}
 
 			/* Standard in all games. */
@@ -166,7 +167,7 @@ static void CG_ParseInfos( const char *buf )
 CG_LoadArenasFromFile
 ===============
 */
-static bool CG_LoadArenasFromFile( std::string filename, bool legacy = false )
+static bool CG_LoadArenasFromFile( Str::StringRef filename, bool legacy = false )
 {
 	if ( legacy )
 	{
@@ -190,7 +191,7 @@ static bool CG_LoadArenasFromFile( std::string filename, bool legacy = false )
 		return false;
 	}
 
-	CG_ParseInfos( text.c_str() );
+	CG_ParseInfos( text );
 
 	return true;
 }
@@ -200,7 +201,7 @@ static bool CG_LoadArenasFromFile( std::string filename, bool legacy = false )
 CG_LoadArenas
 ===============
 */
-void CG_LoadArenas( std::string mapname )
+void CG_LoadArenas( Str::StringRef mapname )
 {
 	arenaList.clear();
 
@@ -238,7 +239,7 @@ void CG_LoadArenas( std::string mapname )
 	Log::Debug( "%i arenas parsed", arenaList.size() );
 }
 
-arenaInfo_t CG_GetArenaInfo( std::string mapName )
+arenaInfo_t CG_GetArenaInfo( Str::StringRef mapName )
 {
 	for ( arenaInfo_t &arenaInfo : arenaList )
 	{

--- a/src/cgame/cg_gameinfo.cpp
+++ b/src/cgame/cg_gameinfo.cpp
@@ -31,6 +31,174 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "common/FileSystem.h"
 #include "cg_local.h"
 
+//
+// arena info
+//
+static int  cg_numArenas;
+static char *cg_arenaInfos[ MAX_ARENAS ];
+
+/*
+===============
+CG_ParseInfos
+===============
+*/
+int CG_ParseInfos( const char *buf, int max, char *infos[] )
+{
+	char *token;
+	int  count = 0;
+	char key[ MAX_TOKEN_CHARS ];
+	char info[ MAX_INFO_STRING ];
+
+	auto infoPostfixLen = strlen( "\\num\\" ) + strlen( va( "%d", MAX_ARENAS ) );
+
+	while ( 1 )
+	{
+		token = COM_Parse( &buf );
+
+		if ( !token[ 0 ] )
+		{
+			break;
+		}
+
+		if ( strcmp( token, "{" ) )
+		{
+			Log::Notice( "Missing { in info file\n" );
+			break;
+		}
+
+		if ( count == max )
+		{
+			Log::Notice( "Max infos exceeded\n" );
+			break;
+		}
+
+		info[ 0 ] = '\0';
+
+		while ( 1 )
+		{
+			token = COM_ParseExt( &buf, true );
+
+			if ( !token[ 0 ] )
+			{
+				Log::Notice( "Unexpected end of info file\n" );
+				break;
+			}
+
+			if ( !strcmp( token, "}" ) )
+			{
+				break;
+			}
+
+			Q_strncpyz( key, token, sizeof( key ) );
+
+			token = COM_ParseExt( &buf, false );
+
+			if ( !token[ 0 ] )
+			{
+				strcpy( token, "<NULL>" );
+			}
+
+			Info_SetValueForKey( info, key, token, false );
+		}
+
+		//NOTE: extra space for arena number
+		infos[ count ] = (char*) BG_Alloc( strlen( info ) + infoPostfixLen + 1 );
+
+		if ( infos[ count ] )
+		{
+			strcpy( infos[ count ], info );
+			count++;
+		}
+	}
+
+	return count;
+}
+
+/*
+===============
+CG_LoadArenasFromFile
+TODO: consider deleting, unless we want to display 'longname' somewhere
+===============
+*/
+void CG_LoadArenasFromFile( char *filename )
+{
+	std::error_code err;
+	std::string text = FS::PakPath::ReadFile( filename, err );
+	if ( err )
+	{
+		Log::Warn( "file not found: %s", filename );
+		return;
+	}
+
+	if ( text.size() >= MAX_ARENAS_TEXT )
+	{
+		Log::Warn( "file too large: %s is %i, max allowed is %i",
+			filename, text.size(), MAX_ARENAS_TEXT );
+		return;
+	}
+
+	cg_numArenas += CG_ParseInfos( text.c_str(), MAX_ARENAS - cg_numArenas, &cg_arenaInfos[ cg_numArenas ] );
+}
+
+/*
+===============
+CG_MapLoadNameCompare
+===============
+*/
+static int CG_MapLoadNameCompare( const void *a, const void *b )
+{
+	arenaInfo_t *A = ( arenaInfo_t * ) a;
+	arenaInfo_t *B = ( arenaInfo_t * ) b;
+
+	return Q_stricmp( A->mapLoadName, B->mapLoadName );
+}
+
+/*
+===============
+CG_LoadArenas
+===============
+*/
+void CG_LoadArenas()
+{
+	int  numdirs;
+	char filename[ 128 ];
+	char dirlist[ 4096 ];
+	char *dirptr;
+	int  i, n;
+	int  dirlen;
+
+	cg_numArenas = 0;
+	rocketInfo.data.arenaCount = 0;
+
+	// get all directories from meta
+	numdirs = trap_FS_GetFileListRecursive( "meta", ".arena", dirlist, sizeof( dirlist ) );
+	dirptr = dirlist;
+
+	for ( i = 0; i < numdirs; i++, dirptr += dirlen + 1 )
+	{
+		dirlen = strlen( dirptr );
+		Q_strncpyz( filename, "meta/", sizeof filename );
+		Q_strcat( filename, sizeof filename, dirptr );
+		CG_LoadArenasFromFile( filename );
+	}
+
+	Log::Warn( S_SKIPNOTIFY "%i arenas parsed\n", cg_numArenas );
+
+	for ( n = 0; n < cg_numArenas; n++ )
+	{
+		rocketInfo.data.arenaList[ rocketInfo.data.arenaCount ].mapLoadName = BG_strdup( Info_ValueForKey( cg_arenaInfos[ n ], "map" ) );
+		rocketInfo.data.arenaList[ rocketInfo.data.arenaCount ].mapName = BG_strdup( Info_ValueForKey( cg_arenaInfos[ n ], "longname" ) );
+		rocketInfo.data.arenaCount++;
+
+		if ( rocketInfo.data.arenaCount >= MAX_ARENA_MAPS )
+		{
+			break;
+		}
+	}
+
+	qsort( rocketInfo.data.arenaList, rocketInfo.data.arenaCount, sizeof( mapInfo_t ), CG_MapLoadNameCompare );
+}
+
 /*
 ===============
 CG_LoadMapList

--- a/src/cgame/cg_gameinfo.cpp
+++ b/src/cgame/cg_gameinfo.cpp
@@ -33,10 +33,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /*
 ===============
-CG_LoadArenas
+CG_LoadMapList
 ===============
 */
-void CG_LoadArenas()
+void CG_LoadMapList()
 {
 	rocketInfo.data.mapList.clear();
 	for (const std::string& mapName : FS::GetAvailableMaps(false))

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1319,6 +1319,7 @@ struct rocketMenu_t
 #define MAX_OUTPUTS 16
 #define MAX_MODS 64
 #define MAX_DEMOS 256
+#define MAX_ARENA_MAPS 128
 
 struct server_t
 {
@@ -1354,6 +1355,12 @@ struct modInfo_t
 {
 	char *name;
 	char *description;
+};
+
+struct arenaInfo_t
+{
+	char *mapName;
+	char *mapLoadName;
 };
 
 struct mapInfo_t
@@ -1392,6 +1399,9 @@ struct rocketDataSource_t
 	char *demoList[ MAX_DEMOS ];
 	int demoCount;
 	int demoIndex;
+
+	arenaInfo_t arenaList[ MAX_ARENA_MAPS ];
+	int arenaCount;
 
 	std::vector<mapInfo_t> mapList;
 	int mapIndex;
@@ -2311,6 +2321,7 @@ float CG_Rocket_ProgressBarValue( Str::StringRef name );
 //
 // cg_gameinfo.c
 //
+void CG_LoadArenas();
 void CG_LoadMapList();
 
 //

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2320,8 +2320,8 @@ float CG_Rocket_ProgressBarValue( Str::StringRef name );
 //
 // cg_gameinfo.c
 //
-void CG_LoadArenas( std::string mapname );
-arenaInfo_t CG_GetArenaInfo( std::string mapName );
+void CG_LoadArenas( Str::StringRef mapname );
+arenaInfo_t CG_GetArenaInfo( Str::StringRef mapName );
 void CG_LoadMapList();
 
 //

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2311,7 +2311,7 @@ float CG_Rocket_ProgressBarValue( Str::StringRef name );
 //
 // cg_gameinfo.c
 //
-void CG_LoadArenas();
+void CG_LoadMapList();
 
 //
 // Rocket Functions

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1222,6 +1222,8 @@ struct cg_t
 	int                     upMoveTime;
 
 	/* loading */
+	std::string mapLongName;
+	std::string mapAuthors;
 	char                    loadingText[ MAX_LOADING_TEXT_LENGTH ];
 	float                   loadingFraction; // loading percentages
 	float                   mediaLoadingFraction;
@@ -1319,7 +1321,6 @@ struct rocketMenu_t
 #define MAX_OUTPUTS 16
 #define MAX_MODS 64
 #define MAX_DEMOS 256
-#define MAX_ARENA_MAPS 128
 
 struct server_t
 {
@@ -1359,8 +1360,9 @@ struct modInfo_t
 
 struct arenaInfo_t
 {
-	char *mapName;
-	char *mapLoadName;
+	std::string name;
+	std::string longName;
+	std::vector<std::string> authors;
 };
 
 struct mapInfo_t
@@ -1399,9 +1401,6 @@ struct rocketDataSource_t
 	char *demoList[ MAX_DEMOS ];
 	int demoCount;
 	int demoIndex;
-
-	arenaInfo_t arenaList[ MAX_ARENA_MAPS ];
-	int arenaCount;
 
 	std::vector<mapInfo_t> mapList;
 	int mapIndex;
@@ -2321,7 +2320,8 @@ float CG_Rocket_ProgressBarValue( Str::StringRef name );
 //
 // cg_gameinfo.c
 //
-void CG_LoadArenas();
+void CG_LoadArenas( std::string mapname );
+arenaInfo_t CG_GetArenaInfo( std::string mapName );
 void CG_LoadMapList();
 
 //

--- a/src/cgame/cg_rocket_datasource.cpp
+++ b/src/cgame/cg_rocket_datasource.cpp
@@ -1083,7 +1083,7 @@ static void CG_Rocket_SortPlayerList( const char*, const char *sortBy )
 static void CG_Rocket_BuildMapList( const char* )
 {
 	Rocket_DSClearTable( "mapList", "default" );
-	CG_LoadArenas();
+	CG_LoadMapList();
 
 	for ( size_t i = 0; i < rocketInfo.data.mapList.size(); ++i )
 	{

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -3467,9 +3467,14 @@ static void CG_Rocket_DrawLoadingText()
 	Rocket_SetInnerRML( cg.loadingText, 0 );
 }
 
+static void CG_Rocket_DrawLevelAuthors()
+{
+	Rocket_SetInnerRML( cg.mapAuthors.c_str(), RP_QUAKE );
+}
+
 static void CG_Rocket_DrawLevelName()
 {
-	Rocket_SetInnerRML( CG_ConfigString( CS_MESSAGE ), RP_QUAKE );
+	Rocket_SetInnerRML( cg.mapLongName.c_str(), RP_QUAKE );
 }
 
 static void CG_Rocket_DrawMOTD()
@@ -3622,6 +3627,7 @@ static const elementRenderCmd_t elementRenderCmdList[] =
 	{ "hostname", &CG_Rocket_DrawHostname, nullptr, ELEMENT_ALL },
 	{ "inventory", &CG_DrawHumanInventory, nullptr, ELEMENT_HUMANS },
 	{ "jetpack", &CG_Rocket_HaveJetpck, nullptr, ELEMENT_HUMANS },
+	{ "levelauthors", &CG_Rocket_DrawLevelAuthors, nullptr, ELEMENT_ALL },
 	{ "levelname", &CG_Rocket_DrawLevelName, nullptr, ELEMENT_ALL },
 	{ "loadingText", &CG_Rocket_DrawLoadingText, nullptr, ELEMENT_ALL },
 	{ "mine_rate", &CG_Rocket_DrawMineRate, nullptr, ELEMENT_BOTH },

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -1688,9 +1688,6 @@ void     BG_AddPredictableEventToPlayerstate( int newEvent, int eventParm, playe
 void     BG_PlayerStateToEntityState( playerState_t *ps, entityState_t *s, bool snap );
 void     BG_PlayerStateToEntityStateExtraPolate( playerState_t *ps, entityState_t *s, int time );
 
-#define MAX_ARENAS      1024
-#define MAX_ARENAS_TEXT 8192
-
 float    atof_neg( const char *token, bool allowNegative );
 int      atoi_neg( const char *token, bool allowNegative );
 


### PR DESCRIPTION
Load information from `.arena` file on map load to display it on map loading screen.

Requires this to display the data:

- https://github.com/UnvanquishedAssets/unvanquished_src.dpkdir/pull/161

Fixes: 

- https://github.com/Unvanquished/Unvanquished/issues/2114