### PR TITLE
rmlui: Bounds check the chat cursor.

### DIFF
--- a/src/cgame/rocket/rocketChatField.h
+++ b/src/cgame/rocket/rocketChatField.h
@@ -284,6 +284,10 @@ protected:
 
 	void MoveCursorForward()
 	{
+		if (cursor_character_index >= text.size() )
+		{
+			return;
+		}
 		cursor_character_index += Q_UTF8_Width( text.c_str() + cursor_character_index );
 	}
 


### PR DESCRIPTION
We let you move the cursor forward every time you press right, even if it is already at the end of the string, this can allow you to go past the end of the string when you try to enter the next character which can lead to a crash.

Thanks to @sweet235 for the report and repro instructions.

Fixes #2138