### PR TITLE
Fixes the energy resupply hint, for weapon types and reload places

### DIFF
--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -626,9 +626,9 @@ static void CG_Menu( int menuType, int arg )
 			break;
 
 		case MN_H_NOENERGYAMMOHERE:
-			longMsg = _("You must be near a Reactor or a powered Armoury "
+			longMsg = _("You must be near a Reactor, a Drill or a powered Armoury "
 			          "in order to purchase energy ammunition.");
-			shortMsg = _("You must be near a Reactor or a powered Armoury");
+			shortMsg = _("You must be near a Reactor, a Drill or a powered Armoury");
 			break;
 
 		case MN_H_NOROOMARMOURCHANGE:

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -351,29 +351,17 @@ static void CG_HumanText( char *text, playerState_t *ps )
 {
 	if ( !ps->ammo && !ps->clips && !BG_Weapon( ps->weapon )->infiniteAmmo )
 	{
-		//no ammo
-		switch ( ps->weapon )
+		// Need to resupply ammo
+		Q_strcat( text, MAX_TUTORIAL_TEXT, COLOR_ALARM );
+		if ( BG_Weapon( ps->weapon )->usesEnergy )
 		{
-			case WP_MACHINEGUN:
-			case WP_CHAINGUN:
-			case WP_SHOTGUN:
-			case WP_FLAMER:
-				Q_strcat( text, MAX_TUTORIAL_TEXT, COLOR_ALARM );
-				Q_strcat( text, MAX_TUTORIAL_TEXT,
-				          _( "Find an Armoury for more ammo\n" ) );
-				break;
-
-			case WP_LAS_GUN:
-			case WP_PULSE_RIFLE:
-			case WP_MASS_DRIVER:
-			case WP_LUCIFER_CANNON:
-				Q_strcat( text, MAX_TUTORIAL_TEXT, COLOR_ALARM );
-				Q_strcat( text, MAX_TUTORIAL_TEXT,
-				          _( "Find an Armoury or Reactor for more ammo\n" ) );
-				break;
-
-			default:
-				break;
+			Q_strcat( text, MAX_TUTORIAL_TEXT,
+				  _( "Find an Armoury, Drill or Reactor for more ammo\n" ) );
+		}
+		else
+		{
+			Q_strcat( text, MAX_TUTORIAL_TEXT,
+				  _( "Find an Armoury for more ammo\n" ) );
 		}
 	}
 	else


### PR DESCRIPTION
1. We can reload energy weapons at drills too
2. The mass driver isn't an energy weapon. Trying to keep the list up to date is bound to be outdated at times

Fixes what https://github.com/Unvanquished/Unvanquished/pull/2227 wanted to fix, and (hopefully) finishes implementing https://github.com/Unvanquished/gameplay/issues/33 / https://github.com/Unvanquished/Unvanquished/pull/1856 correctly.