### PR TITLE
fix condition inversion

### DIFF
--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -644,7 +644,7 @@ static void Cmd_Give_f( gentity_t *ent )
 		{
 			++end;
 			team = BG_PlayableTeamFromString( end );
-			if ( team != TEAM_NONE )
+			if ( team == TEAM_NONE )
 			{
 				team = G_Team( ent );
 			}


### PR DESCRIPTION
This prevented "/give momentum [amount] [team]" to work, while it was still working without any team specified.
Regression introduced by 84f7dda399ef9c6576ad6c7aa53ae7e6ff5b3fbc