### PR TITLE
cp: /cp doesn't conflict with any cgame commands

### DIFF
--- a/src/sgame/sg_svcmds.cpp
+++ b/src/sgame/sg_svcmds.cpp
@@ -693,7 +693,7 @@ static const struct svcmd
 	{ "alienWin",           false, Svcmd_TeamWin_f              },
 	{ "asay",               true,  Svcmd_MessageWrapper         },
 	{ "chat",               true,  Svcmd_MessageWrapper         },
-	{ "cp",                 true,  Svcmd_CenterPrint_f          },
+	{ "cp",                 false, Svcmd_CenterPrint_f          },
 	{ "dumpuser",           false, Svcmd_DumpUser_f             },
 	{ "eject",              false, Svcmd_EjectClient_f          },
 	{ "entityFire",         false, Svcmd_EntityFire_f           },


### PR DESCRIPTION
This allows admins to use /cp to center print stuff.