### PR TITLE
rmlui: Properly handle more edge cases in execForm

### DIFF
--- a/src/cgame/cg_rocket_events.cpp
+++ b/src/cgame/cg_rocket_events.cpp
@@ -222,9 +222,18 @@ static void CG_Rocket_EventExecForm()
 				*ss = 0;
 				Q_strcat( cmd, sizeof( cmd ), k );
 				Q_strcat( cmd, sizeof( cmd ), Info_ValueForKey( params, s + 1 ) );
+				k = ss + 1;
 			}
-
-			k = ss + 1;
+			else
+			{
+				Log::Warn("Unterminated $ in execForm: %s", CG_Argv( 1 ) );
+				return;
+			}
+		}
+		else
+		{
+			Q_strcat( cmd, sizeof( cmd ), k );
+			break;
 		}
 	}
 
@@ -337,5 +346,3 @@ void CG_Rocket_ProcessEvents()
 	}
 
 }
-
-


### PR DESCRIPTION
Before this change, execForm only worked if the Template was terminated by a $ and didn't work otherwise. This properly handles the other cases.

Fixes #2234