### PR TITLE
admin: Fix FIXME where ADMBP_* uses print_tr

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -2403,7 +2403,7 @@ bool G_admin_slap( gentity_t *ent )
 	{
 		ADMP( va( "%s %s", QQ( N_( "^3$1$:^* sorry, but your intended victim has a higher admin"
 		          " level than you" ) ), "slap" ) ); // todo: move this print to a single helper function
-		return false; 
+		return false;
 	}
 
 	const HealthComponent* health = vic->entity->Get<HealthComponent>();
@@ -2457,13 +2457,13 @@ bool G_admin_slap( gentity_t *ent )
 
 	if ( health->Alive() )
 	{
-		AP( va( "print_tr " QQ( N_( "^3slap:^* $1$^* slapped $2$ ^*$3$" ) ) " %s %s %s", 
-			 G_quoted_admin_name( ent ), Quote( vic->client->pers.netname ), 
+		AP( va( "print_tr " QQ( N_( "^3slap:^* $1$^* slapped $2$ ^*$3$" ) ) " %s %s %s",
+			 G_quoted_admin_name( ent ), Quote( vic->client->pers.netname ),
 			 ( damage > 0 ? Quote( va( "with %.0f damage", damage ) ) : QQ( "" ) ) ) );
 	} // only print the chat msg if they don't die. otherwise the MOD_SLAP event will suffice.
 
-	CPx( vic - g_entities, va( "cp_tr " QQ( N_( "[cross]$1$$2$ is not amused![cross]" ) ) " %s %s", 
-		G_quoted_admin_name( ent ), 
+	CPx( vic - g_entities, va( "cp_tr " QQ( N_( "[cross]$1$$2$ is not amused![cross]" ) ) " %s %s",
+		G_quoted_admin_name( ent ),
 		( health->Alive() ) ? "^7" : "^i" ) ); // if they die, make the text red
 
 	return true;
@@ -5626,12 +5626,33 @@ void G_admin_print_plural( gentity_t *ent, Str::StringRef m, int number )
 
 /*
 ================
+ G_admin_print_raw
+
+This function is used to print raw/untranslated things to the clients.
+
+ The supplied string is assumed to be quoted as needed.
+================
+*/
+void G_admin_print_raw( gentity_t *ent, Str::StringRef m )
+{
+	if ( ent )
+	{
+		trap_SendServerCommand( ent->s.number, va( "print %s", m.c_str() ) );
+	}
+	else
+	{
+		trap_SendServerCommand( -2, va( "print %s", m.c_str() ) );
+	}
+}
+
+
+/*
+================
  G_admin_buffer_begin, G_admin_buffer_print, G_admin_buffer_end,
 
  These function facilitates the ADMBP* defines, and output is as for ADMP().
 
  The supplied text is raw; it will be quoted but not marked translatable.
- FIXME: it actually is marked translatable (print_tr is used) but shouldn't be
 ================
 */
 void G_admin_buffer_begin()
@@ -5642,7 +5663,7 @@ void G_admin_buffer_begin()
 
 void G_admin_buffer_end( gentity_t *ent )
 {
-	G_admin_print( ent, G_EscapeServerCommandArg( g_bfb ) );
+	G_admin_print_raw( ent, G_EscapeServerCommandArg( g_bfb ) );
 }
 
 static inline void G_admin_buffer_print_raw( gentity_t *ent, Str::StringRef m, bool appendNewLine )


### PR DESCRIPTION
The strings sent via ADMBP_* are not translatable since they are built up incrementally, so create a new function for use with that function that sends the raw 'print' command instead of 'print_tr'.