### PR TITLE
chatbubble: Restrict when chatbubble is down

### DIFF
--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -2249,7 +2249,7 @@ void ClientThink( int clientNum )
 
 	ent = g_entities + clientNum;
 	trap_GetUsercmd( clientNum, &ent->client->pers.cmd );
-	if ( ent->client->pers.cmd.flags & UF_TYPING )
+	if ( ent->client->pers.cmd.flags & UF_TYPING && !( ent->r.svFlags & SVF_BOT ) && Entities::IsAlive( ent ) )
 	{
 		ent->client->ps.eFlags |= EF_TYPING;
 	}

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -408,6 +408,7 @@ void G_BotThink( gentity_t *self )
 	botCmdBuffer->rightmove = 0;
 	botCmdBuffer->upmove = 0;
 	botCmdBuffer->doubleTap = dtType_t::DT_NONE;
+	botCmdBuffer->flags = 0;
 
 	//acknowledge recieved server commands
 	//MUST be done


### PR DESCRIPTION
 - Ensure bots set the usercmd_t::flag to zero
 - Only set the EF_TYPING flag if the entity is alive and not a bot

This probably helps with #2248