### PR TITLE
Component-based entity iteration replacement for ForEntities

### DIFF
--- a/src/sgame/CBSE.h
+++ b/src/sgame/CBSE.h
@@ -4,14 +4,33 @@
 #ifndef CBSE_H_
 #define CBSE_H_
 
+#include "sg_local.h"
+
+template<typename T> constexpr int ComponentPriority(); // forward declaring from CBSEBackend.h
+
+// Component creating/destruction callbacks. These are used to enable iterating
+// over all entities with a given component.
+void RegisterComponentCreate(int entityNum, int componentNum);
+void RegisterComponentDestroy(int entityNum, int componentNum);
+
+template<typename T>
+void OnComponentCreate(T* component)
+{
+	RegisterComponentCreate(component->entity.oldEnt - g_entities, ComponentPriority<T>());
+}
+
+template<typename T>
+void OnComponentDestroy(T* component)
+{
+	RegisterComponentDestroy(component->entity.oldEnt - g_entities, ComponentPriority<T>());
+}
+
 // Add here any definitions, forward declarations and includes that provide all
 // the types used in the entities definition file (and thus the CBSE backend).
 // Make sure none of the includes in this file includes any header that is part
 // of the CBSE system.
 // You can also define helper macros for use in all components here.
 // ----------------
-
-#include "sg_local.h"
 
 /** A helper to register component thinkers. */
 #define REGISTER_THINKER(METHOD, SCHEDULER, PERIOD) \

--- a/src/sgame/Entities.cpp
+++ b/src/sgame/Entities.cpp
@@ -116,21 +116,21 @@ float Entities::HealthFraction(gentity_t const* ent) {
 bool Entities::AntiHumanRadiusDamage(Entity& entity, float amount, float range, meansOfDeath_t mod) {
 	bool hit = false;
 
-	ForEntities<HumanClassComponent>([&] (Entity& other, HumanClassComponent&) {
+	for (Entity& other : Entities::Having<HumanClassComponent>()) {
 		// Abort early if they have notarget enabled.
-		if (other.oldEnt->flags & FL_NOTARGET) return;
+		if (other.oldEnt->flags & FL_NOTARGET) continue;
 		// TODO: Add LocationComponent.
 		float distance = G_Distance(entity.oldEnt, other.oldEnt);
 		float damage   = amount * (1.0f - 0.7f * distance / range);
 
-		if (distance > range) return;
-		if (damage <= 0.0f) return;
-		if (!G_IsVisible(entity.oldEnt, other.oldEnt, MASK_SOLID)) return;
+		if (distance > range) continue;
+		if (damage <= 0.0f) continue;
+		if (!G_IsVisible(entity.oldEnt, other.oldEnt, MASK_SOLID)) continue;
 
 		if (other.Damage(damage, entity.oldEnt, {}, {}, DAMAGE_NO_LOCDAMAGE, mod)) {
 			hit = true;
 		}
-	});
+	}
 
 	return hit;
 }
@@ -141,20 +141,20 @@ bool Entities::KnockbackRadiusDamage(Entity& entity, float amount, float range, 
 	// FIXME: Only considering entities with HealthComponent.
 	// TODO: Allow ForEntities to iterate over all entities.
 	// NOTE: This will hurt entities with FL_NOTARGET enabled since it isn't really aiming at them.
-	ForEntities<HealthComponent>([&] (Entity& other, HealthComponent&) {
+	for (Entity& other : Entities::Having<HealthComponent>()) {
 		// TODO: Add LocationComponent.
 		float distance = G_Distance(entity.oldEnt, other.oldEnt);
 		float damage   = amount * (1.0f - distance / range);
 
-		if (damage <= 0.0f) return;
-		if (!G_IsVisible(entity.oldEnt, other.oldEnt, MASK_SOLID)) return;
+		if (damage <= 0.0f) continue;
+		if (!G_IsVisible(entity.oldEnt, other.oldEnt, MASK_SOLID)) continue;
 
 		glm::vec3 knockbackDir = VEC2GLM( other.oldEnt->s.origin ) - VEC2GLM( entity.oldEnt->s.origin );
 
 		if (other.Damage(damage, entity.oldEnt, {}, knockbackDir, DAMAGE_NO_LOCDAMAGE | DAMAGE_KNOCKBACK, mod)) {
 			hit = true;
 		}
-	});
+	}
 
 	return hit;
 }

--- a/src/sgame/components/AlienBuildableComponent.cpp
+++ b/src/sgame/components/AlienBuildableComponent.cpp
@@ -28,16 +28,16 @@ void AlienBuildableComponent::Think(int /*timeDelta*/) {
 	float creepSize = (float)BG_Buildable((buildable_t)entity.oldEnt->s.modelindex)->creepSize;
 
 	// Slow close humans.
-	ForEntities<HumanClassComponent>([&] (Entity& other, HumanClassComponent&) {
+	for (Entity& other : Entities::Having<HumanClassComponent>()) {
 		// TODO: Add LocationComponent.
-		if (G_Distance(entity.oldEnt, other.oldEnt) > creepSize) return;
+		if (G_Distance(entity.oldEnt, other.oldEnt) > creepSize) continue;
 
 		// TODO: Send (Creep)Slow message instead.
-		if (other.oldEnt->flags & FL_NOTARGET) return;
-		if (other.oldEnt->client->ps.groundEntityNum == ENTITYNUM_NONE) return;
+		if (other.oldEnt->flags & FL_NOTARGET) continue;
+		if (other.oldEnt->client->ps.groundEntityNum == ENTITYNUM_NONE) continue;
 		other.oldEnt->client->ps.stats[STAT_STATE] |= SS_CREEPSLOWED;
 		other.oldEnt->client->lastCreepSlowTime = level.time;
-	});
+	}
 }
 
 void AlienBuildableComponent::HandleDie(gentity_t* /*killer*/, meansOfDeath_t /*meansOfDeath*/) {

--- a/src/sgame/components/HealthComponent.cpp
+++ b/src/sgame/components/HealthComponent.cpp
@@ -1,5 +1,6 @@
 #include "HealthComponent.h"
 #include "math.h"
+#include "../Entities.h"
 
 static Log::Logger healthLogger("sgame.health");
 
@@ -266,13 +267,13 @@ void HealthComponent::ScaleDamageAccounts(float healthRestored) {
 	// Get total damage account and remember relevant clients.
 	float totalAccreditedDamage = 0.0f;
 	std::vector<Entity*> relevantClients;
-	ForEntities<ClientComponent>([&](Entity& other, ClientComponent&) {
+	for (Entity& other : Entities::Having<ClientComponent>()) {
 		float clientDamage = entity.oldEnt->credits[other.oldEnt->num()].value;
 		if (clientDamage > 0.0f) {
 			totalAccreditedDamage += clientDamage;
 			relevantClients.push_back(&other);
 		}
-	});
+	}
 
 	if (relevantClients.empty()) return;
 

--- a/src/sgame/components/HiveComponent.cpp
+++ b/src/sgame/components/HiveComponent.cpp
@@ -53,15 +53,15 @@ void HiveComponent::Think(int /*timeDelta*/) {
 Entity* HiveComponent::FindTarget() {
 	Entity* target = nullptr;
 
-	ForEntities<HumanClassComponent>([&](Entity& candidate, HumanClassComponent&) {
+	for (Entity& candidate : Entities::Having<HumanClassComponent>()) {
 		// Check if target is valid and in sense range.
-		if (!TargetValid(candidate, true)) return;
+		if (!TargetValid(candidate, true)) continue;
 
 		// Check if better target.
 		if (!target || CompareTargets(candidate, *target)) {
 			target = &candidate;
 		}
-	});
+	}
 
 	return target;
 }

--- a/src/sgame/components/IgnitableComponent.cpp
+++ b/src/sgame/components/IgnitableComponent.cpp
@@ -204,16 +204,16 @@ void IgnitableComponent::ConsiderSpread(int /*timeDelta*/) {
 
 	fireLogger.Notice("Trying to spread.");
 
-	ForEntities<IgnitableComponent>([&](Entity &other, IgnitableComponent &ignitable){
-		if (&other == &entity) return;
+	for (Entity& other : Entities::Having<IgnitableComponent>()) {
+		if (&other == &entity) continue;
 
 		// Don't re-ignite.
-		if (ignitable.onFire) return;
+		if (other.Get<IgnitableComponent>()->onFire) continue;
 
 		// TODO: Use LocationComponent.
 		float distance = G_Distance(other.oldEnt, entity.oldEnt);
 
-		if (distance > SPREAD_RADIUS) return;
+		if (distance > SPREAD_RADIUS) continue;
 
 		float distanceFrac = distance / SPREAD_RADIUS;
 		float distanceMod  = 1.0f - distanceFrac;
@@ -225,7 +225,7 @@ void IgnitableComponent::ConsiderSpread(int /*timeDelta*/) {
 				                  spreadChance*100.0f);
 			}
 		}
-	});
+	}
 
 	// Don't spread again until re-ignited.
 	spreadAt = INT_MAX;

--- a/src/sgame/components/IgnitableComponent.cpp
+++ b/src/sgame/components/IgnitableComponent.cpp
@@ -23,6 +23,7 @@ along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>
 */
 
 #include "IgnitableComponent.h"
+#include "../Entities.h"
 
 static Log::Logger fireLogger("sgame.fire");
 
@@ -163,20 +164,20 @@ void IgnitableComponent::ConsiderStop(int timeDelta) {
 	float averagePostMinBurnTime = BASE_AVERAGE_BURN_TIME - MIN_BURN_TIME;
 
 	// Increase average burn time dynamically for burning entities in range.
-	ForEntities<IgnitableComponent>([&](Entity &other, IgnitableComponent &ignitable){
-		if (&other == &entity) return;
-		if (!ignitable.onFire) return;
+	for (IgnitableComponent& ignitable : Entities::Each<IgnitableComponent>()) {
+		if (&ignitable == this) continue;
+		if (!ignitable.onFire) continue;
 
 		// TODO: Use LocationComponent.
-		float distance = G_Distance(other.oldEnt, entity.oldEnt);
+		float distance = G_Distance(ignitable.entity.oldEnt, entity.oldEnt);
 
-		if (distance > EXTRA_BURN_TIME_RADIUS) return;
+		if (distance > EXTRA_BURN_TIME_RADIUS) continue;
 
 		float distanceFrac = distance / EXTRA_BURN_TIME_RADIUS;
 		float distanceMod  = 1.0f - distanceFrac;
 
 		averagePostMinBurnTime += EXTRA_AVERAGE_BURN_TIME * distanceMod;
-	});
+	}
 
 	// The burn stop chance follows an exponential distribution.
 	float lambda = 1.0f / averagePostMinBurnTime;

--- a/src/sgame/components/OvermindComponent.cpp
+++ b/src/sgame/components/OvermindComponent.cpp
@@ -50,24 +50,24 @@ void OvermindComponent::Think(int timeDelta) {
 Entity* OvermindComponent::FindTarget() {
 	Entity* target = nullptr;
 
-	ForEntities<ClientComponent>([&](Entity& candidate, ClientComponent&) {
+	for (Entity& candidate : Entities::Having<ClientComponent>()) {
 		// Do not target spectators.
-		if (candidate.Get<SpectatorComponent>()) return;
+		if (candidate.Get<SpectatorComponent>()) continue;
 
 		// Do not target dead entities.
-		if (Entities::IsDead(candidate)) return;
+		if (Entities::IsDead(candidate)) continue;
 
 		// Respect the no-target flag.
-		if ((candidate.oldEnt->flags & FL_NOTARGET)) return;
+		if ((candidate.oldEnt->flags & FL_NOTARGET)) continue;
 
 		// Check for line of sight.
-		if (!G_LineOfSight(entity.oldEnt, candidate.oldEnt, MASK_SOLID, false)) return;
+		if (!G_LineOfSight(entity.oldEnt, candidate.oldEnt, MASK_SOLID, false)) continue;
 
 		// Check if better target.
 		if (!target || CompareTargets(candidate, *target)) {
 			target = &candidate;
 		}
-	});
+	}
 
 	return target;
 }

--- a/src/sgame/components/ReactorComponent.cpp
+++ b/src/sgame/components/ReactorComponent.cpp
@@ -1,4 +1,5 @@
 #include "ReactorComponent.h"
+#include "../Entities.h"
 
 const float ReactorComponent::ATTACK_RANGE  = 200.0f;
 const float ReactorComponent::ATTACK_DAMAGE = 25.0f;
@@ -18,24 +19,24 @@ void ReactorComponent::Think(int timeDelta) {
 	float baseDamage = ATTACK_DAMAGE * ((float)timeDelta / 1000.0f);
 
 	// Zap close enemies.
-	ForEntities<AlienClassComponent>([&](Entity& other, AlienClassComponent&) {
+	for (Entity& other : Entities::Having<AlienClassComponent>()) {
 		// Respect the no-target flag.
-		if (other.oldEnt->flags & FL_NOTARGET) return;
+		if (other.oldEnt->flags & FL_NOTARGET) continue;
 
 		// Don't zap through walls
-		if ( !G_LineOfSight( entity.oldEnt, other.oldEnt, MASK_SOLID, false ) ) return;
+		if ( !G_LineOfSight( entity.oldEnt, other.oldEnt, MASK_SOLID, false ) ) continue;
 
 		// TODO: Add LocationComponent and Utility::BBOXDistance.
 		float distance = G_Distance(entity.oldEnt, other.oldEnt);
 
-		if (distance >= ATTACK_RANGE) return;
+		if (distance >= ATTACK_RANGE) continue;
 
 		float damage = baseDamage * (1.0f - (0.7f * distance / ATTACK_RANGE));
 
 		CreateTeslaTrail(other);
 
 		other.Damage(damage, entity.oldEnt, {}, {}, 0, MOD_REACTOR);
-	});
+	}
 }
 
 void ReactorComponent::CreateTeslaTrail(Entity& target) {

--- a/src/sgame/components/RocketpodComponent.cpp
+++ b/src/sgame/components/RocketpodComponent.cpp
@@ -223,14 +223,10 @@ bool RocketpodComponent::SafeShot(int passEntityNumber, const glm::vec3& origin,
 bool RocketpodComponent::EnemyClose() {
 	const missileAttributes_t* missileAttributes = BG_Missile(MIS_ROCKET);
 
-	bool enemyClose = false;
-
-	ForEntities<ClientComponent>([&](Entity& other, ClientComponent&) {
-		if (enemyClose) return;
-
-		if (other.Get<SpectatorComponent>()) return;
-		if (Entities::IsDead(other)) return;
-		if (!Entities::OnOpposingTeams(entity, other)) return;
+	for (Entity& other : Entities::Having<ClientComponent>()) {
+		if (other.Get<SpectatorComponent>()) continue;
+		if (Entities::IsDead(other)) continue;
+		if (!Entities::OnOpposingTeams(entity, other)) continue;
 
 		float distance = G_Distance(entity.oldEnt, other.oldEnt);
 
@@ -252,11 +248,11 @@ bool RocketpodComponent::EnemyClose() {
 		float safetyDistance = splashRadius + turretRadius;
 
 		if (closestExplosionCenter < safetyDistance) {
-			enemyClose = true;
+			return true;
 		}
-	});
+	}
 
-	return enemyClose;
+	return false;
 }
 
 void RocketpodComponent::Shoot() {

--- a/src/sgame/components/TurretComponent.cpp
+++ b/src/sgame/components/TurretComponent.cpp
@@ -62,13 +62,13 @@ Entity* TurretComponent::FindEntityTarget(std::function<bool(Entity&, Entity&)> 
 
 	// Search best target.
 	// TODO: Iterate over all valid targets, do not assume they have to be clients.
-	ForEntities<ClientComponent>([&](Entity& candidate, ClientComponent&) {
+	for (Entity& candidate : Entities::Having<ClientComponent>()) {
 		if (TargetValid(candidate, true)) {
 			if (!target || CompareTargets(candidate, *target->entity)) {
 				target = candidate.oldEnt;
 			}
 		}
-	});
+	}
 
 	if (target) {
 		// TODO: Increase tracked-by counter for a new target.

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -168,17 +168,17 @@ static botEntityAndDistance_t ClosestBuilding(gentity_t *self, bool alignment)
 	botEntityAndDistance_t result;
 	result.distance = HUGE_QFLT;
 	result.ent = nullptr;
-	ForEntities<BuildableComponent>([&](Entity& e, BuildableComponent&) {
+	for (Entity& e : Entities::Having<BuildableComponent>()) {
 		if (!e.Get<HealthComponent>()->Alive() ||
 		    (e.Get<TeamComponent>()->Team() == G_Team(self)) != alignment) {
-			return;
+			continue;
 		}
 		float distance = G_Distance(self, e.oldEnt);
 		if (distance < result.distance) {
 			result.distance = distance;
 			result.ent = e.oldEnt;
 		}
-	});
+	}
 	return result;
 }
 

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1678,11 +1678,11 @@ static void ListTeamEquipment( gentity_t *self, unsigned int (&numUpgrades)[UP_N
 	ASSERT( self );
 	const team_t team = static_cast<team_t>( self->client->pers.team );
 
-	ForEntities<HumanClassComponent>([&](Entity& ent, HumanClassComponent&) {
+	for (Entity& ent : Entities::Having<HumanClassComponent>()) {
 		gentity_t* ally = ent.oldEnt;
 		if ( ally == self || ally->client->pers.team != team )
 		{
-			return;
+			continue;
 		}
 		++numWeapons[ally->client->ps.stats[STAT_WEAPON]];
 
@@ -1698,7 +1698,7 @@ static void ListTeamEquipment( gentity_t *self, unsigned int (&numUpgrades)[UP_N
 				++numUpgrades[up];
 			}
 		}
-	});
+	}
 }
 
 bool BotTeamateHasWeapon( gentity_t *self, int weapon )

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -78,7 +78,8 @@ static gentity_t *LookUpMainBuildable(bool requireActive)
 }
 
 gentity_t *G_Overmind() {
-	return LookUpMainBuildable<OvermindComponent>(false);
+	Entity* ent = Entities::AnyWith<OvermindComponent>();
+	return ent ? ent->oldEnt : nullptr;
 }
 
 gentity_t *G_ActiveOvermind() {
@@ -1706,13 +1707,13 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 	if ( max_miners >= 0 && ( buildable == BA_H_DRILL || buildable == BA_A_LEECH ) )
 	{
 		int miners = 0;
-		ForEntities<MiningComponent> ( [&](Entity& entity, MiningComponent& )
+		for (Entity& entity : Entities::Having<MiningComponent>())
 		{
 			if ( Entities::IsAlive(entity) && G_OnSameTeam( entity.oldEnt, ent ) )
 			{
 				miners++;
 			}
-		});
+		}
 		if ( miners >= max_miners )
 		{
 			return ent->client->pers.team == TEAM_HUMANS ? IBE_NOMOREDRILLS : IBE_NOMORELEECHES;

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -2464,16 +2464,17 @@ void G_RunFrame( int levelTime )
 	}
 
 	// ThinkingComponent should have been called already but who knows maybe we forgot some.
-	ForEntities<ThinkingComponent>([](Entity& entity, ThinkingComponent& thinkingComponent) {
+	for (ThinkingComponent& thinkingComponent : Entities::Each<ThinkingComponent>()) {
 		// A newly created entity can randomly run things, or not, in the above loop over
 		// entities depending on whether it was added in a hole in g_entities or at the end, so
 		// ignore the entity if it was created this frame.
-		if (entity.oldEnt->creationTime != level.time && thinkingComponent.GetLastThinkTime() != level.time
-			&& !entity.oldEnt->freeAfterEvent) {
+		if (thinkingComponent.entity.oldEnt->creationTime != level.time
+			&& thinkingComponent.GetLastThinkTime() != level.time
+			&& !thinkingComponent.entity.oldEnt->freeAfterEvent) {
 			Log::Warn("ThinkingComponent was not called");
 			thinkingComponent.Think();
 		}
-	});
+	}
 
 	// perform final fixups on the players
 	ent = &g_entities[ 0 ];
@@ -2540,9 +2541,9 @@ void G_PrepareEntityNetCode() {
 	}
 
 	// Prepare netcode for specs
-	ForEntities<SpectatorComponent>([&](Entity& entity, SpectatorComponent&){
+	for (Entity& entity : Entities::Having<SpectatorComponent>()) {
 		entity.PrepareNetCode();
-	});
+	}
 }
 
 Str::StringRef G_NextMapCommand()


### PR DESCRIPTION
A drop-in replacement for ForEntities that can be used in a for-each loop (instead of in a lambda) and uses a bit vector to track components instead of `std::set`s. There are companion branches in Daemon (for CountTrailingZeroes) and CBSE (for RegisterComponentCreate/Destroy).

If this is accepted, I'd replace all ForEntities occurrences and remove the component `std::set`s and ForEntities from CBSE.

I made some performance measurements of selected ForEntities occurrences with the existing code and with Entities::Having. I also prepared code to test with the recently introduced `sg_entities_iterator` code, but it crashed so I couldn't produce any results.

```
with ForEntities:
activereac N=24240 min=0us max=25us avg=0us tot=1705us
forbuildable N=7 min=0us max=16us avg=8us tot=57us
forclient N=2114 min=0us max=192us avg=6us tot=12942us

with Entities::Having:
activereac N=24500 min=0us max=24us avg=0us tot=1581us
forbuildable N=7 min=0us max=5us avg=4us tot=33us
forclient N=2116 min=0us max=6us avg=0us tot=158us
```

I did the tests on `operation-dretch`, which has about 450 entities before anyone starts playing, and added 10 bots for 1 minute. `activereac` is a loop over ReactorComponent which would be expected to favor ForEntities since there is only 1 element (but my code was somehow still faster). `forbuildable` is a loop over BuildableComponent which is expected to favor my code because there are over 200 buildable entities. `forclient` is somewhere in the middle (there are 20). On these more dense loops my code is also faster as expected.

I can push the timing code if anyone wants to see it. It only runs on Windows though.