### PR TITLE
GLM: remove last Math::Vec3 in gamelogic

### DIFF
--- a/src/sgame/BaseClustering.cpp
+++ b/src/sgame/BaseClustering.cpp
@@ -39,7 +39,7 @@ namespace Clustering {
 			{}
 
 			void Update(gentity_t *ent) {
-				super::Update(ent, point_type::Load(ent->s.origin));
+				super::Update(ent, VEC2GLM(ent->s.origin));
 			}
 
 			/**
@@ -128,7 +128,7 @@ namespace BaseClustering {
 			// Trace from mean buildable's origin towards cluster center, so that the beacon does
 			// not spawn inside a wall. Then use MoveTowardsRoom on the trace results.
 			trace_t tr;
-			trap_Trace(&tr, mean->s.origin, nullptr, nullptr, center.Data(), 0, MASK_SOLID, 0);
+			trap_Trace(&tr, mean->s.origin, nullptr, nullptr, &center[0], 0, MASK_SOLID, 0);
 			Beacon::MoveTowardsRoom(tr.endpos);
 
 			// Prepare beacon flags.
@@ -139,7 +139,7 @@ namespace BaseClustering {
 			// If a fitting beacon close to the target location already exists, move it silently,
 			// otherwise add a new one.
 			gentity_t *beacon;
-			if (!(beacon = Beacon::MoveSimilar(center.Data(), tr.endpos, BCT_BASE, 0, team, 0,
+			if (!(beacon = Beacon::MoveSimilar(&center[0], tr.endpos, BCT_BASE, 0, team, 0,
 			                                   baseRadius, eFlags, EF_BC_BASE_RELEVANT))) {
 				beacon = Beacon::New(tr.endpos, BCT_BASE, (int)baseRadius, team );
 				beacon->s.eFlags |= eFlags;

--- a/src/sgame/components/TurretComponent.h
+++ b/src/sgame/components/TurretComponent.h
@@ -105,13 +105,13 @@ class TurretComponent: public TurretComponentBase {
 		 */
 		bool TargetValid(Entity& target, bool newTarget);
 
-		Vec3 TorsoAngles() const;
-		Vec3 RelativeAnglesToAbsoluteAngles(const Vec3 relativeAngles) const;
-		Vec3 AbsoluteAnglesToRelativeAngles(const Vec3 absoluteAngles) const;
-		Vec3 DirectionToAbsoluteAngles(const Vec3 direction) const;
-		Vec3 DirectionToRelativeAngles(const Vec3 direction) const;
-		Vec3 AbsoluteAnglesToDirection(const Vec3 absoluteAngles) const;
-		Vec3 RelativeAnglesToDirection(const Vec3 relativeAngles) const;
+		glm::vec3 TorsoAngles() const;
+		glm::vec3 RelativeAnglesToAbsoluteAngles(const glm::vec3 relativeAngles) const;
+		glm::vec3 AbsoluteAnglesToRelativeAngles(const glm::vec3 absoluteAngles) const;
+		glm::vec3 DirectionToAbsoluteAngles(const glm::vec3 direction) const;
+		glm::vec3 DirectionToRelativeAngles(const glm::vec3 direction) const;
+		glm::vec3 AbsoluteAnglesToDirection(const glm::vec3 absoluteAngles) const;
+		glm::vec3 RelativeAnglesToDirection(const glm::vec3 relativeAngles) const;
 
 		/** An entity target that the turret can track. */
 		gentity_t* target;
@@ -120,13 +120,13 @@ class TurretComponent: public TurretComponentBase {
 		float range;
 
 		/** The turret's target direction after construction and a direction reset. */
-		Vec3 baseDirection;
+		glm::vec3 baseDirection;
 
 		/** The direction that the head will move to when asked to make a move. */
-		Vec3 directionToTarget;
+		glm::vec3 directionToTarget;
 
 		/** The angle of the turret's head orientation relative to the turret's torso. */
-		Vec3 relativeAimAngles;
+		glm::vec3 relativeAimAngles;
 
 		/** A timer used to forget about targets that were behind cover for a while. */
 		int lastLineOfSightToTarget;

--- a/src/shared/Clustering.h
+++ b/src/shared/Clustering.h
@@ -22,6 +22,7 @@ along with Unvanquished. If not, see <http://www.gnu.org/licenses/>.
 ===========================================================================
 */
 
+#include <glm/geometric.hpp>
 namespace Clustering {
 	/**
 	 * @brief A cluster of objects located in euclidean space.
@@ -29,7 +30,7 @@ namespace Clustering {
 	template <typename Data, int Dim>
 	class EuclideanCluster {
 		public:
-			using point_type  = Math::Vector<Dim, float>;
+			using point_type  = glm::vec<Dim, float>;
 			using record_type = std::pair<const Data, point_type>;
 			using iter_type   = typename std::unordered_map<Data, point_type>::const_iterator;
 
@@ -124,7 +125,7 @@ namespace Clustering {
 				// Find average distance and mean object
 				for (auto& record : records) {
 					point_type& location = record.second;
-					float distance = Distance(location, center);
+					float distance = glm::distance(location, center);
 					averageDistance += distance;
 					if (distance < smallestDistance) {
 						smallestDistance = distance;
@@ -135,7 +136,7 @@ namespace Clustering {
 
 				// Find standard deviation
 				for (auto& record : records) {
-					float deviation = averageDistance - Distance(record.second, center);
+					float deviation = averageDistance - glm::distance(record.second, center);
 					standardDeviation += deviation * deviation;
 				}
 				standardDeviation = sqrtf(standardDeviation / size);
@@ -200,7 +201,7 @@ namespace Clustering {
 				// Iterate over all other objects and save the distance.
 				for (const vertex_record_type& record : records) {
 					if (edgeVisCallback == nullptr || edgeVisCallback(data, record.first)) {
-						float distance = Distance(location, record.second);
+						float distance = glm::distance(location, record.second);
 						edges.emplace(distance, edge_type(data, record.first));
 					}
 				}


### PR DESCRIPTION
There were 2 files left using it. For one of them I picked a commit from @bmorel and the other I wrote myself since on the glm-complete branch there were a bunch of commits and whitespace changes mixed in.