### PR TITLE
Ignore geometry and movers (doors) in bot obstacle collision code

### DIFF
--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -540,6 +540,15 @@ static bool BotAvoidObstacles( gentity_t *self, glm::vec3 &dir )
 		return false;
 	}
 
+	// ignore some stuff like geometry, movers...
+	switch( blocker->s.eType )
+	{
+		case entityType_t::ET_GENERAL:
+		case entityType_t::ET_MOVER:
+			return false;
+		default:
+			break;
+	}
 	if ( BotShouldJump( self, blocker, dir ) )
 	{
 		BotJump( self );


### PR DESCRIPTION
Rationale:
	You don't need collision tracking to navigate the geometry,
	as navmesh handles it fine, and you don't want to avoid running
	towards the doors.

Expected result:
	This notably improves navigation in vents like raktar's vent and
	avoid bots reseting their goal when encountering a door, or
	trying to walk "around" the door, which makes them look weird.

This is a backport from freem's work
https://github.com/bmorel/Unvanquished/commit/57e3f499256222533606728f1751178a1b5a29c4#diff-5e89a091ba410e0ad4b145236fcaae663f846cb9c374277426db8e20ed525e08R525-R533