### PR TITLE
Bot heal improvements

### DIFF
--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1328,16 +1328,7 @@ AINodeStatus_t BotActionBuy( gentity_t *self, AIGenericNode_t *node )
 
 	if ( self->botMind->currentNode != node )
 	{
-		botEntityAndDistance_t *ngoal;
-
-		ngoal = &self->botMind->closestBuildings[ BA_H_ARMOURY ];
-
-		if ( !ngoal->ent )
-		{
-			return STATUS_FAILURE; // no suitable goal found
-		}
-
-		if ( !BotChangeGoalEntity( self, ngoal->ent ) )
+		if ( !BotChangeGoalEntity( self, self->botMind->closestBuildings[ BA_H_ARMOURY ].ent ) )
 		{
 			return STATUS_FAILURE;
 		}

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1087,7 +1087,7 @@ AINodeStatus_t BotActionHeal( gentity_t *self, AIGenericNode_t *node )
 			return STATUS_FAILURE;
 		}
 
-		if ( !BotChangeGoalEntity( self, BotGetHealTarget( self ) ) )
+		if ( !BotChangeGoalEntity( self, BotGetHealTarget( self ).ent ) )
 		{
 			return STATUS_FAILURE;
 		}

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -221,6 +221,46 @@ Scoring functions for logic
 =======================
 */
 
+botEntityAndDistance_t BotGetClosestBuildingAmongTypes(
+		gentity_t *self, const std::initializer_list<buildable_t> buildables )
+{
+	botEntityAndDistance_t best_choice = { nullptr, 1.0e30f };
+	for ( buildable_t buildable : buildables )
+	{
+		botEntityAndDistance_t candidate =
+			self->botMind->closestBuildings[ buildable ];
+		if ( candidate.ent && candidate.distance < best_choice.distance )
+		{
+			best_choice = candidate;
+		}
+	}
+	return best_choice;
+}
+
+const gentity_t *BotGetHealTarget( gentity_t *self )
+{
+	if ( G_Team(self) == TEAM_HUMANS )
+	{
+		return self->botMind->closestBuildings[BA_H_MEDISTAT].ent;
+	}
+
+	// Aliens
+	if ( self->botMind->closestBuildings[BA_A_BOOSTER].ent )
+	{
+		// powered booster
+		return self->botMind->closestBuildings[BA_A_BOOSTER].ent;
+	}
+	else
+	{
+		// no working booster, rely on creep instead
+		return BotGetClosestBuildingAmongTypes( self,
+				{ BA_A_SPAWN, BA_A_OVERMIND, BA_A_BARRICADE,
+				  BA_A_ACIDTUBE, BA_A_TRAPPER, BA_A_HIVE,
+				  BA_A_LEECH, BA_A_SPIKER }
+				).ent;
+	}
+}
+
 // computes the maximum credits this bot could spend in
 // equipment (or classes) with infinite credits.
 static int GetMaxEquipmentCost( gentity_t const* self )
@@ -348,23 +388,20 @@ float BotGetHealScore( gentity_t *self )
 
 	if ( self->client->pers.team == TEAM_ALIENS )
 	{
-		//Alien code is notoriously bugged if the heal source can not be reached,
-		//which includes sources on walls and ceilings.
-		//This way of doing code more or less works, because boosters have rather
-		//big area (but aliens won't take poison) and players usually put them in
-		//places they can reach without too much hassle.
-		//The bug can be noted if overmind is removed and closest egg is high enough.
 		if ( self->botMind->closestBuildings[ BA_A_BOOSTER ].ent )
 		{
 			distToHealer = self->botMind->closestBuildings[ BA_A_BOOSTER ].distance;
 		}
-		else if ( self->botMind->closestBuildings[ BA_A_OVERMIND ].ent )
+		else
 		{
-			distToHealer = self->botMind->closestBuildings[ BA_A_OVERMIND ].distance;
-		}
-		else if ( self->botMind->closestBuildings[ BA_A_SPAWN ].ent )
-		{
-			distToHealer = self->botMind->closestBuildings[ BA_A_SPAWN ].distance;
+			// no booster, let's use creep instead
+			distToHealer =
+				BotGetClosestBuildingAmongTypes( self,
+					{ BA_A_SPAWN, BA_A_OVERMIND,
+					  BA_A_BARRICADE, BA_A_ACIDTUBE,
+					  BA_A_TRAPPER, BA_A_HIVE, BA_A_LEECH,
+					  BA_A_SPIKER }
+					).distance;
 		}
 	}
 	else

--- a/src/sgame/sg_bot_util.h
+++ b/src/sgame/sg_bot_util.h
@@ -47,9 +47,7 @@ gentity_t* BotFindBuilding( gentity_t *self, int buildingType, int range );
 bool   BotTeamateHasWeapon( gentity_t *self, int weapon );
 void       BotSearchForEnemy( gentity_t *self );
 void       BotPain( gentity_t *self, gentity_t *attacker, int damage );
-botEntityAndDistance_t BotGetClosestBuildingAmongTypes(
-		gentity_t *self, const std::initializer_list<buildable_t> buildables );
-const gentity_t *BotGetHealTarget( gentity_t *self );
+botEntityAndDistance_t BotGetHealTarget( const gentity_t *self );
 
 // aiming
 glm::vec3 BotGetIdealAimLocation( gentity_t *self, const botTarget_t &target );

--- a/src/sgame/sg_bot_util.h
+++ b/src/sgame/sg_bot_util.h
@@ -47,6 +47,9 @@ gentity_t* BotFindBuilding( gentity_t *self, int buildingType, int range );
 bool   BotTeamateHasWeapon( gentity_t *self, int weapon );
 void       BotSearchForEnemy( gentity_t *self );
 void       BotPain( gentity_t *self, gentity_t *attacker, int damage );
+botEntityAndDistance_t BotGetClosestBuildingAmongTypes(
+		gentity_t *self, const std::initializer_list<buildable_t> buildables );
+const gentity_t *BotGetHealTarget( gentity_t *self );
 
 // aiming
 glm::vec3 BotGetIdealAimLocation( gentity_t *self, const botTarget_t &target );


### PR DESCRIPTION
This brings the following improvements:
* (commit1,2,3) simplifies code a fair bit
* (commit1) avoid some edge case where a booster that goes unpowered would still be tried for healing. Instead the action heal now fails and can find a better target the next time. And possibly other small bugs that could have been stayed unnoticed in the different code paths
* (commit2) avoid using a egg or leech on the roof or walls for healing in case overmind is gone.
* (commit2) try healing on leechs if overmind and eggs are all gone (not that it would help surviving much)

I intend to squash the first two commits before merging, they are kept separate for now because the first one has been reviewed already.