### PR TITLE
Omit poorly timed CheckExitRules() call

### DIFF
--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -1233,9 +1233,6 @@ void CalculateRanks()
 	qsort( level.sortedClients, level.numConnectedClients,
 	       sizeof( level.sortedClients[ 0 ] ), SortRanks );
 
-	// see if it is time to end the level
-	CheckExitRules();
-
 	// if we are at the intermission, send the new info to everyone
 	if ( level.intermissiontime )
 	{


### PR DESCRIPTION
CheckExitRules is already called every frame which seems like enough to me. The call in question can cause the intermission to be started in the middle of gamelogic calculations, which is a bad idea because it makes changes to entities.

Closes #1939.