### PR TITLE
Restore navmesh lazy-loading and fix it

### DIFF
--- a/src/sgame/botlib/bot_nav.cpp
+++ b/src/sgame/botlib/bot_nav.cpp
@@ -386,10 +386,10 @@ bool G_BotNavTrace( int botClientNum, botTrace_t *trace, const glm::vec3& start_
 	return true;
 }
 
-void G_BotAddObstacle( const vec3_t mins, const vec3_t maxs, qhandle_t *obstacleHandle )
+void G_BotAddObstacle( const glm::vec3 &mins, const glm::vec3 &maxs, qhandle_t *obstacleHandle )
 {
-	qVec min = mins;
-	qVec max = maxs;
+	qVec min = &mins[0];
+	qVec max = &maxs[0];
 	rBounds box( min, max );
 
 	for ( int i = 0; i < numNavData; i++ )

--- a/src/sgame/botlib/bot_nav_edit.cpp
+++ b/src/sgame/botlib/bot_nav_edit.cpp
@@ -191,6 +191,7 @@ static bool CheckHost( gentity_t *ent )
 	return false;
 }
 
+bool G_BotNavInit();
 void Cmd_NavEdit( gentity_t *ent )
 {
 	if ( !CheckHost( ent ) ) return;
@@ -212,6 +213,11 @@ void Cmd_NavEdit( gentity_t *ent )
 		if ( args.Argc() < 3 )
 		{
 			Log::Notice( usage );
+			return;
+		}
+
+		if ( !G_BotNavInit() )
+		{
 			return;
 		}
 

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -5808,6 +5808,12 @@ static bool BotAddCmd( gentity_t* ent, const Cmd::Args& args )
 
 	const char* behavior = args.Argc() >= 6 ? args[5].data() : BOT_DEFAULT_BEHAVIOR;
 
+	if ( !G_BotInit() )
+	{
+		ADMP( QQ( N_( "Navigation mesh files unavailable for this map" ) ) );
+		return false;
+	}
+
 	bool result = G_BotAdd( name, team, skill, behavior );
 	if ( !result )
 	{
@@ -5846,6 +5852,12 @@ static bool BotFillCmd( gentity_t *ent, const Cmd::Args& args )
 	}
 	int skill = args.Argc() >= 5 ? BotSkillFromString(ent, args[4].data()) : g_bot_default_skill.Get();
 
+	if ( !G_BotInit() )
+	{
+		ADMP( QQ( N_( "Navigation mesh files unavailable for this map" ) ) );
+		return false;
+	}
+
 	for (team_t team : teams)
 	{
 		level.team[team].botFillTeamSize = count;
@@ -5857,7 +5869,7 @@ static bool BotFillCmd( gentity_t *ent, const Cmd::Args& args )
 }
 
 // This command does NOT load the navmesh that it creates.
-// For the time being you need to restart the map for that.
+// However the mesh will be used if you run /navgen before the first bot fill/add command.
 bool G_admin_navgen( gentity_t* ent )
 {
 	static NavmeshGenerator navgen;

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -272,11 +272,7 @@ bool G_BotAdd( const char *name, team_t team, int skill, const char *behavior, b
 	bool autoname = false;
 	bool okay;
 
-	if ( !navMeshLoaded )
-	{
-		Log::Warn( "No Navigation Mesh file is available for this map" );
-		return false;
-	}
+	ASSERT( navMeshLoaded );
 
 	// find what clientNum to use for bot
 	clientNum = trap_BotAllocateClient();
@@ -560,20 +556,22 @@ void G_BotIntermissionThink( gclient_t *client )
 	client->readyToExit = true;
 }
 
+// Initialization happens whenever someone first tries to add a bot.
+// This incurs some delay (a few tenths of a second), but on servers bots
+// are normally added at the beginning of the round so it shouldn't be noticeable.
 bool G_BotInit()
 {
+	if ( treeList.maxTrees == 0 )
+	{
+		InitTreeList( &treeList );
+	}
+
 	if ( !G_BotNavInit() )
 	{
 		Log::Notice( "Failed to load navmeshes" );
 		G_BotNavCleanup();
 		return false;
 	}
-
-	if ( treeList.maxTrees == 0 )
-	{
-		InitTreeList( &treeList );
-	}
-
 	return true;
 }
 

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -42,6 +42,7 @@ Navigation Mesh Loading
 ========================
 */
 
+extern void BotAddSavedObstacles();
 // FIXME: use nav handle instead of classes
 bool G_BotNavInit()
 {
@@ -70,6 +71,7 @@ bool G_BotNavInit()
 		}
 	}
 	navMeshLoaded = true;
+	BotAddSavedObstacles();
 	return true;
 }
 

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -45,6 +45,11 @@ Navigation Mesh Loading
 // FIXME: use nav handle instead of classes
 bool G_BotNavInit()
 {
+	if ( navMeshLoaded )
+	{
+		return true;
+	}
+
 	Log::Notice( "==== Bot Navigation Initialization ====" );
 
 	for ( class_t i : RequiredNavmeshes() )

--- a/src/sgame/sg_bot_public.h
+++ b/src/sgame/sg_bot_public.h
@@ -62,7 +62,7 @@ int  G_BotAddNames(team_t team, int arg, int last);
 //     useful warning, but who knows...
 void G_BotDisableArea( const glm::vec3 &origin, const glm::vec3 &mins, const glm::vec3 &maxs );
 void G_BotEnableArea( const glm::vec3 &origin, const glm::vec3 &mins, const glm::vec3 &maxs );
-void G_BotAddObstacle( const vec3_t mins, const vec3_t maxs, qhandle_t *handle );
+void G_BotAddObstacle( const glm::vec3 &mins, const glm::vec3 &maxs, qhandle_t *handle );
 void G_BotRemoveObstacle( qhandle_t handle );
 void G_BotUpdateObstacles();
 bool G_BotInit();

--- a/src/sgame/sg_bot_public.h
+++ b/src/sgame/sg_bot_public.h
@@ -62,8 +62,8 @@ int  G_BotAddNames(team_t team, int arg, int last);
 //     useful warning, but who knows...
 void G_BotDisableArea( const glm::vec3 &origin, const glm::vec3 &mins, const glm::vec3 &maxs );
 void G_BotEnableArea( const glm::vec3 &origin, const glm::vec3 &mins, const glm::vec3 &maxs );
-void G_BotAddObstacle( const glm::vec3 &mins, const glm::vec3 &maxs, qhandle_t *handle );
-void G_BotRemoveObstacle( qhandle_t handle );
+void G_BotAddObstacle( const glm::vec3 &mins, const glm::vec3 &maxs, int obstacleNum );
+void G_BotRemoveObstacle( int obstacleNum );
 void G_BotUpdateObstacles();
 bool G_BotInit();
 void G_BotCleanup();

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -2022,7 +2022,7 @@ static gentity_t *SpawnBuildable( gentity_t *builder, buildable_t buildable, con
 		maxs[0] *= fixVal; maxs[1] *= fixVal;
 		mins += origin;
 		maxs += origin;
-		G_BotAddObstacle( mins, maxs, &built->obstacleHandle );
+		G_BotAddObstacle( mins, maxs, built - g_entities );
 	}
 
 	G_AddEvent( built, EV_BUILD_CONSTRUCT, 0 );

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -166,10 +166,7 @@ void G_FreeEntity( gentity_t *entity )
 		Log::Debug("Freeing Entity %s", etos(entity));
 	}
 
-	if ( entity->obstacleHandle )
-	{
-		G_BotRemoveObstacle( entity->obstacleHandle );
-	}
+	G_BotRemoveObstacle( entity - g_entities );
 
 	if( entity->eclass && entity->eclass->instanceCounter > 0 )
 	{

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -577,9 +577,6 @@ void G_InitGame( int levelTime, int randomSeed, bool inClient )
 	// load up a custom building layout if there is one
 	G_LayoutLoad();
 
-	// setup bot code
-	G_BotInit();
-
 	// Initialize item locking state
 	BG_InitUnlockackables();
 

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -603,7 +603,7 @@ void BotHandleDoor( gentity_t *ent )
 					G_BotRemoveObstacle( ent->obstacleHandle );
 					ent->obstacleHandle = 0;
 				}
-		G_BotAddObstacle( ent->r.absmin, ent->r.absmax, &ent->obstacleHandle );
+		G_BotAddObstacle( VEC2GLM( ent->r.absmin ), VEC2GLM( ent->r.absmax ), &ent->obstacleHandle );
 			}
 }
 
@@ -2685,7 +2685,7 @@ static void func_spawn_act( gentity_t *self, gentity_t*, gentity_t *activator )
 	{
 		VectorAdd( self->restingPosition, self->r.mins, mins );
 		VectorAdd( self->restingPosition, self->r.maxs, maxs );
-		G_BotAddObstacle( mins, maxs, &self->obstacleHandle );
+		G_BotAddObstacle( VEC2GLM(mins), VEC2GLM(maxs), &self->obstacleHandle );
 		trap_LinkEntity( self );
 		if( !( self->spawnflags & 2 ) )
 			G_KillBrushModel( self, activator );
@@ -2700,7 +2700,7 @@ static void func_spawn_reset( gentity_t *self )
 	{
 		VectorAdd( self->restingPosition, self->r.mins, mins );
 		VectorAdd( self->restingPosition, self->r.maxs, maxs );
-		G_BotAddObstacle( mins, maxs, &self->obstacleHandle );
+		G_BotAddObstacle( VEC2GLM(mins), VEC2GLM(maxs), &self->obstacleHandle );
 		trap_LinkEntity( self );
 	}
 	else

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -597,14 +597,12 @@ bool IsAutomaticMover( const gentity_t *ent )
 void BotHandleDoor( gentity_t *ent )
 {
 	if ( IsDoor( ent ) && !IsAutomaticMover( ent ) )
-			{
-				if ( ent->obstacleHandle )
-				{
-					G_BotRemoveObstacle( ent->obstacleHandle );
-					ent->obstacleHandle = 0;
-				}
-		G_BotAddObstacle( VEC2GLM( ent->r.absmin ), VEC2GLM( ent->r.absmax ), &ent->obstacleHandle );
-			}
+	{
+		// the door might have moved, we don't want to keep an incorrect state
+		G_BotRemoveObstacle( ent->s.clientNum );
+
+		G_BotAddObstacle( VEC2GLM( ent->r.absmin ), VEC2GLM( ent->r.absmax ), ent - g_entities );
+	}
 }
 
 static void SetMoverState( gentity_t *ent, moverState_t moverState, int time )
@@ -2674,18 +2672,14 @@ static void func_spawn_act( gentity_t *self, gentity_t*, gentity_t *activator )
 
 	if( self->r.linked )
 	{
-		if ( self->obstacleHandle )
-		{
-			G_BotRemoveObstacle( self->obstacleHandle );
-			self->obstacleHandle = 0;
-		}
+		G_BotRemoveObstacle( self->s.clientNum );
 		trap_UnlinkEntity( self );
 	}
 	else
 	{
 		VectorAdd( self->restingPosition, self->r.mins, mins );
 		VectorAdd( self->restingPosition, self->r.maxs, maxs );
-		G_BotAddObstacle( VEC2GLM(mins), VEC2GLM(maxs), &self->obstacleHandle );
+		G_BotAddObstacle( VEC2GLM(mins), VEC2GLM(maxs), self - g_entities );
 		trap_LinkEntity( self );
 		if( !( self->spawnflags & 2 ) )
 			G_KillBrushModel( self, activator );
@@ -2700,16 +2694,12 @@ static void func_spawn_reset( gentity_t *self )
 	{
 		VectorAdd( self->restingPosition, self->r.mins, mins );
 		VectorAdd( self->restingPosition, self->r.maxs, maxs );
-		G_BotAddObstacle( VEC2GLM(mins), VEC2GLM(maxs), &self->obstacleHandle );
+		G_BotAddObstacle( VEC2GLM(mins), VEC2GLM(maxs), self - g_entities );
 		trap_LinkEntity( self );
 	}
 	else
 	{
-		if ( self->obstacleHandle )
-		{
-			G_BotRemoveObstacle( self->obstacleHandle );
-			self->obstacleHandle = 0;
-		}
+		G_BotRemoveObstacle( self->s.clientNum );
 		trap_UnlinkEntity( self );
 	}
 }

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -452,9 +452,6 @@ struct gentity_t
 
 	bool    pointAgainstWorld; // don't use the bbox for map collisions
 
-	// handle of obstacle that was added to prevent bots to
-	// move toward it. Used for movers and big enough buildings.
-	qhandle_t   obstacleHandle;
 	botMemory_t *botMind;
 
 	gentity_t   *alienTag, *humanTag;


### PR DESCRIPTION
This creates a little freeze when the navmesh is loaded. I'm not 100% sure this is the best UX, but at least according to https://github.com/Unvanquished/Unvanquished/issues/2265#issuecomment-1284616524 that's the next step for navmesh generation in the gamelogic.

This hopefully fixes every bug that isn't already in master. See https://github.com/Unvanquished/Unvanquished/issues/2271 for the investigation.