### PR TITLE
Entity and client getter functions

### DIFF
--- a/src/sgame/Beacon.cpp
+++ b/src/sgame/Beacon.cpp
@@ -730,7 +730,7 @@ namespace Beacon //this should eventually become a class
 		beacon = New( origin, BCT_TAG, data, team );
 		beacon->tagAttachment = attachment;
 		*attachment = beacon;
-		beacon->s.bc_target = ent - g_entities;
+		beacon->s.bc_target = ent->num();
 
 		// Reset the entity's tag score.
 		ent->tagScore = 0;

--- a/src/sgame/CombatFeedback.cpp
+++ b/src/sgame/CombatFeedback.cpp
@@ -34,6 +34,7 @@ void HitNotify(gentity_t *attacker, gentity_t *victim,
                Util::optional<glm::vec3> point_opt, float damage,
                meansOfDeath_t mod, bool lethal)
 {
+	ASSERT(attacker->client);
 	bool indirect = false;
 	int flags = 0;
 	gentity_t *event;
@@ -70,7 +71,7 @@ void HitNotify(gentity_t *attacker, gentity_t *victim,
 	event->think = G_FreeEntity;
 
 	event->r.svFlags = SVF_SINGLECLIENT | SVF_BROADCAST;
-	event->r.singleClient = attacker->client->ps.clientNum;
+	event->r.singleClient = attacker->num();
 
 	// warning: otherEntityNum2 is only 10 bits wide
 	event->s.otherEntityNum2 = flags;

--- a/src/sgame/CombatFeedback.cpp
+++ b/src/sgame/CombatFeedback.cpp
@@ -76,7 +76,7 @@ void HitNotify(gentity_t *attacker, gentity_t *victim,
 	// warning: otherEntityNum2 is only 10 bits wide
 	event->s.otherEntityNum2 = flags;
 	event->s.angles2[0] = damage;
-	event->s.otherEntityNum = victim - g_entities;
+	event->s.otherEntityNum = victim->num();
 
 	glm::vec3 point;
 	if (!point_opt || indirect)

--- a/src/sgame/botlib/bot_nav_edit.cpp
+++ b/src/sgame/botlib/bot_nav_edit.cpp
@@ -186,7 +186,7 @@ static bool CheckHost( gentity_t *ent )
 	}
 
 	trap_SendServerCommand(
-		ent - g_entities,
+		ent->num(),
 		"print_tr " QQ( "you must be the host of a local devmap to use this command" ) );
 	return false;
 }

--- a/src/sgame/botlib/bot_nav_edit.cpp
+++ b/src/sgame/botlib/bot_nav_edit.cpp
@@ -178,7 +178,7 @@ void BotDebugDrawMesh()
 
 static bool CheckHost( gentity_t *ent )
 {
-	if ( level.inClient && ent->client->ps.clientNum == 0 )
+	if ( level.inClient && ent->num() == 0 )
 	{
 		// It's ok for further messages from commands to use Log::Notice since we have established
 		// that the client console is the server console

--- a/src/sgame/components/BuildableComponent.cpp
+++ b/src/sgame/components/BuildableComponent.cpp
@@ -56,7 +56,7 @@ void BuildableComponent::HandleDie(gentity_t* killer, meansOfDeath_t meansOfDeat
 	G_SetBuildableAnim(entity.oldEnt, Powered() ? BANIM_DESTROY : BANIM_DESTROY_UNPOWERED, true);
 	G_SetIdleBuildableAnim(entity.oldEnt, BANIM_DESTROYED);
 
-	entity.oldEnt->killedBy = killer->s.number;
+	entity.oldEnt->killedBy = killer->num();
 
 	G_LogDestruction(entity.oldEnt, killer, meansOfDeath);
 
@@ -77,7 +77,7 @@ void BuildableComponent::HandleDie(gentity_t* killer, meansOfDeath_t meansOfDeat
 		if (level.time > location->warnTimer) {
 			bool inBase = G_InsideBase(entity.oldEnt);
 
-			G_BroadcastEvent(EV_WARN_ATTACK, inBase ? 0 : location->s.number, team);
+			G_BroadcastEvent(EV_WARN_ATTACK, inBase ? 0 : location->num(), team);
 			Beacon::NewArea(BCT_DEFEND, entity.oldEnt->s.origin, team);
 			location->warnTimer = level.time + ATTACKWARN_NEARBY_PERIOD;
 		}

--- a/src/sgame/components/EggComponent.cpp
+++ b/src/sgame/components/EggComponent.cpp
@@ -6,7 +6,7 @@ EggComponent::EggComponent(Entity& entity, AlienBuildableComponent& r_AlienBuild
 
 void EggComponent::HandleCheckSpawnPoint(Entity *&blocker, glm::vec3& spawnPoint) {
 	CheckSpawnPoint(
-		entity.oldEnt->s.number, VEC2GLM( entity.oldEnt->s.origin ),
+		entity.oldEnt->num(), VEC2GLM( entity.oldEnt->s.origin ),
 		VEC2GLM( entity.oldEnt->s.origin2 ), blocker, spawnPoint
 	);
 }

--- a/src/sgame/components/HealthComponent.cpp
+++ b/src/sgame/components/HealthComponent.cpp
@@ -209,9 +209,9 @@ Util::optional<glm::vec3> direction, int flags, meansOfDeath_t meansOfDeath) {
 		if (source->client) {
 			// Add to the attacker's account on the target.
 			// TODO: Move damage account array to HealthComponent.
-			entity.oldEnt->credits[source->client->ps.clientNum].value += loss;
-			entity.oldEnt->credits[source->client->ps.clientNum].time = level.time;
-			entity.oldEnt->credits[source->client->ps.clientNum].team = (team_t)source->client->pers.team;
+			entity.oldEnt->credits[source->num()].value += loss;
+			entity.oldEnt->credits[source->num()].time = level.time;
+			entity.oldEnt->credits[source->num()].team = (team_t)source->client->pers.team;
 		}
 	}
 

--- a/src/sgame/components/HealthComponent.cpp
+++ b/src/sgame/components/HealthComponent.cpp
@@ -267,7 +267,7 @@ void HealthComponent::ScaleDamageAccounts(float healthRestored) {
 	float totalAccreditedDamage = 0.0f;
 	std::vector<Entity*> relevantClients;
 	ForEntities<ClientComponent>([&](Entity& other, ClientComponent&) {
-		float clientDamage = entity.oldEnt->credits[other.oldEnt->s.number].value;
+		float clientDamage = entity.oldEnt->credits[other.oldEnt->num()].value;
 		if (clientDamage > 0.0f) {
 			totalAccreditedDamage += clientDamage;
 			relevantClients.push_back(&other);
@@ -292,6 +292,6 @@ void HealthComponent::ScaleDamageAccounts(float healthRestored) {
 
 	// Scale down or clear damage accounts.
 	for (Entity* other : relevantClients) {
-		entity.oldEnt->credits[other->oldEnt->s.number].value *= scale;
+		entity.oldEnt->credits[other->oldEnt->num()].value *= scale;
 	}
 }

--- a/src/sgame/components/KnockbackComponent.cpp
+++ b/src/sgame/components/KnockbackComponent.cpp
@@ -54,5 +54,5 @@ void KnockbackComponent::HandleDamage(float amount, gentity_t* /*source*/, Util:
 	}
 
 	knockbackLogger.Debug("Knockback: client: %i, strength: %.1f (massMod: %.1f).",
-	                      entity.oldEnt->s.number, strength, massMod);
+	                      entity.oldEnt->num(), strength, massMod);
 }

--- a/src/sgame/components/OvermindComponent.cpp
+++ b/src/sgame/components/OvermindComponent.cpp
@@ -15,7 +15,7 @@ OvermindComponent::OvermindComponent(Entity& entity, AlienBuildableComponent& r_
 }
 
 void OvermindComponent::HandlePrepareNetCode() {
-	entity.oldEnt->s.otherEntityNum = storedTarget ? storedTarget->s.number : ENTITYNUM_NONE;
+	entity.oldEnt->s.otherEntityNum = storedTarget ? storedTarget->num() : ENTITYNUM_NONE;
 }
 
 void OvermindComponent::HandleFinishConstruction() {

--- a/src/sgame/components/ReactorComponent.cpp
+++ b/src/sgame/components/ReactorComponent.cpp
@@ -40,6 +40,6 @@ void ReactorComponent::Think(int timeDelta) {
 
 void ReactorComponent::CreateTeslaTrail(Entity& target) {
 	gentity_t* trail = G_NewTempEntity( VEC2GLM( entity.oldEnt->s.origin ), EV_TESLATRAIL);
-	trail->s.generic1  = entity.oldEnt->s.number; // Source.
-	trail->s.clientNum = target.oldEnt->s.number; // Destination.
+	trail->s.generic1  = entity.oldEnt->num(); // Source.
+	trail->s.clientNum = target.oldEnt->num(); // Destination.
 }

--- a/src/sgame/components/RocketpodComponent.cpp
+++ b/src/sgame/components/RocketpodComponent.cpp
@@ -175,8 +175,8 @@ bool RocketpodComponent::CompareTargets(Entity &a, Entity &b) {
 	glm::vec3 directionToA = glm::normalize( VEC2GLM( a.oldEnt->s.origin ) - VEC2GLM( entity.oldEnt->s.pos.trBase ) );
 	glm::vec3 directionToB = glm::normalize( VEC2GLM( b.oldEnt->s.origin ) - VEC2GLM( entity.oldEnt->s.pos.trBase ) );
 
-	bool safeToShootAtA = SafeShot( entity.oldEnt->s.number, VEC2GLM( entity.oldEnt->s.pos.trBase ), directionToA );
-	bool safeToShootAtB = SafeShot( entity.oldEnt->s.number, VEC2GLM( entity.oldEnt->s.pos.trBase ), directionToB );
+	bool safeToShootAtA = SafeShot( entity.oldEnt->num(), VEC2GLM( entity.oldEnt->s.pos.trBase ), directionToA );
+	bool safeToShootAtB = SafeShot( entity.oldEnt->num(), VEC2GLM( entity.oldEnt->s.pos.trBase ), directionToB );
 
 	if ( safeToShootAtA && !safeToShootAtB)
 	{
@@ -198,7 +198,7 @@ bool RocketpodComponent::SafeShot() {
 	glm::vec3 aimDirection;
 	AngleVectors( entity.oldEnt->buildableAim, &aimDirection[0], nullptr, nullptr );
 
-	return SafeShot( entity.oldEnt->s.number, VEC2GLM( entity.oldEnt->s.pos.trBase ), aimDirection );
+	return SafeShot( entity.oldEnt->num(), VEC2GLM( entity.oldEnt->s.pos.trBase ), aimDirection );
 }
 
 bool RocketpodComponent::SafeShot(int passEntityNumber, const glm::vec3& origin, const glm::vec3& direction) {

--- a/src/sgame/components/SpawnerComponent.cpp
+++ b/src/sgame/components/SpawnerComponent.cpp
@@ -124,7 +124,7 @@ void SpawnerComponent::WarnBlocker(Entity& blocker, bool lastWarning) {
 
 	message = "cp \"" + message + "\"";
 
-	trap_SendServerCommand(blocker.oldEnt - g_entities, message.c_str());
+	trap_SendServerCommand(blocker.oldEnt->num(), message.c_str());
 }
 
 Entity* SpawnerComponent::CheckSpawnPointHelper(

--- a/src/sgame/components/SpawnerComponent.cpp
+++ b/src/sgame/components/SpawnerComponent.cpp
@@ -44,7 +44,7 @@ void SpawnerComponent::Think(int timeDelta) {
 		}
 
 		// Suicide if blocked by the map.
-		if (blocker->oldEnt->s.number == ENTITYNUM_WORLD
+		if (blocker->oldEnt->num() == ENTITYNUM_WORLD
 		    || blocker->oldEnt->s.eType == entityType_t::ET_MOVER) {
 			Entities::Kill(entity, nullptr, MOD_SUICIDE);
 		}

--- a/src/sgame/components/SpikerComponent.cpp
+++ b/src/sgame/components/SpikerComponent.cpp
@@ -41,7 +41,7 @@ void SpikerComponent::HandleDamage(float /*amount*/, gentity_t* /*source*/, Util
 	// Shoot if there is a viable target.
 	if (lastExpectedDamage > 0.0f) {
 		logger.Verbose("Spiker #%i was hurt while an enemy is close enough to also get hurt, so "
-			"go eye for an eye.", entity.oldEnt->s.number);
+			"go eye for an eye.", entity.oldEnt->num());
 
 		Fire();
 	}
@@ -109,7 +109,7 @@ void SpikerComponent::Think(int /*timeDelta*/) {
 
 			if (!lastSensing) {
 				logger.Verbose("Spiker #%i now senses an enemy and will check more frequently for "
-					"the best moment to shoot.", entity.oldEnt->s.number);
+					"the best moment to shoot.", entity.oldEnt->num());
 
 				RegisterFastThinker();
 			}
@@ -124,7 +124,7 @@ void SpikerComponent::Think(int /*timeDelta*/) {
 
 		if (sensing) {
 			logger.Verbose("Spiker #%i senses an enemy and expects to do %.1f damage.%s%s",
-				entity.oldEnt->s.number, expectedDamage, (lessDamage && !enoughDamage)
+				entity.oldEnt->num(), expectedDamage, (lessDamage && !enoughDamage)
 				? " This has not increased, so it's time to shoot." : "", enoughDamage ?
 				" This is already enough, shoot now." : "");
 		}
@@ -132,7 +132,7 @@ void SpikerComponent::Think(int /*timeDelta*/) {
 		if (senseLost) {
 			logger.Verbose("Spiker #%i lost track of all enemies after expecting to do %.1f damage."
 				" This makes the spiker angry, so it will shoot anyway.",
-				entity.oldEnt->s.number, lastExpectedDamage);
+				entity.oldEnt->num(), lastExpectedDamage);
 		}
 
 		// Shoot when
@@ -163,7 +163,7 @@ bool SpikerComponent::SafeToShoot(glm::vec3 direction) {
 	for (float traceSize : {missileSize, missileSize * SAFETY_TRACE_INFLATION}) {
 		mins[0] = mins[1] = mins[2] = -traceSize;
 		maxs[0] = maxs[1] = maxs[2] =  traceSize;
-		trap_Trace( &trace, entity.oldEnt->s.origin, mins, maxs, &end[0], entity.oldEnt->s.number, ma->clipmask, 0 );
+		trap_Trace( &trace, entity.oldEnt->s.origin, mins, maxs, &end[0], entity.oldEnt->num(), ma->clipmask, 0 );
 		gentity_t* hit = &g_entities[trace.entityNum];
 
 		if (hit && G_OnSameTeam(entity.oldEnt, hit)) {
@@ -178,11 +178,11 @@ bool SpikerComponent::Fire() {
 	gentity_t *self = entity.oldEnt;
 	// Check if still resting.
 	if (restUntil > level.time) {
-		logger.Verbose("Spiker #%i wanted to fire but wasn't ready.", entity.oldEnt->s.number);
+		logger.Verbose("Spiker #%i wanted to fire but wasn't ready.", entity.oldEnt->num());
 
 		return false;
 	} else {
-		logger.Verbose("Spiker #%i is firing!", entity.oldEnt->s.number);
+		logger.Verbose("Spiker #%i is firing!", entity.oldEnt->num());
 	}
 
 	// Play shooting animation.
@@ -235,7 +235,7 @@ bool SpikerComponent::Fire() {
 			bool fire = SafeToShoot(VEC2GLM( dir ));
 
 			logger.Debug("Spiker #%d %s: Row %d/%d: Spike %2d/%2d: "
-				"( Alt %2.0f°, Az %3.0f° → %.2f, %.2f, %.2f )", self->s.number,
+				"( Alt %2.0f°, Az %3.0f° → %.2f, %.2f, %.2f )", self->num(),
 				fire ? "fires" : "skips", row + 1, MISSILEROWS, spike + 1, spikes,
 				RAD2DEG(spikeAltitude), RAD2DEG(spikeAzimuth), dir[0], dir[1], dir[2]);
 

--- a/src/sgame/components/TelenodeComponent.cpp
+++ b/src/sgame/components/TelenodeComponent.cpp
@@ -6,7 +6,7 @@ TelenodeComponent::TelenodeComponent(Entity& entity, HumanBuildableComponent& r_
 
 void TelenodeComponent::HandleCheckSpawnPoint(Entity *&blocker, glm::vec3& spawnPoint) {
 	CheckSpawnPoint(
-		entity.oldEnt->s.number, VEC2GLM( entity.oldEnt->s.origin ),
+		entity.oldEnt->num(), VEC2GLM( entity.oldEnt->s.origin ),
 		VEC2GLM( entity.oldEnt->s.origin2 ), blocker, spawnPoint
 	);
 }

--- a/src/sgame/components/TurretComponent.cpp
+++ b/src/sgame/components/TurretComponent.cpp
@@ -188,10 +188,10 @@ bool TurretComponent::TargetCanBeHit() {
 	glm::vec3 traceEnd     = traceStart + range * aimDirection;
 
 	trace_t tr;
-	trap_Trace(&tr, &traceStart[0], nullptr, nullptr, &traceEnd[0], entity.oldEnt->s.number,
+	trap_Trace(&tr, &traceStart[0], nullptr, nullptr, &traceEnd[0], entity.oldEnt->num(),
 	           MASK_SHOT, 0);
 
-	return (tr.entityNum == target->s.number);
+	return (tr.entityNum == target->num());
 }
 
 bool TurretComponent::TargetValid(Entity& target, bool newTarget) {
@@ -238,7 +238,7 @@ void TurretComponent::SetBaseDirection() {
 	glm::vec3 traceEnd       = traceStart + MINIMUM_CLEARANCE * torsoDirection;
 
 	trace_t tr;
-	trap_Trace(&tr, &traceStart[0], nullptr, nullptr, &traceEnd[0], entity.oldEnt->s.number,
+	trap_Trace(&tr, &traceStart[0], nullptr, nullptr, &traceEnd[0], entity.oldEnt->num(),
 	           MASK_SHOT, 0);
 
 	// TODO: Check the presence of a PhysicsComponent to decide whether the obstacle is permanent.

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -264,7 +264,7 @@ static void ClientShove( gentity_t *ent, gentity_t *victim )
 
 	// Cannot push enemy players unless they are walking on the player
 	if ( !G_OnSameTeam( ent, victim ) &&
-	     victim->client->ps.groundEntityNum != ent - g_entities )
+	     victim->client->ps.groundEntityNum != ent->num() )
 	{
 		return;
 	}
@@ -556,7 +556,7 @@ static void SpectatorThink( gentity_t *ent, usercmd_t *ucmd )
 	if ( G_IsPlayableTeam( team ) )
 	{
 		client->ps.persistant[ PERS_UNLOCKABLES ] = BG_UnlockablesMask( client->pers.team );
-		queued = G_SearchSpawnQueue( &level.team[ team ].spawnQueue, ent - g_entities );
+		queued = G_SearchSpawnQueue( &level.team[ team ].spawnQueue, ent->num() );
 
 		if ( !ClientInactivityTimer( ent, queued || !level.team[ team ].numSpawns ) )
 		{
@@ -1866,7 +1866,7 @@ static void ClientThink_real( gentity_t *self )
 	}
 
 	// client is admin but program hasn't responded to challenge? Resend
-	ClientAdminChallenge( self - g_entities );
+	ClientAdminChallenge( self->num() );
 
 	//
 	// check for exiting intermission

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -2216,7 +2216,7 @@ static void ClientThink_real( gentity_t *self )
 
 			if ( !ent && client->pers.team == TEAM_ALIENS )
 			{
-				G_TriggerMenu( client->ps.clientNum, MN_A_INFEST );
+				G_TriggerMenu( client->num(), MN_A_INFEST );
 			}
 		}
 	}

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -711,12 +711,12 @@ bool ClientInactivityTimer( gentity_t *ent, bool active )
 				trap_SendServerCommand( -1,
 				                        va( "print_tr %s %s %s", QQ( N_("$1$^* moved from $2$ to spectators due to inactivity") ),
 				                            Quote( client->pers.netname ), Quote( BG_TeamName( client->pers.team ) ) ) );
-				G_LogPrintf( "Inactivity: %d.", (int)( client - level.clients ) );
+				G_LogPrintf( "Inactivity: %d.", client->num() );
 				G_ChangeTeam( ent, TEAM_NONE );
 			}
 			else
 			{
-				trap_DropClient( client - level.clients, "Dropped due to inactivity" );
+				trap_DropClient( client->num(), "Dropped due to inactivity" );
 				return false;
 			}
 		}
@@ -726,7 +726,7 @@ bool ClientInactivityTimer( gentity_t *ent, bool active )
 		     !G_admin_permission( ent, ADMF_ACTIVITY ) )
 		{
 			client->inactivityWarning = true;
-			trap_SendServerCommand( client - level.clients,
+			trap_SendServerCommand( client->num(),
 			                        va( "cp_tr %s", putSpec ? QQ( N_("Ten seconds until inactivity spectate!") ) : QQ( N_("Ten seconds until inactivity drop!") ) ) );
 		}
 	}

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -541,7 +541,7 @@ void G_admin_cmdlist( gentity_t *ent )
 	// If this is the local client, no need to send them commands.
 	// The local client will get their commands registered in
 	// G_admin_register_cmds.
-	if ( level.inClient && ent->client->ps.clientNum == 0 )
+	if ( level.inClient && ent->num() == 0 )
 	{
 		return;
 	}

--- a/src/sgame/sg_admin.h
+++ b/src/sgame/sg_admin.h
@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 struct gentity_t;
 
 #define AP(x)         trap_SendServerCommand(-1, x)
-#define CP(x)         trap_SendServerCommand(ent - g_entities, x)
+#define CP(x)         trap_SendServerCommand(ent->num(), x)
 #define CPx(x, y)     trap_SendServerCommand(x, y)
 #define ADMP(x)       G_admin_print(ent, x)
 #define ADMP_P(x,c)   G_admin_print_plural(ent, x, c)

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -423,7 +423,7 @@ void G_BotThink( gentity_t *self )
 
 	//acknowledge recieved server commands
 	//MUST be done
-	while ( trap_BotGetServerCommand( self->client->ps.clientNum, buf, sizeof( buf ) ) );
+	while ( trap_BotGetServerCommand( self->num(), buf, sizeof( buf ) ) );
 
 	BotSearchForEnemy( self );
 	BotFindClosestBuildings( self );
@@ -475,7 +475,7 @@ void G_BotSpectatorThink( gentity_t *self )
 
 	//acknowledge recieved console messages
 	//MUST be done
-	while ( trap_BotGetServerCommand( self->client->ps.clientNum, buf, sizeof( buf ) ) );
+	while ( trap_BotGetServerCommand( self->num(), buf, sizeof( buf ) ) );
 
 	self->botMind->spawnTime = level.time;
 

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -249,13 +249,13 @@ bool G_BotSetDefaults( int clientNum, team_t team, int skill, Str::StringRef beh
 	{
 		return false;
 	}
-	BotSetSkillLevel( &g_entities[clientNum], skill );
+	BotSetSkillLevel( self, skill );
 
-	g_entities[clientNum].r.svFlags |= SVF_BOT;
+	self->r.svFlags |= SVF_BOT;
 
 	if ( team != TEAM_NONE )
 	{
-		level.clients[clientNum].sess.restartTeam = team;
+		self->client->sess.restartTeam = team;
 	}
 
 	self->pain = BotPain;

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -429,10 +429,9 @@ static void BotFindDefaultSteerTarget( gentity_t *self, glm::vec3 &dir )
 	// a vector 90° from dir, pointing right and of same magnitude
 	glm::vec3 right = glm::vec3(dir[1], -dir[0], 0);
 
-	int clientNum = self - g_entities;
 	// We add a delta determined from clientNum to avoid bots
 	// dancing in sync
-	int time = (110 * clientNum + self->client->time1000) % 1000;
+	int time = (110 * self->num() + self->client->time1000) % 1000;
 
 	// 280 instead of 700/2=350 because we want some left/right
 	// asymetry in case it helps

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -978,7 +978,7 @@ botTarget_t BotGetRoamTarget( const gentity_t *self )
 	botTarget_t target;
 	glm::vec3 point;
 
-	if ( !BotFindRandomPointInRadius( self->s.number, VEC2GLM( self->s.origin ), point, 2000 ) )
+	if ( !BotFindRandomPointInRadius( self->num(), VEC2GLM( self->s.origin ), point, 2000 ) )
 	{
 		target = VEC2GLM( self->s.origin );
 	}
@@ -1071,7 +1071,7 @@ void BotTargetToRouteTarget( const gentity_t *self, botTarget_t target, botRoute
 		glm::vec3 invNormal = { 0, 0, -1 };
 		glm::vec3 targetPos = target.getPos();
 		glm::vec3 end = targetPos + 600.f * invNormal;
-		trap_Trace( &trace, targetPos, mins, maxs, end, target.getTargetedEntity()->s.number,
+		trap_Trace( &trace, targetPos, mins, maxs, end, target.getTargetedEntity()->num(),
 		            CONTENTS_SOLID, MASK_ENTITY );
 		routeTarget->setPos( VEC2GLM( trace.endpos ) );
 	}
@@ -1262,7 +1262,7 @@ bool BotTargetInAttackRange( const gentity_t *self, botTarget_t target )
 	maxs = {  width,  width,  width };
 	mins = { -width, -width, -height };
 
-	trap_Trace( &trace, muzzle, mins, maxs, targetPos, self->s.number, MASK_SHOT, 0 );
+	trap_Trace( &trace, muzzle, mins, maxs, targetPos, self->num(), MASK_SHOT, 0 );
 
 	return !G_OnSameTeam( self, &g_entities[trace.entityNum] )
 		&& G_Team( &g_entities[ trace.entityNum ] ) != TEAM_NONE
@@ -1326,7 +1326,7 @@ bool BotTargetIsVisible( const gentity_t *self, botTarget_t target, int mask )
 		return false;
 	}
 
-	trap_Trace( &trace, &muzzle[0], nullptr, nullptr, &targetPos[0], self->s.number, mask, 0 );
+	trap_Trace( &trace, &muzzle[0], nullptr, nullptr, &targetPos[0], self->num(), mask, 0 );
 
 	if ( trace.surfaceFlags & SURF_NOIMPACT )
 	{
@@ -1334,7 +1334,7 @@ bool BotTargetIsVisible( const gentity_t *self, botTarget_t target, int mask )
 	}
 
 	//target is in range
-	if ( ( trace.entityNum == target.getTargetedEntity()->s.number
+	if ( ( trace.entityNum == target.getTargetedEntity()->num()
 				|| trace.fraction == 1.0f )
 			&& !trace.startsolid )
 	{
@@ -1583,7 +1583,7 @@ bool PlayersBehindBotInSpawnQueue( gentity_t *self )
 				}
 			}
 
-			if ( sq->clients[ i ] == self->s.number )
+			if ( sq->clients[ i ] == self->num() )
 			{
 				if ( i < sq->front )
 				{

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -1229,7 +1229,7 @@ static int G_FreeMarkedBuildables( gentity_t *deconner, char *readable,
 
 		if ( nums )
 		{
-			Q_strcat( nums, nsize, va( " %ld", ( long )( ent - g_entities ) ) );
+			Q_strcat( nums, nsize, va( " %ld", ( long )( ent->num() ) ) );
 		}
 
 		numRemoved++;
@@ -2044,8 +2044,8 @@ static gentity_t *SpawnBuildable( gentity_t *builder, buildable_t buildable, con
 		                   Quote( readable ) ) );
 		G_LogPrintf( "Construct: %d %d %s%s: %s^* is building "
 		             "%s%s%s",
-		             ( int )( builder - g_entities ),
-		             ( int )( built - g_entities ),
+		             builder->num(),
+		             built->num(),
 		             BG_Buildable( built->s.modelindex )->name,
 		             buildnums,
 		             builder->client->pers.netname,
@@ -2637,7 +2637,7 @@ static void G_BuildLogRevertThink( gentity_t *ent )
 	G_KillBox( built );
 
 	G_LogPrintf( "revert: restore %d %s",
-	             ( int )( built - g_entities ), BG_Buildable( built->s.modelindex )->name );
+	             built->num(), BG_Buildable( built->s.modelindex )->name );
 
 	G_FreeEntity( ent );
 }
@@ -2676,7 +2676,7 @@ void G_BuildLogRevert( int id )
 						if ( ent->s.eType == entityType_t::ET_BUILDABLE )
 						{
 							G_LogPrintf( "revert: remove %d %s",
-										 ( int )( ent - g_entities ), BG_Buildable( ent->s.modelindex )->name );
+										 ent->num(), BG_Buildable( ent->s.modelindex )->name );
 						}
 
 						// Revert resources

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -548,7 +548,7 @@ static void HArmoury_Use( gentity_t *self, gentity_t*, gentity_t *activator )
 
 	if ( !self->powered || Entities::IsDead(self) )
 	{
-		G_TriggerMenu( activator->client->ps.clientNum, MN_H_NOTPOWERED );
+		G_TriggerMenu( activator->num(), MN_H_NOTPOWERED );
 		return;
 	}
 

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -231,7 +231,7 @@ void ABarricade_Shrink( gentity_t *self, bool shrink )
 		int     anim;
 
 		trap_Trace( &tr, self->s.origin, self->r.mins, self->r.maxs,
-		            self->s.origin, self->s.number, MASK_PLAYERSOLID, 0 );
+		            self->s.origin, self->num(), MASK_PLAYERSOLID, 0 );
 
 		if ( tr.startsolid || tr.fraction < 1.0f )
 		{
@@ -467,7 +467,7 @@ static bool ATrapper_CheckTarget( gentity_t *self, GentityRef target, int range 
 		return false;
 	}
 
-	trap_Trace( &trace, self->s.pos.trBase, nullptr, nullptr, target->s.pos.trBase, self->s.number,
+	trap_Trace( &trace, self->s.pos.trBase, nullptr, nullptr, target->s.pos.trBase, self->num(),
 	            MASK_SHOT, 0 );
 
 	if ( trace.contents & CONTENTS_SOLID ) // can we see the target?
@@ -1085,7 +1085,7 @@ gentity_t *G_GetDeconstructibleBuildable( gentity_t *ent )
 	BG_GetClientViewOrigin( &ent->client->ps, viewOrigin );
 	AngleVectors( ent->client->ps.viewangles, forward, nullptr, nullptr );
 	VectorMA( viewOrigin, BUILDER_DECONSTRUCT_RANGE, forward, end );
-	trap_Trace( &trace, viewOrigin, nullptr, nullptr, end, ent->s.number, MASK_PLAYERSOLID, 0 );
+	trap_Trace( &trace, viewOrigin, nullptr, nullptr, end, ent->num(), MASK_PLAYERSOLID, 0 );
 	buildable = &g_entities[ trace.entityNum ];
 
 	// Check if target is valid.
@@ -1558,7 +1558,7 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 
 	BG_PositionBuildableRelativeToPlayer( ps, mins, maxs, trap_Trace, entity_origin, angles, &tr1 );
 	trap_Trace( &tr2, entity_origin, mins, maxs, entity_origin, ENTITYNUM_NONE, MASK_PLAYERSOLID, 0 );
-	trap_Trace( &tr3, ps->origin, nullptr, nullptr, entity_origin, ent->s.number, MASK_PLAYERSOLID, 0 );
+	trap_Trace( &tr3, ps->origin, nullptr, nullptr, entity_origin, ent->num(), MASK_PLAYERSOLID, 0 );
 
 	VectorCopy( entity_origin, origin );
 	*groundEntNum = tr1.entityNum;
@@ -2183,7 +2183,7 @@ static gentity_t *FinishSpawningBuildable( gentity_t *ent, bool force )
 	VectorScale( built->s.origin2, -4096.0f, dest );
 	VectorAdd( dest, built->s.origin, dest );
 
-	trap_Trace( &tr, built->s.origin, built->r.mins, built->r.maxs, dest, built->s.number,
+	trap_Trace( &tr, built->s.origin, built->r.mins, built->r.maxs, dest, built->num(),
 	            built->clipmask, 0 );
 
 	if ( tr.startsolid && !force )

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -516,7 +516,7 @@ void respawn( gentity_t *ent )
 	for ( i = 0; i < level.maxclients; i++ )
 	{
 		if ( level.clients[ i ].sess.spectatorState == SPECTATOR_FOLLOW &&
-		     level.clients[ i ].sess.spectatorClient == ent - g_entities )
+		     level.clients[ i ].sess.spectatorClient == ent->num() )
 		{
 			if ( !( level.clients[ i ].pers.stickySpec ) )
 			{
@@ -816,9 +816,9 @@ const char *ClientUserinfoChanged( int clientNum, bool forceName )
 	// check for malformed or illegal info strings
 	if ( !Info_Validate( userinfo ) )
 	{
-		trap_SendServerCommand( ent - g_entities,
+		trap_SendServerCommand( ent->num(),
 		                        "disconnect \"illegal or malformed userinfo\"" );
-		trap_DropClient( ent - g_entities,
+		trap_DropClient( ent->num(),
 		                 "dropped: illegal or malformed userinfo" );
 		return "Illegal or malformed userinfo";
 	}
@@ -845,7 +845,7 @@ const char *ClientUserinfoChanged( int clientNum, bool forceName )
 		     level.time - client->pers.namelog->nameChangeTime <=
 		     g_minNameChangePeriod.Get() * 1000 )
 		{
-			trap_SendServerCommand( ent - g_entities, va(
+			trap_SendServerCommand( ent->num(), va(
 			                          "print_tr %s %g", QQ( N_("Name change spam protection (g_minNameChangePeriod = $1$)") ),
 			                          g_minNameChangePeriod.Get() ) );
 			revertName = true;
@@ -853,25 +853,25 @@ const char *ClientUserinfoChanged( int clientNum, bool forceName )
 		else if ( !forceName && g_maxNameChanges.Get() > 0 &&
 		          client->pers.namelog->nameChanges >= g_maxNameChanges.Get() )
 		{
-			trap_SendServerCommand( ent - g_entities, va(
+			trap_SendServerCommand( ent->num(), va(
 			                          "print_tr %s %d", QQ( N_("Maximum name changes reached (g_maxNameChanges = $1$)") ),
 			                          g_maxNameChanges.Get() ) );
 			revertName = true;
 		}
 		else if ( !forceName && client->pers.namelog->muted )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s", QQ( N_("You cannot change your name while you are muted") ) ) );
 			revertName = true;
 		}
 		else if ( !G_admin_name_check( ent, newname, err, sizeof( err ) ) )
 		{
-			trap_SendServerCommand( ent - g_entities, va( "print_tr %s %s %s", QQ( "$1t$ $2$" ), Quote( err ), Quote( newname ) ) );
+			trap_SendServerCommand( ent->num(), va( "print_tr %s %s %s", QQ( "$1t$ $2$" ), Quote( err ), Quote( newname ) ) );
 			revertName = true;
 		}
 		else if ( Q_UTF8_Strlen( newname ) > MAX_NAME_CHARACTERS )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s %d", QQ( N_("Name is too long! Must be less than $1$ characters.") ), MAX_NAME_CHARACTERS ) );
 			revertName = true;
 
@@ -1135,7 +1135,7 @@ const char *ClientConnect( int clientNum, bool firstTime )
 	// if a player reconnects quickly after a disconnect, the client disconnect may never be called, thus flag can get lost in the ether
 	if ( ent->inuse )
 	{
-		G_LogPrintf( "Forcing disconnect on active client: %i", (int)( ent - g_entities ) );
+		G_LogPrintf( "Forcing disconnect on active client: %i", ent->num() );
 		// so lets just fix up anything that should happen on a disconnect
 		ClientDisconnect( ent-g_entities );
 	}
@@ -1346,7 +1346,7 @@ void ClientBegin( int clientNum )
 
 	if ( !startMsg.empty() )
 	{
-		trap_SendServerCommand( ent - g_entities, va( "cpd %d %s", g_mapStartupMessageDelay.Get(), Quote( startMsg.c_str() ) ) );
+		trap_SendServerCommand( ent->num(), va( "cpd %d %s", g_mapStartupMessageDelay.Get(), Quote( startMsg.c_str() ) ) );
 	}
 
 	G_namelog_restore( client );
@@ -1502,7 +1502,7 @@ void ClientSpawn( gentity_t *ent, gentity_t *spawn, const vec3_t origin, const v
 	bool evolving = ent == spawn;
 	ClientSpawnCBSE(ent, evolving);
 
-	index = ent - g_entities;
+	index = ent->num();
 	client = ent->client;
 
 	teamLocal = client->pers.team;
@@ -1808,7 +1808,7 @@ void ClientSpawn( gentity_t *ent, gentity_t *spawn, const vec3_t origin, const v
 	// evolving several times to run down the attack cooldown
 	client->ps.commandTime = level.time - (evolving ? 1 : 100);
 	ent->client->pers.cmd.serverTime = level.time;
-	ClientThink( ent - g_entities );
+	ClientThink( ent->num() );
 
 	// positively link the client, even if the command times are weird
 	if ( client->sess.spectatorState == SPECTATOR_NOT )

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -1371,7 +1371,7 @@ void ClientBegin( int clientNum )
 		default:
 			if ( !client->pers.admin )
 		case 1:
-			G_TriggerMenu( client->ps.clientNum, MN_WELCOME );
+			G_TriggerMenu( clientNum, MN_WELCOME );
 		}
 	}
 }

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -633,11 +633,7 @@ static const char *G_UnnamedClientName( gclient_t *client )
 
 	client->pers.namelog->unnamedNumber = number;
 
-	gentity_t *ent;
-	int clientNum = client - level.clients;
-	ent = g_entities + clientNum;
-
-	if ( ent->r.svFlags & SVF_BOT )
+	if ( client->ent()->r.svFlags & SVF_BOT )
 	{
 		Com_sprintf( name, sizeof( name ), "%.*s%d", (int)sizeof( name ) - 11,
 			!g_unnamedBotNamePrefix.Get().empty() ? g_unnamedBotNamePrefix.Get().c_str() : UNNAMED_BOT "#",

--- a/src/sgame/sg_cm_world.cpp
+++ b/src/sgame/sg_cm_world.cpp
@@ -48,12 +48,12 @@ worldEntity_t wentities[ MAX_GENTITIES ];
 
 static worldEntity_t *G_CM_WorldEntityForGentity( gentity_t *gEnt )
 {
-	if ( !gEnt || gEnt->s.number < 0 || gEnt->s.number >= MAX_GENTITIES )
+	if ( !gEnt || gEnt->num() < 0 || gEnt->num() >= MAX_GENTITIES )
 	{
 		Sys::Drop( "G_CM_WorldEntityForGentity: bad gEnt" );
 	}
 
-	return &wentities[ gEnt->s.number ];
+	return &wentities[ gEnt->num() ];
 }
 
 static gentity_t *G_CM_GEntityForWorldEntity( worldEntity_t *ent )
@@ -78,12 +78,12 @@ void G_CM_SetBrushModel( gentity_t *ent, const char *name )
 
 	if ( !name )
 	{
-		Sys::Drop( "G_CM_SetBrushModel: NULL for #%i", ent->s.number );
+		Sys::Drop( "G_CM_SetBrushModel: NULL for #%i", ent->num() );
 	}
 
 	if ( name[ 0 ] != '*' )
 	{
-		Sys::Drop( "G_CM_SetBrushModel: %s of #%i isn't a brush model", name, ent->s.number );
+		Sys::Drop( "G_CM_SetBrushModel: %s of #%i isn't a brush model", name, ent->num() );
 	}
 
 	ent->s.modelindex = atoi( name + 1 );
@@ -716,7 +716,7 @@ void G_CM_ClipToEntity( trace_t *trace, const vec3_t start, const vec3_t mins, c
 
 	if ( trace->fraction < 1 )
 	{
-		trace->entityNum = touch->s.number;
+		trace->entityNum = touch->num();
 	}
 }
 
@@ -810,12 +810,12 @@ static void G_CM_ClipMoveToEntities( moveclip_t *clip )
 		if ( trace.allsolid )
 		{
 			clip->trace.allsolid = true;
-			trace.entityNum = touch->s.number;
+			trace.entityNum = touch->num();
 		}
 		else if ( trace.startsolid )
 		{
 			clip->trace.startsolid = true;
-			trace.entityNum = touch->s.number;
+			trace.entityNum = touch->num();
 		}
 
 		if ( trace.fraction < clip->trace.fraction )
@@ -825,7 +825,7 @@ static void G_CM_ClipMoveToEntities( moveclip_t *clip )
 			// make sure we keep a startsolid from a previous trace
 			oldStart = clip->trace.startsolid;
 
-			trace.entityNum = touch->s.number;
+			trace.entityNum = touch->num();
 			clip->trace = trace;
 			clip->trace.startsolid |= oldStart;
 		}

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -2365,15 +2365,15 @@ static bool FindRoomForClassChangeVertically(
 	// before starting the real trace
 	VectorCopy( newOrigin, temp );
 	temp[ 2 ] += nudgeHeight;
-	trap_Trace( &tr, newOrigin, toMins, toMaxs, temp, ent->s.number, MASK_PLAYERSOLID, 0 );
+	trap_Trace( &tr, newOrigin, toMins, toMaxs, temp, ent->num(), MASK_PLAYERSOLID, 0 );
 	temp[ 2 ] = newOrigin[2] + nudgeHeight * tr.fraction;
 
 	// trace down to the ground so that we can evolve on slopes
-	trap_Trace( &tr, temp, toMins, toMaxs, newOrigin, ent->s.number, MASK_PLAYERSOLID, 0 );
+	trap_Trace( &tr, temp, toMins, toMaxs, newOrigin, ent->num(), MASK_PLAYERSOLID, 0 );
 	VectorCopy( tr.endpos, newOrigin );
 
 	// make REALLY sure
-	trap_Trace( &tr, newOrigin, toMins, toMaxs, newOrigin, ent->s.number, MASK_PLAYERSOLID, 0 );
+	trap_Trace( &tr, newOrigin, toMins, toMaxs, newOrigin, ent->num(), MASK_PLAYERSOLID, 0 );
 	return !tr.startsolid && tr.fraction == 1.0f;
 }
 
@@ -2410,14 +2410,14 @@ static bool FindRoomForClassChangeLaterally(
 		vec3_t start_point;
 		VectorMA( origin, distance, delta, start_point );
 		trap_Trace( &trace, start_point, toMins, toMaxs,
-				origin, ent->s.number,
+				origin, ent->num(),
 				MASK_PLAYERSOLID, 0 );
 
 		vec3_t first_trace_end;
 		VectorCopy(trace.endpos, first_trace_end);
 		// make REALLY sure
 		trap_Trace( &trace, first_trace_end, toMins, toMaxs,
-				first_trace_end, ent->s.number,
+				first_trace_end, ent->num(),
 				MASK_PLAYERSOLID, 0 );
 
 		if ( trace.startsolid || trace.fraction < 1.0f )
@@ -2857,7 +2857,7 @@ static void Cmd_Ignite_f( gentity_t *player )
 	BG_GetClientViewOrigin( &player->client->ps, viewOrigin );
 	AngleVectors( player->client->ps.viewangles, forward, nullptr, nullptr );
 	VectorMA( viewOrigin, 1000, forward, end );
-	trap_Trace( &trace, viewOrigin, nullptr, nullptr, end, player->s.number, MASK_PLAYERSOLID, 0 );
+	trap_Trace( &trace, viewOrigin, nullptr, nullptr, end, player->num(), MASK_PLAYERSOLID, 0 );
 
 	if ( trace.entityNum == ENTITYNUM_WORLD ) {
 		G_SpawnFire( trace.endpos, trace.plane.normal, player );
@@ -4578,7 +4578,7 @@ static void Cmd_Beacon_f( gentity_t *ent )
 	VectorMA( origin, 65536, forward, end );
 
 	G_UnlaggedOn( ent, origin, 65536 );
-	trap_Trace( &tr, origin, nullptr, nullptr, end, ent->s.number, MASK_PLAYERSOLID, 0 );
+	trap_Trace( &tr, origin, nullptr, nullptr, end, ent->num(), MASK_PLAYERSOLID, 0 );
 	G_UnlaggedOff( );
 
 	// Evaluate flood limit.
@@ -4588,7 +4588,7 @@ static void Cmd_Beacon_f( gentity_t *ent )
 	if ( !( flags & BCF_PRECISE ) )
 		Beacon::MoveTowardsRoom( tr.endpos );
 
-	Beacon::Propagate( Beacon::New( tr.endpos, type, 0, team, ent->s.number, BCH_REMOVE ) );
+	Beacon::Propagate( Beacon::New( tr.endpos, type, 0, team, ent->num(), BCH_REMOVE ) );
 	return;
 }
 

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -430,7 +430,7 @@ void ScoreboardMessage( gentity_t *ent )
 		stringlength += j;
 	}
 
-	trap_SendServerCommand( ent - g_entities, va( "scores %i %i%s",
+	trap_SendServerCommand( ent->num(), va( "scores %i %i%s",
 	                        level.team[ TEAM_ALIENS ].kills, level.team[ TEAM_HUMANS ].kills, string ) );
 }
 
@@ -774,7 +774,7 @@ static void Cmd_God_f( gentity_t *ent )
 		msg = QQ( N_("godmode ON") );
 	}
 
-	trap_SendServerCommand( ent - g_entities, va( "print_tr %s", msg ) );
+	trap_SendServerCommand( ent->num(), va( "print_tr %s", msg ) );
 }
 
 /*
@@ -801,7 +801,7 @@ static void Cmd_Notarget_f( gentity_t *ent )
 		msg = QQ( N_("notarget ON") );
 	}
 
-	trap_SendServerCommand( ent - g_entities, va( "print_tr %s", msg ) );
+	trap_SendServerCommand( ent->num(), va( "print_tr %s", msg ) );
 }
 
 void Cmd_PrintMomentum_f( gentity_t * )
@@ -841,7 +841,7 @@ static void Cmd_Noclip_f( gentity_t *ent )
 		trap_LinkEntity( ent );
 	}
 
-	trap_SendServerCommand( ent - g_entities, va( "print_tr %s", msg ) );
+	trap_SendServerCommand( ent->num(), va( "print_tr %s", msg ) );
 }
 
 /*
@@ -859,12 +859,12 @@ static void Cmd_Kill_f( gentity_t *ent )
 	{
 		if ( ent->suicideTime == 0 )
 		{
-			trap_SendServerCommand( ent - g_entities, va( "print_tr %s %d", QQ( N_("You will commit suicide in $1$ seconds") ), g_killDelay.Get() ) );
+			trap_SendServerCommand( ent->num(), va( "print_tr %s %d", QQ( N_("You will commit suicide in $1$ seconds") ), g_killDelay.Get() ) );
 			ent->suicideTime = level.time + g_killDelay.Get() * 1000;
 		}
 		else if ( ent->suicideTime > level.time )
 		{
-			trap_SendServerCommand( ent - g_entities, "print_tr \"" N_("Suicide cancelled") "\"" );
+			trap_SendServerCommand( ent->num(), "print_tr \"" N_("Suicide cancelled") "\"" );
 			ent->suicideTime = 0;
 		}
 	}
@@ -910,7 +910,7 @@ static void Cmd_Team_f( gentity_t *ent )
 	{
 		float remaining = ceil( ( ( ent->client->lastCombatTime + g_combatCooldown.Get() * 1000 ) - level.time ) / 1000 );
 
-		trap_SendServerCommand( ent - g_entities,
+		trap_SendServerCommand( ent->num(),
 		    va( "print_tr %s %i %.0f", QQ( N_("You cannot leave your team until $1$ after combat. Try again in $2$s.") ),
 		        g_combatCooldown.Get(), remaining ) );
 
@@ -920,7 +920,7 @@ static void Cmd_Team_f( gentity_t *ent )
 	// disallow joining teams during warmup
 	if ( g_doWarmup.Get() && ( ( level.warmupTime - level.time ) / 1000 ) > 0 )
 	{
-		G_TriggerMenu( ent - g_entities, MN_WARMUP );
+		G_TriggerMenu( ent->num(), MN_WARMUP );
 		return;
 	}
 
@@ -928,7 +928,7 @@ static void Cmd_Team_f( gentity_t *ent )
 
 	if ( !s[ 0 ] )
 	{
-		trap_SendServerCommand( ent - g_entities, va( "print_tr %s %s", QQ( N_("team: $1$") ),
+		trap_SendServerCommand( ent->num(), va( "print_tr %s %s", QQ( N_("team: $1$") ),
 		                        Quote( BG_TeamName( oldteam ) ) ) );
 		return;
 	}
@@ -972,7 +972,7 @@ static void Cmd_Team_f( gentity_t *ent )
 				//TODO move code in a function common with next case
 				if ( level.team[ TEAM_ALIENS ].locked )
 				{
-					G_TriggerMenu( ent - g_entities, MN_A_TEAMLOCKED );
+					G_TriggerMenu( ent->num(), MN_A_TEAMLOCKED );
 					return;
 				}
 				else if ( level.team[ TEAM_HUMANS ].locked )
@@ -986,14 +986,14 @@ static void Cmd_Team_f( gentity_t *ent )
 					// tell the player to join the other team.
 					if ( g_teamForceBalance.Get() == 1 && players[ TEAM_ALIENS ] > players[ TEAM_HUMANS ] )
 					{
-						G_TriggerMenu( ent - g_entities, MN_A_TEAMFULL );
+						G_TriggerMenu( ent->num(), MN_A_TEAMFULL );
 						return;
 					}
 					// 2: Check for this team having more player than the other
 					// theam only if the other team is not empty.
 					else if ( g_teamForceBalance.Get() == 2 && players[ TEAM_HUMANS ] > 0 && players[ TEAM_ALIENS ] > players[ TEAM_HUMANS ] )
 					{
-						G_TriggerMenu( ent - g_entities, MN_A_TEAMFULL );
+						G_TriggerMenu( ent->num(), MN_A_TEAMFULL );
 						return;
 					}
 				}
@@ -1005,7 +1005,7 @@ static void Cmd_Team_f( gentity_t *ent )
 				//TODO move code in a function common with previous case
 				if ( level.team[ TEAM_HUMANS ].locked )
 				{
-					G_TriggerMenu( ent - g_entities, MN_H_TEAMLOCKED );
+					G_TriggerMenu( ent->num(), MN_H_TEAMLOCKED );
 					return;
 				}
 				else if ( level.team[ TEAM_ALIENS ].locked )
@@ -1019,14 +1019,14 @@ static void Cmd_Team_f( gentity_t *ent )
 					// tell the player to join the other team.
 					if ( g_teamForceBalance.Get() == 1 && players[ TEAM_HUMANS ] > players[ TEAM_ALIENS ] )
 					{
-						G_TriggerMenu( ent - g_entities, MN_H_TEAMFULL );
+						G_TriggerMenu( ent->num(), MN_H_TEAMFULL );
 						return;
 					}
 					// 2: Check for this team having more player than the other
 					// theam only if the other team is not empty.
 					else if ( g_teamForceBalance.Get() == 2 && players[ TEAM_ALIENS ] > 0 && players[ TEAM_HUMANS ] > players[ TEAM_ALIENS ] )
 					{
-						G_TriggerMenu( ent - g_entities, MN_H_TEAMFULL );
+						G_TriggerMenu( ent->num(), MN_H_TEAMFULL );
 						return;
 					}
 				}
@@ -1035,7 +1035,7 @@ static void Cmd_Team_f( gentity_t *ent )
 				break;
 
 			default:
-				trap_SendServerCommand( ent - g_entities,
+				trap_SendServerCommand( ent->num(),
 				                        va( "print_tr %s %s", QQ( N_("Unknown team: $1$") ), Quote( s ) ) );
 				return;
 		}
@@ -1048,7 +1048,7 @@ static void Cmd_Team_f( gentity_t *ent )
 	{
 		if ( G_admin_joindelay( specOnly ) == -1 )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        "print_tr \"" N_("You cannot join a team until the next game.") "\"" );
 			return;
 		}
@@ -1057,7 +1057,7 @@ static void Cmd_Team_f( gentity_t *ent )
 		{
 			int remaining = G_admin_joindelay( specOnly ) - t;
 
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s %d", QQ( N_("You cannot join a team for another $1$s.") ), remaining ) );
 			return;
 		}
@@ -1072,7 +1072,7 @@ static void Cmd_Team_f( gentity_t *ent )
 	if ( team != TEAM_NONE && g_maxGameClients.Get() &&
 	     level.numPlayingClients >= g_maxGameClients.Get() )
 	{
-		G_TriggerMenu( ent - g_entities, MN_PLAYERLIMIT );
+		G_TriggerMenu( ent->num(), MN_PLAYERLIMIT );
 		return;
 	}
 
@@ -1124,14 +1124,14 @@ static bool G_SayTo( gentity_t *ent, gentity_t *other, saymode_t mode, const cha
 
 	if ( mode == SAY_ALL_ADMIN )
 	{
-		trap_SendServerCommand( other - g_entities, va( "achat %s %d %s",
+		trap_SendServerCommand( other->num(), va( "achat %s %d %s",
 		                        G_quoted_admin_name( ent ),
 		                        mode, Quote( message ) ) );
 	}
 	else
 	{
-		trap_SendServerCommand( other - g_entities, va( "chat %ld %d %s",
-		                        ent ? ( long )( ent - g_entities ) : -1,
+		trap_SendServerCommand( other->num(), va( "chat %d %d %s",
+		                        ent ? ent->num() : -1,
 		                        mode, Quote( message ) ) );
 	}
 
@@ -1148,7 +1148,7 @@ void G_Say( gentity_t *ent, saymode_t mode, const char *chatText )
 	     ( ent ) && ( ent->client->pers.team == TEAM_NONE ) &&
 	     ( !G_admin_permission( ent, ADMF_NOCENSORFLOOD ) ) )
 	{
-		trap_SendServerCommand( ent - g_entities, "print_tr \"" N_("say: Global chatting for "
+		trap_SendServerCommand( ent->num(), "print_tr \"" N_("say: Global chatting for "
 		                        "spectators has been disabled. You may only use team chat.") "\"" );
 		mode = SAY_TEAM;
 	}
@@ -1157,14 +1157,14 @@ void G_Say( gentity_t *ent, saymode_t mode, const char *chatText )
 	{
 		case SAY_ALL:
 			G_LogPrintf( "Say: %d \"%s^*\": ^2%s",
-			             ( ent ) ? ( int )( ent - g_entities ) : -1,
-			             ( ent ) ? ent->client->pers.netname : "console", chatText );
+			             ent ? ent->num() : -1,
+			             ent ? ent->client->pers.netname : "console", chatText );
 			break;
 
 		case SAY_ALL_ADMIN:
 			G_LogPrintf( "Say: %d \"%s^*\": ^6%s",
-			             ( ent ) ? ( int )( ent - g_entities ) : -1,
-			             ( ent ) ? ent->client->pers.netname : "console", chatText );
+			             ent ? ent->num() : -1,
+			             ent ? ent->client->pers.netname : "console", chatText );
 			break;
 
 		case SAY_TEAM:
@@ -1176,7 +1176,7 @@ void G_Say( gentity_t *ent, saymode_t mode, const char *chatText )
 			}
 
 			G_LogPrintf( "SayTeam: %d \"%s^*\": ^5%s",
-			             ( int )( ent - g_entities ), ent->client->pers.netname, chatText );
+			             ent->num(), ent->client->pers.netname, chatText );
 			break;
 
 		case SAY_RAW:
@@ -1226,7 +1226,7 @@ static void Cmd_SayArea_f( gentity_t *ent )
 	}
 
 	G_LogPrintf( "SayArea: %d \"%s^*\": ^4%s",
-	             ( int )( ent - g_entities ), ent->client->pers.netname, msg );
+	             ent->num(), ent->client->pers.netname, msg );
 
 	VectorAdd( ent->s.origin, range, maxs );
 	VectorSubtract( ent->s.origin, range, mins );
@@ -1271,7 +1271,7 @@ static void Cmd_SayAreaTeam_f( gentity_t *ent )
 	}
 
 	G_LogPrintf( "SayAreaTeam: %d \"%s^*\": ^4%s",
-	             ( int )( ent - g_entities ), ent->client->pers.netname, msg );
+	             ent->num(), ent->client->pers.netname, msg );
 
 	VectorAdd( ent->s.origin, range, maxs );
 	VectorSubtract( ent->s.origin, range, mins );
@@ -1393,21 +1393,21 @@ static void Cmd_VSay_f( gentity_t *ent )
 
 	if ( trap_Argc() < 2 )
 	{
-		trap_SendServerCommand( ent - g_entities, va(
+		trap_SendServerCommand( ent->num(), va(
 		                          "print_tr %s %s", QQ( N_("usage: $1$ command [text]") ),  arg ) );
 		return;
 	}
 
 	if ( !level.voices )
 	{
-		trap_SendServerCommand( ent - g_entities, va(
+		trap_SendServerCommand( ent->num(), va(
 		                          "print_tr %s %s", QQ( N_("$1$: voice system is not installed on this server") ), arg ) );
 		return;
 	}
 
 	if ( !g_enableVsays.Get() )
 	{
-		trap_SendServerCommand( ent - g_entities, va(
+		trap_SendServerCommand( ent->num(), va(
 		                          "print_tr %s %s", QQ( N_("$1$: voice system administratively disabled on this server") ),
 		                          arg ) );
 		return;
@@ -1441,7 +1441,7 @@ static void Cmd_VSay_f( gentity_t *ent )
 
 	if ( !voice )
 	{
-		trap_SendServerCommand( ent - g_entities, va(
+		trap_SendServerCommand( ent->num(), va(
 		                          "print_tr %s %s %s", QQ( N_("$1$: voice '$2$' not found") ), vsay, Quote( voiceName ) ) );
 		return;
 	}
@@ -1451,7 +1451,7 @@ static void Cmd_VSay_f( gentity_t *ent )
 
 	if ( !cmd )
 	{
-		trap_SendServerCommand( ent - g_entities, va(
+		trap_SendServerCommand( ent->num(), va(
 		                          "print_tr %s %s %s %s", QQ( N_("$1$: command '$2$' not found in voice '$3$'") ),
 		                          vsay, Quote( voiceCmd ), Quote( voiceName ) ) );
 		return;
@@ -1471,7 +1471,7 @@ static void Cmd_VSay_f( gentity_t *ent )
 
 	if ( !track )
 	{
-		trap_SendServerCommand( ent - g_entities, va("print_tr %s %s %s %d %d %d %d %s",
+		trap_SendServerCommand( ent->num(), va("print_tr %s %s %s %d %d %d %d %s",
 		                          QQ( N_("$1$: no available track for command '$2$', team $3$, "
 		                          "class $4$, weapon $5$, and enthusiasm $6$ in voice '$7$'") ),
 		                          vsay, Quote( voiceCmd ), ent->client->pers.team,
@@ -1495,20 +1495,20 @@ static void Cmd_VSay_f( gentity_t *ent )
 	{
 		case VOICE_CHAN_ALL:
 			trap_SendServerCommand( -1, va(
-			                          "voice %ld %d %d %d %s",
-			                          ( long )( ent - g_entities ), vchan, cmdNum, trackNum, Quote( arg ) ) );
+			                          "voice %d %d %d %d %s",
+			                          ent->num(), vchan, cmdNum, trackNum, Quote( arg ) ) );
 			break;
 
 		case VOICE_CHAN_TEAM:
 			G_TeamCommand( (team_t) ent->client->pers.team, va(
-			                 "voice %ld %d %d %d %s",
-			                 ( long )( ent - g_entities ), vchan, cmdNum, trackNum, Quote( arg ) ) );
+			                 "voice %d %d %d %d %s",
+			                 ent->num(), vchan, cmdNum, trackNum, Quote( arg ) ) );
 			break;
 
 		case VOICE_CHAN_LOCAL:
 			G_AreaTeamCommand( ent, va(
-			                 "voice %ld %d %d %d %s",
-			                 ( long )( ent - g_entities ), vchan, cmdNum, trackNum, Quote( arg ) ) );
+			                 "voice %d %d %d %d %s",
+			                 ent->num(), vchan, cmdNum, trackNum, Quote( arg ) ) );
 			break;
 
 		default:
@@ -1528,7 +1528,7 @@ static void Cmd_Where_f( gentity_t *ent )
 		return;
 	}
 
-	trap_SendServerCommand( ent - g_entities,
+	trap_SendServerCommand( ent->num(),
 	                        va( "print_tr %s %f %f %f", QQ( N_("origin: $1$ $2$ $3$") ),
 	                            ent->s.origin[ 0 ], ent->s.origin[ 1 ],
 	                            ent->s.origin[ 2 ] ) );
@@ -1654,14 +1654,14 @@ static void Cmd_CallVote_f( gentity_t *ent )
 
 	if ( !g_allowVote.Get() )
 	{
-		trap_SendServerCommand( ent - g_entities,
+		trap_SendServerCommand( ent->num(),
 		                        va( "print_tr %s %s", QQ( N_("$1$: voting not allowed here") ), cmd ) );
 		return;
 	}
 
 	if ( level.team[ team ].voteTime )
 	{
-		trap_SendServerCommand( ent - g_entities,
+		trap_SendServerCommand( ent->num(),
 		                        va( "print_tr %s %s", QQ( N_("$1$: a vote is already in progress") ), cmd ) );
 		return;
 	}
@@ -1694,8 +1694,8 @@ static void Cmd_CallVote_f( gentity_t *ent )
 	{
 		bool added = false;
 
-		trap_SendServerCommand( ent - g_entities, "print_tr \"" N_("Invalid vote string") "\"" );
-		trap_SendServerCommand( ent - g_entities, va( "print_tr %s", team == TEAM_NONE ? QQ( N_("Valid vote commands are: ") ) :
+		trap_SendServerCommand( ent->num(), "print_tr \"" N_("Invalid vote string") "\"" );
+		trap_SendServerCommand( ent->num(), va( "print_tr %s", team == TEAM_NONE ? QQ( N_("Valid vote commands are: ") ) :
 			QQ( N_("Valid team-vote commands are: ") ) ) );
 		cmd[0] = '\0';
 
@@ -1715,7 +1715,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 		}
 
 		Q_strcat( cmd, sizeof( cmd ), "\"" );
-		trap_SendServerCommand( ent - g_entities, cmd );
+		trap_SendServerCommand( ent->num(), cmd );
 
 		return;
 	}
@@ -1724,7 +1724,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 	     ent->client->pers.namelog->voteCount >= g_voteLimit.Get() &&
 	     !G_admin_permission( ent, ADMF_NO_VOTE_LIMIT ) )
 	{
-		trap_SendServerCommand( ent - g_entities, va(
+		trap_SendServerCommand( ent->num(), va(
 		                          "print_tr %s %s %d", QQ( N_("$1$: you have already called the maximum number of votes ($2$)") ),
 		                          cmd, g_voteLimit.Get() ) );
 		return;
@@ -1734,7 +1734,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 		voteInfo[voteId].percentage->Get() : 50;
 	if ( voteThreshold <= 0 || isDisabledVoteType(vote) )
 	{
-		trap_SendServerCommand( ent - g_entities, va( "print_tr %s %s", QQ( N_("'$1$' votes have been disabled") ), voteInfo[voteId].name ) );
+		trap_SendServerCommand( ent->num(), va( "print_tr %s %s", QQ( N_("'$1$' votes have been disabled") ), voteInfo[voteId].name ) );
 		return;
 	}
 	if ( voteThreshold > 100)
@@ -1752,7 +1752,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 	case VOTE_BEFORE:
 		if ( level.numConnectedPlayers > 1 && level.matchTime >= ( voteInfo[voteId].specialCvar->Get() * 60000 ) )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s %s %d", QQ( N_("'$1$' votes are not allowed once $2$ minutes have passed") ), voteInfo[voteId].name, voteInfo[voteId].specialCvar->Get() ) );
 			return;
 		}
@@ -1762,7 +1762,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 	case VOTE_AFTER:
 		if ( level.numConnectedPlayers > 1 && level.matchTime < ( voteInfo[voteId].specialCvar->Get() * 60000 ) )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s %s %d", QQ( N_("'$1$' votes are not allowed until $2$ minutes have passed") ), voteInfo[voteId].name, voteInfo[voteId].specialCvar->Get() ) );
 			return;
 		}
@@ -1772,7 +1772,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 	case VOTE_REMAIN:
 		if ( !level.timelimit || level.matchTime < ( level.timelimit - voteInfo[voteId].specialCvar->Get() / 2 ) * 60000 )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s %s %d", QQ( N_("'$1$' votes are only allowed with less than $2$ minutes remaining") ),
 			                            voteInfo[voteId].name, voteInfo[voteId].specialCvar->Get() / 2 ) );
 			return;
@@ -1804,7 +1804,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 
 		if ( !arg[ 0 ] )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s %s", QQ( N_("$1$: no target") ), cmd ) );
 			return;
 		}
@@ -1823,14 +1823,14 @@ static void Cmd_CallVote_f( gentity_t *ent )
 
 		if ( g_entities[clientNum].r.svFlags & SVF_BOT )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s %s", QQ( N_("$1$: player is a bot") ), cmd ) );
 			return;
 		}
 
 		if ( voteInfo[voteId].adminImmune && G_admin_permission( g_entities + clientNum, ADMF_IMMUNITY ) )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s %s", QQ( N_("$1$: admin is immune") ), cmd ) );
 			G_AdminMessage( nullptr,
 			                va( "^7%s^3 attempted %s %s"
@@ -1844,7 +1844,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 
 		if ( level.clients[ clientNum ].pers.localClient )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s %s", QQ( N_("$1$: admin is immune") ), cmd ) );
 			return;
 		}
@@ -1852,7 +1852,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 		if ( team != TEAM_NONE &&
 			 ent->client->pers.team != level.clients[ clientNum ].pers.team )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s %s", QQ( N_("$1$: player is not on your team") ), cmd ) );
 			return;
 		}
@@ -1862,7 +1862,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 	     !( voteInfo[voteId].adminImmune && G_admin_permission( ent, ADMF_UNACCOUNTABLE ) ) &&
 	     !( voteInfo[voteId].reasonFlag && voteInfo[voteId].reasonFlag->Get() ) )
 	{
-		trap_SendServerCommand( ent - g_entities,
+		trap_SendServerCommand( ent->num(),
 		                        va( "print_tr %s %s", QQ( N_("$1$: You must provide a reason") ), cmd ) );
 		return;
 	}
@@ -1896,7 +1896,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 			if ( numBots == 0 )
 			{
 				trap_SendServerCommand(
-					ent - g_entities,
+					ent->num(),
 					va( "print_tr %s %s", QQ( N_("$1$: there are no active bots") ), cmd ) );
 				return;
 			}
@@ -1912,7 +1912,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 			int num = 0;
 			if ( !botFillVoteParseArg( num, arg ) )
 			{
-				trap_SendServerCommand( ent - g_entities, va( "print_tr %s %s %s", QQ( N_("$1$: number must be non-negative and smaller than $2$") ), cmd, std::to_string( g_maxVoteFillBots.Get() + 1 ).c_str() ) );
+				trap_SendServerCommand( ent->num(), va( "print_tr %s %s %s", QQ( N_("$1$: number must be non-negative and smaller than $2$") ), cmd, std::to_string( g_maxVoteFillBots.Get() + 1 ).c_str() ) );
 				return;
 			}
 
@@ -1927,7 +1927,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 			int num = 0;
 			if ( !botFillVoteParseArg( num, arg ) )
 			{
-				trap_SendServerCommand( ent - g_entities, va( "print_tr %s %s %s", QQ( N_("$1$: number must be non-negative and smaller than $2$") ), cmd, std::to_string( g_maxVoteFillBots.Get() + 1 ).c_str() ) );
+				trap_SendServerCommand( ent->num(), va( "print_tr %s %s %s", QQ( N_("$1$: number must be non-negative and smaller than $2$") ), cmd, std::to_string( g_maxVoteFillBots.Get() + 1 ).c_str() ) );
 				return;
 			}
 
@@ -1942,7 +1942,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 			int num = 0;
 			if ( !botFillVoteParseArg( num, arg ) )
 			{
-				trap_SendServerCommand( ent - g_entities, va( "print_tr %s %s %s", QQ( N_("$1$: number must be non-negative and smaller than $2$") ), cmd, std::to_string( g_maxVoteFillBots.Get() + 1 ).c_str() ) );
+				trap_SendServerCommand( ent->num(), va( "print_tr %s %s %s", QQ( N_("$1$: number must be non-negative and smaller than $2$") ), cmd, std::to_string( g_maxVoteFillBots.Get() + 1 ).c_str() ) );
 				return;
 			}
 
@@ -1955,7 +1955,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 	case VOTE_MUTE:
 		if ( level.clients[ clientNum ].pers.namelog->muted )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s %s", QQ( N_("$1$: player is already muted") ), cmd ) );
 			return;
 		}
@@ -1970,7 +1970,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 	case VOTE_UNMUTE:
 		if ( !level.clients[ clientNum ].pers.namelog->muted )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s %s", QQ( N_("$1$: player is not currently muted") ), cmd ) );
 			return;
 		}
@@ -1985,7 +1985,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 	case VOTE_DENYBUILD:
 		if ( level.clients[ clientNum ].pers.namelog->denyBuild )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s %s", QQ( N_("$1$: player already lost building rights") ), cmd ) );
 			return;
 		}
@@ -2000,7 +2000,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 	case VOTE_ALLOWBUILD:
 		if ( !level.clients[ clientNum ].pers.namelog->denyBuild )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s %s", QQ( N_("$1$: player already has building rights") ), cmd ) );
 			return;
 		}
@@ -2042,7 +2042,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 	case VOTE_MAP:
 		if ( !G_MapExists( arg ) )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s %s %s", QQ( N_("$1$: 'maps/$2$.bsp' could not be found on the server") ),
 			                            cmd, Quote( arg ) ) );
 			return;
@@ -2079,7 +2079,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 			if ( Q_stricmp( arg, S_BUILTIN_LAYOUT ) &&
 			     !G_LayoutExists( map, arg ) )
 			{
-				trap_SendServerCommand( ent - g_entities, va( "print_tr %s %s", QQ( N_("callvote: "
+				trap_SendServerCommand( ent->num(), va( "print_tr %s %s", QQ( N_("callvote: "
 				                        "layout '$1$' could not be found on the server") ), Quote( arg ) ) );
 				return;
 			}
@@ -2093,7 +2093,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 	case VOTE_NEXT_MAP:
 		if ( G_MapExists( g_nextMap.Get().c_str() ) )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s %s %s", QQ( N_("$1$: the next map is already set to '$2$'") ),
 			                            cmd, Quote( g_nextMap.Get().c_str() ) ) );
 			return;
@@ -2101,7 +2101,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 
 		if ( !G_MapExists( arg ) )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s %s %s", QQ( N_("$1$: 'maps/$2$.bsp' could not be found on the server") ),
 			                            cmd, Quote( arg ) ) );
 			return;
@@ -2147,7 +2147,7 @@ static void Cmd_CallVote_f( gentity_t *ent )
 
 	G_LogPrintf( "%s: %d \"%s^*\": %s",
 	             team == TEAM_NONE ? "CallVote" : "CallTeamVote",
-	             ( int )( ent - g_entities ), ent->client->pers.netname, level.team[ team ].voteString );
+	             ent->num(), ent->client->pers.netname, level.team[ team ].voteString );
 
 	if ( team == TEAM_NONE )
 	{
@@ -2216,19 +2216,19 @@ static void Cmd_Vote_f( gentity_t *ent )
 
 	if ( !level.team[ team ].voteTime )
 	{
-		trap_SendServerCommand( ent - g_entities,
+		trap_SendServerCommand( ent->num(),
 		                        va( "print_tr %s %s", QQ( N_("$1$: no vote in progress") ), cmd ) );
 		return;
 	}
 
 	if ( ent->client->pers.voted & ( 1 << team ) )
 	{
-		trap_SendServerCommand( ent - g_entities,
+		trap_SendServerCommand( ent->num(),
 		                        va( "print_tr %s %s", QQ( N_("$1$: vote already cast") ),  cmd ) );
 		return;
 	}
 
-	trap_SendServerCommand( ent - g_entities,
+	trap_SendServerCommand( ent->num(),
 	                        va( "print_tr %s %s", QQ( N_("$1$: vote cast") ), cmd ) );
 
 	trap_Argv( 1, vote, sizeof( vote ) );
@@ -2261,7 +2261,7 @@ static void Cmd_SetViewpos_f( gentity_t *ent )
 
 	if ( trap_Argc() < 4 && trap_Argc() != 2 )
 	{
-		trap_SendServerCommand( ent - g_entities, "print_tr \"" N_("usage: setviewpos (<x> <y> <z> [<yaw> [<pitch>]] | <entitynum>)") "\"" );
+		trap_SendServerCommand( ent->num(), "print_tr \"" N_("usage: setviewpos (<x> <y> <z> [<yaw> [<pitch>]] | <entitynum>)") "\"" );
 		return;
 	}
 
@@ -2928,7 +2928,7 @@ static void Cmd_ActivateItem_f( gentity_t *ent )
 	}
 	else
 	{
-		trap_SendServerCommand( ent - g_entities, va( "print_tr %s %s", QQ( N_("You don't have the $1$") ), Quote( s ) ) );
+		trap_SendServerCommand( ent->num(), va( "print_tr %s %s", QQ( N_("You don't have the $1$") ), Quote( s ) ) );
 	}
 }
 
@@ -2953,7 +2953,7 @@ static void Cmd_DeActivateItem_f( gentity_t *ent )
 	}
 	else
 	{
-		trap_SendServerCommand( ent - g_entities, va( "print_tr %s %s", QQ( N_("You don't have the $1$") ), Quote( s ) ) );
+		trap_SendServerCommand( ent->num(), va( "print_tr %s %s", QQ( N_("You don't have the $1$") ), Quote( s ) ) );
 	}
 }
 
@@ -3006,7 +3006,7 @@ static void Cmd_ToggleItem_f( gentity_t *ent )
 	}
 	else
 	{
-		trap_SendServerCommand( ent - g_entities, va( "print_tr %s %s", QQ( N_("You don't have the $1$") ), Quote( s ) ) );
+		trap_SendServerCommand( ent->num(), va( "print_tr %s %s", QQ( N_("You don't have the $1$") ), Quote( s ) ) );
 	}
 }
 
@@ -3147,7 +3147,7 @@ static bool Cmd_Sell_internal( gentity_t *ent, const char *s )
 		//are we /allowed/ to sell this?
 		if ( !BG_Weapon( weapon )->purchasable )
 		{
-			trap_SendServerCommand( ent - g_entities, "print_tr \"" N_("You can't sell this weapon") "\"" );
+			trap_SendServerCommand( ent->num(), "print_tr \"" N_("You can't sell this weapon") "\"" );
 			return false;
 		}
 
@@ -3180,7 +3180,7 @@ static bool Cmd_Sell_internal( gentity_t *ent, const char *s )
 		//are we /allowed/ to sell this?
 		if ( !BG_Upgrade( upgrade )->purchasable )
 		{
-			trap_SendServerCommand( ent - g_entities, "print_tr \"" N_("You can't sell this item") "\"" );
+			trap_SendServerCommand( ent->num(), "print_tr \"" N_("You can't sell this item") "\"" );
 			return false;
 		}
 
@@ -3470,11 +3470,11 @@ static bool Cmd_Buy_internal( gentity_t *ent, const char *s, bool sellConflictin
 	return false;
 
 cant_buy:
-	trap_SendServerCommand( ent - g_entities, va( "print_tr \"" N_("You can't buy this item ($1$)") "\" %s", Quote( s ) ) );
+	trap_SendServerCommand( ent->num(), va( "print_tr \"" N_("You can't buy this item ($1$)") "\" %s", Quote( s ) ) );
 	return false;
 
 not_alien:
-	trap_SendServerCommand( ent - g_entities, "print_tr \"" N_("You can't buy alien items") "\"" );
+	trap_SendServerCommand( ent->num(), "print_tr \"" N_("You can't buy alien items") "\"" );
 	return false;
 }
 
@@ -3653,20 +3653,20 @@ void Cmd_TeamStatus_f( gentity_t * ent )
 
 	if ( g_teamStatus.Get() <= 0 ) 
 	{
-		trap_SendServerCommand( ent - g_entities, "print \"teamstatus is disabled.\n\"" );
+		trap_SendServerCommand( ent->num(), "print \"teamstatus is disabled.\n\"" );
 		return;
 	}
 
 	if ( ent->client->pers.namelog->muted ) 
 	{
-		trap_SendServerCommand( ent - g_entities, "print \"You are muted and cannot use message commands.\n\"" );
+		trap_SendServerCommand( ent->num(), "print \"You are muted and cannot use message commands.\n\"" );
 		return;
 	}
 
 	if ( level.team[ G_Team( ent ) ].lastTeamStatus
 		&& ( level.time - level.team[ G_Team( ent ) ].lastTeamStatus ) < g_teamStatus.Get() * 1000 ) 
 	{
-		trap_SendServerCommand( ent - g_entities, va( "print \"Your team's status may only be checked every %i seconds.\"", g_teamStatus.Get() ) );
+		trap_SendServerCommand( ent->num(), va( "print \"Your team's status may only be checked every %i seconds.\"", g_teamStatus.Get() ) );
 		return;
 	}
 
@@ -3804,7 +3804,7 @@ void G_StopFollowing( gentity_t *ent )
 	ent->client->ps.stats[ STAT_STATE ] = 0;
 	ent->client->ps.stats[ STAT_VIEWLOCK ] = 0;
 	ent->client->ps.eFlags &= ~( EF_WALLCLIMB | EF_WALLCLIMBCEILING );
-	ent->client->ps.clientNum = ent - g_entities;
+	ent->client->ps.clientNum = ent->num();
 	ent->client->ps.persistant[ PERS_CREDIT ] = ent->client->pers.credit;
 
 	if ( ent->client->pers.team == TEAM_NONE )
@@ -4018,7 +4018,7 @@ static void Cmd_Follow_f( gentity_t *ent )
 
 		if ( i == -1 )
 		{
-			trap_SendServerCommand( ent - g_entities,
+			trap_SendServerCommand( ent->num(),
 			                        va( "print_tr %s %s %s", QQ( "$1$: $2t$" ), "follow", Quote( err ) ) );
 			return;
 		}
@@ -4093,7 +4093,7 @@ static void Cmd_Ignore_f( gentity_t *ent )
 
 	if ( trap_Argc() < 2 )
 	{
-		trap_SendServerCommand( ent - g_entities, va( "print_tr \"" S_SKIPNOTIFY
+		trap_SendServerCommand( ent->num(), va( "print_tr \"" S_SKIPNOTIFY
 		                        "%s\" %s", N_("usage: $1$ [clientNum | partial name match]"), cmd ) );
 		return;
 	}
@@ -4103,7 +4103,7 @@ static void Cmd_Ignore_f( gentity_t *ent )
 
 	if ( matches < 1 )
 	{
-		trap_SendServerCommand( ent - g_entities, va( "print_tr \"" S_SKIPNOTIFY
+		trap_SendServerCommand( ent->num(), va( "print_tr \"" S_SKIPNOTIFY
 		                        "%s\" %s %s", N_("$1$: no clients match the name '$2$'"), cmd, Quote( name ) ) );
 		return;
 	}
@@ -4116,13 +4116,13 @@ static void Cmd_Ignore_f( gentity_t *ent )
 			{
 				Com_ClientListAdd( &ent->client->sess.ignoreList, pids[ i ] );
 				ClientUserinfoChanged( ent->client->ps.clientNum, false );
-				trap_SendServerCommand( ent - g_entities, va( "print_tr \"" S_SKIPNOTIFY
+				trap_SendServerCommand( ent->num(), va( "print_tr \"" S_SKIPNOTIFY
 				                        "%s\" %s", N_("ignore: added $1$^* to your ignore list"),
 				                        Quote( level.clients[ pids[ i ] ].pers.netname ) ) );
 			}
 			else
 			{
-				trap_SendServerCommand( ent - g_entities, va( "print_tr \"" S_SKIPNOTIFY
+				trap_SendServerCommand( ent->num(), va( "print_tr \"" S_SKIPNOTIFY
 				                        "%s\" %s", N_("ignore: $1$^* is already on your ignore list"),
 				                        Quote( level.clients[ pids[ i ] ].pers.netname ) ) );
 			}
@@ -4133,13 +4133,13 @@ static void Cmd_Ignore_f( gentity_t *ent )
 			{
 				Com_ClientListRemove( &ent->client->sess.ignoreList, pids[ i ] );
 				ClientUserinfoChanged( ent->client->ps.clientNum, false );
-				trap_SendServerCommand( ent - g_entities, va( "print_tr \"" S_SKIPNOTIFY
+				trap_SendServerCommand( ent->num(), va( "print_tr \"" S_SKIPNOTIFY
 				                        "%s\" %s", N_("unignore: removed $1$^* from your ignore list"),
 				                        Quote( level.clients[ pids[ i ] ].pers.netname ) ) );
 			}
 			else
 			{
-				trap_SendServerCommand( ent - g_entities, va( "print_tr \"" S_SKIPNOTIFY
+				trap_SendServerCommand( ent->num(), va( "print_tr \"" S_SKIPNOTIFY
 				                        "%s\" %s", N_("unignore: $1$^* is not on your ignore list"),
 				                        Quote( level.clients[ pids[ i ] ].pers.netname ) )  );
 			}
@@ -4549,7 +4549,7 @@ static void Cmd_Beacon_f( gentity_t *ent )
 	// Check usage.
 	if ( trap_Argc( ) < 2 )
 	{
-		trap_SendServerCommand( ent - g_entities,
+		trap_SendServerCommand( ent->num(),
 		                        va( "print_tr %s", QQ( N_("Usage: beacon [type]") ) ) );
 		return;
 	}
@@ -4562,7 +4562,7 @@ static void Cmd_Beacon_f( gentity_t *ent )
 	// Check arguments.
 	if ( !battr || battr->flags & BCF_RESERVED )
 	{
-		trap_SendServerCommand( ent - g_entities,
+		trap_SendServerCommand( ent->num(),
 		                        va( "print_tr %s %s", QQ( N_("Unknown beacon type $1$") ),
 		                            Quote( type_str ) ) );
 		return;
@@ -4633,7 +4633,7 @@ int G_FloodLimited( gentity_t *ent )
 		return 0;
 	}
 
-	trap_SendServerCommand( ent - g_entities, va( "print_tr %s %d", QQ( N_("You are flooding: "
+	trap_SendServerCommand( ent->num(), va( "print_tr %s %d", QQ( N_("You are flooding: "
 	                        "please wait $1$s before trying again") ),
 	                        ( ms + 999 ) / 1000 ) );
 	return ms;
@@ -4881,9 +4881,9 @@ void Cmd_PrivateMessage_f( gentity_t *ent )
 		          color.c_str(), count, Quote( recipients ) ) );
 
 		G_LogPrintf( "%s: %d \"%s^*\" \"%s\": %s%s",
-		             ( teamonly ) ? "TPrivMsg" : "PrivMsg",
-		             ( ent ) ? ( int )( ent - g_entities ) : -1,
-		             ( ent ) ? ent->client->pers.netname : "console",
+		             teamonly ? "TPrivMsg" : "PrivMsg",
+		             ent ? ent->num() : -1,
+		             ent ? ent->client->pers.netname : "console",
 		             name, color.c_str(), msg );
 	}
 }

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -2525,7 +2525,7 @@ static void G_AlienEvolve_evolve( gentity_t *ent, class_t newClass, const vec3_t
 //     last step, this allows knowing if you can evolve
 bool G_AlienEvolve( gentity_t *ent, class_t newClass, bool report, bool dryRun )
 {
-	int       clientNum = ent->client->ps.clientNum;
+	int       clientNum = ent->num();
 	vec3_t    infestOrigin;
 	class_t   currentClass = ent->client->pers.classSelection;
 
@@ -2663,7 +2663,7 @@ Cmd_Class_f
 */
 static bool Cmd_Class_spawn_internal( gentity_t *ent, const char *s, bool report )
 {
-	int clientNum = ent->client->ps.clientNum;
+	int clientNum = ent->num();
 	team_t team = G_Team( ent );
 	class_t newClass = BG_ClassByName( s )->number;
 
@@ -2745,7 +2745,7 @@ static bool Cmd_Class_spawn_internal( gentity_t *ent, const char *s, bool report
 
 static bool Cmd_Class_internal( gentity_t *ent, const char *s, bool report )
 {
-	int clientNum = ent->client - level.clients;
+	int clientNum = ent->num();
 
 	if ( ent->client->sess.spectatorState != SPECTATOR_NOT )
 	{

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -1241,7 +1241,7 @@ static void Cmd_SayArea_f( gentity_t *ent )
 	//Send to ADMF_SPEC_ALLCHAT candidates
 	for ( i = 0; i < level.maxclients; i++ )
 	{
-		if ( g_entities[ i ].client->pers.team == TEAM_NONE &&
+		if ( g_clients[ i ].pers.team == TEAM_NONE &&
 		     G_admin_permission( &g_entities[ i ], ADMF_SPEC_ALLCHAT ) )
 		{
 			G_SayTo( ent, &g_entities[ i ], SAY_AREA, msg );
@@ -3920,7 +3920,7 @@ bool G_FollowNewClient( gentity_t *ent, int dir )
 		}
 
 		// can't follow self
-		if ( &g_entities[ clientnum ] == ent )
+		if ( clientnum == ent->num() )
 		{
 			continue;
 		}

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -135,15 +135,15 @@ static void LookAtKiller( gentity_t *self, gentity_t *inflictor, gentity_t *atta
 {
 	if ( attacker && attacker != self )
 	{
-		self->client->ps.stats[ STAT_VIEWLOCK ] = attacker - g_entities;
+		self->client->ps.stats[ STAT_VIEWLOCK ] = attacker->num();
 	}
 	else if ( inflictor && inflictor != self )
 	{
-		self->client->ps.stats[ STAT_VIEWLOCK ] = inflictor - g_entities;
+		self->client->ps.stats[ STAT_VIEWLOCK ] = inflictor->num();
 	}
 	else
 	{
-		self->client->ps.stats[ STAT_VIEWLOCK ] = self - g_entities;
+		self->client->ps.stats[ STAT_VIEWLOCK ] = self->num();
 	}
 }
 
@@ -389,7 +389,7 @@ void G_PlayerDie( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, in
 	{
 		G_LogPrintf( "Die: %d %d %s %d %d: %s^* killed %s^*; %s^* assisted",
 		             killer,
-		             ( int )( self - g_entities ),
+		             self->num(),
 		             obit,
 		             assistant,
 		             assistantTeam,
@@ -401,7 +401,7 @@ void G_PlayerDie( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, in
 	{
 		G_LogPrintf( "Die: %d %d %s: %s^* killed %s",
 		             killer,
-		             ( int )( self - g_entities ),
+		             self->num(),
 		             obit,
 		             killerName,
 		             self->client->pers.netname );
@@ -440,7 +440,7 @@ void G_PlayerDie( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, in
 		}
 		else if ( g_showKillerHP.Get() )
 		{
-			trap_SendServerCommand( self - g_entities, va( "print_tr %s %s %3i", QQ( N_("Your killer, $1$^*, had $2$ HP.") ),
+			trap_SendServerCommand( self->num(), va( "print_tr %s %s %3i", QQ( N_("Your killer, $1$^*, had $2$ HP.") ),
 			                        Quote( killerName ),
 			                        (int)std::ceil(attacker->entity->Get<HealthComponent>()->Health()) ) );
 		}
@@ -569,7 +569,7 @@ void G_PlayerDie( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, in
 
 		// use own entityid if killed by non-client to prevent uint8_t overflow
 		G_AddEvent( self, EV_DEATH1 + i,
-		            ( killer < MAX_CLIENTS ) ? killer : self - g_entities );
+		            ( killer < MAX_CLIENTS ) ? killer : self->num() );
 
 		// globally cycle through the different death animations
 		i = ( i + 1 ) % 3;
@@ -1036,8 +1036,8 @@ void G_LogDestruction( gentity_t *self, gentity_t *actor, int mod )
 	}
 
 	G_LogPrintf( "^3Deconstruct: %d %d %s %s: %s %s by %s",
-	             ( int )( actor - g_entities ),
-	             ( int )( self - g_entities ),
+	             actor->num(),
+	             self->num(),
 	             BG_Buildable( self->s.modelindex )->name,
 	             modNames[ mod ],
 	             BG_Buildable( self->s.modelindex )->humanName,

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -466,9 +466,7 @@ void G_PlayerDie( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, in
 	// or they would get stale scoreboards
 	for ( int i = 0; i < level.maxclients; i++ )
 	{
-		gclient_t *client;
-
-		client = &level.clients[ i ];
+		gclient_t *client = &level.clients[ i ];
 
 		if ( client->pers.connected != CON_CONNECTED )
 		{

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -170,7 +170,7 @@ static const gentity_t *G_FindKillAssist( const gentity_t *self, const gentity_t
 	damage = self->entity->Get<HealthComponent>()->MaxHealth() / 4.0f;
 	if ( killer && killer->client )
 	{
-		damage = std::min( damage, self->credits[ killer->s.number ].value );
+		damage = std::min( damage, self->credits[ killer->num() ].value );
 	}
 
 	// Find the best assistant
@@ -346,7 +346,7 @@ void G_PlayerDie( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, in
 
 	if ( attacker )
 	{
-		killer = attacker->s.number;
+		killer = attacker->num();
 
 		if ( attacker->client )
 		{
@@ -367,7 +367,7 @@ void G_PlayerDie( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, in
 
 	if ( assistantEnt )
 	{
-		assistant = assistantEnt->s.number;
+		assistant = assistantEnt->num();
 
 		if ( assistantEnt->client )
 		{
@@ -416,7 +416,7 @@ void G_PlayerDie( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, in
 	// broadcast the death event to everyone
 	ent = G_NewTempEntity( VEC2GLM( self->r.currentOrigin ), EV_OBITUARY );
 	ent->s.eventParm = meansOfDeath;
-	ent->s.otherEntityNum = self->s.number;
+	ent->s.otherEntityNum = self->num();
 	ent->s.otherEntityNum2 = killer;
 	ent->s.otherEntityNum3 = assistant;
 	ent->s.generic1 = assistantTeam;
@@ -480,7 +480,7 @@ void G_PlayerDie( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, in
 			continue;
 		}
 
-		if ( client->sess.spectatorClient == self->s.number )
+		if ( client->sess.spectatorClient == self->num() )
 		{
 			ScoreboardMessage( g_entities + i );
 		}
@@ -817,7 +817,7 @@ bool G_CanDamage( gentity_t *targ, vec3_t origin )
 	VectorCopy( midpoint, dest );
 	trap_Trace( &tr, origin, vec3_origin, vec3_origin, dest, ENTITYNUM_NONE, MASK_SOLID, 0 );
 
-	if ( tr.fraction == 1.0  || tr.entityNum == targ->s.number )
+	if ( tr.fraction == 1.0  || tr.entityNum == targ->num() )
 	{
 		return true;
 	}

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -258,7 +258,7 @@ const char *etos( const gentity_t *entity )
 
 	Com_sprintf( resultString, MAX_ETOS_LENGTH,
 			"%s%s^7(^5%s^*|^5#%i^*)",
-			entity->names[0] ? entity->names[0] : "", entity->names[0] ? " " : "", entity->classname, entity->s.number
+			entity->names[0] ? entity->names[0] : "", entity->names[0] ? " " : "", entity->classname, entity->num()
 			);
 
 	return resultString;
@@ -927,7 +927,7 @@ bool G_IsVisible( gentity_t *start, gentity_t *end, int contents )
 	trace_t trace;
 
 	trap_Trace( &trace, start->s.pos.trBase, nullptr, nullptr, end->s.pos.trBase,
-	            start->s.number, contents, 0 );
+	            start->num(), contents, 0 );
 
 	return trace.fraction >= 1.0f || trace.entityNum == end - g_entities;
 }

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -62,13 +62,13 @@ void G_InitGentity( gentity_t *entity )
 	entity->inuse = true;
 	entity->enabled = true;
 	entity->classname = "noclass";
-	entity->s.number = entity - g_entities;
+	entity->s.number = entity->num();
 	entity->r.ownerNum = ENTITYNUM_NONE;
 	entity->creationTime = level.time;
 	
 	if ( g_debugEntities.Get() > 2 )
 	{
-		Log::Debug("Initing Entity %i", entity - g_entities );
+		Log::Debug("Initing Entity %i", entity->num() );
 	}
 }
 
@@ -929,7 +929,7 @@ bool G_IsVisible( gentity_t *start, gentity_t *end, int contents )
 	trap_Trace( &trace, start->s.pos.trBase, nullptr, nullptr, end->s.pos.trBase,
 	            start->num(), contents, 0 );
 
-	return trace.fraction >= 1.0f || trace.entityNum == end - g_entities;
+	return trace.fraction >= 1.0f || trace.entityNum == end->num();
 }
 
 /*

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -31,9 +31,6 @@ along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>
 
 extern  level_locals_t level;
 
-extern gentity_t *g_entities;
-extern gclient_t *g_clients;
-
 extern bool g_cheats;
 
 // ---------

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -1546,6 +1546,8 @@ static void GetAverageCredits( int teamCredits[], int teamValue[] )
 	{
 		client = &g_clients[ playerNum ];
 
+		if ( !client->ent()->inuse ) continue;
+
 		team = client->pers.team;
 
 		teamCredits[ team ] += client->pers.credit;

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -1454,8 +1454,8 @@ void G_AdminMessage( gentity_t *ent, const char *msg )
 	char string[ 1024 ];
 	int  i;
 
-	Com_sprintf( string, sizeof( string ), "chat %ld %d %s",
-	             ent ? ( long )( ent - g_entities ) : -1,
+	Com_sprintf( string, sizeof( string ), "chat %d %d %s",
+	             ent ? ent->num() : -1,
 	             G_admin_permission( ent, ADMF_ADMINCHAT ) ? SAY_ADMINS : SAY_ADMINS_PUBLIC,
 	             Quote( msg ) );
 
@@ -1471,7 +1471,7 @@ void G_AdminMessage( gentity_t *ent, const char *msg )
 	// Send to the logfile and server console
 	G_LogPrintf( "%s: %d \"%s^*\": ^6%s",
 	             G_admin_permission( ent, ADMF_ADMINCHAT ) ? "AdminMsg" : "AdminMsgPublic",
-	             ent ? ( int )( ent - g_entities ) : -1, ent ? ent->client->pers.netname : "console",
+	             ent ? ent->num() : -1, ent ? ent->client->pers.netname : "console",
 	             msg );
 }
 

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -846,7 +846,7 @@ int G_PopSpawnQueue( spawnQueue_t *sq )
 		sq->clients[ sq->front ] = -1;
 		sq->front = QUEUE_PLUS1( sq->front );
 		G_StopFollowing( g_entities + clientNum );
-		g_entities[ clientNum ].client->ps.pm_flags &= ~PMF_QUEUED;
+		g_clients[ clientNum ].ps.pm_flags &= ~PMF_QUEUED;
 
 		return clientNum;
 	}
@@ -908,7 +908,7 @@ bool G_PushSpawnQueue( spawnQueue_t *sq, int clientNum )
 	sq->back = QUEUE_PLUS1( sq->back );
 	sq->clients[ sq->back ] = clientNum;
 
-	g_entities[ clientNum ].client->ps.pm_flags |= PMF_QUEUED;
+	g_clients[ clientNum ].ps.pm_flags |= PMF_QUEUED;
 	return true;
 }
 
@@ -941,7 +941,7 @@ bool G_RemoveFromSpawnQueue( spawnQueue_t *sq, int clientNum )
 				while ( i != QUEUE_PLUS1( sq->back ) );
 
 				sq->back = QUEUE_MINUS1( sq->back );
-				g_entities[ clientNum ].client->ps.pm_flags &= ~PMF_QUEUED;
+				g_clients[ clientNum ].ps.pm_flags &= ~PMF_QUEUED;
 
 				return true;
 			}
@@ -1532,7 +1532,6 @@ static void GetAverageCredits( int teamCredits[], int teamValue[] )
 {
 	int       teamCnt[ NUM_TEAMS ];
 	int       playerNum;
-	gentity_t *playerEnt;
 	gclient_t *client;
 	int       team;
 
@@ -1543,15 +1542,9 @@ static void GetAverageCredits( int teamCredits[], int teamValue[] )
 		teamValue[ team ] = 0;
 	}
 
-	for ( playerNum = 0; playerNum < MAX_CLIENTS; playerNum++ )
+	for ( playerNum = 0; playerNum < level.maxclients; playerNum++ )
 	{
-		playerEnt = &g_entities[ playerNum ];
-		client = playerEnt->client;
-
-		if ( !client )
-		{
-			continue;
-		}
+		client = &g_clients[ playerNum ];
 
 		team = client->pers.team;
 

--- a/src/sgame/sg_maprotation.cpp
+++ b/src/sgame/sg_maprotation.cpp
@@ -804,13 +804,13 @@ void G_PrintCurrentRotation( gentity_t *ent )
 
 	if ( mapRotation == nullptr )
 	{
-		trap_SendServerCommand( ent - g_entities, "print_tr " QQ( N_("^3listrotation:^* there is no active map rotation on this server") ) );
+		trap_SendServerCommand( ent->num(), "print_tr " QQ( N_("^3listrotation:^* there is no active map rotation on this server") ) );
 		return;
 	}
 
 	if ( mapRotation->numNodes == 0 )
 	{
-		trap_SendServerCommand( ent - g_entities, "print_tr " QQ( N_("^3listrotation:^* there are no maps in the active map rotation") ) );
+		trap_SendServerCommand( ent->num(), "print_tr " QQ( N_("^3listrotation:^* there are no maps in the active map rotation") ) );
 		return;
 	}
 

--- a/src/sgame/sg_missile.cpp
+++ b/src/sgame/sg_missile.cpp
@@ -208,7 +208,7 @@ static int ImpactFlamer( gentity_t *ent, trace_t *trace, gentity_t *hitEnt )
 	}
 
 	// set the environment on fire
-	if ( hitEnt->s.number == ENTITYNUM_WORLD )
+	if ( hitEnt->num() == ENTITYNUM_WORLD )
 	{
 		if ( random() < FLAMER_LEAVE_FIRE_CHANCE )
 		{
@@ -225,7 +225,7 @@ static int ImpactFirebombSub( gentity_t *ent, trace_t *trace, gentity_t *hitEnt 
 	hitEnt->entity->Ignite( ent->parent );
 
 	// set the environment on fire
-	if ( hitEnt->s.number == ENTITYNUM_WORLD )
+	if ( hitEnt->num() == ENTITYNUM_WORLD )
 	{
 		G_SpawnFire( trace->endpos, trace->plane.normal, ent->parent );
 	}
@@ -315,7 +315,7 @@ static int ImpactHive( gentity_t *ent, trace_t*, gentity_t *hitEnt )
 	else
 	{
 		// Prevent a collision with the client when returning.
-		ent->r.ownerNum = hitEnt->s.number;
+		ent->r.ownerNum = hitEnt->num();
 
 		ent->think = G_ExplodeMissile;
 		ent->nextthink = level.time + FRAMETIME;
@@ -430,7 +430,7 @@ static void MissileImpact( gentity_t *ent, trace_t *trace )
 		{
 			G_AddEvent( ent, EV_MISSILE_HIT_ENTITY, dirAsByte );
 
-			ent->s.otherEntityNum = hitEnt->s.number;
+			ent->s.otherEntityNum = hitEnt->num();
 		}
 		else if ( trace->surfaceFlags & SURF_METAL )
 		{
@@ -621,7 +621,7 @@ gentity_t *G_SpawnMissile( missile_t missile, gentity_t *parent, const vec3_t st
 	// generic
 	m->s.eType             = entityType_t::ET_MISSILE;
 	m->s.modelindex        = missile;
-	m->r.ownerNum          = parent->s.number;
+	m->r.ownerNum          = parent->num();
 	m->parent              = parent;
 	m->target              = target;
 	m->think               = think;
@@ -715,7 +715,7 @@ gentity_t *G_SpawnFire( vec3_t origin, vec3_t normal, gentity_t *fireStarter )
 	fire->entity->Ignite(fireStarter);
 
 	// attacker
-	fire->r.ownerNum = fireStarter->s.number;
+	fire->r.ownerNum = fireStarter->num();
 
 	// normal
 	VectorNormalize( normal ); // make sure normal is a direction

--- a/src/sgame/sg_momentum.cpp
+++ b/src/sgame/sg_momentum.cpp
@@ -253,7 +253,7 @@ static float AddMomentum( momentum_t type, team_t team, float amount,
 			{
 				event = G_NewTempEntity( VEC2GLM( client->ps.origin ), EV_MOMENTUM );
 				event->r.svFlags = SVF_SINGLECLIENT;
-				event->r.singleClient = client->ps.clientNum;
+				event->r.singleClient = client->num();
 			}
 		}
 		else

--- a/src/sgame/sg_namelog.cpp
+++ b/src/sgame/sg_namelog.cpp
@@ -73,7 +73,7 @@ void G_namelog_connect( gclient_t *client )
 	}
 
 	client->pers.namelog = n;
-	n->slot = client - level.clients;
+	n->slot = client->num();
 	n->banned = false;
 
 	newname = n->name[ n->nameOffset ];

--- a/src/sgame/sg_physics.cpp
+++ b/src/sgame/sg_physics.cpp
@@ -128,7 +128,7 @@ void G_Physics( gentity_t *ent, int )
 
 			VectorMA( origin, -2.0f, ent->s.origin2, origin );
 
-			trap_Trace( &tr, ent->r.currentOrigin, ent->r.mins, ent->r.maxs, origin, ent->s.number,
+			trap_Trace( &tr, ent->r.currentOrigin, ent->r.mins, ent->r.maxs, origin, ent->num(),
 			            ent->clipmask, 0 );
 
 			if ( tr.fraction == 1.0f )
@@ -147,7 +147,7 @@ void G_Physics( gentity_t *ent, int )
 	// get current position
 	BG_EvaluateTrajectory( &ent->s.pos, level.time, origin );
 
-	trap_Trace( &tr, ent->r.currentOrigin, ent->r.mins, ent->r.maxs, origin, ent->s.number,
+	trap_Trace( &tr, ent->r.currentOrigin, ent->r.mins, ent->r.maxs, origin, ent->num(),
 	            ent->clipmask, 0 );
 
 	VectorCopy( tr.endpos, ent->r.currentOrigin );

--- a/src/sgame/sg_session.cpp
+++ b/src/sgame/sg_session.cpp
@@ -86,7 +86,7 @@ void G_ReadSessionData( gclient_t *client )
 	char       botTree[ MAX_QPATH ];
 	char       ignorelist[ 17 ];
 
-	var = va( "session%li", ( long )( client - level.clients ) );
+	var = va( "session%i", client->num() );
 	trap_Cvar_VariableStringBuffer( var, s, sizeof( s ) );
 
 	sscanf( s, "%i %i %i %i %i %63s %16s",
@@ -126,7 +126,7 @@ void G_InitSessionData( gclient_t *client, const char *userinfo )
 	memset( &sess->ignoreList, 0, sizeof( sess->ignoreList ) );
 	sess->seenWelcome = 0;
 
-	G_WriteClientSessionData( client - level.clients );
+	G_WriteClientSessionData( client->num() );
 }
 
 /*

--- a/src/sgame/sg_spawn.cpp
+++ b/src/sgame/sg_spawn.cpp
@@ -524,7 +524,7 @@ static bool G_CallSpawnFunction( gentity_t *spawnedEntity )
 	{
 		//don't even warn about spawning-errors with -2 (maps might still work at least partly if we ignore these willingly)
 		if ( g_debugEntities.Get() > -2 )
-			Log::Warn("Entity ^5#%i^* is missing classname – we are unable to spawn it.", spawnedEntity->s.number );
+			Log::Warn("Entity ^5#%i^* is missing classname – we are unable to spawn it.", spawnedEntity->num() );
 		return false;
 	}
 
@@ -573,7 +573,7 @@ static bool G_CallSpawnFunction( gentity_t *spawnedEntity )
 		{
 			std::string count = spawnedEntity->eclass ? std::to_string(spawnedEntity->eclass->instanceCounter) : "??";
 			Log::Notice("Successfully spawned entity ^5#%i^* as ^3#%s^*th instance of ^5%s",
-			            spawnedEntity->s.number, count, spawnedClass->name);
+			            spawnedEntity->num(), count, spawnedClass->name);
 		}
 
 		/*
@@ -588,7 +588,7 @@ static bool G_CallSpawnFunction( gentity_t *spawnedEntity )
 	{
 		if (!Q_stricmp(S_WORLDSPAWN, spawnedEntity->classname))
 		{
-			Log::Warn("a ^5" S_WORLDSPAWN "^* class was misplaced into position ^5#%i^* of the spawn string – Ignoring", spawnedEntity->s.number );
+			Log::Warn("a ^5" S_WORLDSPAWN "^* class was misplaced into position ^5#%i^* of the spawn string – Ignoring", spawnedEntity->num() );
 		}
 		else
 		{
@@ -810,11 +810,11 @@ static void G_SpawnGEntityFromSpawnVars()
 	{
 		if ( level.numSpawnVars == 1 )
 		{
-			Log::Warn("encountered ghost-entity #%i with only one field: %s = %s", spawningEntity->s.number, level.spawnVars[ 0 ][ 0 ], level.spawnVars[ 0 ][ 1 ] );
+			Log::Warn("encountered ghost-entity #%i with only one field: %s = %s", spawningEntity->num(), level.spawnVars[ 0 ][ 0 ], level.spawnVars[ 0 ][ 1 ] );
 		}
 		else
 		{
-			Log::Warn("encountered ghost entity #%i with no fields", spawningEntity->s.number);
+			Log::Warn("encountered ghost entity #%i with no fields", spawningEntity->num());
 		}
 		G_FreeEntity( spawningEntity );
 		return;
@@ -896,7 +896,7 @@ bool G_WarnAboutDeprecatedEntityField( gentity_t *entity, const char *expectedFi
 	{
 		if ( typeOfDeprecation < ENT_V_TMPORARY || g_debugEntities.Get() >= 1 )
 		{
-			Log::Warn("Entity ^5#%i^* contains deprecated field ^5%s^* — use ^5%s^* instead", entity->s.number, actualFieldname, expectedFieldname );
+			Log::Warn("Entity ^5#%i^* contains deprecated field ^5%s^* — use ^5%s^* instead", entity->num(), actualFieldname, expectedFieldname );
 		}
 	}
 

--- a/src/sgame/sg_spawn_generic.cpp
+++ b/src/sgame/sg_spawn_generic.cpp
@@ -49,7 +49,7 @@ static void target_print_act( gentity_t *self, gentity_t*, gentity_t *activator 
 	{
 		if ( activator && activator->client )
 		{
-			trap_SendServerCommand( activator - g_entities, va( "cp %s", Quote( self->message ) ) );
+			trap_SendServerCommand( activator->num(), va( "cp %s", Quote( self->message ) ) );
 		}
 
 		return;

--- a/src/sgame/sg_spawn_gfx.cpp
+++ b/src/sgame/sg_spawn_gfx.cpp
@@ -189,7 +189,7 @@ static void gfx_portal_locateCamera( gentity_t *self )
 		return;
 	}
 
-	self->r.ownerNum = owner->s.number;
+	self->r.ownerNum = owner->num();
 
 	// frame holds the rotate speed
 	if ( owner->spawnflags & 1 )

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -70,12 +70,12 @@ static gentity_t *G_TestEntityPosition( gentity_t *ent )
 	if ( ent->client )
 	{
 		trap_Trace( &tr, ent->client->ps.origin, ent->r.mins, ent->r.maxs, ent->client->ps.origin,
-		            ent->s.number, ent->clipmask, 0 );
+		            ent->num(), ent->clipmask, 0 );
 	}
 	else
 	{
 		trap_Trace( &tr, ent->s.pos.trBase, ent->r.mins, ent->r.maxs, ent->s.pos.trBase,
-		            ent->s.number, ent->clipmask, 0 );
+		            ent->num(), ent->clipmask, 0 );
 	}
 
 	if ( tr.startsolid )
@@ -146,14 +146,14 @@ static bool G_TryPushingEntity( gentity_t *check, gentity_t *pusher, vec3_t move
 	// EF_MOVER_STOP will just stop when contacting another entity
 	// instead of pushing it, but entities can still ride on top of it
 	if ( ( pusher->s.eFlags & EF_MOVER_STOP ) &&
-	     check->s.groundEntityNum != pusher->s.number )
+	     check->s.groundEntityNum != pusher->num() )
 	{
 		return false;
 	}
 
 	//don't try to move buildables unless standing on a mover
 	if ( check->s.eType == entityType_t::ET_BUILDABLE &&
-	     check->s.groundEntityNum != pusher->s.number )
+	     check->s.groundEntityNum != pusher->num() )
 	{
 		return false;
 	}
@@ -206,7 +206,7 @@ static bool G_TryPushingEntity( gentity_t *check, gentity_t *pusher, vec3_t move
 	}
 
 	// may have pushed them off an edge
-	if ( check->s.groundEntityNum != pusher->s.number )
+	if ( check->s.groundEntityNum != pusher->num() )
 	{
 		check->s.groundEntityNum = ENTITYNUM_NONE;
 	}
@@ -339,7 +339,7 @@ static bool G_MoverPush( gentity_t *pusher, vec3_t move, vec3_t amove, gentity_t
 		}
 
 		// if the entity is standing on the pusher, it will definitely be moved
-		if ( check->s.groundEntityNum != pusher->s.number )
+		if ( check->s.groundEntityNum != pusher->num() )
 		{
 			// see if the ent needs to be tested
 			if ( check->r.absmin[ 0 ] >= maxs[ 0 ]
@@ -1246,7 +1246,7 @@ static void reset_moverspeed( gentity_t *self, float fallbackSpeed )
 	float    distance;
 
 	if(!fallbackSpeed)
-		Sys::Drop("No default speed was supplied to reset_moverspeed for entity #%i of type %s.", self->s.number, self->classname);
+		Sys::Drop("No default speed was supplied to reset_moverspeed for entity #%i of type %s.", self->num(), self->classname);
 
 	G_ResetFloatField(&self->speed, true, self->config.speed, self->eclass->config.speed, fallbackSpeed);
 
@@ -1363,7 +1363,7 @@ static void reset_rotatorspeed( gentity_t *self, float fallbackSpeed )
 	float    angle;
 
 	if(!fallbackSpeed)
-		Sys::Drop("No default speed was supplied to reset_rotatorspeed for entity #%i of type %s.", self->s.number, self->classname);
+		Sys::Drop("No default speed was supplied to reset_rotatorspeed for entity #%i of type %s.", self->num(), self->classname);
 
 	// calculate time to reach second position from speed
 	VectorSubtract( self->activatedPosition, self->restingPosition, move );
@@ -1858,7 +1858,7 @@ void SP_func_door_model( gentity_t *self )
 	// for drawing, but clip against the brushes
 	if ( !self->model2 )
 	{
-		Log::Warn("func_door_model %d spawned with no model2 key", self->s.number );
+		Log::Warn("func_door_model %d spawned with no model2 key", self->num() );
 	}
 	else
 	{

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -160,6 +160,9 @@ struct GentityRef_impl
 	}
 };
 
+extern gentity_t *g_entities;
+extern gclient_t *g_clients;
+
 using GentityRef = GentityRef_impl<gentity_t *>;
 using GentityConstRef = GentityRef_impl<const gentity_t *>;
 
@@ -458,6 +461,13 @@ struct gentity_t
 	gentity_t   **tagAttachment;
 	int         tagScore;
 	int         tagScoreTime;
+
+	// gives the entityNum
+	int num() const {
+		ASSERT(this - g_entities >= 0);
+		ASSERT(this - g_entities < MAX_GENTITIES);
+		return this - g_entities;
+	}
 };
 
 /**
@@ -620,6 +630,13 @@ struct gclient_t
 	int        nextCrushTime;
 
 	int        lastLevel1SlowTime;
+
+	// gives the entityNum
+	int num() const {
+		ASSERT(this - g_clients >= 0);
+		ASSERT(this - g_clients < MAX_CLIENTS);
+		return this - g_clients;
+	}
 };
 
 /**

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -637,6 +637,20 @@ struct gclient_t
 		ASSERT(this - g_clients < MAX_CLIENTS);
 		return this - g_clients;
 	}
+
+	// strictly speaking, we could return a non-const pointer, but this is
+	// probably more in phase with the idea
+	const gentity_t *ent() const {
+		ASSERT(this - g_clients >= 0);
+		ASSERT(this - g_clients < MAX_CLIENTS);
+		return &g_entities[this - g_clients];
+	}
+
+	gentity_t *ent() {
+		ASSERT(this - g_clients >= 0);
+		ASSERT(this - g_clients < MAX_CLIENTS);
+		return &g_entities[this - g_clients];
+	}
 };
 
 /**

--- a/src/sgame/sg_svcmds.cpp
+++ b/src/sgame/sg_svcmds.cpp
@@ -305,7 +305,7 @@ static void Svcmd_ForceTeam_f()
 		return;
 	}
 
-	G_ChangeTeam( &g_entities[ cl - level.clients ], team );
+	G_ChangeTeam( cl->ent(), team );
 }
 
 /*
@@ -552,7 +552,7 @@ static void Svcmd_EjectClient_f()
 			return;
 		}
 
-		trap_DropClient( cl - level.clients, reason );
+		trap_DropClient( cl->num(), reason );
 	}
 }
 
@@ -577,7 +577,7 @@ static void Svcmd_DumpUser_f()
 		return;
 	}
 
-	trap_GetUserinfo( cl - level.clients, userinfo, sizeof( userinfo ) );
+	trap_GetUserinfo( cl->num(), userinfo, sizeof( userinfo ) );
 	info = &userinfo[ 0 ];
 	Log::Notice( "userinfo--------" );
 

--- a/src/sgame/sg_svcmds.cpp
+++ b/src/sgame/sg_svcmds.cpp
@@ -92,7 +92,7 @@ static void Svcmd_EntityFire_f()
 static inline void PrintEntityOverviewLine( gentity_t *entity )
 {
 	Log::Notice( "%3i: %15s/^5%-24s^*%s%s",
-			entity->s.number, Com_EntityTypeName( entity->s.eType ), entity->classname,
+			entity->num(), Com_EntityTypeName( entity->s.eType ), entity->classname,
 			entity->names[0] ? entity->names[0] : "", entity->names[1] ? " …" : "");
 }
 

--- a/src/sgame/sg_team.cpp
+++ b/src/sgame/sg_team.cpp
@@ -164,7 +164,7 @@ static clientList_t G_ClientListForTeam( team_t team )
 
 		if ( ent->inuse && ( ent->client->pers.team == team ) )
 		{
-			Com_ClientListAdd( &clientList, ent->client->ps.clientNum );
+			Com_ClientListAdd( &clientList, ent->num() );
 		}
 	}
 

--- a/src/sgame/sg_utils.cpp
+++ b/src/sgame/sg_utils.cpp
@@ -316,7 +316,7 @@ void G_KillBrushModel( gentity_t *ent, gentity_t *activator )
       continue;
 
     trap_Trace( &tr, e->r.currentOrigin, e->r.mins, e->r.maxs,
-                e->r.currentOrigin, e->s.number, e->clipmask, 0 );
+                e->r.currentOrigin, e->num(), e->clipmask, 0 );
 
 	if( tr.entityNum != ENTITYNUM_NONE ) {
 	  Entities::Kill(e, activator, MOD_CRUSH);
@@ -358,7 +358,7 @@ void G_AddEvent( gentity_t *ent, int event, int eventParm )
 
 	if ( !event )
 	{
-		Log::Warn( "G_AddEvent: zero event added for entity %i", ent->s.number );
+		Log::Warn( "G_AddEvent: zero event added for entity %i", ent->num() );
 		return;
 	}
 
@@ -809,10 +809,10 @@ bool G_LineOfSight( const gentity_t *from, const gentity_t *to, int mask, bool u
 	}
 
 	trap_Trace( &trace, useTrajBase ? from->s.pos.trBase : from->s.origin, nullptr, nullptr, to->s.origin,
-	            from->s.number, mask, 0 );
+	            from->num(), mask, 0 );
 
 	// Also check for fraction in case the mask is chosen so that the trace skips the target entity
-	return ( trace.entityNum == to->s.number || trace.fraction == 1.0f );
+	return ( trace.entityNum == to->num() || trace.fraction == 1.0f );
 }
 
 /**

--- a/src/sgame/sg_utils.cpp
+++ b/src/sgame/sg_utils.cpp
@@ -785,6 +785,8 @@ void G_TeamToClientmask( team_t team, int *loMask, int *hiMask )
 	{
 		client = &g_clients[ clientNum ];
 
+		if ( !client->ent()->inuse ) continue;
+
 		if ( client->pers.team == team )
 		{
 			if ( clientNum < 32 )

--- a/src/sgame/sg_utils.cpp
+++ b/src/sgame/sg_utils.cpp
@@ -781,11 +781,11 @@ void G_TeamToClientmask( team_t team, int *loMask, int *hiMask )
 
 	*loMask = *hiMask = 0;
 
-	for ( clientNum = 0; clientNum < MAX_CLIENTS; clientNum++ )
+	for ( clientNum = 0; clientNum < level.maxclients; clientNum++ )
 	{
-		client = g_entities[ clientNum ].client;
+		client = &g_clients[ clientNum ];
 
-		if ( client && client->pers.team == team )
+		if ( client->pers.team == team )
 		{
 			if ( clientNum < 32 )
 			{

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -1004,14 +1004,14 @@ static void FireBuild( gentity_t *self, dynMenu_t menu )
 	// open build menu
 	if ( buildable <= BA_NONE )
 	{
-		G_TriggerMenu( self->client->ps.clientNum, menu );
+		G_TriggerMenu( self->num(), menu );
 		return;
 	}
 
 	// can't build just yet
 	if ( self->client->ps.stats[ STAT_MISC ] > 0 )
 	{
-		G_AddEvent( self, EV_BUILD_DELAY, self->client->ps.clientNum );
+		G_AddEvent( self, EV_BUILD_DELAY, self->num() );
 		return;
 	}
 
@@ -1804,7 +1804,7 @@ void G_FireUpgrade( gentity_t *self, upgrade_t upgrade )
 	{
 		case UP_GRENADE:
 		case UP_FIREBOMB:
-			trap_SendServerCommand( self->client->ps.clientNum, "vcommand grenade" );
+			trap_SendServerCommand( self->num(), "vcommand grenade" );
 			break;
 
 		default:


### PR DESCRIPTION
So I've grown a bit annoyed at entityNum being so impractical to get. This provides a way of doing that, and also drops the worst old usages.

### Motivation

`client->ent()` is much more practical than `g_entities[client->ps.clientNum]` and `ent->num()` much more readable than `ent - g_entities`.

It also can avoid stupid bugs. For example, getting the entityNum using `ent->client->ps.clientNum` does work only for clients or trying to use `(gentity_t*)->s.clientNum` which has nothing to do with clients, or nums.