### PR TITLE
Fix rotating door obstacles

### DIFF
--- a/src/sgame/sg_cm_world.cpp
+++ b/src/sgame/sg_cm_world.cpp
@@ -444,16 +444,16 @@ void G_CM_LinkEntity( gentity_t *gEnt )
 	// set the abs box
 	if ( gEnt->r.bmodel && ( angles[ 0 ] || angles[ 1 ] || angles[ 2 ] ) )
 	{
-		// expand for rotation
-		float max;
+		glm::mat3 matrix = RotationMatrix( VEC2GLM( angles ) );
 
-		max = RadiusFromBounds( gEnt->r.mins, gEnt->r.maxs );
+		glm::vec3 mins = matrix * VEC2GLM( gEnt->r.mins );
+		glm::vec3 maxs = matrix * VEC2GLM( gEnt->r.maxs );
 
-		for ( int i = 0; i < 3; i++ )
-		{
-			gEnt->r.absmin[ i ] = origin[ i ] - max;
-			gEnt->r.absmax[ i ] = origin[ i ] + max;
-		}
+		glm::vec3 absmin = glm::min(mins, maxs) + VEC2GLM(origin);
+		glm::vec3 absmax = glm::max(mins, maxs) + VEC2GLM(origin);
+
+		VectorCopy(absmin, gEnt->r.absmin);
+		VectorCopy(absmax, gEnt->r.absmax);
 	}
 	else
 	{

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -677,6 +677,7 @@ static void SetMoverState( gentity_t *ent, moverState_t moverState, int time )
 			ent->s.apos.trType = trType_t::TR_LINEAR_STOP;
 			break;
 
+		// TODO: have bots treat them as obstacles too, because they *are* obstacles.
 		case MODEL_POS1:
 			break;
 

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -1819,6 +1819,7 @@ void BG_BoundingBox( class_t cl, glm::vec3* mins, glm::vec3* maxs, glm::vec3* cm
 void BG_BoundingBox( buildable_t buildablel, glm::vec3* mins, glm::vec3* maxs );
 
 void AngleVectors( const glm::vec3 &angles, glm::vec3 *forward, glm::vec3 *right, glm::vec3 *up );
+WARN_UNUSED_RESULT glm::mat3 RotationMatrix( const glm::vec3 &angles );
 
 //==================================================================
 #endif /* BG_PUBLIC_H_ */

--- a/src/shared/bg_utilities.cpp
+++ b/src/shared/bg_utilities.cpp
@@ -220,3 +220,11 @@ void AngleVectors( const glm::vec3 &angles, glm::vec3 *forward, glm::vec3 *right
 		(*up)[2] = cr * cp;
 	}
 }
+
+// This is a drop in replacement for AnglesToAxis
+WARN_UNUSED_RESULT glm::mat3 RotationMatrix( const glm::vec3 &angles ) {
+	glm::mat3 m;
+	AngleVectors( angles, &m[0], &m[1], &m[2] );
+	m[1] *= -1.0f;
+	return m;
+}


### PR DESCRIPTION
I've tested this with the tremship map. I've also added some debug draw to visualise it, but it's not part of this PR.

Here's tremship's main door before it opens:

![Screenshot from 2022-10-30 02-02-18](https://user-images.githubusercontent.com/59283660/198860319-ddb013c2-0e57-4a62-82bd-3aad266fb80d.png)

Here's tremship's main door after it opens, without this patch:

![Screenshot from 2022-10-30 02-03-32](https://user-images.githubusercontent.com/59283660/198860368-fc5b0c9b-5499-458b-8861-72dfe50c89fb.png)

What you can see on this picture is two huge cubes.

And here's the main door after it opens, with this patch:

![Screenshot from 2022-11-06 14-44-51](https://user-images.githubusercontent.com/59283660/200175580-0f875e73-ae29-4b18-8351-520c238a6a1f.png)

Bots can now pass through