### PR TITLE
Correct bot aim prediction

### DIFF
--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1408,7 +1408,7 @@ static glm::vec3 BotPredictPosition( gentity_t *self, gentity_t const *predict, 
 	botTarget_t target;
 	target = predict;
 	glm::vec3 aimLoc = BotGetIdealAimLocation( self, target );
-	return aimLoc + time / 1000.0f * VEC2GLM( predict->s.apos.trDelta );
+	return aimLoc + time / 1000.0f * VEC2GLM( predict->s.pos.trDelta );
 }
 
 void BotAimAtEnemy( gentity_t *self )


### PR DESCRIPTION
This was broken, as apos.trDelta means changes in "angular position". the calculation should use pos.trDelta instead to predict where the target will be.