### PR TITLE
Fix obstacle handling

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -559,7 +559,7 @@ void G_admin_cmdlist( gentity_t *ent )
 
 		if ( len + outlen >= sizeof( out ) - 1 )
 		{
-			trap_SendServerCommand( ent - g_entities, va( "cmds%s", out ) );
+			trap_SendServerCommand( ent->num(), va( "cmds%s", out ) );
 			outlen = 0;
 		}
 
@@ -567,7 +567,7 @@ void G_admin_cmdlist( gentity_t *ent )
 		outlen += len;
 	}
 
-	trap_SendServerCommand( ent - g_entities, va( "cmds%s", out ) );
+	trap_SendServerCommand( ent->num(), va( "cmds%s", out ) );
 }
 
 // match a certain flag within these flags
@@ -787,7 +787,7 @@ bool G_admin_name_check( gentity_t *ent, const char *name, char *err, int len )
 		}
 
 		// can rename ones self to the same name using different colors
-		if ( i == ( ent - g_entities ) )
+		if ( i == ( ent->num() ) )
 		{
 			continue;
 		}
@@ -1130,7 +1130,7 @@ void G_admin_authlog( gentity_t *ent )
 	             ( level ) ? level->flags : "" );
 
 	G_LogPrintf( "AdminAuth: %i \"%s^*\" \"%s^*\" [%d] (%s): %s",
-	             ( int )( ent - g_entities ), ent->client->pers.netname,
+	             ent->num(), ent->client->pers.netname,
 	             ent->client->pers.admin->name, ent->client->pers.admin->level,
 	             ent->client->pers.guid, aflags );
 }
@@ -2348,7 +2348,7 @@ bool G_admin_setlevel( gentity_t *ent )
 
 		if ( l && !a->pubkey[ 0 ] )
 		{
-			trap_GetPlayerPubkey( vic - g_entities, a->pubkey, sizeof( a->pubkey ) );
+			trap_GetPlayerPubkey( vic->num(), a->pubkey, sizeof( a->pubkey ) );
 		}
 
 		vic->client->pers.pubkey_authenticated = 1;
@@ -2466,7 +2466,7 @@ bool G_admin_slap( gentity_t *ent )
 			 ( damage > 0 ? Quote( va( "with %.0f damage", damage ) ) : QQ( "" ) ) ) );
 	} // only print the chat msg if they don't die. otherwise the MOD_SLAP event will suffice.
 
-	CPx( vic - g_entities, va( "cp_tr " QQ( N_( "[cross]$1$$2$ is not amused![cross]" ) ) " %s %s",
+	CPx( vic->num(), va( "cp_tr " QQ( N_( "[cross]$1$$2$ is not amused![cross]" ) ) " %s %s",
 		G_quoted_admin_name( ent ),
 		( health->Alive() ) ? "^7" : "^i" ) ); // if they die, make the text red
 
@@ -5563,7 +5563,7 @@ bool G_admin_register( gentity_t *ent )
 	}
 
 	trap_SendConsoleCommand( va( "setlevel %d %d;",
-	                         ( int )( ent - g_entities ),
+	                         ent->num(),
 	                         level ) );
 
 	AP( va( "print_tr %s %s", QQ( N_("^3register:^* $1$^* is now a protected name") ),
@@ -5585,8 +5585,7 @@ bool G_admin_unregister( gentity_t *ent )
 		return false;
 	}
 
-	trap_SendConsoleCommand( va( "setlevel %d 0;",
-	                         ( int )( ent - g_entities ) ) );
+	trap_SendConsoleCommand( va( "setlevel %d 0;", ent->num() ) );
 
 	AP( va( "print_tr %s %s", QQ( N_("^3unregister:^* $1$^* is now an unprotected name") ),
 	        Quote( ent->client->pers.admin->name ) ) );
@@ -6086,7 +6085,7 @@ bool G_admin_listbots( gentity_t *ent )
 		{
 			return;
 		}
-		ADMBP( va( "%zu %s", ent - g_entities, G_BotToString( ent ).c_str() ) );
+		ADMBP( va( "%i %s", ent->num(), G_BotToString( ent ).c_str() ) );
 	} );
 	ADMBP_end();
 	return true;

--- a/src/sgame/sg_api.cpp
+++ b/src/sgame/sg_api.cpp
@@ -205,6 +205,6 @@ bool trap_InPVSIgnorePortals(const vec3_t p1, const vec3_t p2)
 
 void trap_AdjustAreaPortalState(gentity_t *ent, bool open)
 {
-	VM::SendMsg<AdjustAreaPortalStateMsg>(ent - g_entities, open);
+	VM::SendMsg<AdjustAreaPortalStateMsg>(ent->num(), open);
 	G_CM_AdjustAreaPortalState( ent, open );
 }

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -2022,7 +2022,7 @@ static gentity_t *SpawnBuildable( gentity_t *builder, buildable_t buildable, con
 		maxs[0] *= fixVal; maxs[1] *= fixVal;
 		mins += origin;
 		maxs += origin;
-		G_BotAddObstacle( mins, maxs, built - g_entities );
+		G_BotAddObstacle( mins, maxs, built->num() );
 	}
 
 	G_AddEvent( built, EV_BUILD_CONSTRUCT, 0 );

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -1735,7 +1735,7 @@ void ClientSpawn( gentity_t *ent, gentity_t *spawn, const vec3_t origin, const v
 	// the respawned flag will be cleared after the attack and jump keys come up
 	client->ps.pm_flags |= PMF_RESPAWNED;
 
-	trap_GetUsercmd( client - level.clients, &ent->client->pers.cmd );
+	trap_GetUsercmd( client->num(), &ent->client->pers.cmd );
 	G_SetClientViewAngle( ent, spawn_angles );
 
 	if ( client->sess.spectatorState == SPECTATOR_NOT )

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -124,7 +124,7 @@ gentity_t *G_NewEntity()
 		{
 			if ( g_debugEntities.Get() ) {
 				Log::Verbose( "Reusing Entity %i, freed at %i (%ims ago)",
-				              forcedEnt-g_entities, forcedEnt->freetime, level.time - forcedEnt->freetime );
+				              forcedEnt->num(), forcedEnt->freetime, level.time - forcedEnt->freetime );
 			}
 			// reuse this slot
 			G_InitGentity( forcedEnt );
@@ -166,7 +166,7 @@ void G_FreeEntity( gentity_t *entity )
 		Log::Debug("Freeing Entity %s", etos(entity));
 	}
 
-	G_BotRemoveObstacle( entity - g_entities );
+	G_BotRemoveObstacle( entity->num() );
 
 	if( entity->eclass && entity->eclass->instanceCounter > 0 )
 	{

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -599,7 +599,7 @@ void BotHandleDoor( gentity_t *ent )
 	if ( IsDoor( ent ) && !IsAutomaticMover( ent ) )
 	{
 		// the door might have moved, we don't want to keep an incorrect state
-		G_BotRemoveObstacle( ent->s.clientNum );
+		G_BotRemoveObstacle( ent->num() );
 
 		G_BotAddObstacle( VEC2GLM( ent->r.absmin ), VEC2GLM( ent->r.absmax ), ent - g_entities );
 	}

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -601,7 +601,7 @@ void BotHandleDoor( gentity_t *ent )
 		// the door might have moved, we don't want to keep an incorrect state
 		G_BotRemoveObstacle( ent->num() );
 
-		G_BotAddObstacle( VEC2GLM( ent->r.absmin ), VEC2GLM( ent->r.absmax ), ent - g_entities );
+		G_BotAddObstacle( VEC2GLM( ent->r.absmin ), VEC2GLM( ent->r.absmax ), ent->num() );
 	}
 }
 
@@ -2679,7 +2679,7 @@ static void func_spawn_act( gentity_t *self, gentity_t*, gentity_t *activator )
 	{
 		VectorAdd( self->restingPosition, self->r.mins, mins );
 		VectorAdd( self->restingPosition, self->r.maxs, maxs );
-		G_BotAddObstacle( VEC2GLM(mins), VEC2GLM(maxs), self - g_entities );
+		G_BotAddObstacle( VEC2GLM(mins), VEC2GLM(maxs), self->num() );
 		trap_LinkEntity( self );
 		if( !( self->spawnflags & 2 ) )
 			G_KillBrushModel( self, activator );
@@ -2694,7 +2694,7 @@ static void func_spawn_reset( gentity_t *self )
 	{
 		VectorAdd( self->restingPosition, self->r.mins, mins );
 		VectorAdd( self->restingPosition, self->r.maxs, maxs );
-		G_BotAddObstacle( VEC2GLM(mins), VEC2GLM(maxs), self - g_entities );
+		G_BotAddObstacle( VEC2GLM(mins), VEC2GLM(maxs), self->num() );
 		trap_LinkEntity( self );
 	}
 	else

--- a/src/sgame/sg_team.cpp
+++ b/src/sgame/sg_team.cpp
@@ -328,7 +328,7 @@ void G_ChangeTeam( gentity_t *ent, team_t newTeam )
 	Beacon::PropagateAll( );
 
 	G_LogPrintf( "ChangeTeam: %d %s: %s^* switched teams",
-	             ( int )( ent - g_entities ), BG_TeamName( newTeam ), ent->client->pers.netname );
+	             ent->num(), BG_TeamName( newTeam ), ent->client->pers.netname );
 
 	G_namelog_update_score( ent->client );
 	TeamplayInfoMessage( ent );
@@ -506,7 +506,7 @@ void TeamplayInfoMessage( gentity_t *ent )
 
 	if( string[ 0 ] )
 	{
-		trap_SendServerCommand( ent - g_entities, va( "tinfo%s", string ) );
+		trap_SendServerCommand( ent->num(), va( "tinfo%s", string ) );
 		ent->client->pers.teamInfo = level.time;
 	}
 }

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -1397,7 +1397,7 @@ void G_ChargeAttack( gentity_t *self, gentity_t *victim )
 	{
 		for ( i = 0; i < MAX_TRAMPLE_BUILDABLES_TRACKED; i++ )
 		{
-			if ( self->client->trampleBuildablesHit[ i ] == victim - g_entities )
+			if ( self->client->trampleBuildablesHit[ i ] == victim->num() )
 			{
 				return;
 			}
@@ -1405,7 +1405,7 @@ void G_ChargeAttack( gentity_t *self, gentity_t *victim )
 
 		self->client->trampleBuildablesHit[
 		  self->client->trampleBuildablesHitPos++ % MAX_TRAMPLE_BUILDABLES_TRACKED ] =
-		    victim - g_entities;
+		    victim->num();
 	}
 
 	damage = LEVEL4_TRAMPLE_DMG * self->client->ps.weaponCharge / LEVEL4_TRAMPLE_DURATION;


### PR DESCRIPTION
The two errors here are the `[i]` instead of `[obstacleNum]` and the `ent->s.clientNum`.

There are a few problems that I encountered that made this especially annoying to track down.
* that the types lack any kind of type safety and are converted implicitely (`typeof(entityNum) = int = qhandle_t ≃ dtObstacleRef = unsigned int`)
* that the detour removeObstacle function returns `DT_SUCCESS` when the obstacle doesn't exist
* that ent->s.clientNum returns garbage when the entity isn't a client