### PR TITLE
Delete cg_customCrosshair

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1782,7 +1782,6 @@ extern Cvar::Cvar<bool> cg_drawBuildableHealth;
 extern Cvar::Cvar<bool> cg_drawMinimap;
 extern Cvar::Cvar<int> cg_minimapActive;
 extern Cvar::Cvar<float> cg_crosshairSize;
-extern Cvar::Cvar<std::string> cg_crosshairFile;
 extern Cvar::Range<Cvar::Cvar<int>> cg_teamOverlayUserinfo;
 extern Cvar::Cvar<bool> cg_draw2D;
 extern Cvar::Cvar<bool> cg_animSpeed;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -59,7 +59,6 @@ Cvar::Cvar<bool> cg_drawBuildableHealth("cg_drawBuildableHealth", "show buildabl
 Cvar::Cvar<bool> cg_drawMinimap("cg_drawMinimap", "show minimap", Cvar::NONE, true);
 Cvar::Cvar<int> cg_minimapActive("cg_minimapActive", "FOR INTERNAL USE", Cvar::NONE, 0);
 Cvar::Cvar<float> cg_crosshairSize("cg_crosshairSize", "crosshair scale factor", Cvar::NONE, 1);
-Cvar::Cvar<std::string> cg_crosshairFile("cg_crosshairFile", "VFS path of custom crosshairs file", Cvar::NONE, "");
 Cvar::Cvar<bool> cg_draw2D("cg_draw2D", "show HUD", Cvar::NONE, true);
 Cvar::Cvar<bool> cg_debugAnim("cg_debuganim", "show animation debug logs", Cvar::CHEAT, false);
 Cvar::Cvar<bool> cg_debugEvents("cg_debugevents", "log received events", Cvar::CHEAT, false);

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -75,120 +75,6 @@ void CG_RegisterUpgrade( int upgradeNum )
 }
 
 /*
-=======================
-CG_LoadCustomCrosshairs
-
-Load custom crosshairs specified by the user
-=======================
-*/
-
-static void CG_LoadCustomCrosshairs()
-{
-	const char         *text_p, *token;
-	weapon_t     weapon;
-
-	std::string filename = cg_crosshairFile.Get();
-	if ( filename.empty() )
-	{
-		return;
-	}
-	std::error_code err;
-	std::string text = FS::PakPath::ReadFile( filename, err );
-	if ( err )
-	{
-		Log::Warn( "couldn't read custom crosshair file '%s': %s", filename, err.message() );
-		return;
-	}
-
-	// parse the text
-	text_p = text.c_str();
-
-	while ( 1 )
-	{
-		token = COM_Parse2( &text_p );
-
-		if ( !*token )
-		{
-			break;
-		}
-
-		if ( ( weapon = BG_WeaponNumberByName( token ) ) )
-		{
-			token = COM_Parse( &text_p );
-
-			if ( !Q_stricmp( token, "crosshair" ) )
-			{
-				token = COM_Parse( &text_p );
-
-				if ( !token )
-				{
-					break;
-				}
-
-				cg_weapons[ weapon ].crossHair = trap_R_RegisterShader( token, RSF_DEFAULT );
-
-				if ( !cg_weapons[ weapon ].crossHair )
-				{
-					Log::Warn( "weapon crosshair not found %s", token );
-				}
-
-				continue;
-			}
-			else if ( !Q_stricmp( token, "crosshairIndicator" ) )
-			{
-				token = COM_Parse( &text_p );
-
-				if ( !token )
-				{
-					break;
-				}
-
-				cg_weapons[ weapon ].crossHairIndicator = trap_R_RegisterShader( token, RSF_DEFAULT );
-
-				if ( !cg_weapons[ weapon ].crossHairIndicator )
-				{
-					Log::Warn( "weapon crosshair indicator not found %s", token );
-				}
-
-				continue;
-			}
-			else if ( !Q_stricmp( token, "crosshairSize" ) )
-			{
-				int size;
-
-				token = COM_Parse( &text_p );
-
-				if ( !token )
-				{
-					break;
-				}
-
-				size = atoi( token );
-
-				if ( size < 0 )
-				{
-					size = 0;
-				}
-
-				cg_weapons[ weapon ].crossHairSize = size;
-
-				continue;
-			}
-			else
-			{
-				Log::Warn( "Unexpected keyword %s in crosshair file", token );
-				break;
-			}
-		}
-		else
-		{
-			Log::Warn( "Unknown weapon %s in crosshair file", token );
-			break;
-		}
-	}
-}
-
-/*
 ===============
 CG_InitUpgrades
 
@@ -204,11 +90,6 @@ void CG_InitUpgrades()
 	for ( i = UP_NONE + 1; i < UP_NUM_UPGRADES; i++ )
 	{
 		CG_RegisterUpgrade( i );
-	}
-
-	if ( !cg_crosshairFile.Get().empty() )
-	{
-		CG_LoadCustomCrosshairs();
 	}
 }
 


### PR DESCRIPTION
I haven't tested whether the custom crosshair feature works, but at least this allows it to load a file.

The commit message for 6b5df72075e8bf359577d5b15e0ee50a16ff8acd contains the only documentation for this feature :stuck_out_tongue: 