### PR TITLE
Improve bot barbs

### DIFF
--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -108,6 +108,7 @@ enum bot_skill
 	BOT_A_LEAP_ON_FLEE, // mantis
 	BOT_A_POUNCE_ON_FLEE, // dragoon and adv dragoon
 	BOT_A_TYRANT_CHARGE_ON_FLEE,
+	BOT_A_SAFE_BARBS, // don't barb yourself as adv goon
 	BOT_H_RUN_ON_FLEE, // when fleeing, RUN
 	BOT_H_BUY_ARMOR, // knows armor exists at all, if the bot doesn't have BOT_H_PREFER_ARMOR too it will always prefer to buy guns
 	BOT_H_PREFER_ARMOR, // prefer to buy armor rather than guns
@@ -116,6 +117,7 @@ enum bot_skill
 	// fighting skills
 	BOT_B_BASIC_FIGHT, // doesn't do anything as of now
 	BOT_A_AIM_HEAD,
+	BOT_A_AIM_BARBS, // precisely target barbs
 	BOT_H_PREDICTIVE_AIM, // predict where to aim depending on weapon and enemy speed
 
 	BOT_NUM_SKILLS

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -164,12 +164,10 @@ std::pair<std::string, skillSet_t> BotDetermineSkills(gentity_t *bot, int skill)
 	std::vector<botSkillTreeElement_t> possible_choices = initial_unlockable_skills;
 	// aliens have 61 points to spend max
 	// humans have 40 points to spend max
-	// here we give a bit more money to humans because they have more
-	// expensive skills
-	float max = G_Team(bot) == TEAM_ALIENS ? 61.0f : 46.0f;
+	float max = G_Team(bot) == TEAM_ALIENS ? 61.0f : 40.0f;
 
-	// unlock every skill at skill 8
-	int skill_points = static_cast<float>(skill) / 8.0f * max;
+	// unlock every skill at skill 7
+	int skill_points = static_cast<float>(skill) / 7.0f * max;
 
 	// rng preparation
 	std::string name = bot->client->pers.netname;

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -68,6 +68,7 @@ static const std::vector<botSkillTreeElement_t> survival_skills = {
 	{ "mantis-flee-jump",   BOT_A_LEAP_ON_FLEE,          3, pred_alien, {} },
 	{ "goon-flee-jump",     BOT_A_POUNCE_ON_FLEE,        4, pred_alien, {} },
 	{ "tyrant-flee-run",    BOT_A_TYRANT_CHARGE_ON_FLEE, 4, pred_alien, {} },
+	{ "safe-barbs",         BOT_A_SAFE_BARBS,            3, pred_alien, {} },
 
 	// humans
 	{ "buy-armor",          BOT_H_BUY_ARMOR,   10, pred_human, {
@@ -80,6 +81,7 @@ static const std::vector<botSkillTreeElement_t> survival_skills = {
 static const std::vector<botSkillTreeElement_t> fighting_skills = {
 	// aliens
 	{ "aim-head",           BOT_A_AIM_HEAD,      10, pred_alien, {} },
+	{ "aim-barbs",          BOT_A_AIM_BARBS,     7,  pred_alien, {} },
 
 	// humans
 	{ "predict-aim",        BOT_H_PREDICTIVE_AIM, 5, pred_human, {} },
@@ -160,11 +162,11 @@ static Util::optional<botSkillTreeElement_t> ChooseOneSkill(const gentity_t *bot
 std::pair<std::string, skillSet_t> BotDetermineSkills(gentity_t *bot, int skill)
 {
 	std::vector<botSkillTreeElement_t> possible_choices = initial_unlockable_skills;
-	// aliens have 51 points to spend max
+	// aliens have 61 points to spend max
 	// humans have 40 points to spend max
 	// here we give a bit more money to humans because they have more
 	// expensive skills
-	float max = G_Team(bot) == TEAM_ALIENS ? 51.0f : 46.0f;
+	float max = G_Team(bot) == TEAM_ALIENS ? 61.0f : 46.0f;
 
 	// unlock every skill at skill 8
 	int skill_points = static_cast<float>(skill) / 8.0f * max;

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1928,7 +1928,7 @@ void BotFireWeaponAI( gentity_t *self )
 			// barb themselves too easily. The safety factor
 			// hopefully accounts for the movement of the bot and
 			// its target
-			constexpr float barbSafetyFactor = 4.0f/3.0f;
+			constexpr float barbSafetyFactor = 5.0f/3.0f;
 			if ( self->client->ps.ammo > 0 && distance > LEVEL3_CLAW_UPG_RANGE && distance > (barbSafetyFactor * BG_Missile(MIS_BOUNCEBALL)->splashRadius) )
 			{
 				botCmdBuffer->angles[PITCH] = ANGLE2SHORT( -CalcBarbAimPitch( self, target ) ); //compute and apply correct aim pitch to hit target

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1932,7 +1932,7 @@ void BotFireWeaponAI( gentity_t *self )
 			// hopefully accounts for the movement of the bot and
 			// its target
 			constexpr float barbSafetyFactor = 5.0f/3.0f;
-			bool barbIsSafe = distance > (barbSafetyFactor * BG_Missile(MIS_BOUNCEBALL)->splashRadius);
+			bool barbIsSafe = distance > (barbSafetyFactor * BG_Missile(MIS_BOUNCEBALL)->splashRadius) || !self->botMind->botSkillSet[BOT_A_SAFE_BARBS];
 
 			if ( outOfClawsRange && hasBarbs && barbIsSafe )
 			{
@@ -1948,7 +1948,7 @@ void BotFireWeaponAI( gentity_t *self )
 				float scalarAlignment = Alignment2D(delta, forward);
 				bool barbAimed = scalarAlignment > 0.997f; // acos(0.997) is 4.4° in the 2D plane
 
-				if ( barbAimed )
+				if ( barbAimed || !self->botMind->botSkillSet[BOT_A_AIM_BARBS] )
 				{
 					BotFireWeapon( WPM_TERTIARY, botCmdBuffer ); //goon barb
 				}

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1924,12 +1924,15 @@ void BotFireWeaponAI( gentity_t *self )
 			break;
 		case WP_ALEVEL3_UPG:
 		{
+			bool hasBarbs = self->client->ps.ammo > 0;
+			bool outOfClawsRange = distance > LEVEL3_CLAW_UPG_RANGE;
 			// We add some protection for barbs so that bots don't
 			// barb themselves too easily. The safety factor
 			// hopefully accounts for the movement of the bot and
 			// its target
 			constexpr float barbSafetyFactor = 5.0f/3.0f;
-			if ( self->client->ps.ammo > 0 && distance > LEVEL3_CLAW_UPG_RANGE && distance > (barbSafetyFactor * BG_Missile(MIS_BOUNCEBALL)->splashRadius) )
+			bool barbIsSafe = distance > (barbSafetyFactor * BG_Missile(MIS_BOUNCEBALL)->splashRadius);
+			if ( outOfClawsRange && hasBarbs && barbIsSafe )
 			{
 				botCmdBuffer->angles[PITCH] = ANGLE2SHORT( -CalcBarbAimPitch( self, target ) ); //compute and apply correct aim pitch to hit target
 				BotFireWeapon( WPM_TERTIARY, botCmdBuffer ); //goon barb


### PR DESCRIPTION
* Increase bot barbs safety distance: I have seen alien bots still barbing themselves
* Make barbs handling more clear
* Make advanced goon aim its barbs before firing them. This is devilishly effective (which is why it's hidden behind a skill in the next commit).
* Add bot barb skills
* Give more skill points to alien bots. This adjusts aliens skill point number to have them unlock every skill at skill level 7 like humans already do, and make skill point attribution simpler.
