### PR TITLE
Cvars for different BP budgets for teams

### DIFF
--- a/src/sgame/sg_buildpoints.cpp
+++ b/src/sgame/sg_buildpoints.cpp
@@ -69,8 +69,21 @@ float G_RGSPredictEfficiencyDelta(vec3_t origin, team_t team) {
  * @brief Calculate the build point budgets for both teams.
  */
 void G_UpdateBuildPointBudgets() {
+	int abp = g_BPInitialBudgetAliens.Get();
+	int hbp = g_BPInitialBudgetHumans.Get();
 	for (team_t team = TEAM_NONE; (team = G_IterateTeams(team)); ) {
-		level.team[team].totalBudget = g_buildPointInitialBudget.Get();
+		if ( team == TEAM_ALIENS && abp >= 0 )
+		{
+			level.team[team].totalBudget = abp;
+		}
+		else if ( team == TEAM_HUMANS && hbp >= 0 )
+		{
+			level.team[team].totalBudget = hbp;
+		}
+		else
+		{
+			level.team[team].totalBudget = g_buildPointInitialBudget.Get();
+		}
 	}
 
 	ForEntities<MiningComponent>([&] (Entity& entity, MiningComponent& miningComponent) {

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -84,6 +84,8 @@ extern Cvar::Cvar<int> g_fillBotsVotesPercent;
 extern Cvar::Cvar<int> g_fillBotsTeamVotesPercent;
 
 extern  Cvar::Callback<Cvar::Cvar<int>> g_buildPointInitialBudget;
+extern  Cvar::Callback<Cvar::Cvar<int>> g_BPInitialBudgetHumans;
+extern  Cvar::Callback<Cvar::Cvar<int>> g_BPInitialBudgetAliens;
 extern  Cvar::Callback<Cvar::Cvar<int>> g_buildPointBudgetPerMiner;
 extern  Cvar::Cvar<int> g_buildPointRecoveryInitialRate;
 extern  Cvar::Cvar<int> g_buildPointRecoveryRateHalfLife;

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -104,6 +104,22 @@ Cvar::Callback<Cvar::Cvar<int>> g_buildPointInitialBudget(
 		[](int) {
 			G_UpdateBuildPointBudgets();
 		});
+Cvar::Callback<Cvar::Cvar<int>> g_BPInitialBudgetHumans(
+		"g_BPInitialBudgetHumans",
+		"Initial build points count for humans",
+		Cvar::SERVERINFO,
+		-1,
+		[](int) {
+			G_UpdateBuildPointBudgets();
+		});
+Cvar::Callback<Cvar::Cvar<int>> g_BPInitialBudgetAliens(
+		"g_BPInitialBudgetAliens",
+		"Initial build points count for humans",
+		Cvar::SERVERINFO,
+		-1,
+		[](int) {
+			G_UpdateBuildPointBudgets();
+		});
 Cvar::Callback<Cvar::Cvar<int>> g_buildPointBudgetPerMiner(
 		"g_BPBudgetPerMiner",
 		"Budget per Miner",


### PR DESCRIPTION
There is some demand for this. One use case is big PvE layouts. Another is to balance maps that favour one team.

This adds two cvars `g_BPInitialBudgetAliens` and `g_BPInitialBudgetHumans`. They are -1 (disabled) by default. Making them non-negative gives them priority over `g_BPInitialBudget`.

Once we add a 3rd team, we can simply add a 3rd cvar for that team. This approach seems easier to me than changing how `g_BPInitialBudget` works.