### PR TITLE
`listplayers`: don't show any admin information for non-authed admins

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -3891,9 +3891,9 @@ bool G_admin_listplayers( gentity_t *ent )
 		           denied,
 		           canseeWarn ? ( p->pers.hasWarnings ? "^3W" : " " ) : "",
 		           p->pers.netname,
-		           ( registeredname && authed ) ? "(a.k.a. " : "",
-		           ( registeredname && authed ) ? registeredname : "",
-		           ( registeredname && authed ) ? "^*)" : "",
+		           ( registeredname ) ? "(a.k.a. " : "",
+		           ( registeredname ) ? registeredname : "",
+		           ( registeredname ) ? "^*)" : "",
 		           ( !authed ) ? "^1NOT AUTHED" : "" ) );
 	}
 

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -3787,7 +3787,7 @@ bool G_admin_listplayers( gentity_t *ent )
 	char            *registeredname;
 	char            lname[ MAX_NAME_LENGTH ];
 	char            bot, muted, denied;
-	int             authed = 1;
+	int             authed;
 	char            namecleaned[ MAX_NAME_LENGTH ];
 	char            name2cleaned[ MAX_NAME_LENGTH ];
 	g_admin_level_t *l;
@@ -3839,6 +3839,9 @@ bool G_admin_listplayers( gentity_t *ent )
 		l = d;
 		registeredname = nullptr;
 		hint = canset;
+
+		authed = 1; // bots don't have a pubkey, so this is required otherwise
+		            // the "authed" state is stuck until the next real player.
 
 		if ( p->pers.admin )
 		{

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -3882,7 +3882,7 @@ bool G_admin_listplayers( gentity_t *ent )
 		           i,
 		           Color::ToString( color ).c_str(),
 		           t,
-		           ( l && authed ) ? l->level : 0,
+		           l ? l->level : 0,
 		           hint ? '*' : ' ',
 		           admin_level_maxname + colorlen,
 		           lname,

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -3849,7 +3849,7 @@ bool G_admin_listplayers( gentity_t *ent )
 				hint = admin_higher( ent, &g_entities[ i ] );
 			}
 
-			if ( hint || !G_admin_permission( &g_entities[ i ], ADMF_INCOGNITO ) )
+			if ( authed && ( hint || !G_admin_permission( &g_entities[ i ], ADMF_INCOGNITO ) ) )
 			{
 				l = G_admin_level( p->pers.admin->level );
 				G_SanitiseString( p->pers.netname, namecleaned,
@@ -3879,7 +3879,7 @@ bool G_admin_listplayers( gentity_t *ent )
 		           i,
 		           Color::ToString( color ).c_str(),
 		           t,
-		           l ? l->level : 0,
+		           ( l && authed ) ? l->level : 0,
 		           hint ? '*' : ' ',
 		           admin_level_maxname + colorlen,
 		           lname,
@@ -3888,9 +3888,9 @@ bool G_admin_listplayers( gentity_t *ent )
 		           denied,
 		           canseeWarn ? ( p->pers.hasWarnings ? "^3W" : " " ) : "",
 		           p->pers.netname,
-		           ( registeredname ) ? "(a.k.a. " : "",
-		           ( registeredname ) ? registeredname : "",
-		           ( registeredname ) ? "^*)" : "",
+		           ( registeredname && authed ) ? "(a.k.a. " : "",
+		           ( registeredname && authed ) ? registeredname : "",
+		           ( registeredname && authed ) ? "^*)" : "",
 		           ( !authed ) ? "^1NOT AUTHED" : "" ) );
 	}
 


### PR DESCRIPTION
this fixes /listplayers leaking incognito admin details