### PR TITLE
layouts: Reset the layout cvar when the builtin layout is used.

### DIFF
--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -2384,6 +2384,7 @@ void G_LayoutSelect()
 		else
 		{
 			//use the map's builtin layout
+			Cvar::SetValue( "layout", "" );
 			return;
 		}
 	}
@@ -2417,6 +2418,7 @@ void G_LayoutSelect()
 	if ( !cnt )
 	{
 		Log::Warn( "None of the specified layouts could be found, using map default." );
+		Cvar::SetValue( "layout", "" );
 		return;
 	}
 


### PR DESCRIPTION
Previously, we wouldn't update the layout if we return early causing the previous layout's cfg to be loaded.

Fixes #2176