### PR TITLE
fix level name alignment in `listplayers` & `listadmins`, and add a legend to `listplayers`

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -1302,14 +1302,16 @@ static int admin_out( void *admin, char *str )
 	l = G_admin_level( a->level );
 
 	int lncol = Color::StrlenNocolor( l->name );
+	int namelen  = strlen( l->name );
 
 	if ( a->lastSeen.tm_mday )
 	{
 		trap_GetTimeString( lastSeen, sizeof( lastSeen ), "%Y-%m-%d", &a->lastSeen );
 	}
 
-	Com_sprintf( str, MAX_STRING_CHARS, "%-6d %*s %s %s",
-	             a->level, admin_level_maxname + lncol, l ? l->name : "(null)",
+	Com_sprintf( str, MAX_STRING_CHARS, "%-6d %*s ^*%s %s",
+	             a->level, namelen + ( admin_level_maxname - lncol ), 
+	             l ? l->name : "(null)",
 	             lastSeen, a->name );
 
 	return 0;
@@ -3877,6 +3879,7 @@ bool G_admin_listplayers( gentity_t *ent )
 		}
 
 		int colorlen = Color::StrlenNocolor( lname );
+		int namelen  = strlen( lname );
 
 		ADMBP( va( "%2i %s%c^7 %-2i^2%c^7 %*s^* ^5%c^1%c%c%s^7 %s^* %s%s%s %s",
 		           i,
@@ -3884,7 +3887,7 @@ bool G_admin_listplayers( gentity_t *ent )
 		           t,
 		           l ? l->level : 0,
 		           hint ? '*' : ' ',
-		           admin_level_maxname + colorlen,
+		           namelen + ( admin_level_maxname - colorlen ),
 		           lname,
 		           bot,
 		           muted,

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -1293,7 +1293,6 @@ static int admin_out( void *admin, char *str )
 	g_admin_admin_t *a = ( g_admin_admin_t * ) admin;
 	g_admin_level_t *l;
 	char            lastSeen[64] = "          ";
-	char            lname[ MAX_NAME_LENGTH ];
 
 	if ( !str )
 	{
@@ -1302,10 +1301,8 @@ static int admin_out( void *admin, char *str )
 
 	l = G_admin_level( a->level );
 
-	Q_strncpyz( lname, l->name, sizeof( lname ) );
-
-	int lncol = Color::StrlenNocolor( lname );
-	int namelen = strlen( lname );
+	int lncol = Color::StrlenNocolor( l->name );
+	int namelen  = strlen( l->name );
 
 	if ( a->lastSeen.tm_mday )
 	{
@@ -1314,7 +1311,7 @@ static int admin_out( void *admin, char *str )
 
 	Com_sprintf( str, MAX_STRING_CHARS, "%-6d %*s ^*%s %s",
 	             a->level, namelen + ( admin_level_maxname - lncol ), 
-	             l ? lname : "(null)",
+	             l ? l->name : "(null)",
 	             lastSeen, a->name );
 
 	return 0;

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -1293,6 +1293,7 @@ static int admin_out( void *admin, char *str )
 	g_admin_admin_t *a = ( g_admin_admin_t * ) admin;
 	g_admin_level_t *l;
 	char            lastSeen[64] = "          ";
+	char            lname[ MAX_NAME_LENGTH ];
 
 	if ( !str )
 	{
@@ -1301,8 +1302,10 @@ static int admin_out( void *admin, char *str )
 
 	l = G_admin_level( a->level );
 
-	int lncol = Color::StrlenNocolor( l->name );
-	int namelen  = strlen( l->name );
+	Q_strncpyz( lname, l->name, sizeof( lname ) );
+
+	int lncol = Color::StrlenNocolor( lname );
+	int namelen = strlen( lname );
 
 	if ( a->lastSeen.tm_mday )
 	{
@@ -1311,7 +1314,7 @@ static int admin_out( void *admin, char *str )
 
 	Com_sprintf( str, MAX_STRING_CHARS, "%-6d %*s ^*%s %s",
 	             a->level, namelen + ( admin_level_maxname - lncol ), 
-	             l ? l->name : "(null)",
+	             l ? lname : "(null)",
 	             lastSeen, a->name );
 
 	return 0;

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -3903,6 +3903,15 @@ bool G_admin_listplayers( gentity_t *ent )
 		           ( !authed ) ? "^1NOT AUTHED" : "" ) );
 	}
 
+	ADMBP( va( "\n^3listplayers:^* legend:" ) );
+
+	if ( canset ){
+		ADMBP( va( "^2*^* = you may set this player's admin level." ) );
+	}
+
+	ADMBP( va( "^5R^* = this player is a bot.       ^1M^* = this player is muted." ) );
+	ADMBP( va( "^1B^* = this player may not build.  %s", ( canseeWarn ? "^3W^* = this player has been warned." : "" ) ) );
+
 	ADMBP_end();
 	return true;
 }


### PR DESCRIPTION
This PR fixes the broken alignment and additional padding in `listplayers`, as well as fixes the alignment in `listadmins`.

It also adds a variable legend to the `listplayers` command, as some of the hints are not immediately obvious to new admins.
The `setlevel` and `warn` description will only show if the admin has permission to see these hints in `listplayers` in the first place.

To fix the alignment, I change the `admin_level_maxname` variable to be the name length _including_ the colours, as we don't use this variable for any other reason other than to format these lists (and the method previously used was broken). This fixes the calculation of characters required to align the level names correctly.

Here is a comparison:
**BEFORE**
![listplayers-alignment](https://user-images.githubusercontent.com/13281185/209662659-d35f58ee-a59c-4221-ac5f-57e38750dcf3.png)

![listadmins-alignment](https://user-images.githubusercontent.com/13281185/209662676-303efb5c-82fc-4e8e-a829-fb1d4e933ba6.png)

**AFTER**
![listplayers-fixed](https://user-images.githubusercontent.com/13281185/209662690-2bf90e34-a6f7-4e42-a4f4-253df98ca6a4.png)

![listadmins-fixed](https://user-images.githubusercontent.com/13281185/209662691-928c9ca4-da6a-4e9e-be27-b63ba1b3002b.png)
