### PR TITLE
On-demand background navmesh generation

### DIFF
--- a/src/sgame/botlib/bot_nav.cpp
+++ b/src/sgame/botlib/bot_nav.cpp
@@ -405,14 +405,13 @@ struct bbox_t {
 static std::map<int, bbox_t> savedObstacles;
 static std::map<int, std::array<dtObstacleRef, MAX_NAV_DATA>> obstacleHandles; // handles of detour's obstacles, if any
 
-extern bool navMeshLoaded;
 void G_BotAddObstacle( const glm::vec3 &mins, const glm::vec3 &maxs, int obstacleNum )
 {
 	qVec min = &mins[0];
 	qVec max = &maxs[0];
 	rBounds box( min, max );
 
-	if ( !navMeshLoaded )
+	if ( navMeshLoaded != navMeshStatus_t::LOADED )
 	{
 		savedObstacles[obstacleNum] = { mins, maxs };
 		return;

--- a/src/sgame/botlib/bot_nav_edit.cpp
+++ b/src/sgame/botlib/bot_nav_edit.cpp
@@ -33,6 +33,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 
 #include "common/cm/cm_public.h"
 #include "sgame/sg_local.h"
+#include "sgame/sg_bot_util.h"
 #include "DetourDebugDraw.h"
 #ifdef __GNUC__
 #pragma GCC diagnostic push
@@ -191,7 +192,6 @@ static bool CheckHost( gentity_t *ent )
 	return false;
 }
 
-bool G_BotNavInit();
 void Cmd_NavEdit( gentity_t *ent )
 {
 	if ( !CheckHost( ent ) ) return;
@@ -216,8 +216,10 @@ void Cmd_NavEdit( gentity_t *ent )
 			return;
 		}
 
-		if ( !G_BotNavInit() )
+		G_BotNavInit( false );
+		if ( navMeshLoaded != navMeshStatus_t::LOADED )
 		{
+			Log::Warn( "Couldn't load navmeshes" );
 			return;
 		}
 

--- a/src/sgame/botlib/bot_nav_edit.cpp
+++ b/src/sgame/botlib/bot_nav_edit.cpp
@@ -216,7 +216,7 @@ void Cmd_NavEdit( gentity_t *ent )
 			return;
 		}
 
-		G_BotNavInit( false );
+		G_BotNavInit( 0 );
 		if ( navMeshLoaded != navMeshStatus_t::LOADED )
 		{
 			Log::Warn( "Couldn't load navmeshes" );

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -28,7 +28,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "Entities.h"
 
 static Cvar::Modified<Cvar::Cvar<int>> g_bot_defaultFill("g_bot_defaultFill", "fills both teams with that number of bots at start of game", Cvar::NONE, 0);
-static Cvar::Cvar<bool> generateNeededMesh("g_bot_navgen_onDemand", "automatically generate navmeshes when a bot is added", Cvar::NONE, false);
+static Cvar::Range<Cvar::Cvar<int>> generateNeededMesh(
+	"g_bot_navgen_onDemand",
+	"automatically generate navmeshes when a bot is added (1 = in background, -1 = blocking)",
+	Cvar::NONE, 1, -1, 1);
 
 static botMemory_t g_botMind[MAX_CLIENTS];
 static AITreeList_t treeList;
@@ -271,7 +274,7 @@ bool G_BotAdd( const char *name, team_t team, int skill, const char *behavior, b
 	const char* s = 0;
 	bool autoname = false;
 
-	ASSERT_EQ( navMeshLoaded, navMeshStatus_t::LOADED );
+	ASSERT( navMeshLoaded == navMeshStatus_t::LOADED || navMeshLoaded == navMeshStatus_t::GENERATING );
 
 	// find what clientNum to use for bot
 	int clientNum = trap_BotAllocateClient();
@@ -477,6 +480,11 @@ void G_BotSpectatorThink( gentity_t *self )
 	//MUST be done
 	while ( trap_BotGetServerCommand( self->num(), buf, sizeof( buf ) ) );
 
+	if ( navMeshLoaded == navMeshStatus_t::GENERATING )
+	{
+		return;
+	}
+
 	self->botMind->spawnTime = level.time;
 
 	if ( self->client->ps.pm_flags & PMF_QUEUED )
@@ -557,11 +565,16 @@ void G_BotIntermissionThink( gclient_t *client )
 // Assuming the meshes already exist, this incurs some delay (a few tenths of a second), but on
 // servers bots are normally added at the beginning of the round so it shouldn't be noticeable.
 //
-// If the mesh has to be generated on demand, that may take several tens of seconds.
+// If the mesh does not already exist and g_bot_navgen_onDemand is 1, the function returns true
+// and bots can join, but they don't spawn until the navmesh is finished.
+//
+// If the mesh does not exist and g_bot_navgen_onDemand is -1, the function will block and the
+// server will freeze until the navmesh is done (usually tens of seconds).
 bool G_BotInit()
 {
 	switch ( navMeshLoaded )
 	{
+	case navMeshStatus_t::GENERATING:
 	case navMeshStatus_t::LOADED:
 		return true;
 	case navMeshStatus_t::LOAD_FAILED:
@@ -573,7 +586,7 @@ bool G_BotInit()
 
 	G_BotNavInit( generateNeededMesh.Get() );
 
-	if ( navMeshLoaded != navMeshStatus_t::LOADED )
+	if ( navMeshLoaded != navMeshStatus_t::LOADED && navMeshLoaded != navMeshStatus_t::GENERATING )
 	{
 		Log::Notice( "Failed to load navmeshes" );
 		return false;

--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -38,6 +38,14 @@ This file contains the headers of the internal functions used by bot only.
 
 #include <bitset>
 
+enum class navMeshStatus_t
+{
+	UNINITIALIZED,
+	LOAD_FAILED,
+	LOADED,
+};
+extern navMeshStatus_t navMeshLoaded;
+
 struct botEntityAndDistance_t
 {
 	gentity_t const *ent;
@@ -177,7 +185,7 @@ private:
 	bool exhausted = false;
 };
 
-bool G_BotSetupNav( const botClass_t *botClass, qhandle_t *navHandle );
+navMeshStatus_t G_BotSetupNav( const botClass_t *botClass, qhandle_t *navHandle );
 void G_BotShutdownNav();
 void G_BotSetNavMesh( int botClientNum, qhandle_t navHandle );
 bool G_BotFindRoute( int botClientNum, const botRouteTarget_t *target, bool allowPartial );

--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -41,6 +41,7 @@ This file contains the headers of the internal functions used by bot only.
 enum class navMeshStatus_t
 {
 	UNINITIALIZED,
+	GENERATING,
 	LOAD_FAILED,
 	LOADED,
 };

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "botlib/bot_types.h"
 #include "botlib/bot_api.h"
 #include "shared/bot_nav_shared.h"
+#include "shared/navgen/navgen.h"
 
 #include "shared/bg_local.h"
 
@@ -35,6 +36,36 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 //tells if all navmeshes loaded successfully
 bool navMeshLoaded = false;
+
+/*
+===========================
+Navigation Mesh Generation
+===========================
+*/
+
+// blocks the main thread!
+void G_BlockingGenerateNavmesh( std::bitset<PCL_NUM_CLASSES> classes )
+{
+	std::string mapName = Cvar::GetValue( "mapname" );
+	NavmeshGenerator navgen;
+
+	for ( int i = PCL_NONE; ++i < PCL_NUM_CLASSES; )
+	{
+		if ( !classes[ i ] )
+		{
+			continue;
+		}
+
+		navgen.Init( mapName );
+		navgen.StartGeneration( Util::enum_cast<class_t>( i ) );
+
+		while ( !navgen.Step() )
+		{
+			// ping the engine with a useless message so that it does not think the sgame VM has hung
+			Cvar::GetValue( "x" );
+		}
+	}
+}
 
 /*
 ========================

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -35,6 +35,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <glm/gtx/norm.hpp>
 
 //tells if all navmeshes loaded successfully
+// Only G_BotNavInit and G_BotNavCleanup should set it
 navMeshStatus_t navMeshLoaded = navMeshStatus_t::UNINITIALIZED;
 
 /*
@@ -67,6 +68,83 @@ void G_BlockingGenerateNavmesh( std::bitset<PCL_NUM_CLASSES> classes )
 	}
 }
 
+static Cvar::Range<Cvar::Cvar<int>> msecPerFrame(
+	"g_bot_navgen_msecPerFrame", "time budget per frame for navmesh generation",
+	Cvar::NONE, 20, 1, 1500 );
+
+static NavmeshGenerator navgen;
+static std::vector<class_t> navgenQueue;
+static class_t generatingNow;
+static int nextLogTime;
+
+static void G_BotBackgroundNavgenShutdown()
+{
+	navgen.~NavmeshGenerator();
+	new (&navgen) NavmeshGenerator();
+	navgenQueue.clear();
+	generatingNow = PCL_NONE;
+}
+
+void G_BotBackgroundNavgen()
+{
+	if ( navgenQueue.empty() )
+	{
+		return;
+	}
+
+	ASSERT_EQ( navMeshLoaded, navMeshStatus_t::GENERATING );
+
+	int stopTime = Sys::Milliseconds() + msecPerFrame.Get();
+
+	navgen.Init( Cvar::GetValue( "mapname" ) );
+
+	if ( generatingNow == PCL_NONE )
+	{
+		class_t next = navgenQueue.back();
+		generatingNow = next;
+		navgen.StartGeneration( next );
+	}
+
+	if ( level.time > nextLogTime )
+	{
+		std::string percent = std::to_string( int(navgen.SpeciesFractionCompleted() * 100) );
+		trap_SendServerCommand( -1, va( "print_tr %s %s %s",
+			QQ( N_( "Server: generating bot navigation mesh for $1$... $2$%" ) ),
+			BG_Class( generatingNow )->name, percent.c_str() ) );
+		nextLogTime = level.time + 10000;
+	}
+
+	while ( Sys::Milliseconds() < stopTime )
+	{
+		if ( navgen.Step() )
+		{
+			ASSERT_EQ( generatingNow, navgenQueue.back() );
+			navgenQueue.pop_back();
+			generatingNow = PCL_NONE;
+			break;
+		}
+	}
+
+	if ( navgenQueue.empty() ) // finished?
+	{
+		G_BotBackgroundNavgenShutdown();
+
+		navMeshLoaded = navMeshStatus_t::UNINITIALIZED; // HACK: make G_BotNavInit not return at the start
+		G_BotNavInit( 0 );
+
+		if ( navMeshLoaded == navMeshStatus_t::LOAD_FAILED )
+		{
+			trap_SendServerCommand( -1, "print_tr " QQ( N_( "^1Bot navmesh generation failed!" ) ) );
+			G_BotDelAllBots();
+		}
+		else
+		{
+			ASSERT_EQ( navMeshLoaded, navMeshStatus_t::LOADED );
+			// Bots on spectate will now join in their think function
+		}
+	}
+}
+
 /*
 ========================
 Navigation Mesh Loading
@@ -75,7 +153,8 @@ Navigation Mesh Loading
 
 extern void BotAddSavedObstacles();
 // FIXME: use nav handle instead of classes
-void G_BotNavInit( bool generateNeeded )
+// see g_bot_navgen_onDemand for meaning of generateNeeded
+void G_BotNavInit( int generateNeeded )
 {
 	if ( navMeshLoaded != navMeshStatus_t::UNINITIALIZED )
 	{
@@ -120,8 +199,25 @@ void G_BotNavInit( bool generateNeeded )
 	if ( missing.any() )
 	{
 		G_BotShutdownNav(); // TODO: allow shutdown/load of individual species
-		G_BlockingGenerateNavmesh( missing );
-		return G_BotNavInit( false );
+
+		if ( generateNeeded == -1 )
+		{
+			G_BlockingGenerateNavmesh( missing );
+			return G_BotNavInit( 0 );
+		}
+		else
+		{
+			ASSERT( navgenQueue.empty() );
+			for ( int i = PCL_NUM_CLASSES; --i > PCL_NONE; )
+			{
+				if ( missing[ i ] )
+				{
+					navgenQueue.push_back( Util::enum_cast<class_t>( i ) );
+				}
+			}
+			navMeshLoaded = navMeshStatus_t::GENERATING;
+			return;
+		}
 	}
 
 	navMeshLoaded = navMeshStatus_t::LOADED;
@@ -131,6 +227,7 @@ void G_BotNavInit( bool generateNeeded )
 void G_BotNavCleanup()
 {
 	G_BotShutdownNav();
+	G_BotBackgroundNavgenShutdown();
 	navMeshLoaded = navMeshStatus_t::UNINITIALIZED;
 }
 

--- a/src/sgame/sg_bot_public.h
+++ b/src/sgame/sg_bot_public.h
@@ -67,6 +67,7 @@ void G_BotEnableArea( const glm::vec3 &origin, const glm::vec3 &mins, const glm:
 void G_BotAddObstacle( const glm::vec3 &mins, const glm::vec3 &maxs, int obstacleNum );
 void G_BotRemoveObstacle( int obstacleNum );
 void G_BotUpdateObstacles();
+void G_BotBackgroundNavgen();
 bool G_BotInit();
 void G_BotCleanup();
 void G_BotFill( bool immediately );

--- a/src/sgame/sg_bot_util.h
+++ b/src/sgame/sg_bot_util.h
@@ -115,7 +115,7 @@ enum botMoveDir_t
 void G_BlockingGenerateNavmesh( std::bitset<PCL_NUM_CLASSES> classes );
 
 // global navigation
-void         G_BotNavInit( bool generateNeeded );
+void         G_BotNavInit( int generateNeeded );
 void         G_BotNavCleanup();
 bool     FindRouteToTarget( gentity_t *self, botTarget_t target, bool allowPartial );
 bool         BotMoveToGoal( gentity_t *self );

--- a/src/sgame/sg_bot_util.h
+++ b/src/sgame/sg_bot_util.h
@@ -115,9 +115,7 @@ enum botMoveDir_t
 void G_BlockingGenerateNavmesh( std::bitset<PCL_NUM_CLASSES> classes );
 
 // global navigation
-extern bool navMeshLoaded;
-
-bool         G_BotNavInit();
+void         G_BotNavInit( bool generateNeeded );
 void         G_BotNavCleanup();
 bool     FindRouteToTarget( gentity_t *self, botTarget_t target, bool allowPartial );
 bool         BotMoveToGoal( gentity_t *self );

--- a/src/sgame/sg_bot_util.h
+++ b/src/sgame/sg_bot_util.h
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #ifndef BOT_UTIL_H_
 #define BOT_UTIL_H_
+#include <bitset>
 #include "sg_local.h"
 #include "botlib/bot_types.h"
 #include "sg_bot_local.h"
@@ -109,6 +110,9 @@ enum botMoveDir_t
 	MOVE_LEFT = BIT( 2 ),
 	MOVE_RIGHT = BIT( 3 )
 };
+
+// navmesh generation
+void G_BlockingGenerateNavmesh( std::bitset<PCL_NUM_CLASSES> classes );
 
 // global navigation
 extern bool navMeshLoaded;

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -2510,6 +2510,7 @@ void G_RunFrame( int levelTime )
 	// see if it is time to end the level
 	CheckExitRules();
 
+	G_BotBackgroundNavgen();
 	G_BotFill( false );
 
 	// update to team status?


### PR DESCRIPTION
Stacked on #2352.

On-demand navmesh generation in the background in sgame is ready to test out. Just load a map and add a bot. Well also you need valid navmeshes to not already exist; you can delete them from `<homepath>/game/maps/` if applicable, or edit `NAVMESHSET_VERSION` in the source to invalidate all existing meshes.