### PR TITLE
admin: implement negative flags

### DIFF
--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -561,10 +561,8 @@ static void CG_Menu( int menuType, int arg )
 			break;
 
 		case MN_B_REVOKED:
-			longMsg = _("Your teammates have lost faith in your ability to build "
-			          "for the team. You will not be allowed to build until your "
-			          "team votes to reinstate your building rights.");
-			shortMsg = _("Your building rights have been revoked");
+			longMsg = _("You are no longer permitted to build.");
+			shortMsg = _("You are no longer permitted to build");
 			break;
 
 		case MN_B_SURRENDER:

--- a/src/sgame/sg_admin.h
+++ b/src/sgame/sg_admin.h
@@ -64,6 +64,12 @@ struct gentity_t;
  * INCOGNITO - does not show up as an admin in /listplayers
  * ALLFLAGS - all flags (including command flags) apply to this player
  * ADMINCHAT - receives and can send /a admin messages
+ =======================================================================
+ * .NOGLOBALCHAT - may not use the global chat
+ * .NOTEAMCHAT - may not use the team chat
+ * .NOVOTE - may not call global votes
+ * .NOTEAMVOTE - may not call team votes
+ * .NOBUILD - may not build
  */
 #define ADMF_IMMUNITY        "IMMUNITY"
 #define ADMF_NOCENSORFLOOD   "NOCENSORFLOOD"
@@ -78,6 +84,13 @@ struct gentity_t;
 #define ADMF_INCOGNITO       "INCOGNITO"
 #define ADMF_ALLFLAGS        "ALLFLAGS"
 #define ADMF_ADMINCHAT       "ADMINCHAT"
+
+// "negative" flags
+#define ADMF_NO_GLOBALCHAT  ".NOGLOBALCHAT"
+#define ADMF_NO_TEAMCHAT    ".NOTEAMCHAT"
+#define ADMF_NO_GLOBALVOTE  ".NOGLOBALVOTE"
+#define ADMF_NO_TEAMVOTE    ".NOTEAMVOTE"
+#define ADMF_NO_BUILD       ".NOBUILD"
 
 #define MAX_ADMIN_LISTITEMS  20
 #define MAX_ADMIN_SHOWBANS   10

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -1075,7 +1075,7 @@ gentity_t *G_GetDeconstructibleBuildable( gentity_t *ent )
 	gentity_t *buildable;
 
 	// Check for revoked building rights.
-	if ( ent->client->pers.namelog->denyBuild )
+	if ( ent->client->pers.namelog->denyBuild || G_admin_permission( ent, ADMF_NO_BUILD ) )
 	{
 		G_TriggerMenu( ent->client->ps.clientNum, MN_B_REVOKED );
 		return nullptr;


### PR DESCRIPTION
This PR includes all work required to implement negative flags as described originally in #2196, allowing server owners to flag individuals or levels with certain "negative" flags, such as `.NOBUILD`, `.NOGLOBALCHAT`, `.NOGLOBALVOTE`, etc, and possibly `.NOTACTIC` depending on whether #2355 is merged. This could be expanded upon in future.

This could be useful for making a level which could not chat or vote (perhaps the server admin requires name registration first?), or for muting / denybuilding troll players beyond a single game, and generally provides the framework required should any future servers owners, developers or modders wish to add such flags.

For the two chat flags, I have made highlight the "mute" flag in listplayers. In future it might do to expand upon these and include vote restrictions later too, but that is not within the scope of this PR.

I intend to squash the commits into one if this is approved.