### PR TITLE
Allow setting g_BPInitialBudget to a value per team, in one cvar

### DIFF
--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -83,7 +83,7 @@ extern Cvar::Cvar<int> g_maxVoteFillBots;
 extern Cvar::Cvar<int> g_fillBotsVotesPercent;
 extern Cvar::Cvar<int> g_fillBotsTeamVotesPercent;
 
-extern  Cvar::Callback<Cvar::Cvar<int>> g_buildPointInitialBudget;
+extern  Cvar::Callback<Cvar::Cvar<std::string>> g_buildPointInitialBudget;
 extern  Cvar::Callback<Cvar::Cvar<int>> g_buildPointBudgetPerMiner;
 extern  Cvar::Cvar<int> g_buildPointRecoveryInitialRate;
 extern  Cvar::Cvar<int> g_buildPointRecoveryRateHalfLife;

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -96,12 +96,12 @@ Cvar::Cvar<float> g_minNameChangePeriod("g_minNameChangePeriod", "player must wa
 Cvar::Cvar<int> g_maxNameChanges("g_maxNameChanges", "max name changes per game", Cvar::NONE, 5);
 
 // gameplay: mining
-Cvar::Callback<Cvar::Cvar<int>> g_buildPointInitialBudget(
+Cvar::Callback<Cvar::Cvar<std::string>> g_buildPointInitialBudget(
 		"g_BPInitialBudget",
 		"Initial build points count",
 		Cvar::SERVERINFO,
-		DEFAULT_BP_INITIAL_BUDGET,
-		[](int) {
+		XSTRING( DEFAULT_BP_INITIAL_BUDGET ),
+		[](std::string) {
 			G_UpdateBuildPointBudgets();
 		});
 Cvar::Callback<Cvar::Cvar<int>> g_buildPointBudgetPerMiner(
@@ -1606,9 +1606,9 @@ static void G_LogGameplayStats( int state )
 			             "# Time:    %02i:%02i:%02i\n"
 			             "# Format:  %i\n"
 			             "#\n"
-			             "# g_momentumHalfLife:        %4g\n"
-			             "# g_initialBuildPoints:      %4i\n"
-			             "# g_budgetPerMiner:          %4i\n"
+			             "# g_momentumHalfLife:       %4g\n"
+			             "# g_BPInitialBudget:        %s\n"
+			             "# g_BPBudgetPerMiner:       %4i\n"
 			             "#\n"
 			             "#  1  2  3    4    5    6    7    8    9   10   11   12   13   14   15   16\n"
 			             "#  T #A #H AMom HMom ---- ATBP HTBP AUBP HUBP ABRV HBRV ACre HCre AVal HVal\n"
@@ -1619,7 +1619,7 @@ static void G_LogGameplayStats( int state )
 			             t.tm_hour, t.tm_min, t.tm_sec,
 			             LOG_GAMEPLAY_STATS_VERSION,
 			             g_momentumHalfLife.Get(),
-			             g_buildPointInitialBudget.Get(),
+			             g_buildPointInitialBudget.Get().c_str(),
 			             g_buildPointBudgetPerMiner.Get() );
 
 			break;


### PR DESCRIPTION
Setting "g_BPInitialBudget 10,50" will give 10 bp to the first team (aliens) and 50bp to the second (humans).

If the list isn't long enough, the last value will be used. This means that this is backward compatible as if there is only one value, it will be used for every team.

This approach has the advantage of extending to more teams should we add support for that; and doesn't need a change in netradiant for each team we add either.
