### PR TITLE
Add obstacle debug draw

### DIFF
--- a/src/sgame/botlib/bot_local.h
+++ b/src/sgame/botlib/bot_local.h
@@ -191,6 +191,22 @@ struct Bot_t
 	dtRouteResult     routeResults[ MAX_ROUTE_CACHE ];
 };
 
+
+/*
+ * These are used to keep in mind what obstacles we sent to Detour
+ */
+struct bbox_t {
+	glm::vec3 mins;
+	glm::vec3 maxs;
+};
+struct saved_obstacle_t {
+	bool added;
+	bbox_t bbox;
+};
+extern std::map<int, saved_obstacle_t> savedObstacles;
+extern std::map<int, std::array<dtObstacleRef, MAX_NAV_DATA>> obstacleHandles; // handles of detour's obstacles, if any
+
+
 extern int numNavData;
 extern NavData_t BotNavData[ MAX_NAV_DATA ];
 extern Bot_t agents[ MAX_CLIENTS ];


### PR DESCRIPTION
This is a cleanup version of the code I used to debug bots' obstacles. I found it to be very useful.

Screenshots:
![Screenshot from 2023-01-08 12-33-23](https://user-images.githubusercontent.com/59283660/211794890-93587acf-0c7d-4b77-afa9-53169c357bbe.png)
![Screenshot from 2023-01-10 10-06-34](https://user-images.githubusercontent.com/59283660/211794754-1d69eb10-c508-48e9-a11c-af7936aa0a9f.png)
![Screenshot from 2022-11-06 14-44-51](https://user-images.githubusercontent.com/59283660/211795180-bd1da724-7a60-4b42-b7bc-cfbb2f8c5d68.png)
