### PR TITLE
tactic command: show allowed behaviors, group functions in header

### DIFF
--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -3706,7 +3706,7 @@ static void Cmd_Tactic_f( gentity_t * ent )
 	int milliSeconds = g_tacticMilliseconds.Get();
 	if ( milliSeconds < 0 )
 	{
-		ADMP( va( "%s", QQ( N_("^3tactic^* is disabled") ) ) );
+		ADMP( va( "%s", QQ( N_("^3tactic:^* not allowed by server") ) ) );
 		return;
 	}
 

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -3719,7 +3719,7 @@ static void Cmd_Tactic_f( gentity_t * ent )
 
 	if ( trap_Argc() < 2 )
 	{
-		std::string behaviors = BG_TacticBehaviorsToString( " " );
+		std::string behaviors = BG_TacticBehaviorsToString( ", " );
 		if ( behaviors.empty() )
 		{
 			ADMP( QQ( N_( "^3tactic:^* not allowed by server" ) ) );

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -3719,7 +3719,16 @@ static void Cmd_Tactic_f( gentity_t * ent )
 
 	if ( trap_Argc() < 2 )
 	{
-		ADMP( QQ( N_( "^3tactic:^* usage: tactic <behavior> [how-many-bots]" ) ) ) ;
+		std::string behaviors = BG_TacticBehaviorsToString( " " );
+		if ( behaviors.empty() )
+		{
+			ADMP( QQ( N_( "^3tactic:^* not allowed by server" ) ) );
+		}
+		else
+		{
+			ADMP( QQ( N_( "^3tactic:^* usage: tactic <behavior> [how-many-bots]" ) ) ) ;
+			ADMP( va( "%s %s", QQ( N_("   <behavior> is one of: $1$") ), Quote( behaviors.c_str() ) ) );
+		}
 		return;
 	}
 

--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -2274,6 +2274,22 @@ bool BG_TacticBehaviorAllowed( std::string behavior )
 	return bg_tacticBehaviors.find( behavior ) != bg_tacticBehaviors.end();
 }
 
+std::string BG_TacticBehaviorsToString( std::string sep )
+{
+	std::string result = "";
+	std::set<std::string>::iterator behavior = bg_tacticBehaviors.begin();
+	while ( behavior != bg_tacticBehaviors.end() )
+	{
+		result.append( *behavior );
+		behavior++;
+		if ( behavior != bg_tacticBehaviors.end() )
+		{
+			result.append( sep );
+		}
+	}
+	return result;
+}
+
 /*
 ============
 BG_SetForbiddenEquipment

--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -2264,17 +2264,17 @@ BoundedVector<buildable_t, BA_NUM_BUILDABLES>
 	return results;
 }
 
-void BG_SetTacticBehaviors( std::string behaviorsCsv )
+void BG_SetTacticBehaviors( Str::StringRef behaviorsCsv )
 {
 	bg_tacticBehaviors = BG_ParseTacticBehaviorsList( behaviorsCsv );
 }
 
-bool BG_TacticBehaviorAllowed( std::string behavior )
+bool BG_TacticBehaviorAllowed( Str::StringRef behavior )
 {
 	return bg_tacticBehaviors.find( behavior ) != bg_tacticBehaviors.end();
 }
 
-std::string BG_TacticBehaviorsToString( std::string sep )
+std::string BG_TacticBehaviorsToString( Str::StringRef sep )
 {
 	std::string result = "";
 	std::set<std::string>::iterator behavior = bg_tacticBehaviors.begin();

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -1717,9 +1717,9 @@ bool BG_BuildableDisabled( int buildable );
 
 weapon_t BG_PrimaryWeapon( int const stats[] );
 
-void BG_SetTacticBehaviors(std::string tacticCsv);
-bool BG_TacticBehaviorAllowed(std::string behavior);
-std::string BG_TacticBehaviorsToString(std::string sep);
+void BG_SetTacticBehaviors( Str::StringRef tacticCsv );
+bool BG_TacticBehaviorAllowed( Str::StringRef behavior );
+std::string BG_TacticBehaviorsToString( Str::StringRef sep );
 
 // bg_voice.c
 #define MAX_VOICES             8

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -1709,17 +1709,17 @@ void BG_SetForbiddenEquipment(std::string forbidden_csv);
 void BG_SetForbiddenClasses(std::string forbidden_csv);
 void BG_SetForbiddenBuildables(std::string forbidden_csv);
 
-void BG_SetTacticBehaviors(std::string tacticCsv);
-
 bool BG_WeaponDisabled( int weapon );
 bool BG_UpgradeDisabled( int upgrade );
 
 bool BG_ClassDisabled( int class_ );
 bool BG_BuildableDisabled( int buildable );
 
-bool BG_TacticBehaviorAllowed(std::string behavior);
-
 weapon_t BG_PrimaryWeapon( int const stats[] );
+
+void BG_SetTacticBehaviors(std::string tacticCsv);
+bool BG_TacticBehaviorAllowed(std::string behavior);
+std::string BG_TacticBehaviorsToString(std::string sep);
 
 // bg_voice.c
 #define MAX_VOICES             8


### PR DESCRIPTION
This shows the allowed behaviors from `g_tacticBehaviors` in the usage message. Without this, there is no way for a user to find out what the allowed behaviors are.

PR also groups the tactic functions in bg_public.h.