### PR TITLE
cgame: better viewpos command

### DIFF
--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -62,9 +62,9 @@ Debugging command to print the current position
 */
 static void CG_Viewpos_f()
 {
-	Log::Notice( "(%i %i %i) : %i", ( int ) cg.refdef.vieworg[ 0 ],
-	           ( int ) cg.refdef.vieworg[ 1 ], ( int ) cg.refdef.vieworg[ 2 ],
-	           ( int ) cg.refdefViewAngles[ YAW ] );
+	Log::Notice( "%.0f %.0f %.0f %.0f %.0f", cg.refdef.vieworg[ 0 ],
+	           cg.refdef.vieworg[ 1 ], cg.refdef.vieworg[ 2 ],
+	           cg.refdefViewAngles[ YAW ], cg.refdefViewAngles[ PITCH ] );
 }
 
 /*


### PR DESCRIPTION
- also print the pitch  
something I needed for years
- do a float round and not an in truncation  
make sure numbers printed by `viewpos` is the same as the one set with `setviewpos`

Before printing the pitch:

```
]/viewpos
(0 2688 192) : -90
```

Before doing a float round:

```
]/viewpos
-1013 -378 130 -47 -30
]/setviewpos -1013 -378 130 -47 -30
]/viewpos
-1013 -378 130 -46 -29
```