### PR TITLE
Add command /bot info

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -5897,7 +5897,7 @@ static bool BotInfoCmd( gentity_t *ent, const Cmd::Args& args )
 		return false;
 	}
 	int botIds[ MAX_CLIENTS ] = { 0 };
-	for ( int i = 2; i < argc; i++ )
+	for ( int i = 2; i < argc && i - 2 < MAX_CLIENTS; i++ )
 	{
 		char err[ MAX_STRING_CHARS ];
 		botIds[ i - 2 ] = G_ClientNumberFromString( args[ i ].data(), err, sizeof( err ) );


### PR DESCRIPTION
Shows the same information as current `listbots` tries to show, but lets a user select a set of bots. This is to give us the the freedom to fix https://github.com/Unvanquished/Unvanquished/issues/2341 in any way we see fit, even by reverting to the old `listbots`.

Edit:
Usage example:
```
]/listbots
listbots: 6 bots in game: 
Slot Name Team [s=skill ss=skillset b=behavior g=goal] 
1 [bot] Morgan: alien [s=5 ss="fighting aim-head aim-barbs movement tyrant-attack-run mara-attack-jump mantis-attack-jump goon-attack-jump feels-pain" b=default g=(723 138 32)] 
2 [bot] Alaric: human [s=5 ss="fighting predict-aim feels-pain medkit flee-run" b=default g=(-865 1803 -6)] 
3 [bot] Soizic: alien [s=5 ss="fighting movement mara-attack-jump goon-attack-jump aim-barbs tyrant-attack-run mantis-attack-jump aim-head feels-pain" b=default g=(909 1984 -8)] 
4 [bot] Baudry: human [s=5 ss="feels-pain buy-armor prefer-armor medkit" b=default g=(-1063 1752 -11)] 
5 [bot] Itsaso: alien [s=5 ss="fighting aim-head movement aim-barbs goon-attack-jump feels-pain mantis-attack-jump tyrant-flee-run mantis-flee-jump" b=default g=(1710 860 127)] 
6 [bot] Ferdinand: human [s=5 ss="feels-pain buy-armor prefer-armor flee-run" b=default g=<invalid>] 

]/bot info 1 3 5
Slot Name Team [s=skill ss=skillset b=behavior g=goal] 
1 [bot] Morgan: alien [s=5 ss="fighting aim-head aim-barbs movement tyrant-attack-run mara-attack-jump mantis-attack-jump goon-attack-jump feels-pain" b=default g=(1432 354 106)]
3 [bot] Soizic: alien [s=5 ss="fighting movement mara-attack-jump goon-attack-jump aim-barbs tyrant-attack-run mantis-attack-jump aim-head feels-pain" b=default g=(player|#4)]
5 [bot] Itsaso: alien [s=5 ss="fighting aim-head movement aim-barbs goon-attack-jump feels-pain mantis-attack-jump tyrant-flee-run mantis-flee-jump" b=default g=(342 2317 -114)]
 ```

Since a user can control the output size, it is less of a problem if the output becomes too big.