### PR TITLE
Add entity debug field

### DIFF
--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -2664,7 +2664,9 @@ static const NetcodeTable playerStateFields =
 	{ PSF( ammo              ), 12               , 0 },
 	{ PSF( clips             ), 4                , 0 },
 	{ PSF( tauntTimer        ), 12               , 0 },
-	{ PSF( weaponAnim        ), ANIM_BITS        , 0 }
+	{ PSF( weaponAnim        ), ANIM_BITS        , 0 },
+	{ PSF( debugColor        ), 32               , 0 },
+	{ PSF( debugNumbers      ), 32               , 0 },
 };
 static_assert( (1<<LOW_OXYGEN_TIME_BITS) > OXYGEN_MAX_TIME, "you need to make LOW_OXYGEN_TIME_BITS large enough to accomodate OXYGEN_MAX_TIME" );
 

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -146,6 +146,9 @@ struct playerState_t
 	int           tauntTimer; // don't allow another taunt until this runs out
 	int           misc[ MAX_MISC ]; // misc data
 
+	int debugColor;
+	int debugNumbers;
+
 	bool IsWeaponReady() const;
 };
 


### PR DESCRIPTION
This will allow for a better implementation of https://github.com/Unvanquished/Unvanquished/pull/2270

This has [a daemon counterpart too](https://github.com/DaemonEngine/Daemon/pull/790), because the intent was to modify entityState_t, and apparently entityState_t has to be kept in sync with playerState_t, and entityState_t lies in daemon for now. Yep.