### PR TITLE
Improve bot trace navigation

### DIFF
--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -590,13 +590,13 @@ static void BotFindDefaultSteerTarget( gentity_t *self, glm::vec3 &dir )
 
 	// We add a delta determined from clientNum to avoid bots
 	// dancing in sync
-	int time = (110 * self->num() + self->client->time1000) % 1000;
+	int time = (110 * self->num() + self->client->time10000) % 1600;
 
-	// 280 instead of 700/2=350 because we want some left/right
+	bool invert = time < 800;
+	// part of the time we go straight instead
+	// 600 instead of 800 because we want some left/right
 	// asymetry in case it helps
-	bool invert = time < 280;
-	// half of the time we go straight instead
-	bool sideways = time > 700;
+	bool sideways = std::abs(time - 600) < 500;
 
 	if ( sideways )
 	{

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -600,8 +600,8 @@ void BotHandleDoor( gentity_t *ent, moverState_t moverState )
 {
 	switch ( moverState )
 	{
-		// See comment below for MOVER_POS2
 		case MOVER_POS1:
+		case MOVER_POS2:
 		case ROTATOR_POS1:
 		case ROTATOR_POS2:
 			if ( IsDoor( ent ) )
@@ -611,24 +611,6 @@ void BotHandleDoor( gentity_t *ent, moverState_t moverState )
 				{
 					G_BotAddObstacle( VEC2GLM( ent->r.absmin ), VEC2GLM( ent->r.absmax ), ent->num() );
 				}
-			}
-			break;
-
-		// We add regular opened doors as obstacles even if the doors are not automatic to avoid bots
-		// walking through the door pane, when it's opened (it's
-		// considered an obstacle because the door can't open further).
-		// See https://github.com/Unvanquished/Unvanquished/issues/2358
-		//
-		// We can't do that for rotating doors as this would break
-		// round "iris" doors, the axis-aligned bounding box would
-		// disable too much navmesh, making passing through the door
-		// difficult.
-		// https://github.com/Unvanquished/Unvanquished/pull/2360#issuecomment-1376145592
-		case MOVER_POS2:
-			if ( IsDoor( ent ) )
-			{
-				G_BotRemoveObstacle( ent->num() );
-				G_BotAddObstacle( VEC2GLM( ent->r.absmin ), VEC2GLM( ent->r.absmax ), ent->num() );
 			}
 			break;
 


### PR DESCRIPTION
This PR should help bot better navigate despite imperfect navmesh or crowding. It is not a valid replacement for good quality navmesh (for example this doesn't fix UTCS' boxes and guardrail), but should help nonetheless.

See individual commits and code comments for explanations.