### PR TITLE
Navgen: use BSP patches

### DIFF
--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -49,7 +49,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 #define MIN_WALK_NORMAL 0.7f
 
 static const int NAVMESHSET_MAGIC = 'M'<<24 | 'S'<<16 | 'E'<<8 | 'T'; //'MSET';
-static const int NAVMESHSET_VERSION = 6; // Increment when navgen algorithm or data format changes
+static const int NAVMESHSET_VERSION = 7; // Increment when navgen algorithm or data format changes
 
 enum navPolyFlags
 {
@@ -84,8 +84,9 @@ struct NavgenConfig {
 	int excludeCaulk; // boolean - exclude caulk surfaces
 	int excludeSky; // boolean - exclude surfaces with surfaceparm sky from navmesh generation
 	int filterGaps; // boolean - add new walkable spans so bots can walk over small gaps
+	int generatePatchTris; // boolean - generate triangles from the BSP's patches
 
-	static NavgenConfig Default() { return { 2.0f, STEPSIZE, 1, 1, 1 }; }
+	static NavgenConfig Default() { return { 2.0f, STEPSIZE, 1, 1, 1, 1 }; }
 };
 
 struct NavgenMapIdentification

--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -352,18 +352,6 @@ void NavmeshGenerator::LoadTris( std::vector<float> &verts, std::vector<int> &tr
 	std::swap( mins[ 1 ], mins[ 2 ] );
 	std::swap( maxs[ 1 ], maxs[ 2 ] );
 
-	vec3_t tmin, tmax;
-
-	// need to recalculate mins and maxs because they no longer represent
-	// the minimum and maximum vector components respectively
-	ClearBounds( tmin, tmax );
-
-	AddPointToBounds( mins, tmin, tmax );
-	AddPointToBounds( maxs, tmin, tmax );
-
-	VectorCopy( tmin, mins );
-	VectorCopy( tmax, maxs );
-
 	for ( int k = model->firstSurface, n = 0; n < model->numSurfaces; k++, n++ )
 	{
 		const dsurface_t *surface = &bspSurfaces[ k ];
@@ -389,6 +377,7 @@ void NavmeshGenerator::LoadTris( std::vector<float> &verts, std::vector<int> &tr
 		const drawVert_t *curveVerts = &bspVerts[surface->firstVert];
 
 		// make sure the patch intersects the bounds of the brushes
+		vec3_t tmin, tmax;
 		ClearBounds( tmin, tmax );
 
 		for ( int x = 0; x < grid.width; x++ )

--- a/src/shared/navgen/navgen.h
+++ b/src/shared/navgen/navgen.h
@@ -150,7 +150,7 @@ private:
 
 	void LoadBSP();
 	void LoadGeometry();
-	void LoadBrushTris(std::vector<float>& verts, std::vector<int>& tris);
+	void LoadTris(std::vector<float>& verts, std::vector<int>& tris);
 	void WriteFile();
 
 public:


### PR DESCRIPTION
The navmesh in the location under the Chasm pipes as shown in #2389 indeed looks different when using the patches. I haven't attempt to test whether bot navigation is really better.

On most maps the number of triangles increases only modestly, but on Perseus it increases 72%. Maybe that would be a good candidate to set up a configuration to ignore patches (assuming it doesn't actually fix the navigation bugs there).