### PR TITLE
Use a config file to customize navgen options

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1102,6 +1102,7 @@ static void GenerateNavmeshes()
 {
 	std::string mapName = Cvar::GetValue( "mapname" );
 	std::vector<class_t> missing;
+	NavgenConfig config = ReadNavgenConfig( mapName );
 	for ( class_t species : RequiredNavmeshes() )
 	{
 		fileHandle_t f;
@@ -1112,7 +1113,7 @@ static void GenerateNavmeshes()
 			continue;
 		}
 		NavMeshSetHeader header;
-		std::string error = GetNavmeshHeader( f, header, mapName );
+		std::string error = GetNavmeshHeader( f, config, header, mapName );
 		if ( !error.empty() )
 		{
 			Log::Notice( "Existing navmesh file %s can't be used: %s", filename, error );

--- a/src/sgame/botlib/bot_load.cpp
+++ b/src/sgame/botlib/bot_load.cpp
@@ -289,12 +289,12 @@ static void BotLoadOffMeshConnections( const char *species, OffMeshConnections &
 
 // Returns UNINITIALIZED (if cache is invalidated),
 // LOAD_FAILED (for cached failure or internal error), or LOADED
-static navMeshStatus_t BotLoadNavMesh( int f, const char *species, NavData_t &nav )
+static navMeshStatus_t BotLoadNavMesh( int f, const NavgenConfig &config, const char *species, NavData_t &nav )
 {
 	constexpr auto internalErrorStatus = navMeshStatus_t::LOAD_FAILED;
 
 	NavMeshSetHeader header;
-	std::string error = GetNavmeshHeader( f, header, Cvar::GetValue( "mapname" ) );
+	std::string error = GetNavmeshHeader( f, config, header, Cvar::GetValue( "mapname" ) );
 	if ( !error.empty() )
 	{
 		Log::Warn( "Loading navmesh for %s failed: %s", species, error );
@@ -454,7 +454,7 @@ void G_BotShutdownNav()
 	numNavData = 0;
 }
 
-navMeshStatus_t G_BotSetupNav( const botClass_t *botClass, qhandle_t *navHandle )
+navMeshStatus_t G_BotSetupNav( const NavgenConfig &config, const botClass_t *botClass, qhandle_t *navHandle )
 {
 	if ( numNavData == MAX_NAV_DATA )
 	{
@@ -477,7 +477,7 @@ navMeshStatus_t G_BotSetupNav( const botClass_t *botClass, qhandle_t *navHandle 
 
 	Log::Notice( " loading navigation mesh file '%s'...", filePath );
 
-	navMeshStatus_t loadStatus =  BotLoadNavMesh( f, species, *nav );
+	navMeshStatus_t loadStatus =  BotLoadNavMesh( f, config, species, *nav );
 	if ( loadStatus != navMeshStatus_t::LOADED )
 	{
 		return loadStatus;

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -5950,6 +5950,7 @@ bool G_admin_navgen( gentity_t* ent )
 		}
 		else if ( Str::IsIEqual ( args.Argv( i ), "missing" ) )
 		{
+			NavgenConfig config = ReadNavgenConfig( mapName );
 			for (class_t species : RequiredNavmeshes())
 			{
 				fileHandle_t f;
@@ -5961,7 +5962,7 @@ bool G_admin_navgen( gentity_t* ent )
 					continue;
 				}
 				NavMeshSetHeader header;
-				std::string error = GetNavmeshHeader( f, header, mapName );
+				std::string error = GetNavmeshHeader( f, config, header, mapName );
 				if ( !error.empty() )
 				{
 					targets[ species ] = true;

--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -189,7 +189,8 @@ private:
 	bool exhausted = false;
 };
 
-navMeshStatus_t G_BotSetupNav( const botClass_t *botClass, qhandle_t *navHandle );
+struct NavgenConfig;
+navMeshStatus_t G_BotSetupNav( const NavgenConfig &config, const botClass_t *botClass, qhandle_t *navHandle );
 void G_BotShutdownNav();
 void G_BotSetNavMesh( int botClientNum, qhandle_t navHandle );
 bool G_BotFindRoute( int botClientNum, const botRouteTarget_t *target, bool allowPartial );

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -180,6 +180,7 @@ void G_BotNavInit( int generateNeeded )
 	Log::Notice( "==== Bot Navigation Initialization ====" );
 
 	std::bitset<PCL_NUM_CLASSES> missing;
+	NavgenConfig config = ReadNavgenConfig( Cvar::GetValue( "mapname" ) );
 
 	for ( class_t i : RequiredNavmeshes() )
 	{
@@ -193,7 +194,7 @@ void G_BotNavInit( int generateNeeded )
 
 		Q_strncpyz( bot.name, BG_Class( i )->name, sizeof( bot.name ) );
 
-		switch ( G_BotSetupNav( &bot, &model->navHandle ) )
+		switch ( G_BotSetupNav( config, &bot, &model->navHandle ) )
 		{
 		case navMeshStatus_t::UNINITIALIZED:
 			if ( generateNeeded )

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -119,7 +119,9 @@ struct NavMeshSetHeader
 };
 
 NavgenMapIdentification GetNavgenMapId( Str::StringRef mapName );
-std::string GetNavmeshHeader( fileHandle_t f, NavMeshSetHeader& header, Str::StringRef mapName );
+NavgenConfig ReadNavgenConfig( Str::StringRef mapName );
+std::string GetNavmeshHeader(
+	fileHandle_t f, const NavgenConfig& config, NavMeshSetHeader& header, Str::StringRef mapName );
 
 inline unsigned ProductVersionHash()
 {

--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -1037,9 +1037,7 @@ void NavmeshGenerator::Init(Str::StringRef mapName)
 {
 	if (mapName == mapName_) return;
 
-	// TODO: some way of setting the config (former daemonmap flags)?
-	config_ = NavgenConfig::Default();
-
+	config_ = ReadNavgenConfig( mapName );
 	mapName_ = mapName;
 	recastContext_.enableLog(true);
 	initStatus_ = {};


### PR DESCRIPTION
A configuration file can be placed in the VFS or in <homepath>/game/ that will
customize the values in NavgenConfig (the former daemonmap flags).
For example:
```
/* C or C++-style comments can be used in here since it's based on COM_Parse */
filtergaps 1
excludeCaulk 0
cellheight 2.5
```

The path `maps/$map.navcfg` is a placeholder; hopefully someone will suggest something better. Actually it would be nice to reorganize the paths somehow so that all of the cache stuff (`*.navMesh`) is not in the same directory as the config or non-cached data (navcons).

This is stacked on #2409