### PR TITLE
Add cvars to control the bot skillset

### DIFF
--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // aliens have 61 points to spend max
 // humans have 40 points to spend max
 Cvar::Cvar<int> g_skillsetBudgetAliens( "g_skillsetBudgetAliens", "the skillset budget for aliens.", Cvar::NONE, 61 );
-Cvar::Cvar<int> g_skillsetBudgetHumans( "g_skillsetBudgetHumans", "the skillset budget for humans.", Cvar::NONE, 42 );
+Cvar::Cvar<int> g_skillsetBudgetHumans( "g_skillsetBudgetHumans", "the skillset budget for humans.", Cvar::NONE, 40 );
 
 static std::set<std::string> bg_allowedSkillset;
 

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -38,7 +38,7 @@ static void G_UpdateSkillsets()
 	}
 }
 
-static std::set<std::string> G_ParseSkillsetList( const std::string &skillsCsv )
+static std::set<std::string> G_ParseSkillsetList( Str::StringRef skillsCsv )
 {
 	std::set<std::string> skills;
 

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -26,6 +26,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "sg_bot_util.h"
 #include "../shared/parse.h"
 
+// aliens have 61 points to spend max
+// humans have 40 points to spend max
+Cvar::Cvar<int> g_skillsetBudgetAliens( "g_skillsetBudgetAliens", "the skillset budget for aliens.", Cvar::NONE, 61 );
+Cvar::Cvar<int> g_skillsetBudgetHumans( "g_skillsetBudgetHumans", "the skillset budget for humans.", Cvar::NONE, 42 );
+
 static std::set<std::string> bg_allowedSkillset;
 
 static std::set<std::string> BG_ParseAllowedSkillsetList( const std::string &behaviorsCsv )
@@ -195,9 +200,8 @@ static Util::optional<botSkillTreeElement_t> ChooseOneSkill(const gentity_t *bot
 std::pair<std::string, skillSet_t> BotDetermineSkills(gentity_t *bot, int skill)
 {
 	std::vector<botSkillTreeElement_t> possible_choices = initial_unlockable_skills;
-	// aliens have 61 points to spend max
-	// humans have 40 points to spend max
-	float max = G_Team(bot) == TEAM_ALIENS ? 61.0f : 40.0f;
+
+	float max = G_Team(bot) == TEAM_ALIENS ? static_cast<float>( g_skillsetBudgetAliens.Get() ) : static_cast<float>( g_skillsetBudgetHumans.Get() );
 
 	// unlock every skill at skill 7
 	int skill_points = static_cast<float>(skill) / 7.0f * max;

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -33,11 +33,11 @@ Cvar::Cvar<int> g_skillsetBudgetHumans( "g_skillsetBudgetHumans", "the skillset 
 
 static std::set<std::string> bg_allowedSkillset;
 
-static std::set<std::string> BG_ParseAllowedSkillsetList( const std::string &behaviorsCsv )
+static std::set<std::string> BG_ParseAllowedSkillsetList( const std::string &skillsCsv )
 {
 	std::set<std::string> skills;
 
-	for (Parse_WordListSplitter i(behaviorsCsv); *i; ++i)
+	for (Parse_WordListSplitter i(skillsCsv); *i; ++i)
 	{
 		skills.insert( *i );
 	}
@@ -45,9 +45,9 @@ static std::set<std::string> BG_ParseAllowedSkillsetList( const std::string &beh
 	return skills;
 }
 
-static void BG_SetAllowedSkillset( Str::StringRef behaviorsCsv )
+static void BG_SetAllowedSkillset( Str::StringRef skillsCsv )
 {
-	bg_allowedSkillset = BG_ParseAllowedSkillsetList( behaviorsCsv );
+	bg_allowedSkillset = BG_ParseAllowedSkillsetList( skillsCsv );
 }
 
 static bool BG_SkillAllowed( Str::StringRef behavior )

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -31,13 +31,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 Cvar::Cvar<int> g_skillsetBudgetAliens( "g_skillsetBudgetAliens", "the skillset budget for aliens.", Cvar::NONE, 61 );
 Cvar::Cvar<int> g_skillsetBudgetHumans( "g_skillsetBudgetHumans", "the skillset budget for humans.", Cvar::NONE, 40 );
 
-static std::set<std::string>& G_GetAllowedSkillset()
+static std::set<std::string>& G_GetDisabledSkillset()
 {
-	static std::set<std::string> allowedSkillset;
-	return allowedSkillset;
+	static std::set<std::string> disabledSkillset;
+	return disabledSkillset;
 }
 
-static std::set<std::string> G_ParseAllowedSkillsetList( const std::string &skillsCsv )
+static std::set<std::string> G_ParseDisabledSkillsetList( const std::string &skillsCsv )
 {
 	std::set<std::string> skills;
 
@@ -49,25 +49,24 @@ static std::set<std::string> G_ParseAllowedSkillsetList( const std::string &skil
 	return skills;
 }
 
-static void G_SetAllowedSkillset( Str::StringRef skillsCsv )
+static void G_SetDisabledSkillset( Str::StringRef skillsCsv )
 {
-	G_GetAllowedSkillset() = G_ParseAllowedSkillsetList( skillsCsv );
+	G_GetDisabledSkillset() = G_ParseDisabledSkillsetList( skillsCsv );
 }
 
-static bool G_SkillAllowed( Str::StringRef behavior )
+static bool G_SkillDisabled( Str::StringRef behavior )
 {
-	return G_GetAllowedSkillset().find( behavior ) != G_GetAllowedSkillset().end();
+	return G_GetDisabledSkillset().find( behavior ) != G_GetDisabledSkillset().end();
 }
 
 void G_InitSkilltreeCvars()
 {
-	std::string defaultSkillset = "mara-attack-jump, mantis-attack-jump, goon-attack-jump, tyrant-attack-run, mara-flee-jump, mantis-flee-jump, goon-flee-jump, tyrant-flee-run, safe-barbs, buy-modern-armor, prefer-armor, flee-run, medkit, aim-head, aim-barbs, predict-aim, movement, fighting, feels-pain";
-	static Cvar::Callback<Cvar::Cvar<std::string>> g_allowedSkillset(
-        "g_allowedSkillset",
-		"Allowed skills for bots, example: " QQ("mantis-attack-jump, prefer-armor"),
+	static Cvar::Callback<Cvar::Cvar<std::string>> g_disabledSkillset(
+        "g_disabledSkillset",
+		"Disabled skills for bots, example: " QQ("mantis-attack-jump, prefer-armor"),
 		Cvar::NONE,
-		defaultSkillset,
-		G_SetAllowedSkillset
+		"",
+		G_SetDisabledSkillset
         );
 }
 
@@ -232,7 +231,7 @@ std::pair<std::string, skillSet_t> BotDetermineSkills(gentity_t *bot, int skill)
 			break;
 		}
 
-		if ( !G_SkillAllowed( new_skill->name ) )
+		if ( G_SkillDisabled( new_skill->name ) )
 		{
 			continue;
 		}

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -104,33 +104,33 @@ static void G_SetSkillsetBudgetAliens( int val )
 void G_InitSkilltreeCvars()
 {
 	static Cvar::Callback<Cvar::Cvar<std::string>> g_disabledSkillset(
-        "g_disabledSkillset",
+		"g_disabledSkillset",
 		"Disabled skills for bots, example: " QQ("mantis-attack-jump, prefer-armor"),
 		Cvar::NONE,
 		"",
 		G_SetDisabledSkillset
-        );
+		);
 	static Cvar::Callback<Cvar::Cvar<std::string>> g_preferredSkillset(
-        "g_preferredSkillset",
+		"g_preferredSkillset",
 		"Preferred skills for bots, example: " QQ("mantis-attack-jump, prefer-armor"),
 		Cvar::NONE,
 		"",
 		G_SetPreferredSkillset
-        );
+		);
 	static Cvar::Callback<Cvar::Cvar<int>> g_skillsetBudgetAliens(
-	    "g_skillsetBudgetAliens",
+		"g_skillsetBudgetAliens",
 		"the skillset budget for aliens.",
 		Cvar::NONE,
 		skillsetBudgetAliens,
 		G_SetSkillsetBudgetAliens
-        );
+		);
 	static Cvar::Callback<Cvar::Cvar<int>> g_skillsetBudgetHumans(
-	    "g_skillsetBudgetHumans",
+		"g_skillsetBudgetHumans",
 		"the skillset budget for humans.",
 		Cvar::NONE,
 		skillsetBudgetHumans,
 		G_SetSkillsetBudgetHumans
-        );
+		);
 }
 
 struct botSkillTreeElement_t {

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -612,6 +612,8 @@ void G_InitGame( int levelTime, int randomSeed, bool inClient )
 	G_InitSpawnQueue( &level.team[ TEAM_ALIENS ].spawnQueue );
 	G_InitSpawnQueue( &level.team[ TEAM_HUMANS ].spawnQueue );
 
+	G_InitSkilltreeCvars();
+
 	if ( g_debugMapRotation.Get() )
 	{
 		G_PrintRotations();

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -349,4 +349,7 @@ namespace CombatFeedback
   void HitNotify(gentity_t *attacker, gentity_t *victim, Util::optional<glm::vec3> point, float damage, meansOfDeath_t mod, bool lethal);
 }
 
+// sg_bot_skilltree.cpp
+void G_InitSkilltreeCvars();
+
 #endif // SG_PUBLIC_H_


### PR DESCRIPTION
Currently, all bot skillset skills are allowed. Add three cvars:

- `g_allowedSkillset`
- `g_skillsetBudgetAliens`
- `g_skillsetBudgetHumans`

`g_allowedSkillset` is a comma-separated list of allowed skills. `g_skillsetBudget{Aliens,Humans}` replace the magic numbers 61 and 40 in `sg_bot_skilltree.cpp`.

This will allow server owners to enable/disable certain skills. We will be able to add skills that fail on some maps, and simply disable them for these maps. The skilltree code can become a unified interface to program and control experimental bot behaviors.

For example: to give every skill to each bot, set `g_skillsetBudget{Aliens,Humans}` to 1000. This is easy to do when testing a new bot skill.