### PR TITLE
Auto navgen quality of life improvements

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -5871,12 +5871,13 @@ static bool BotFillCmd( gentity_t *ent, const Cmd::Args& args )
 		BotUsage( ent );
 		return false;
 	}
-	int count = 0;
-	if ( !Str::ParseInt( count, args[2].data() ) || count < 0 )
+	int count;
+	if ( !Str::ParseInt( count, args[2].data() ) )
 	{
 		BotUsage( ent );
 		return false;
 	}
+	count = Math::Clamp( count, 0, MAX_CLIENTS );
 	std::vector<team_t> teams;
 	if ( args.Argc() >= 4 && args[3] != "*" )
 	{
@@ -5898,7 +5899,7 @@ static bool BotFillCmd( gentity_t *ent, const Cmd::Args& args )
 	// would be checked but the command should take precedence.
 	g_bot_defaultFill.GetModifiedValue();
 
-	if ( level.inClient && g_clients[ 0 ].pers.connected < CON_CONNECTED )
+	if ( count != 0 && level.inClient && g_clients[ 0 ].pers.connected < CON_CONNECTED )
 	{
 		bool navgenOnLoad;
 		if ( Cvar::ParseCvarValue( Cvar::GetValue( "cg_navgenOnLoad" ), navgenOnLoad ) && navgenOnLoad )
@@ -5908,7 +5909,7 @@ static bool BotFillCmd( gentity_t *ent, const Cmd::Args& args )
 		}
 	}
 
-	if ( !G_BotInit() )
+	if ( count != 0 && !G_BotInit() )
 	{
 		ADMP( QQ( N_( "Navigation mesh files unavailable for this map" ) ) );
 		return false;

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -5884,6 +5884,10 @@ static bool BotFillCmd( gentity_t *ent, const Cmd::Args& args )
 	}
 	int skill = args.Argc() >= 5 ? BotSkillFromString(ent, args[4].data()) : 0;
 
+	// Clear the cvar's modified flag. A bot command in the map config will be processed before the cvar
+	// would be checked but the command should take precedence.
+	g_bot_defaultFill.GetModifiedValue();
+
 	if ( !G_BotInit() )
 	{
 		ADMP( QQ( N_( "Navigation mesh files unavailable for this map" ) ) );

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -5840,6 +5840,16 @@ static bool BotAddCmd( gentity_t* ent, const Cmd::Args& args )
 
 	const char* behavior = args.Argc() >= 6 ? args[5].data() : BOT_DEFAULT_BEHAVIOR;
 
+	if ( level.inClient && g_clients[ 0 ].pers.connected < CON_CONNECTED )
+	{
+		bool navgenOnLoad;
+		if ( Cvar::ParseCvarValue( Cvar::GetValue( "cg_navgenOnLoad" ), navgenOnLoad ) && navgenOnLoad )
+		{
+			Log::Warn( "Calling 'bot add' before the cgame has loaded - navmeshes may be generated twice."
+			           " Consider disabling cg_navgenOnLoad" );
+		}
+	}
+
 	if ( !G_BotInit() )
 	{
 		ADMP( QQ( N_( "Navigation mesh files unavailable for this map" ) ) );
@@ -5887,6 +5897,16 @@ static bool BotFillCmd( gentity_t *ent, const Cmd::Args& args )
 	// Clear the cvar's modified flag. A bot command in the map config will be processed before the cvar
 	// would be checked but the command should take precedence.
 	g_bot_defaultFill.GetModifiedValue();
+
+	if ( level.inClient && g_clients[ 0 ].pers.connected < CON_CONNECTED )
+	{
+		bool navgenOnLoad;
+		if ( Cvar::ParseCvarValue( Cvar::GetValue( "cg_navgenOnLoad" ), navgenOnLoad ) && navgenOnLoad )
+		{
+			Log::Warn( "Calling 'bot fill' before the cgame has loaded - navmeshes may be generated twice."
+			           " Consider disabling cg_navgenOnLoad" );
+		}
+	}
 
 	if ( !G_BotInit() )
 	{

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -617,8 +617,9 @@ static void G_BotCheckDefaultFill()
 	Util::optional<int> fillCount = g_bot_defaultFill.GetModifiedValue();
 	if ( fillCount ) // if modified
 	{
+		int adjustedCount = Math::Clamp( *fillCount, 0, MAX_CLIENTS );
 		// init bots if they aren't already and if we need to
-		if ( fillCount != 0 && !G_BotInit() )
+		if ( adjustedCount != 0 && !G_BotInit() )
 		{
 			Log::Warn( "Navigation mesh files unavailable for this map" );
 			return;
@@ -626,7 +627,7 @@ static void G_BotCheckDefaultFill()
 
 		for ( int team = TEAM_NONE + 1; team < NUM_TEAMS; ++team )
 		{
-			level.team[team].botFillTeamSize = *fillCount;
+			level.team[team].botFillTeamSize = adjustedCount;
 			level.team[team].botFillSkillLevel = 0; // default
 		}
 	}

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "sg_bot_util.h"
 #include "Entities.h"
 
-static Cvar::Modified<Cvar::Cvar<int>> g_bot_defaultFill("g_bot_defaultFill", "fills both teams with that number of bots at start of game", Cvar::NONE, 0);
+Cvar::Modified<Cvar::Cvar<int>> g_bot_defaultFill("g_bot_defaultFill", "fills both teams with that number of bots at start of game", Cvar::NONE, 0);
 static Cvar::Range<Cvar::Cvar<int>> generateNeededMesh(
 	"g_bot_navgen_onDemand",
 	"automatically generate navmeshes when a bot is added (1 = in background, -1 = blocking)",
@@ -388,6 +388,7 @@ void G_BotDelAllBots()
 		}
 	}
 
+	g_bot_defaultFill.GetModifiedValue(); // clear modified flag
 	for ( auto &team : level.team )
 	{
 		team.botFillTeamSize = 0;

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -639,6 +639,13 @@ void G_BotFill(bool immediately)
 		return;  // don't check every frame to prevent warning spam
 	}
 
+	if ( !immediately && level.inClient && g_clients[ 0 ].pers.connected < CON_CONNECTED )
+	{
+		// In case cg_navgenOnLoad is enabled, give that a chance to finish so
+		// that we don't have two dueling navgens.
+		return;
+	}
+
 	G_BotCheckDefaultFill();
 
 	nextCheck = level.time + 2000;

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -213,5 +213,6 @@ extern Cvar::Cvar<int> g_bot_chasetime;
 extern Cvar::Cvar<int> g_bot_reactiontime;
 extern Cvar::Cvar<bool> g_bot_infiniteFunds;
 extern Cvar::Cvar<bool> g_bot_infiniteMomentum;
+extern Cvar::Modified<Cvar::Cvar<int>> g_bot_defaultFill;
 
 #endif // SG_EXTERN_H_

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -573,10 +573,6 @@ void G_InitGame( int levelTime, int randomSeed, bool inClient )
 
 	BotAssertionInit();
 
-	// initalize bot fill team size from g_bot_defaultFill now so that it will be overwritten
-	// by a `bot fill` in map configs
-	G_BotFill(false);
-
 	// retrieve map name and layout to load configs.
 	{
 		std::string map = Cvar::GetValue( "mapname");


### PR DESCRIPTION
Fix some of the issues touched on in #2403:
- Don't generate navmeshes twice if `g_bot_defaultFill` and `cg_navgenOnLoad` are used together
- Warn if `bot fill` or `bot add` is used in a local game map config which might make navmeshes be generated twice
- Don't require navmeshes on `bot fill 0`
- Improve the responsiveness of the server during navgen. It was not quite as "background" as intended and could hang the server for several seconds at a time.