### PR TITLE
bot: store bot skill and generation status in slotBots B cvar and display it on scoreboard (reuse ping cell)

### DIFF
--- a/src/cgame/cg_rocket_datasource.cpp
+++ b/src/cgame/cg_rocket_datasource.cpp
@@ -936,7 +936,28 @@ void CG_Rocket_BuildPlayerList( const char* )
 
 		Info_SetValueForKey( buf, "num", va( "%d", score->client ), false );
 		Info_SetValueForKey( buf, "score", va( "%d", score->score ), false );
-		Info_SetValueForKey( buf, "ping", va( "%d", score->ping ), false );
+
+		const char* B = Info_ValueForKey( CG_ConfigString( CS_SERVERINFO ),"B" );
+		const char bot_status = B[ score->client ];
+
+		// HACK: Display bot status in “Ping” column.
+		if ( bot_status == '-' )
+		{
+			// This player is not a bot.
+			Info_SetValueForKey( buf, "ping", va( "%d", score->ping ), false );
+		}
+		// Bot skill can be 0 while spawning, just before skill is set.
+		else if ( bot_status >= '0' && bot_status <= '9' )
+		{
+			// Bot skill.
+			Info_SetValueForKey( buf, "ping", va( "sk%c", bot_status ), false );
+		}
+		else
+		{
+			// Example: “G” is for “Generating navmeshes”.
+			Info_SetValueForKey( buf, "ping", va( "%c", bot_status ), false );
+		}
+
 		Info_SetValueForKey( buf, "weapon", va( "%d", score->weapon ), false );
 		Info_SetValueForKey( buf, "upgrade", va( "%d", score->upgrade ), false );
 		Info_SetValueForKey( buf, "time", va( "%d", score->time ), false );

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -1193,7 +1193,20 @@ void CalculateRanks()
 
 			if ( bot )
 			{
-				B[ clientNum ] = 'b';
+				if ( navMeshLoaded == navMeshStatus_t::GENERATING )
+				{
+					B[ clientNum ] = 'G';
+				}
+				else
+				{
+					int skill = level.gentities[ clientNum ].botMind->botSkill.level;
+
+					// Bot skill can be 0 while spawning, just before skill is set.
+					ASSERT( skill >= 0 && skill <= 9 );
+
+					B[ clientNum ] = '0' + (char) skill;
+				}
+
 				level.team[ team ].numBots++;
 			}
 			else


### PR DESCRIPTION
Better implementation than:

- https://github.com/Unvanquished/Unvanquished/pull/2436

Right now the data is stored in scoreboard in “Ping” column, but we can do other things like appending `(generating…)` to bot name or things like that.