### PR TITLE
Fix damage and destructible map entities

### DIFF
--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -166,7 +166,7 @@ static void P_WorldEffects( gentity_t *ent )
 				// don't play a general pain sound
 				ent->pain_debounce_time = level.time + 200;
 
-				ent->entity->Damage((float)ent->client->lowOxygenDamage, nullptr, Util::nullopt, Util::nullopt,
+				ent->Damage((float)ent->client->lowOxygenDamage, nullptr, Util::nullopt, Util::nullopt,
 				                    DAMAGE_PURE, MOD_WATER);
 			}
 		}
@@ -187,12 +187,12 @@ static void P_WorldEffects( gentity_t *ent )
 		{
 			if ( ent->watertype & CONTENTS_LAVA )
 			{
-				ent->entity->Damage(30.0f * waterlevel, nullptr, Util::nullopt, Util::nullopt, 0, MOD_LAVA);
+				ent->Damage(30.0f * waterlevel, nullptr, Util::nullopt, Util::nullopt, 0, MOD_LAVA);
 			}
 
 			if ( ent->watertype & CONTENTS_SLIME )
 			{
-				ent->entity->Damage(10.0f * waterlevel, nullptr, Util::nullopt, Util::nullopt, 0, MOD_SLIME);
+				ent->Damage(10.0f * waterlevel, nullptr, Util::nullopt, Util::nullopt, 0, MOD_SLIME);
 			}
 		}
 	}
@@ -1027,7 +1027,7 @@ static void ClientTimerActions( gentity_t *ent, int msec )
 		// deal poison damage
 		if ( client->ps.stats[ STAT_STATE ] & SS_POISONED )
 		{
-			ent->entity->Damage(ALIEN_POISON_DMG, client->lastPoisonClient, Util::nullopt,
+			ent->Damage(ALIEN_POISON_DMG, client->lastPoisonClient, Util::nullopt,
 			                    Util::nullopt, DAMAGE_NO_LOCDAMAGE, MOD_POISON);
 		}
 
@@ -1035,13 +1035,13 @@ static void ClientTimerActions( gentity_t *ent, int msec )
 		if ( client->pers.team == TEAM_ALIENS &&
 		     level.surrenderTeam == TEAM_ALIENS )
 		{
-			ent->entity->Damage((float)BG_Class(client->ps.stats[STAT_CLASS])->regenRate,
+			ent->Damage((float)BG_Class(client->ps.stats[STAT_CLASS])->regenRate,
 			                    nullptr, Util::nullopt, Util::nullopt, DAMAGE_PURE, MOD_SUICIDE);
 		}
 		else if ( client->pers.team == TEAM_HUMANS &&
 		          level.surrenderTeam == TEAM_HUMANS )
 		{
-			ent->entity->Damage(5.0f, nullptr, Util::nullopt, Util::nullopt, DAMAGE_PURE, MOD_SUICIDE);
+			ent->Damage(5.0f, nullptr, Util::nullopt, Util::nullopt, DAMAGE_PURE, MOD_SUICIDE);
 		}
 
 		// lose some voice enthusiasm
@@ -1177,7 +1177,7 @@ static void ClientEvents( gentity_t *ent, int oldEventSequence )
 				VectorAdd( client->ps.origin, mins, point );
 
 				ent->pain_debounce_time = level.time + 200; // no general pain sound
-				ent->entity->Damage((float)damage, nullptr, VEC2GLM( point ), VEC2GLM( dir ),
+				ent->Damage((float)damage, nullptr, VEC2GLM( point ), VEC2GLM( dir ),
 				                    DAMAGE_NO_LOCDAMAGE, MOD_FALLING);
 				break;
 

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -2466,7 +2466,7 @@ bool G_admin_slap( gentity_t *ent )
 		damage = atoi( dmg_str );
 	}
 
-	vic->entity->Damage( damage, ent, Util::nullopt, Util::nullopt, 0, MOD_SLAP );
+	vic->Damage( damage, ent, Util::nullopt, Util::nullopt, 0, MOD_SLAP );
 
 	if ( health->Alive() )
 	{

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -144,6 +144,7 @@ bool G_DretchCanDamageEntity( const gentity_t *self, const gentity_t *ent )
 	switch (ent->s.eType)
 	{
 		case entityType_t::ET_PLAYER:
+		case entityType_t::ET_MOVER:
 			return true;
 		case entityType_t::ET_BUILDABLE:
 			// dretches can only bite buildables in construction or turrets

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -709,7 +709,7 @@ static void Cmd_Give_f( gentity_t *ent )
 				valid = true;
 				if (amount < 0)
 				{
-					ent->entity->Damage(-amount, nullptr, Util::nullopt, Util::nullopt, 0, MOD_LAVA);
+					ent->Damage(-amount, nullptr, Util::nullopt, Util::nullopt, 0, MOD_LAVA);
 				}
 				else
 				{
@@ -4671,7 +4671,7 @@ static void Cmd_Damage_f( gentity_t *ent )
 	point[ 1 ] += dy;
 	point[ 2 ] += dz;
 
-	ent->entity->Damage((float)damage, nullptr, point, Util::nullopt,
+	ent->Damage((float)damage, nullptr, point, Util::nullopt,
 	                    nonloc ? DAMAGE_NO_LOCDAMAGE : 0, MOD_TARGET_LASER);
 }
 

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -790,7 +790,7 @@ void G_SelectiveDamage( gentity_t *targ, gentity_t * /*inflictor*/, gentity_t *a
 {
 	if ( targ->client && ( team != targ->client->pers.team ) )
 	{
-		targ->entity->Damage((float)damage, attacker, VEC2GLM( point ), VEC2GLM( dir ), dflags,
+		targ->Damage((float)damage, attacker, VEC2GLM( point ), VEC2GLM( dir ), dflags,
 		                     (meansOfDeath_t)mod);
 	}
 }
@@ -916,7 +916,7 @@ bool G_SelectiveRadiusDamage( vec3_t origin, gentity_t *attacker, float damage,
 		if ( G_CanDamage( ent, origin ) && ent->client &&
 		     ent->client->pers.team != ignoreTeam )
 		{
-			hitClient = ent->entity->Damage(points, attacker, VEC2GLM( origin ), Util::nullopt,
+			hitClient = ent->Damage(points, attacker, VEC2GLM( origin ), Util::nullopt,
 			                                DAMAGE_NO_LOCDAMAGE, (meansOfDeath_t)mod);
 		}
 	}
@@ -978,7 +978,7 @@ bool G_RadiusDamage( vec3_t origin, gentity_t *attacker, float damage,
 				dir[ 2 ] += 24;
 				VectorNormalize( dir );
 
-				hitSomething = ent->entity->Damage(points, attacker, VEC2GLM( origin ), VEC2GLM( dir ),
+				hitSomething = ent->Damage(points, attacker, VEC2GLM( origin ), VEC2GLM( dir ),
 				                                   (DAMAGE_NO_LOCDAMAGE | dflags), (meansOfDeath_t)mod);
 			}
 			else if ( G_Team( ent ) == testHit && Entities::IsAlive( ent ) )

--- a/src/sgame/sg_missile.cpp
+++ b/src/sgame/sg_missile.cpp
@@ -379,7 +379,7 @@ static void MissileImpact( gentity_t *ent, trace_t *trace )
 	// Deal impact damage.
 	if ( !( impactFlags & MIF_NO_DAMAGE ) )
 	{
-		if ( ent->damage && Entities::IsAlive( hitEnt ) )
+		if ( ent->damage && ( Entities::IsAlive( hitEnt ) || ( hitEnt && hitEnt->s.eType == entityType_t::ET_MOVER ) ) )
 		{
 			vec3_t dir;
 
@@ -394,7 +394,7 @@ static void MissileImpact( gentity_t *ent, trace_t *trace )
 			if ( !ma->doLocationalDamage ) dflags |= DAMAGE_NO_LOCDAMAGE;
 			if ( ma->doKnockback )         dflags |= DAMAGE_KNOCKBACK;
 
-			hitEnt->entity->Damage(ent->damage * MissileTimeDmgMod(ent), attacker,
+			hitEnt->Damage(ent->damage * MissileTimeDmgMod(ent), attacker,
 			                       VEC2GLM( trace->endpos ), VEC2GLM( dir ), dflags,
 			                       (meansOfDeath_t)ent->methodOfDeath);
 		}

--- a/src/sgame/sg_spawn_afx.cpp
+++ b/src/sgame/sg_spawn_afx.cpp
@@ -232,7 +232,7 @@ static void env_afx_hurt_touch( gentity_t *self, gentity_t *other, trace_t* )
 		dflags = 0;
 	}
 
-	other->entity->Damage((float)self->damage, self, Util::nullopt, Util::nullopt, dflags,
+	other->Damage((float)self->damage, self, Util::nullopt, Util::nullopt, dflags,
 	                      MOD_TRIGGER_HURT);
 }
 

--- a/src/sgame/sg_spawn_generic.cpp
+++ b/src/sgame/sg_spawn_generic.cpp
@@ -169,7 +169,7 @@ static void target_hurt_act( gentity_t *self, gentity_t*, gentity_t *activator )
 		return;
 	}
 
-	activator->entity->Damage((float)self->damage, self, Util::nullopt, Util::nullopt, 0,
+	activator->Damage((float)self->damage, self, Util::nullopt, Util::nullopt, 0,
 	                          MOD_TRIGGER_HURT);
 }
 

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -574,7 +574,7 @@ bool IsDoor( const gentity_t *ent )
 // for now, but not sure how this should be handled.
 bool IsAutomaticMover( const gentity_t *ent )
 {
-	if ( ent->takedamage )
+	if ( ent->config.health )
 	{
 		return false;
 	}
@@ -1102,6 +1102,11 @@ void BinaryMover_act( gentity_t *ent, gentity_t *other, gentity_t *activator )
 		// open areaportal
 		if ( ent->groupMaster == ent || !ent->groupMaster )
 			trap_AdjustAreaPortalState( ent, true );
+
+		//HACK: this is really ugly, should have specialise code,
+		//but I'm both lazy, buzy to fix old mess, and annoyed by
+		//said years-old mess
+		ent->health = ent->config.health;
 	}
 	else if ( ent->moverState == MOVER_2TO1 )
 	{
@@ -1466,7 +1471,7 @@ static void func_door_block( gentity_t *self, gentity_t *other )
 
 	if ( self->damage )
 	{
-		other->entity->Damage((float)self->damage, self, Util::nullopt, Util::nullopt, 0, MOD_CRUSH);
+		other->Damage((float)self->damage, self, Util::nullopt, Util::nullopt, 0, MOD_CRUSH);
 	}
 
 	if ( self->spawnflags & 4 )
@@ -1566,12 +1571,18 @@ static void Think_SpawnNewDoorTrigger( gentity_t *self )
 	}
 }
 
+static void Think_MoverDeath( gentity_t *self, gentity_t*, gentity_t* attacker, int )
+{
+	if ( self->moverState == MOVER_POS1 )
+	{
+		BinaryMover_act( self, nullptr, attacker );
+	}
+}
+
 static void func_door_reset( gentity_t *self )
 {
 	G_ResetIntField(&self->health, true, self->config.health, self->eclass->config.health, 0);
 	G_ResetIntField(&self->damage, true, self->config.damage, self->eclass->config.damage, 2);
-
-	self->takedamage = !!self->health;
 
 	reset_moverspeed( self, 400 );
 }
@@ -1661,11 +1672,17 @@ void SP_func_door( gentity_t *self )
 	InitMover( self );
 
 	self->nextthink = level.time + FRAMETIME;
+	self->health = self->config.health;
 
 	if ( self->names[ 0 ] || self->config.health ) //FIXME wont work yet with class fallbacks
 	{
 		// non touch/shoot doors
 		self->think = Think_MatchGroup;
+		if ( self->config.health )
+		{
+			self->health = self->config.health;
+			self->die = Think_MoverDeath;
+		}
 	}
 	else
 	{
@@ -1676,8 +1693,6 @@ void SP_func_door( gentity_t *self )
 static void func_door_rotating_reset( gentity_t *self )
 {
 	G_ResetIntField(&self->health, true, self->config.health, self->eclass->config.health, 0);
-
-	self->takedamage = !!self->health;
 
 	reset_rotatorspeed( self, 120 );
 }
@@ -1801,8 +1816,6 @@ static void func_door_model_reset( gentity_t *self )
 {
 	G_ResetFloatField(&self->speed, true, self->config.speed, self->eclass->config.speed, 200);
 	G_ResetIntField(&self->health, true, self->config.health, self->eclass->config.health, 0);
-
-	self->takedamage = !!self->health;
 
 	self->s.torsoAnim = self->s.weapon * ( 1000.0f / self->speed ); //framerate
 	if ( self->s.torsoAnim <= 0 )
@@ -2121,8 +2134,6 @@ static void func_button_reset( gentity_t *self )
 {
 	G_ResetIntField(&self->health, true, self->config.health, self->eclass->config.health, 0);
 
-	self->takedamage = !!self->health;
-
 	reset_moverspeed( self, 40 );
 }
 
@@ -2172,6 +2183,10 @@ void SP_func_button( gentity_t *self )
 	{
 		// touchable button
 		self->touch = Touch_Button;
+	}
+	else
+	{
+		self->die = Think_MoverDeath;
 	}
 
 	self->use = func_button_use;
@@ -2747,7 +2762,6 @@ void SP_func_spawn( gentity_t *self )
 
 static void func_destructable_die( gentity_t *self, gentity_t*, gentity_t *attacker, int )
 {
-	self->takedamage = false;
 	trap_UnlinkEntity( self );
 
 	G_RadiusDamage( self->restingPosition, attacker, self->splashDamage, self->splashRadius, self,
@@ -2758,7 +2772,6 @@ static void func_destructable_die( gentity_t *self, gentity_t*, gentity_t *attac
 static void func_destructable_reset( gentity_t *self )
 {
 	G_ResetIntField(&self->health, true, self->config.health, self->eclass->config.health, 100);
-	self->takedamage = true;
 }
 
 /*
@@ -2770,7 +2783,6 @@ static void func_destructable_act( gentity_t *self, gentity_t *caller, gentity_t
 {
   if( self->r.linked )
   {
-	self->takedamage = false;
     trap_UnlinkEntity( self );
     if( self->health <= 0 )
     {
@@ -2782,7 +2794,6 @@ static void func_destructable_act( gentity_t *self, gentity_t *caller, gentity_t
     trap_LinkEntity( self );
     G_KillBrushModel( self, activator );
 		func_destructable_reset ( self );
-    self->takedamage = true;
   }
 }
 
@@ -2797,6 +2808,12 @@ void SP_func_destructable( gentity_t *self )
 
   G_SpawnInt( "damage", "0", &self->splashDamage );
   G_SpawnInt( "radius", "0", &self->splashRadius );
+
+	if ( ( self->splashDamage != 0 && self->splashRadius == 0 )
+		|| ( self->splashDamage == 0 && self->splashRadius != 0 ) )
+	{
+		Log::Warn( "Destructible entity %d have only one of: \"radius, damage\", which makes no sense.", self->num() );
+	}
 
   //ent->r.svFlags = SVF_USE_CURRENT_ORIGIN;
   self->s.eType = entityType_t::ET_MOVER;
@@ -2819,6 +2836,5 @@ void SP_func_destructable( gentity_t *self )
   if( !( self->spawnflags & 1 ) )
   {
     trap_LinkEntity( self );
-    self->takedamage = true;
   }
 }

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -1189,6 +1189,11 @@ void BinaryMover_act( gentity_t *ent, gentity_t *other, gentity_t *activator )
 		// open areaportal
 		if ( ent->groupMaster == ent || !ent->groupMaster )
 			trap_AdjustAreaPortalState( ent, true );
+
+		//HACK: this is really ugly, should have specialise code,
+		//but I'm both lazy, buzy to fix old mess, and annoyed by
+		//said years-old mess
+		ent->health = ent->config.health;
 	}
 	else if ( ent->moverState == ROTATOR_2TO1 )
 	{
@@ -1573,7 +1578,7 @@ static void Think_SpawnNewDoorTrigger( gentity_t *self )
 
 static void Think_MoverDeath( gentity_t *self, gentity_t*, gentity_t* attacker, int )
 {
-	if ( self->moverState == MOVER_POS1 )
+	if ( self->moverState == MOVER_POS1 || self->moverState == ROTATOR_POS1 )
 	{
 		BinaryMover_act( self, nullptr, attacker );
 	}
@@ -1800,11 +1805,16 @@ void SP_func_door_rotating( gentity_t *self )
 	InitRotator( self );
 
 	self->nextthink = level.time + FRAMETIME;
+	self->health = self->config.health;
 
 	if ( self->names[ 0 ] || self->config.health ) //FIXME wont work yet with class fallbacks
 	{
 		// non touch/shoot doors
 		self->think = Think_MatchGroup;
+		if ( self->config.health )
+		{
+			self->die = Think_MoverDeath;
+		}
 	}
 	else
 	{

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -1698,6 +1698,7 @@ void SP_func_door( gentity_t *self )
 static void func_door_rotating_reset( gentity_t *self )
 {
 	G_ResetIntField(&self->health, true, self->config.health, self->eclass->config.health, 0);
+	G_ResetIntField(&self->damage, true, self->config.damage, self->eclass->config.damage, 2);
 
 	reset_rotatorspeed( self, 120 );
 }

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -390,8 +390,6 @@ struct gentity_t
 	void ( *pain )( gentity_t *self, gentity_t *attacker, int damage );
 	void ( *die )( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int mod );
 
-	bool  takedamage;
-
 	int       flightSplashDamage; // quad will increase this without increasing radius
 	int       flightSplashRadius;
 	int       splashDamage; // quad will increase this without increasing radius
@@ -474,6 +472,11 @@ struct gentity_t
 		ASSERT(this - g_entities < MAX_GENTITIES);
 		return this - g_entities;
 	}
+
+	bool Damage( float amount, gentity_t* source,
+		Util::optional<glm::vec3> location,
+		Util::optional<glm::vec3> direction,
+		int flags, meansOfDeath_t meansOfDeath );
 };
 
 /**


### PR DESCRIPTION
Fix #843 

This fix 3 types of movers:

* func_door with health
* func_button with health
* func_destructable

func_door_rotating and models are left in their current state. There is no way to test that a change to those would work, though, as no map of my knowledge use those with damages.

add non-cbse interface for damaging entities

doors can die

buttons can die

melee damages can kill movers

movers only open when they die

warn when exploding entities do not have radius

reset healh of damage movers when they return

ents with health obviously take damages if not dead

missiles deal damages to entities, too