### PR TITLE
+activate no longer affects doors and buttons

### DIFF
--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -1608,7 +1608,6 @@ void SP_func_door( gentity_t *self )
 
 	self->blocked = func_door_block;
 	self->reset = func_door_reset;
-	self->use = func_door_use;
 
 	// default wait of 2 seconds
 	if ( !self->config.wait.time )
@@ -1703,7 +1702,6 @@ void SP_func_door_rotating( gentity_t *self )
 
 	self->blocked = func_door_block;
 	self->reset = func_door_rotating_reset;
-	self->use = func_door_use;
 
 	// if speed is negative, positize it and add reverse flag
 	if ( self->config.speed < 0 )
@@ -1834,7 +1832,6 @@ void SP_func_door_model( gentity_t *self )
 	}
 
 	self->reset = func_door_model_reset;
-	self->use = func_door_use;
 
 	//default wait of 2 seconds
 	if ( self->config.wait.time <= 0 )
@@ -2173,8 +2170,6 @@ void SP_func_button( gentity_t *self )
 		// touchable button
 		self->touch = Touch_Button;
 	}
-
-	self->use = func_button_use;
 
 	InitMover( self );
 }

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -1576,11 +1576,21 @@ static void func_door_reset( gentity_t *self )
 	reset_moverspeed( self, 400 );
 }
 
+#if 0
+// allows to trigger doors and buttons with +activate
 static void func_door_use( gentity_t *self, gentity_t *caller, gentity_t *activator )
 {
 	if (GetMoverGroupState( self ) != MOVER_1TO2 )
 		BinaryMover_act( self, caller, activator );
 }
+
+static void func_button_use( gentity_t *self, gentity_t *caller, gentity_t *activator )
+{
+	if ( self->moverState == MOVER_POS1 )
+		BinaryMover_act( self, caller, activator );
+}
+#endif
+
 
 void SP_func_door( gentity_t *self )
 {
@@ -2106,12 +2116,6 @@ static void Touch_Button( gentity_t *ent, gentity_t *other, trace_t* )
 	{
 		BinaryMover_act( ent, other, other );
 	}
-}
-
-static void func_button_use( gentity_t *self, gentity_t *caller, gentity_t *activator )
-{
-	if ( self->moverState == MOVER_POS1 )
-		BinaryMover_act( self, caller, activator );
 }
 
 static void func_button_reset( gentity_t *self )


### PR DESCRIPTION
This fix #2453 but should probably not be merged as is, since I believe this disables something that would be a useful feature if it was handled in a better way and had a good interface. See #2454 