### PR TITLE
No team kill penalty for suicide

### DIFF
--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -426,7 +426,7 @@ void G_PlayerDie( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, in
 	{
 		if ( G_OnSameTeam( self, attacker ) )
 		{
-			// punish team kills
+			// punish team kills and suicides
 			if ( attacker->client->pers.team == TEAM_ALIENS )
 			{
 				// don't punish suicides with reduced funds

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -424,9 +424,9 @@ void G_PlayerDie( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, in
 
 	if ( attacker && attacker->client )
 	{
-		if ( ( attacker == self || G_OnSameTeam( self, attacker ) ) )
+		if ( attacker != self && G_OnSameTeam( self, attacker ) )
 		{
-			//punish team kills and suicides
+			//punish team kills, don't punish suicides
 			if ( attacker->client->pers.team == TEAM_ALIENS )
 			{
 				G_AddCreditToClient( attacker->client, -ALIEN_TK_SUICIDE_PENALTY, true );

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -424,17 +424,24 @@ void G_PlayerDie( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, in
 
 	if ( attacker && attacker->client )
 	{
-		if ( attacker != self && G_OnSameTeam( self, attacker ) )
+		if ( G_OnSameTeam( self, attacker ) )
 		{
-			//punish team kills, don't punish suicides
+			// punish team kills
 			if ( attacker->client->pers.team == TEAM_ALIENS )
 			{
-				G_AddCreditToClient( attacker->client, -ALIEN_TK_SUICIDE_PENALTY, true );
+				// don't punish suicides with reduced funds
+				if ( attacker != self )
+				{
+					G_AddCreditToClient( attacker->client, -ALIEN_TK_SUICIDE_PENALTY, true );
+				}
 				G_AddCreditsToScore( attacker, -ALIEN_TK_SUICIDE_PENALTY );
 			}
 			else if ( attacker->client->pers.team == TEAM_HUMANS )
 			{
-				G_AddCreditToClient( attacker->client, -HUMAN_TK_SUICIDE_PENALTY, true );
+				if ( attacker != self )
+				{
+					G_AddCreditToClient( attacker->client, -HUMAN_TK_SUICIDE_PENALTY, true );
+				}
 				G_AddCreditsToScore( attacker, -HUMAN_TK_SUICIDE_PENALTY );
 			}
 		}


### PR DESCRIPTION
This is to fix https://github.com/Unvanquished/Unvanquished/issues/2456

Team kill penalty for suicide has been the case forever. I'm not sure why, but there might have been a reason.

One reason I can think of is that we might want to penalize teleporting back to base. However, there is no penalty for suicide by kill zones on the map. In any case, suicide will lead to loss of purchased equipment/class.