### PR TITLE
Add bot action stayHere

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -5791,7 +5791,7 @@ static void BotUsage( gentity_t *ent )
 	                                        "            bot del (<name> | all)\n"
 	                                        "            bot names (aliens | humans) <names>…\n"
 	                                        "            bot names (clear | list)\n"
-	                                        "            bot behavior (<name> | <slot#>) <behavior> [<vector>]\n"
+	                                        "            bot behavior (<name> | <slot#>) <behavior> [<x> <y> <z>]\n"
 	                                        "            bot skill <skill level> [<team>]" ) );
 	ADMP( bot_usage );
 }
@@ -6042,7 +6042,7 @@ bool G_admin_bot( gentity_t *ent )
 		// set the argument vector if present
 		if ( args.Argc() != 7 )
 		{
-			g_entities[ clientNum ].botMind->argVector = Util::nullopt;
+			g_entities[ clientNum ].botMind->userSpecifiedPosition = Util::nullopt;
 		}
 		else
 		{
@@ -6057,7 +6057,7 @@ bool G_admin_bot( gentity_t *ent )
 				}
 				coords[ i ] = static_cast< float >( val );
 			}
-			g_entities[ clientNum ].botMind->argVector = glm::vec3( coords[0], coords[1], coords[2] );
+			g_entities[ clientNum ].botMind->userSpecifiedPosition = glm::vec3( coords[0], coords[1], coords[2] );
 		}
 		const char *behavior = args[3].data();
 		G_BotChangeBehavior( clientNum, behavior );

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -6049,13 +6049,11 @@ bool G_admin_bot( gentity_t *ent )
 			float coords[ 3 ];
 			for ( int i = 0; i < 3; i++ )
 			{
-				int val;
-				if ( !Str::ParseInt( val, args[4 + i].data() ) )
+				if ( !Cvar::ParseCvarValue( args[ 4 + i ].data(), coords[ i ] ) )
 				{
 					BotUsage( ent );
 					return false;
 				}
-				coords[ i ] = static_cast< float >( val );
 			}
 			g_entities[ clientNum ].botMind->userSpecifiedPosition = glm::vec3( coords[0], coords[1], coords[2] );
 		}

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -5791,7 +5791,7 @@ static void BotUsage( gentity_t *ent )
 	                                        "            bot del (<name> | all)\n"
 	                                        "            bot names (aliens | humans) <names>…\n"
 	                                        "            bot names (clear | list)\n"
-	                                        "            bot behavior (<name> | <slot#>) <behavior>\n"
+	                                        "            bot behavior (<name> | <slot#>) <behavior> [<vector>]\n"
 	                                        "            bot skill <skill level> [<team>]" ) );
 	ADMP( bot_usage );
 }
@@ -6027,7 +6027,7 @@ bool G_admin_bot( gentity_t *ent )
 			G_BotDel( clientNum ); //delete the bot
 		}
 	}
-	else if ( !Q_stricmp( arg1, "behavior" ) && args.Argc() == 4 )
+	else if ( !Q_stricmp( arg1, "behavior" ) && (args.Argc() == 4 || args.Argc() == 7) )
 	{
 		RETURN_IF_INTERMISSION;
 
@@ -6038,6 +6038,26 @@ bool G_admin_bot( gentity_t *ent )
 		{
 			ADMP( va( "%s %s %s", QQ( "^3$1$:^* $2t$" ), "bot", Quote( err ) ) );
 			return false;
+		}
+		// set the argument vector if present
+		if ( args.Argc() != 7 )
+		{
+			g_entities[ clientNum ].botMind->argVector = Util::nullopt;
+		}
+		else
+		{
+			float coords[ 3 ];
+			for ( int i = 0; i < 3; i++ )
+			{
+				int val;
+				if ( !Str::ParseInt( val, args[4 + i].data() ) )
+				{
+					BotUsage( ent );
+					return false;
+				}
+				coords[ i ] = static_cast< float >( val );
+			}
+			g_entities[ clientNum ].botMind->argVector = glm::vec3( coords[0], coords[1], coords[2] );
 		}
 		const char *behavior = args[3].data();
 		G_BotChangeBehavior( clientNum, behavior );

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1078,6 +1078,37 @@ AINodeStatus_t BotActionRush( gentity_t *self, AIGenericNode_t *node )
 	return BotMoveToGoal( self ) ? STATUS_RUNNING : STATUS_FAILURE;
 }
 
+AINodeStatus_t BotActionStayHere( gentity_t *self, AIGenericNode_t *node )
+{
+	glm::vec3 point;
+
+	if ( ! self->botMind->hasArgVector() )
+	{
+		return STATUS_FAILURE;
+	}
+
+	if ( node != self->botMind->currentNode )
+	{
+		if ( !BotFindRandomPointInRadius( self->s.number, self->botMind->getArgVector(), point, 500 ) )
+		{
+			return STATUS_FAILURE;
+		}
+
+		if ( !BotChangeGoalPos( self, point ) )
+		{
+			return STATUS_FAILURE;
+		}
+		self->botMind->currentNode = node;
+	}
+
+	if ( GoalInRange( self, BotGetGoalRadius( self ) ) )
+	{
+		return STATUS_SUCCESS;
+	}
+
+	return BotMoveToGoal( self ) ? STATUS_RUNNING : STATUS_FAILURE;
+}
+
 static AINodeStatus_t BotActionReachHealA( gentity_t *self );
 static AINodeStatus_t BotActionReachHealH( gentity_t *self );
 AINodeStatus_t BotActionHeal( gentity_t *self, AIGenericNode_t *node )

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1083,17 +1083,17 @@ AINodeStatus_t BotActionStayHere( gentity_t *self, AIGenericNode_t *node )
 	AIActionNode_t *a = ( AIActionNode_t * ) node;
 	float radius = AIUnBoxFloat( a->params[ 0 ] );
 
-	if ( !self->botMind->argVector )
+	if ( !self->botMind->userSpecifiedPosition )
 	{
 		return STATUS_FAILURE;
 	}
 
 	if ( node != self->botMind->currentNode )
 	{
-		glm::vec3 argVector = *self->botMind->argVector;
+		glm::vec3 userSpecifiedPosition = *self->botMind->userSpecifiedPosition;
 		glm::vec3 point;
 
-		if ( !BotFindRandomPointInRadius( self->s.number, argVector, point, radius ) )
+		if ( !BotFindRandomPointInRadius( self->s.number, userSpecifiedPosition, point, radius ) )
 		{
 			return STATUS_FAILURE;
 		}

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1083,16 +1083,17 @@ AINodeStatus_t BotActionStayHere( gentity_t *self, AIGenericNode_t *node )
 	AIActionNode_t *a = ( AIActionNode_t * ) node;
 	float radius = AIUnBoxFloat( a->params[ 0 ] );
 
-	if ( ! self->botMind->hasArgVector() )
+	if ( !self->botMind->argVector )
 	{
 		return STATUS_FAILURE;
 	}
 
 	if ( node != self->botMind->currentNode )
 	{
+		glm::vec3 argVector = *self->botMind->argVector;
 		glm::vec3 point;
 
-		if ( !BotFindRandomPointInRadius( self->s.number, self->botMind->getArgVector(), point, radius ) )
+		if ( !BotFindRandomPointInRadius( self->s.number, argVector, point, radius ) )
 		{
 			return STATUS_FAILURE;
 		}

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1080,7 +1080,8 @@ AINodeStatus_t BotActionRush( gentity_t *self, AIGenericNode_t *node )
 
 AINodeStatus_t BotActionStayHere( gentity_t *self, AIGenericNode_t *node )
 {
-	glm::vec3 point;
+	AIActionNode_t *a = ( AIActionNode_t * ) node;
+	float radius = AIUnBoxFloat( a->params[ 0 ] );
 
 	if ( ! self->botMind->hasArgVector() )
 	{
@@ -1089,7 +1090,9 @@ AINodeStatus_t BotActionStayHere( gentity_t *self, AIGenericNode_t *node )
 
 	if ( node != self->botMind->currentNode )
 	{
-		if ( !BotFindRandomPointInRadius( self->s.number, self->botMind->getArgVector(), point, 500 ) )
+		glm::vec3 point;
+
+		if ( !BotFindRandomPointInRadius( self->s.number, self->botMind->getArgVector(), point, radius ) )
 		{
 			return STATUS_FAILURE;
 		}

--- a/src/sgame/sg_bot_ai.h
+++ b/src/sgame/sg_bot_ai.h
@@ -270,5 +270,6 @@ AINodeStatus_t BotActionSuicide( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotActionJump( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotActionResetStuckTime( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotActionGesture( gentity_t *self, AIGenericNode_t* );
+AINodeStatus_t BotActionStayHere( gentity_t *self, AIGenericNode_t* );
 
 #endif

--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -180,10 +180,17 @@ public:
 	glm::vec3 stuckPosition;
 
 	int spawnTime;
+
+	void setArgVector( glm::vec3 &val ) { argVector = val; hasArgVectorPrivate = true; }
+	bool hasArgVector( ) { return hasArgVectorPrivate; }
+	glm::vec3 getArgVector( ) { return argVector; }
 private:
 	//avoid relying on buttons to remember what AI was doing
 	bool wantSprinting = false;
 	bool exhausted = false;
+
+    bool hasArgVectorPrivate = false;
+	glm::vec3 argVector;
 };
 
 navMeshStatus_t G_BotSetupNav( const botClass_t *botClass, qhandle_t *navHandle );

--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -181,7 +181,7 @@ public:
 
 	int spawnTime;
 
-	Util::optional< glm::vec3 > argVector;
+	Util::optional< glm::vec3 > userSpecifiedPosition;
 private:
 	//avoid relying on buttons to remember what AI was doing
 	bool wantSprinting = false;

--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -181,16 +181,11 @@ public:
 
 	int spawnTime;
 
-	void setArgVector( glm::vec3 &val ) { argVector = val; hasArgVectorPrivate = true; }
-	bool hasArgVector( ) { return hasArgVectorPrivate; }
-	glm::vec3 getArgVector( ) { return argVector; }
+	Util::optional< glm::vec3 > argVector;
 private:
 	//avoid relying on buttons to remember what AI was doing
 	bool wantSprinting = false;
 	bool exhausted = false;
-
-    bool hasArgVectorPrivate = false;
-	glm::vec3 argVector;
 };
 
 navMeshStatus_t G_BotSetupNav( const botClass_t *botClass, qhandle_t *navHandle );

--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -952,6 +952,7 @@ static const struct AIActionMap_s
 	{ "roamInRadius",      BotActionRoamInRadius,      2, 2 },
 	{ "rush",              BotActionRush,              0, 0 },
 	{ "say",               BotActionSay,               2, 2 },
+	{ "stayHere",          BotActionStayHere,          0, 0 },
 	{ "strafeDodge",       BotActionStrafeDodge,       0, 0 },
 	{ "suicide",           BotActionSuicide,           0, 0 },
 	{ "teleport",          BotActionTeleport,          3, 3 },

--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -952,7 +952,7 @@ static const struct AIActionMap_s
 	{ "roamInRadius",      BotActionRoamInRadius,      2, 2 },
 	{ "rush",              BotActionRush,              0, 0 },
 	{ "say",               BotActionSay,               2, 2 },
-	{ "stayHere",          BotActionStayHere,          0, 0 },
+	{ "stayHere",          BotActionStayHere,          1, 1 },
 	{ "strafeDodge",       BotActionStrafeDodge,       0, 0 },
 	{ "suicide",           BotActionSuicide,           0, 0 },
 	{ "teleport",          BotActionTeleport,          3, 3 },

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -3770,6 +3770,9 @@ static void Cmd_Tactic_f( gentity_t * ent )
 		}
 		// now we know: it is a bot on the commanding player's team
 		G_BotChangeBehavior( id, behavior );
+		// use the commanding player's position as the bot's arg vector
+		glm::vec3 position = VEC2GLM( ent->s.origin );
+		g_entities[ id ].botMind->setArgVector( position );
 		level.team[ userTeam ].lastTacticId = id;
 		changedBots++;
 	} while ( ( changedBots < numBots && id != stopId ) );

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -3771,8 +3771,15 @@ static void Cmd_Tactic_f( gentity_t * ent )
 		// now we know: it is a bot on the commanding player's team
 		G_BotChangeBehavior( id, behavior );
 		// use the commanding player's position as the bot's arg vector
-		glm::vec3 position = VEC2GLM( ent->s.origin );
-		g_entities[ id ].botMind->argVector = position;
+		if ( Entities::IsAlive( ent ) )
+		{
+			glm::vec3 position = VEC2GLM( ent->s.origin );
+			g_entities[ id ].botMind->argVector = position;
+		}
+		else
+		{
+			g_entities[ id ].botMind->argVector = Util::nullopt;
+		}
 		level.team[ userTeam ].lastTacticId = id;
 		changedBots++;
 	} while ( ( changedBots < numBots && id != stopId ) );

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -3774,11 +3774,11 @@ static void Cmd_Tactic_f( gentity_t * ent )
 		if ( Entities::IsAlive( ent ) )
 		{
 			glm::vec3 position = VEC2GLM( ent->s.origin );
-			g_entities[ id ].botMind->argVector = position;
+			g_entities[ id ].botMind->userSpecifiedPosition = position;
 		}
 		else
 		{
-			g_entities[ id ].botMind->argVector = Util::nullopt;
+			g_entities[ id ].botMind->userSpecifiedPosition = Util::nullopt;
 		}
 		level.team[ userTeam ].lastTacticId = id;
 		changedBots++;

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -3772,7 +3772,7 @@ static void Cmd_Tactic_f( gentity_t * ent )
 		G_BotChangeBehavior( id, behavior );
 		// use the commanding player's position as the bot's arg vector
 		glm::vec3 position = VEC2GLM( ent->s.origin );
-		g_entities[ id ].botMind->setArgVector( position );
+		g_entities[ id ].botMind->argVector = position;
 		level.team[ userTeam ].lastTacticId = id;
 		changedBots++;
 	} while ( ( changedBots < numBots && id != stopId ) );

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -3770,7 +3770,8 @@ static void Cmd_Tactic_f( gentity_t * ent )
 		}
 		// now we know: it is a bot on the commanding player's team
 		G_BotChangeBehavior( id, behavior );
-		// use the commanding player's position as the bot's arg vector
+		// if alive, use the commanding player's position as the bot's user specified position
+		// not all bot actions use this position, but it cannot hurt to set it
 		if ( Entities::IsAlive( ent ) )
 		{
 			glm::vec3 position = VEC2GLM( ent->s.origin );


### PR DESCRIPTION
This is a cleaner variant of what I use on my server right now. You can try this on my server by using `stay-here.bt` (ping me for permission if you need it).

The action `stayHere(500)` will make a bot roam in radius 500 around an optional user-specified point. `/tactic` saves the user's position in the bot's mind if the user is alive. `/bot behavior` can optionally take a vector argument to specify the position. If the position is not specified, the action fails.

No change to the .bt syntax is required. The idea is to have a .bt file like this:
```
action stayHere( 500 )
action roam
```