### PR TITLE
CG_Obituary improvements

### DIFF
--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -78,7 +78,7 @@ static const struct {
 	{ "[basilisk]",    false, true,  TEAM_ALIENS },
 	{ "[dragoon]",     false, true,  TEAM_ALIENS },
 	{ "[dragoon]",     false, true,  TEAM_ALIENS }, // pounce
-	{ "[advdragoon]",  false, true,  TEAM_ALIENS },
+	{ "[advdragoon]",  false, true,  TEAM_ALIENS }, // barbs
 	{ "[marauder]",    false, true,  TEAM_ALIENS },
 	{ "[advmarauder]", false, true,  TEAM_ALIENS }, // zap
 	{ "[tyrant]",      false, true,  TEAM_ALIENS },
@@ -89,17 +89,17 @@ static const struct {
 	{ "[booster]",     false, true,  TEAM_ALIENS }, // poison
 	{ "[hive]",        true,  true,  TEAM_ALIENS },
 
-	{ LONGFORM,        true,  false, TEAM_HUMANS }, // H spawn
-	{ "^dR[turret]",   true,  true,  TEAM_HUMANS }, // rocket pod FIXME: we need a rocket pod emoticon
+	{ LONGFORM,        true,  false, TEAM_HUMANS }, // H spawn (human building explosion)
+	{ "^dR[turret]",   true,  true,  TEAM_HUMANS }, // rocket pod. FIXME: we need a rocket pod emoticon
 	{ "[turret]",      true,  true,  TEAM_HUMANS },
 	{ "[reactor]",     true,  true,  TEAM_HUMANS },
 
-	{ LONGFORM,        true,  false, TEAM_ALIENS }, // A spawn
+	{ LONGFORM,        true,  false, TEAM_ALIENS }, // A spawn (alien building explosion)
 	{ "[acidtube]",    true,  true,  TEAM_ALIENS },
-	{ "[hovel]",       true,  true,  TEAM_ALIENS }, // spiker. FIXME: we need a hovel emoticon
+	{ "[hovel]",       true,  true,  TEAM_ALIENS }, // spiker. FIXME: we need a spiker emoticon
 	{ "[overmind]",    true,  false, TEAM_ALIENS },
-	{ "",              true,  false, TEAM_NONE },
-	{ "",              true,  false, TEAM_NONE },
+	{ "",              true,  false, TEAM_NONE },   // (MOD_DECONSTRUCT)
+	{ "",              true,  false, TEAM_NONE },   // (MOD_REPLACE)
 };
 
 static void CG_Obituary( entityState_t *ent )

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -61,7 +61,7 @@ static const struct {
 	{ "[fire]",        false, true,  TEAM_HUMANS }, // burn
 	{ "[grenade]",     false, true,  TEAM_HUMANS },
 	{ "[firebomb]",    false, true,  TEAM_HUMANS },
-	{ "crushed",       false, true,  TEAM_HUMANS }, // crushed by human player. FIXME: emoticon
+	{ "crushed",       false, true,  TEAM_HUMANS }, // crushed by human player. FIXME: emoticon?
 	{ LONGFORM,        true,  false, TEAM_NONE   }, // water
 	{ LONGFORM,        true,  false, TEAM_NONE   }, // slime
 	{ LONGFORM,        true,  false, TEAM_NONE   }, // lava
@@ -75,7 +75,7 @@ static const struct {
 
 	{ "[granger]",     false, true,  TEAM_ALIENS }, // granger claw
 	{ "[dretch]",      false, true,  TEAM_ALIENS },
-	{ "[basilisk]",    false, true,  TEAM_ALIENS },
+	{ "[mantis]",      false, true,  TEAM_ALIENS },
 	{ "[dragoon]",     false, true,  TEAM_ALIENS },
 	{ "[dragoon]",     false, true,  TEAM_ALIENS }, // pounce
 	{ "[advdragoon]",  false, true,  TEAM_ALIENS }, // barbs

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -212,26 +212,47 @@ static void CG_Obituary( entityState_t *ent )
 			{
 				if ( meansOfDeath[ mod ].showAssist && assistantInfo )
 				{
-					Log::Notice( "%s (+ %s%s^*) %s %s%s", teamTag[ attackerTeam ], teamTag[ assistantTeam ], assistantName, meansOfDeath[ mod ].icon, teamTag[ ci->team ], targetName );
+					Log::Notice( "%s (+ %s%s%s^*) %s %s%s", 
+					             teamTag[ attackerTeam ], 
+								 teamTag[ assistantTeam ], 
+								 assistantName, 
+								 ( assistantTeam == ci->team ? " ^a!!" : "" ),
+								 meansOfDeath[ mod ].icon, 
+								 teamTag[ ci->team ], targetName );
 				}
 				else
 				{
-					Log::Notice( "%s %s %s%s", teamTag[ attackerTeam ], meansOfDeath[ mod ].icon, teamTag[ ci->team ], targetName );
+					Log::Notice( "%s %s %s%s", 
+					             teamTag[ attackerTeam ], 
+								 meansOfDeath[ mod ].icon, 
+								 teamTag[ ci->team ], targetName );
 				}
 			}
 			else if ( attacker == target )
 			{
-				Log::Notice( "%s %s%s", meansOfDeath[ mod ].icon, teamTag[ ci->team ], targetName );
+				Log::Notice( "%s %s%s", 
+				             meansOfDeath[ mod ].icon, 
+							 teamTag[ ci->team ], targetName );
 			}
 			else
 			{
 				if ( meansOfDeath[ mod ].showAssist && assistantInfo )
 				{
-					Log::Notice( "%s%s^* (+ %s%s^*) %s %s%s", teamTag[ attackerTeam ], attackerName, teamTag[ assistantTeam ], assistantName, meansOfDeath[ mod ].icon, teamTag[ ci->team ], targetName );
+					Log::Notice( "%s%s%s^* (+ %s%s%s^*) %s %s%s", 
+					             teamTag[ attackerTeam ], attackerName, 
+								 ( attackerTeam == ci->team ? " ^1!!!^*" : "" ),
+								 teamTag[ assistantTeam ], assistantName, 
+								 ( assistantTeam == ci->team ? " ^a!!" : "" ),
+								 meansOfDeath[ mod ].icon, 
+								 teamTag[ ci->team ], targetName );
 				}
 				else
 				{
-					Log::Notice( "%s%s^* %s %s%s", teamTag[ attackerTeam ], attackerName, meansOfDeath[ mod ].icon, teamTag[ ci->team ], targetName );
+					Log::Notice( "%s%s%s^* %s %s%s", 
+					             teamTag[ attackerTeam ], attackerName, 
+								 ( attackerTeam == ci->team ? " ^1!!!^*" : "" ),
+								 meansOfDeath[ mod ].icon, 
+								 teamTag[ ci->team ], targetName );
 				}
 
 				// nice big message for teamkills
@@ -290,49 +311,49 @@ static void CG_Obituary( entityState_t *ent )
 
 			case MOD_MGTURRET:
 				message = G_( "%s%s ^*was gunned down by a turret" );
-				messageAssisted = G_( "%s%s ^*was gunned down by a turret; %s%s^* assisted" );
+				messageAssisted = G_( "%s%s ^*was gunned down by a turret; %s%s%s^* assisted" );
 				break;
 
 			case MOD_ROCKETPOD:
 				message = G_( "%s%s ^*caught a rocket" );
-				messageAssisted = G_( "%s%s ^*caught a rocket; %s%s^* assisted" );
+				messageAssisted = G_( "%s%s ^*caught a rocket; %s%s%s^* assisted" );
 				break;
 
 			case MOD_ATUBE:
 				message = G_( "%s%s ^*was melted by an acid tube" );
-				messageAssisted = G_( "%s%s ^*was melted by an acid tube; %s%s^* assisted" );
+				messageAssisted = G_( "%s%s ^*was melted by an acid tube; %s%s%s^* assisted" );
 				break;
 
 			case MOD_SPIKER:
 				message = G_( "%s%s ^*was flechetted by a spiker" );
-				messageAssisted = G_( "%s%s ^*was flechetted by a spiker; %s%s^* assisted" );
+				messageAssisted = G_( "%s%s ^*was flechetted by a spiker; %s%s%s^* assisted" );
 				break;
 
 			case MOD_OVERMIND:
 				message = G_( "%s%s ^*was whipped by the overmind" );
-				messageAssisted = G_( "%s%s ^*was whipped by the overmind; %s%s^* assisted" );
+				messageAssisted = G_( "%s%s ^*was whipped by the overmind; %s%s%s^* assisted" );
 				break;
 
 			case MOD_REACTOR:
 				message = G_( "%s%s ^*was fried by the reactor" );
-				messageAssisted = G_( "%s%s ^*was fried by the reactor; %s%s^* assisted" );
+				messageAssisted = G_( "%s%s ^*was fried by the reactor; %s%s%s^* assisted" );
 				break;
 
 			case MOD_SLOWBLOB:
 				message = G_( "%s%s ^*couldn't avoid the granger" );
-				messageAssisted = G_( "%s%s ^*couldn't avoid the granger; %s%s^* assisted" );
+				messageAssisted = G_( "%s%s ^*couldn't avoid the granger; %s%s%s^* assisted" );
 				break;
 
 			case MOD_SWARM:
 				message = G_( "%s%s ^*was consumed by the swarm" );
-				messageAssisted = G_( "%s%s ^*was consumed by the swarm; %s%s^* assisted" );
+				messageAssisted = G_( "%s%s ^*was consumed by the swarm; %s%s%s^* assisted" );
 				break;
 
 			// Shouldn't happen
 
 			case MOD_TARGET_LASER:
 				message = G_( "%s%s ^*saw the light" );
-				messageAssisted = G_( "%s%s ^*saw the light; %s%s^* assisted" );
+				messageAssisted = G_( "%s%s ^*saw the light; %s%s%s^* assisted" );
 				break;
 
 			default:
@@ -358,163 +379,163 @@ static void CG_Obituary( entityState_t *ent )
 		switch ( mod )
 		{
 			case MOD_PAINSAW:
-				message = G_( "%s%s ^*was sawn by %s%s" );
-				messageAssisted = G_( "%s%s ^*was sawn by %s%s^*; %s%s^* assisted" );
+				message = G_( "%s%s ^*was sawn by %s%s%s" );
+				messageAssisted = G_( "%s%s ^*was sawn by %s%s%s^*; %s%s%s^* assisted" );
 				break;
 
 			case MOD_BLASTER:
-				message = G_( "%s%s ^*was blasted by %s%s" );
-				messageAssisted = G_( "%s%s ^*was blasted by %s%s^*; %s%s^* assisted" );
+				message = G_( "%s%s ^*was blasted by %s%s%s" );
+				messageAssisted = G_( "%s%s ^*was blasted by %s%s%s^*; %s%s%s^* assisted" );
 				break;
 
 			case MOD_MACHINEGUN:
-				message = G_( "%s%s ^*was machinegunned by %s%s" );
-				messageAssisted = G_( "%s%s ^*was machinegunned by %s%s^*; %s%s^* assisted" );
+				message = G_( "%s%s ^*was machinegunned by %s%s%s" );
+				messageAssisted = G_( "%s%s ^*was machinegunned by %s%s%s^*; %s%s%s^* assisted" );
 				break;
 
 			case MOD_CHAINGUN:
-				message = G_( "%s%s ^*was mowed down by %s%s" );
-				messageAssisted = G_( "%s%s ^*was mowed down by %s%s^*; %s%s^* assisted" );
+				message = G_( "%s%s ^*was mowed down by %s%s%s" );
+				messageAssisted = G_( "%s%s ^*was mowed down by %s%s%s^*; %s%s%s^* assisted" );
 				break;
 
 			case MOD_SHOTGUN:
-				message = G_( "%s%s ^*was gunned down by %s%s" );
-				messageAssisted = G_( "%s%s ^*was gunned down by %s%s^*; %s%s^* assisted" );
+				message = G_( "%s%s ^*was gunned down by %s%s%s" );
+				messageAssisted = G_( "%s%s ^*was gunned down by %s%s%s^*; %s%s%s^* assisted" );
 				break;
 
 			case MOD_PRIFLE:
-				message = G_( "%s%s ^*was seared by %s%s^*'s pulse blast" );
-				messageAssisted = G_( "%s%s ^*was seared by %s%s^*'s pulse blast; %s%s^* assisted" );
+				message = G_( "%s%s ^*was seared by %s%s%s^*'s pulse blast" );
+				messageAssisted = G_( "%s%s ^*was seared by %s%s%s^*'s pulse blast; %s%s%s^* assisted" );
 				break;
 
 			case MOD_MDRIVER:
-				message = G_( "%s%s ^*was sniped by %s%s" );
-				messageAssisted = G_( "%s%s ^*was sniped by %s%s^*; %s%s^* assisted" );
+				message = G_( "%s%s ^*was sniped by %s%s%s" );
+				messageAssisted = G_( "%s%s ^*was sniped by %s%s%s^*; %s%s%s^* assisted" );
 				break;
 
 			case MOD_LASGUN:
-				message = G_( "%s%s ^*was lasered by %s%s" );
-				messageAssisted = G_( "%s%s ^*was lasered by %s%s^*; %s%s^* assisted" );
+				message = G_( "%s%s ^*was lasered by %s%s%s" );
+				messageAssisted = G_( "%s%s ^*was lasered by %s%s%s^*; %s%s%s^* assisted" );
 				break;
 
 			case MOD_FLAMER:
 			case MOD_FLAMER_SPLASH:
-				message = G_( "%s%s ^*was grilled by %s%s^*'s flame" );
-				messageAssisted = G_( "%s%s ^*was grilled by %s%s^*'s flame; %s%s^* assisted" );
+				message = G_( "%s%s ^*was grilled by %s%s%s^*'s flame" );
+				messageAssisted = G_( "%s%s ^*was grilled by %s%s%s^*'s flame; %s%s%s^* assisted" );
 				messageSuicide = G_( "%s%s ^*was charred to a crisp" );
 				break;
 
 			case MOD_BURN:
-				message = G_( "%s%s ^*was burned by %s%s^*'s fire" );
-				messageAssisted = G_( "%s%s ^*was burned by %s%s^*'s fire; %s%s^* assisted" );
+				message = G_( "%s%s ^*was burned by %s%s%s^*'s fire" );
+				messageAssisted = G_( "%s%s ^*was burned by %s%s%s^*'s fire; %s%s%s^* assisted" );
 				messageSuicide = G_( "%s%s ^*was burned to death" );
 				break;
 
 			case MOD_LCANNON:
-				message = G_( "%s%s ^*was annihilated by %s%s^*'s plasma blast" );
-				messageAssisted = G_( "%s%s ^*was annihilated by %s%s^*'s plasma blast; %s%s^* assisted" );
+				message = G_( "%s%s ^*was annihilated by %s%s%s^*'s plasma blast" );
+				messageAssisted = G_( "%s%s ^*was annihilated by %s%s%s^*'s plasma blast; %s%s%s^* assisted" );
 				break;
 
 			case MOD_LCANNON_SPLASH:
-				message = G_( "%s%s ^*was irradiated by %s%s^*'s plasma blast" );
-				messageAssisted = G_( "%s%s ^*was irradiated by %s%s^*'s plasma blast; %s%s^* assisted" );
+				message = G_( "%s%s ^*was irradiated by %s%s%s^*'s plasma blast" );
+				messageAssisted = G_( "%s%s ^*was irradiated by %s%s%s^*'s plasma blast; %s%s%s^* assisted" );
 				messageSuicide = G_( "%s%s ^*was irradiated" );
 				break;
 
 			case MOD_GRENADE:
-				message = G_( "%s%s ^*was blown up by %s%s^*'s grenade" );
-				messageAssisted = G_( "%s%s ^*was blown up by %s%s^*'s grenade; %s%s^* assisted" );
+				message = G_( "%s%s ^*was blown up by %s%s%s^*'s grenade" );
+				messageAssisted = G_( "%s%s ^*was blown up by %s%s%s^*'s grenade; %s%s%s^* assisted" );
 				messageSuicide = G_( "%s%s ^*was blown up" );
 				break;
 
 			case MOD_FIREBOMB:
-				message = G_( "%s%s ^*was incinerated by %s%s^*'s firebomb" );
-				messageAssisted = G_( "%s%s ^*was incinerated by %s%s^*'s firebomb; %s%s^* assisted" );
+				message = G_( "%s%s ^*was incinerated by %s%s%s^*'s firebomb" );
+				messageAssisted = G_( "%s%s ^*was incinerated by %s%s%s^*'s firebomb; %s%s%s^* assisted" );
 				messageSuicide = G_( "%s%s ^*was incinerated" );
 				break;
 
 			case MOD_ABUILDER_CLAW:
-				message = G_( "%s%s ^*was gently nibbled by %s%s^*'s granger" );
-				messageAssisted = G_( "%s%s ^*was gently nibbled by %s%s^*'s granger; %s%s^* assisted" );
+				message = G_( "%s%s ^*was gently nibbled by %s%s%s^*'s granger" );
+				messageAssisted = G_( "%s%s ^*was gently nibbled by %s%s%s^*'s granger; %s%s%s^* assisted" );
 				break;
 
 			case MOD_LEVEL0_BITE:
-				message = G_( "%s%s ^*was bitten by %s%s" );
-				messageAssisted = G_( "%s%s ^*was bitten by %s%s^*; %s%s^* assisted" );
+				message = G_( "%s%s ^*was bitten by %s%s%s" );
+				messageAssisted = G_( "%s%s ^*was bitten by %s%s%s^*; %s%s%s^* assisted" );
 				break;
 
 			case MOD_LEVEL1_CLAW:
-				message = G_( "%s%s ^*was sliced by %s%s^*'s %s" );
-				messageAssisted = G_( "%s%s ^*was sliced by %s%s^*'s %s^*; %s%s^* assisted" );
+				message = G_( "%s%s ^*was sliced by %s%s%s^*'s %s" );
+				messageAssisted = G_( "%s%s ^*was sliced by %s%s%s^*'s %s^*; %s%s%s^* assisted" );
 				attackerClass = PCL_ALIEN_LEVEL1;
 				break;
 
 			case MOD_LEVEL2_CLAW:
-				message = G_( "%s%s ^*was shredded by %s%s^*'s %s" );
-				messageAssisted = G_( "%s%s ^*was shredded by %s%s^*'s %s^*; %s%s^* assisted" );
+				message = G_( "%s%s ^*was shredded by %s%s%s^*'s %s" );
+				messageAssisted = G_( "%s%s ^*was shredded by %s%s%s^*'s %s^*; %s%s%s^* assisted" );
 				attackerClass = PCL_ALIEN_LEVEL2;
 				break;
 
 			case MOD_LEVEL2_ZAP:
-				message = G_( "%s%s ^*was electrocuted by %s%s^*'s %s" );
-				messageAssisted = G_( "%s%s ^*was electrocuted by %s%s^*'s %s^*; %s%s^* assisted" );
+				message = G_( "%s%s ^*was electrocuted by %s%s%s^*'s %s" );
+				messageAssisted = G_( "%s%s ^*was electrocuted by %s%s%s^*'s %s^*; %s%s%s^* assisted" );
 				attackerClass = PCL_ALIEN_LEVEL2;
 				break;
 
 			case MOD_LEVEL3_CLAW:
-				message = G_( "%s%s ^*was eviscerated by %s%s^*'s %s" );
-				messageAssisted = G_( "%s%s ^*was eviscerated by %s%s^*'s %s^*; %s%s^* assisted" );
+				message = G_( "%s%s ^*was eviscerated by %s%s%s^*'s %s" );
+				messageAssisted = G_( "%s%s ^*was eviscerated by %s%s%s^*'s %s^*; %s%s%s^* assisted" );
 				attackerClass = PCL_ALIEN_LEVEL3;
 				break;
 
 			case MOD_LEVEL3_POUNCE:
-				message = G_( "%s%s ^*was pounced upon by %s%s^*'s %s" );
-				messageAssisted = G_( "%s%s ^*was pounced upon by %s%s^*'s %s^*; %s%s^* assisted" );
+				message = G_( "%s%s ^*was pounced upon by %s%s%s^*'s %s" );
+				messageAssisted = G_( "%s%s ^*was pounced upon by %s%s%s^*'s %s^*; %s%s%s^* assisted" );
 				attackerClass = PCL_ALIEN_LEVEL3;
 				break;
 
 			case MOD_LEVEL3_BOUNCEBALL:
-				message = G_( "%s%s ^*was barbed by %s%s^*'s %s" );
-				messageAssisted = G_( "%s%s ^*was barbed by %s%s^*'s %s^*; %s%s^* assisted" );
+				message = G_( "%s%s ^*was barbed by %s%s%s^*'s %s" );
+				messageAssisted = G_( "%s%s ^*was barbed by %s%s%s^*'s %s^*; %s%s%s^* assisted" );
 				messageSuicide = G_( "%s%s ^*was barbed" );
 				attackerClass = PCL_ALIEN_LEVEL3;
 				break;
 
 			case MOD_LEVEL4_CLAW:
-				message = G_( "%s%s ^*was mauled by %s%s^*'s %s" );
-				messageAssisted = G_( "%s%s ^*was mauled by %s%s^*'s %s^*; %s%s^* assisted" );
+				message = G_( "%s%s ^*was mauled by %s%s%s^*'s %s" );
+				messageAssisted = G_( "%s%s ^*was mauled by %s%s%s^*'s %s^*; %s%s%s^* assisted" );
 				attackerClass = PCL_ALIEN_LEVEL4;
 				break;
 
 			case MOD_LEVEL4_TRAMPLE:
-				message = G_( "%s%s ^*should have gotten out of the way of %s%s^*'s %s" );
-				messageAssisted = G_( "%s%s ^*should have gotten out of the way of %s%s^*'s %s^*; %s%s^* assisted" );
+				message = G_( "%s%s ^*should have gotten out of the way of %s%s%s^*'s %s" );
+				messageAssisted = G_( "%s%s ^*should have gotten out of the way of %s%s%s^*'s %s^*; %s%s%s^* assisted" );
 				attackerClass = PCL_ALIEN_LEVEL4;
 				break;
 
 			case MOD_WEIGHT_H:
 			case MOD_WEIGHT_A:
-				message = G_( "%s%s ^*was crushed under %s%s^*'s weight" );
-				messageAssisted = G_( "%s%s ^*was crushed under %s%s^*'s weight; %s%s^* assisted" );
+				message = G_( "%s%s ^*was crushed under %s%s%s^*'s weight" );
+				messageAssisted = G_( "%s%s ^*was crushed under %s%s%s^*'s weight; %s%s%s^* assisted" );
 				break;
 
 			case MOD_POISON:
-				message = G_( "%s%s ^*should have used a medkit against %s%s^*'s poison" );
-				messageAssisted = G_( "%s%s ^*should have used a medkit against %s%s^*'s poison; %s%s^* assisted" );
+				message = G_( "%s%s ^*should have used a medkit against %s%s%s^*'s poison" );
+				messageAssisted = G_( "%s%s ^*should have used a medkit against %s%s%s^*'s poison; %s%s%s^* assisted" );
 				break;
 
 			case MOD_TELEFRAG:
-				message = G_( "%s%s ^*tried to invade %s%s^*'s personal space" );
+				message = G_( "%s%s ^*tried to invade %s%s%s^*'s personal space" );
 				break;
 
 			case MOD_SLAP:
-				message = G_( "%s%s ^*felt %s%s^*'s authority" );
-				messageAssisted = G_( "%s%s ^*felt %s%s^*'s authority; %s%s^* assisted" );
+				message = G_( "%s%s ^*felt %s%s%s^*'s authority" );
+				messageAssisted = G_( "%s%s ^*felt %s%s%s^*'s authority; %s%s%s^* assisted" );
 				break;
 
 			default:
-				message = G_( "%s%s ^*was killed by %s%s" );
-				messageAssisted = G_( "%s%s ^*was killed by %s%s^* and %s%s" );
+				message = G_( "%s%s ^*was killed by %s%s%s" );
+				messageAssisted = G_( "%s%s ^*was killed by %s%s%s^* and %s%s%s" );
 				messageSuicide = G_( "%s%s ^*committed suicide" );
 				break;
 		}
@@ -531,22 +552,40 @@ static void CG_Obituary( entityState_t *ent )
 			{
 				if ( attackerClass != -1 )
 				{
-					Log::Notice( messageAssisted, teamTag[ ci->team ], targetName, teamTag[ attackerTeam ], attackerName, BG_ClassModelConfig( attackerClass )->humanName, teamTag[ assistantTeam ], assistantName );
+					Log::Notice( messageAssisted, 
+					             teamTag[ ci->team ], targetName, 
+								 ( attackerTeam == ci->team ? "^1TEAMMATE " : "" ),
+								 teamTag[ attackerTeam ], attackerName, 
+								 BG_ClassModelConfig( attackerClass )->humanName, 
+								 ( assistantTeam == ci->team ? "^aTEAMMATE " : "" ),
+								 teamTag[ assistantTeam ], assistantName );
 				}
 				else
 				{
-					Log::Notice( messageAssisted, teamTag[ ci->team ], targetName, teamTag[ attackerTeam ], attackerName, teamTag[ assistantTeam ], assistantName );
+					Log::Notice( messageAssisted, 
+					             teamTag[ ci->team ], targetName, 
+								 ( attackerTeam == ci->team ? "^1TEAMMATE " : "" ),
+								 teamTag[ attackerTeam ], attackerName, 
+								 ( assistantTeam == ci->team ? "^aTEAMMATE " : "" ),
+								 teamTag[ assistantTeam ], assistantName );
 				}
 			}
 			else
 			{
 				if ( attackerClass != -1 )
 				{
-					Log::Notice( message, teamTag[ ci->team ], targetName, teamTag[ attackerTeam ], attackerName, BG_ClassModelConfig( attackerClass )->humanName );
+					Log::Notice( message, 
+					             teamTag[ ci->team ], targetName, 
+								 ( attackerTeam == ci->team ? "^1TEAMMATE " : "" ),
+								 teamTag[ attackerTeam ], attackerName, 
+								 BG_ClassModelConfig( attackerClass )->humanName );
 				}
 				else
 				{
-					Log::Notice( message, teamTag[ ci->team ], targetName, teamTag[ attackerTeam ], attackerName );
+					Log::Notice( message, 
+					             teamTag[ ci->team ], targetName, 
+								 ( attackerTeam == ci->team ? "^1TEAMMATE " : "" ),
+								 teamTag[ attackerTeam ], attackerName );
 				}
 			}
 

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -134,7 +134,8 @@ static void CG_Obituary( entityState_t *ent )
 	ci = &cgs.clientinfo[ target ];
 	gender = ci->gender;
 
-	if ( !cgs.clientinfo[ attacker ].infoValid )
+	if ( ( attacker < 0 || attacker >= MAX_CLIENTS ) 
+	     || ( !cgs.clientinfo[ attacker ].infoValid ) )
 	{
 		attacker = ENTITYNUM_WORLD;
 		attackerInfo = nullptr;

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -134,7 +134,7 @@ static void CG_Obituary( entityState_t *ent )
 	ci = &cgs.clientinfo[ target ];
 	gender = ci->gender;
 
-	if ( attacker < 0 || attacker >= MAX_CLIENTS )
+	if ( !cgs.clientinfo[ attacker ].infoValid )
 	{
 		attacker = ENTITYNUM_WORLD;
 		attackerInfo = nullptr;
@@ -226,7 +226,7 @@ static void CG_Obituary( entityState_t *ent )
 								 teamTag[ ci->team ], targetName );
 				}
 			}
-			else if ( attacker == target )
+			else if ( !cgs.clientinfo[ attacker ].infoValid || attacker == target )
 			{
 				Log::Notice( "%s %s%s", 
 				             meansOfDeath[ mod ].icon, 
@@ -542,7 +542,7 @@ static void CG_Obituary( entityState_t *ent )
 		{
 
 			// Argument order: victim, attacker, [class,] [assistant]. Each has team tag first.
-			if ( messageSuicide && attacker == target )
+			if ( messageSuicide && ( !cgs.clientinfo[ attacker ].infoValid || attacker == target ) )
 			{
 				Log::Notice( messageSuicide, teamTag[ ci->team ], targetName );
 			}

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -215,22 +215,22 @@ static void CG_Obituary( entityState_t *ent )
 				{
 					Log::Notice( "%s %s (+ %s%s%s^*) killed %s%s",
 					             teamTag[ attackerTeam ], meansOfDeath[ mod ].icon, 
-								 teamTag[ assistantTeam ], assistantName, 
-								 ( assistantTeam == ci->team ? " ^a!!" : "" ),
-								 teamTag[ ci->team ], targetName );
+					             teamTag[ assistantTeam ], assistantName, 
+					             ( assistantTeam == ci->team ? " ^a!!" : "" ),
+					             teamTag[ ci->team ], targetName );
 				}
 				else
 				{
 					Log::Notice( "%s %s %s%s", 
 					             teamTag[ attackerTeam ], meansOfDeath[ mod ].icon, 
-								 teamTag[ ci->team ], targetName );
+					             teamTag[ ci->team ], targetName );
 				}
 			}
 			else if ( !cgs.clientinfo[ attacker ].infoValid || attacker == target )
 			{
 				Log::Notice( "%s %s%s", 
 				             meansOfDeath[ mod ].icon, 
-							 teamTag[ ci->team ], targetName );
+				             teamTag[ ci->team ], targetName );
 			}
 			else
 			{
@@ -238,19 +238,19 @@ static void CG_Obituary( entityState_t *ent )
 				{
 					Log::Notice( "%s%s%s^* (+ %s%s%s^*) %s %s%s", 
 					             teamTag[ attackerTeam ], attackerName, 
-								 ( attackerTeam == ci->team ? " ^1!!!^*" : "" ),
-								 teamTag[ assistantTeam ], assistantName, 
-								 ( assistantTeam == ci->team ? " ^a!!" : "" ),
-								 meansOfDeath[ mod ].icon, 
-								 teamTag[ ci->team ], targetName );
+					             ( attackerTeam == ci->team ? " ^1!!!^*" : "" ),
+					             teamTag[ assistantTeam ], assistantName, 
+					             ( assistantTeam == ci->team ? " ^a!!" : "" ),
+					             meansOfDeath[ mod ].icon, 
+					             teamTag[ ci->team ], targetName );
 				}
 				else
 				{
 					Log::Notice( "%s%s%s^* %s %s%s", 
 					             teamTag[ attackerTeam ], attackerName, 
-								 ( attackerTeam == ci->team ? " ^1!!!^*" : "" ),
-								 meansOfDeath[ mod ].icon, 
-								 teamTag[ ci->team ], targetName );
+					             ( attackerTeam == ci->team ? " ^1!!!^*" : "" ),
+					             meansOfDeath[ mod ].icon, 
+					             teamTag[ ci->team ], targetName );
 				}
 
 				// nice big message for teamkills
@@ -363,7 +363,10 @@ static void CG_Obituary( entityState_t *ent )
 		{
 			if ( messageAssisted && assistantInfo )
 			{
-				Log::Notice( messageAssisted, teamTag[ ci->team ], targetName , teamTag[ assistantTeam ], assistantName);
+				Log::Notice( messageAssisted, 
+				             teamTag[ ci->team ], targetName, 
+				             ( assistantTeam == ci->team ? "^aTEAMMATE " : "" ),
+				             teamTag[ assistantTeam ], assistantName);
 			}
 			else
 			{
@@ -552,20 +555,20 @@ static void CG_Obituary( entityState_t *ent )
 				{
 					Log::Notice( messageAssisted, 
 					             teamTag[ ci->team ], targetName, 
-								 ( attackerTeam == ci->team ? "^1TEAMMATE " : "" ),
-								 teamTag[ attackerTeam ], attackerName, 
-								 BG_ClassModelConfig( attackerClass )->humanName, 
-								 ( assistantTeam == ci->team ? "^aTEAMMATE " : "" ),
-								 teamTag[ assistantTeam ], assistantName );
+					             ( attackerTeam == ci->team ? "^1TEAMMATE " : "" ),
+					             teamTag[ attackerTeam ], attackerName, 
+					             BG_ClassModelConfig( attackerClass )->humanName, 
+					             ( assistantTeam == ci->team ? "^aTEAMMATE " : "" ),
+					             teamTag[ assistantTeam ], assistantName );
 				}
 				else
 				{
 					Log::Notice( messageAssisted, 
 					             teamTag[ ci->team ], targetName, 
-								 ( attackerTeam == ci->team ? "^1TEAMMATE " : "" ),
-								 teamTag[ attackerTeam ], attackerName, 
-								 ( assistantTeam == ci->team ? "^aTEAMMATE " : "" ),
-								 teamTag[ assistantTeam ], assistantName );
+					             ( attackerTeam == ci->team ? "^1TEAMMATE " : "" ),
+					             teamTag[ attackerTeam ], attackerName, 
+					             ( assistantTeam == ci->team ? "^aTEAMMATE " : "" ),
+					             teamTag[ assistantTeam ], assistantName );
 				}
 			}
 			else
@@ -574,16 +577,16 @@ static void CG_Obituary( entityState_t *ent )
 				{
 					Log::Notice( message, 
 					             teamTag[ ci->team ], targetName, 
-								 ( attackerTeam == ci->team ? "^1TEAMMATE " : "" ),
-								 teamTag[ attackerTeam ], attackerName, 
-								 BG_ClassModelConfig( attackerClass )->humanName );
+					             ( attackerTeam == ci->team ? "^1TEAMMATE " : "" ),
+					             teamTag[ attackerTeam ], attackerName, 
+					             BG_ClassModelConfig( attackerClass )->humanName );
 				}
 				else
 				{
 					Log::Notice( message, 
 					             teamTag[ ci->team ], targetName, 
-								 ( attackerTeam == ci->team ? "^1TEAMMATE " : "" ),
-								 teamTag[ attackerTeam ], attackerName );
+					             ( attackerTeam == ci->team ? "^1TEAMMATE " : "" ),
+					             teamTag[ attackerTeam ], attackerName );
 				}
 			}
 

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -45,7 +45,7 @@ static const struct {
 	team_t   team;
 } meansOfDeath[] = {
 	// Icon            Envkill Assist? (Team)
-	{ "☠",             false, false, TEAM_HUMANS }, // unknown
+	{ "☠",             false, false, TEAM_NONE   }, // unknown
 	{ "[shotgun]",     false, true,  TEAM_HUMANS },
 	{ "[blaster]",     false, true,  TEAM_HUMANS },
 	{ "[painsaw]",     false, true,  TEAM_HUMANS },
@@ -61,7 +61,7 @@ static const struct {
 	{ "[fire]",        false, true,  TEAM_HUMANS }, // burn
 	{ "[grenade]",     false, true,  TEAM_HUMANS },
 	{ "[firebomb]",    false, true,  TEAM_HUMANS },
-	{ "crushed",       false, true,  TEAM_HUMANS }, // weight (H) // FIXME
+	{ "crushed",       false, true,  TEAM_HUMANS }, // crushed by human player. FIXME: emoticon
 	{ LONGFORM,        true,  false, TEAM_NONE   }, // water
 	{ LONGFORM,        true,  false, TEAM_NONE   }, // slime
 	{ LONGFORM,        true,  false, TEAM_NONE   }, // lava
@@ -73,7 +73,7 @@ static const struct {
 	{ LONGFORM,        true,  false, TEAM_NONE   }, // target laser - shouldn't happen
 	{ LONGFORM,        true,  false, TEAM_NONE   }, // trigger hurt
 
-	{ "[granger]",     false, true,  TEAM_ALIENS },
+	{ "[granger]",     false, true,  TEAM_ALIENS }, // granger claw
 	{ "[dretch]",      false, true,  TEAM_ALIENS },
 	{ "[basilisk]",    false, true,  TEAM_ALIENS },
 	{ "[dragoon]",     false, true,  TEAM_ALIENS },
@@ -83,7 +83,7 @@ static const struct {
 	{ "[advmarauder]", false, true,  TEAM_ALIENS }, // zap
 	{ "[tyrant]",      false, true,  TEAM_ALIENS },
 	{ "[tyrant]",      false, true,  TEAM_ALIENS }, // trample
-	{ "crushed",       false, true,  TEAM_ALIENS }, // weight (A) // FIXME
+	{ "crushed",       false, true,  TEAM_ALIENS }, // crushed by alien player. FIXME: emoticon?
 
 	{ "[advgranger]",  false, true,  TEAM_ALIENS }, // granger spit (slowblob)
 	{ "[booster]",     false, true,  TEAM_ALIENS }, // poison

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -45,7 +45,7 @@ static const struct {
 	team_t   team;
 } meansOfDeath[] = {
 	// Icon            Envkill Assist? (Team)
-	{ "☠",             false, false, TEAM_HUMANS },
+	{ "☠",             false, false, TEAM_HUMANS }, // unknown
 	{ "[shotgun]",     false, true,  TEAM_HUMANS },
 	{ "[blaster]",     false, true,  TEAM_HUMANS },
 	{ "[painsaw]",     false, true,  TEAM_HUMANS },
@@ -58,15 +58,16 @@ static const struct {
 	{ "[lcannon]",     false, true,  TEAM_HUMANS }, // splash
 	{ "[flamer]",      false, true,  TEAM_HUMANS },
 	{ "[flamer]",      false, true,  TEAM_HUMANS }, // splash
-	{ "[flamer]",      false, true,  TEAM_HUMANS }, // burn
+	{ "[fire]",        false, true,  TEAM_HUMANS }, // burn
 	{ "[grenade]",     false, true,  TEAM_HUMANS },
 	{ "[firebomb]",    false, true,  TEAM_HUMANS },
-	{ "crushed",       true,  false, TEAM_NONE   }, // weight (H) // FIXME
+	{ "crushed",       false, true,  TEAM_HUMANS }, // weight (H) // FIXME
 	{ LONGFORM,        true,  false, TEAM_NONE   }, // water
 	{ LONGFORM,        true,  false, TEAM_NONE   }, // slime
 	{ LONGFORM,        true,  false, TEAM_NONE   }, // lava
 	{ LONGFORM,        true,  false, TEAM_NONE   }, // crush
 	{ "[telenode]",    false, false, TEAM_NONE   }, // telefrag
+	{ "[cross]",       false, false, TEAM_NONE   }, // Admin Authority™ (/slap command)
 	{ LONGFORM,        true,  false, TEAM_NONE   }, // falling
 	{ "☠",             false, false, TEAM_NONE   }, // suicide
 	{ LONGFORM,        true,  false, TEAM_NONE   }, // target laser - shouldn't happen
@@ -79,24 +80,24 @@ static const struct {
 	{ "[dragoon]",     false, true,  TEAM_ALIENS }, // pounce
 	{ "[advdragoon]",  false, true,  TEAM_ALIENS },
 	{ "[marauder]",    false, true,  TEAM_ALIENS },
-	{ "[advmarauder]", false, true,  TEAM_ALIENS },
+	{ "[advmarauder]", false, true,  TEAM_ALIENS }, // zap
 	{ "[tyrant]",      false, true,  TEAM_ALIENS },
 	{ "[tyrant]",      false, true,  TEAM_ALIENS }, // trample
 	{ "crushed",       false, true,  TEAM_ALIENS }, // weight (A) // FIXME
 
-	{ "[granger]",     false, true,  TEAM_ALIENS }, // granger spit (slowblob)
+	{ "[advgranger]",  false, true,  TEAM_ALIENS }, // granger spit (slowblob)
 	{ "[booster]",     false, true,  TEAM_ALIENS }, // poison
 	{ "[hive]",        true,  true,  TEAM_ALIENS },
 
 	{ LONGFORM,        true,  false, TEAM_HUMANS }, // H spawn
-	{ "[rocketpod]",   true,  true,  TEAM_HUMANS },
+	{ "^dR[turret]",   true,  true,  TEAM_HUMANS }, // rocket pod FIXME: we need a rocket pod emoticon
 	{ "[turret]",      true,  true,  TEAM_HUMANS },
 	{ "[reactor]",     true,  true,  TEAM_HUMANS },
 
 	{ LONGFORM,        true,  false, TEAM_ALIENS }, // A spawn
 	{ "[acidtube]",    true,  true,  TEAM_ALIENS },
-	{ "[overmind]",    true,  true,  TEAM_ALIENS },
-	{ "",              true,  false, TEAM_NONE },
+	{ "[hovel]",       true,  true,  TEAM_ALIENS }, // spiker. FIXME: we need a hovel emoticon
+	{ "[overmind]",    true,  false, TEAM_ALIENS },
 	{ "",              true,  false, TEAM_NONE },
 	{ "",              true,  false, TEAM_NONE },
 };
@@ -212,19 +213,16 @@ static void CG_Obituary( entityState_t *ent )
 			{
 				if ( meansOfDeath[ mod ].showAssist && assistantInfo )
 				{
-					Log::Notice( "%s (+ %s%s%s^*) %s %s%s", 
-					             teamTag[ attackerTeam ], 
-								 teamTag[ assistantTeam ], 
-								 assistantName, 
+					Log::Notice( "%s %s (+ %s%s%s^*) killed %s%s",
+					             teamTag[ attackerTeam ], meansOfDeath[ mod ].icon, 
+								 teamTag[ assistantTeam ], assistantName, 
 								 ( assistantTeam == ci->team ? " ^a!!" : "" ),
-								 meansOfDeath[ mod ].icon, 
 								 teamTag[ ci->team ], targetName );
 				}
 				else
 				{
 					Log::Notice( "%s %s %s%s", 
-					             teamTag[ attackerTeam ], 
-								 meansOfDeath[ mod ].icon, 
+					             teamTag[ attackerTeam ], meansOfDeath[ mod ].icon, 
 								 teamTag[ ci->team ], targetName );
 				}
 			}


### PR DESCRIPTION
This PR improves obituaries in several ways:
The horrible "noname killed X" message should be seen less often, and instead, where there's no valid attacker (usually caused by the attacker disconnecting just before the event takes place, see #2460 and #2462), the suicide message will be used.

Obituaries now show teamkills (and where a teammate assists a kill) more obviously, without having to look at the team tag.

Emoticon obituaries are now fixed, adding MOD_SLAP, MOD_SPIKER and fixing a few other things such as missing emoticons / incorrect emoticons. It also fixes the arrangement of the obituary text when a player assists a world object in killing. Further details are in the commit message.

MOD_SLAP uses the red "Cross" emoticon.
MOD_SPIKER uses the legacy "Hovel" emoticon until we can find something better.

Now some screenshots of the new teamkill messages (the !! & !!! identifies a teamkill in Emoticon only mode)
![Screenshot_20230218_192409](https://user-images.githubusercontent.com/13281185/219895391-a83e2ef5-88b1-47c3-82e1-52aa89a3e000.png)
![Screenshot_20230218_192443](https://user-images.githubusercontent.com/13281185/219895401-0561422d-52bc-478f-b589-2acba1319460.png)
![Screenshot_20230218_192517](https://user-images.githubusercontent.com/13281185/219895423-678db60c-f4a7-4b9b-93cd-3816bafcea6b.png)
![Screenshot_20230218_192545](https://user-images.githubusercontent.com/13281185/219895441-7558b0d2-9599-4e53-afbb-4477d3fc7fac.png)

Rocket pods are now identified as follows, until we get a suitable asset:
![image](https://user-images.githubusercontent.com/13281185/219895651-535dd32f-75a8-4b74-9d05-52468b27d828.png)

In future, it would do to move the Emoticon obituaries out of the chat, make them larger, and use the icons from the circle menu as they are more distinguishable, but that is outside the scope of this PR. Then we could have several modes for Emoticon obituaries (disabled, include in chat, or have them shown separately).