### PR TITLE
Add bot action follow

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -5791,7 +5791,7 @@ static void BotUsage( gentity_t *ent )
 	                                        "            bot del (<name> | all)\n"
 	                                        "            bot names (aliens | humans) <names>…\n"
 	                                        "            bot names (clear | list)\n"
-	                                        "            bot behavior (<name> | <slot#>) <behavior> [<x> <y> <z>]\n"
+	                                        "            bot behavior (<name> | <slot#>) <behavior> [<name> | <slot#> | <x> <y> <z>]\n"
 	                                        "            bot skill <skill level> [<team>]" ) );
 	ADMP( bot_usage );
 }
@@ -6027,7 +6027,7 @@ bool G_admin_bot( gentity_t *ent )
 			G_BotDel( clientNum ); //delete the bot
 		}
 	}
-	else if ( !Q_stricmp( arg1, "behavior" ) && (args.Argc() == 4 || args.Argc() == 7) )
+	else if ( !Q_stricmp( arg1, "behavior" ) && (args.Argc() == 4 || args.Argc() == 5 || args.Argc() == 7) )
 	{
 		RETURN_IF_INTERMISSION;
 
@@ -6039,12 +6039,20 @@ bool G_admin_bot( gentity_t *ent )
 			ADMP( va( "%s %s %s", QQ( "^3$1$:^* $2t$" ), "bot", Quote( err ) ) );
 			return false;
 		}
-		// set the argument vector if present
-		if ( args.Argc() != 7 )
+		g_entities[ clientNum ].botMind->userSpecifiedPosition = Util::nullopt;
+		g_entities[ clientNum ].botMind->userSpecifiedClientNum = Util::nullopt;
+
+		if ( args.Argc() == 5 )
 		{
-			g_entities[ clientNum ].botMind->userSpecifiedPosition = Util::nullopt;
+			int followPid = G_ClientNumberFromString( args[4].data(), err, sizeof( err ) );
+			if ( followPid == -1 )
+			{
+				ADMP( va( "%s %s %s", QQ( "^3$1$:^* $2t$" ), "bot", Quote( err ) ) );
+				return false;
+			}
+			g_entities[ clientNum ].botMind->userSpecifiedClientNum = followPid;
 		}
-		else
+		else if ( args.Argc() == 7 )
 		{
 			float coords[ 3 ];
 			for ( int i = 0; i < 3; i++ )

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -6044,6 +6044,7 @@ bool G_admin_bot( gentity_t *ent )
 
 		if ( args.Argc() == 5 )
 		{
+			// set the user-specified client number
 			int followPid = G_ClientNumberFromString( args[4].data(), err, sizeof( err ) );
 			if ( followPid == -1 )
 			{
@@ -6054,6 +6055,7 @@ bool G_admin_bot( gentity_t *ent )
 		}
 		else if ( args.Argc() == 7 )
 		{
+			// set the user-specified position
 			float coords[ 3 ];
 			for ( int i = 0; i < 3; i++ )
 			{

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1113,6 +1113,47 @@ AINodeStatus_t BotActionStayHere( gentity_t *self, AIGenericNode_t *node )
 	return BotMoveToGoal( self ) ? STATUS_RUNNING : STATUS_FAILURE;
 }
 
+AINodeStatus_t BotActionFollow( gentity_t *self, AIGenericNode_t *node )
+{
+	AIActionNode_t *a = ( AIActionNode_t * ) node;
+	float radius = AIUnBoxFloat( a->params[ 0 ] );
+
+	if ( !self->botMind->userSpecifiedClientNum )
+	{
+		return STATUS_FAILURE;
+	}
+
+	int userSpecifiedClientNum = *self->botMind->userSpecifiedClientNum;
+
+	if ( !Entities::IsAlive( &g_entities[ userSpecifiedClientNum ] ) )
+	{
+		return STATUS_FAILURE;
+	}
+
+	if ( node != self->botMind->currentNode )
+	{
+		glm::vec3 point;
+
+		if ( !BotFindRandomPointInRadius( self->s.number, VEC2GLM( g_entities[ userSpecifiedClientNum ].s.origin ), point, radius ) )
+		{
+			return STATUS_FAILURE;
+		}
+
+		if ( !BotChangeGoalPos( self, point ) )
+		{
+			return STATUS_FAILURE;
+		}
+		self->botMind->currentNode = node;
+	}
+
+	if ( GoalInRange( self, BotGetGoalRadius( self ) ) )
+	{
+		return STATUS_SUCCESS;
+	}
+
+	return BotMoveToGoal( self ) ? STATUS_RUNNING : STATUS_FAILURE;
+}
+
 static AINodeStatus_t BotActionReachHealA( gentity_t *self );
 static AINodeStatus_t BotActionReachHealH( gentity_t *self );
 AINodeStatus_t BotActionHeal( gentity_t *self, AIGenericNode_t *node )

--- a/src/sgame/sg_bot_ai.h
+++ b/src/sgame/sg_bot_ai.h
@@ -271,5 +271,6 @@ AINodeStatus_t BotActionJump( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotActionResetStuckTime( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotActionGesture( gentity_t *self, AIGenericNode_t* );
 AINodeStatus_t BotActionStayHere( gentity_t *self, AIGenericNode_t* );
+AINodeStatus_t BotActionFollow( gentity_t *self, AIGenericNode_t* );
 
 #endif

--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -182,6 +182,7 @@ public:
 	int spawnTime;
 
 	Util::optional< glm::vec3 > userSpecifiedPosition;
+	Util::optional< int > userSpecifiedClientNum;
 private:
 	//avoid relying on buttons to remember what AI was doing
 	bool wantSprinting = false;

--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -940,6 +940,7 @@ static const struct AIActionMap_s
 	{ "fight",             BotActionFight,             0, 0 },
 	{ "fireWeapon",        BotActionFireWeapon,        0, 0 },
 	{ "flee",              BotActionFlee,              0, 0 },
+	{ "follow",            BotActionFollow,            1, 1 },
 	{ "gesture",           BotActionGesture,           0, 0 },
 	{ "heal",              BotActionHeal,              0, 0 },
 	{ "jump",              BotActionJump,              0, 0 },

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -3781,6 +3781,9 @@ static void Cmd_Tactic_f( gentity_t * ent )
 		{
 			g_entities[ id ].botMind->userSpecifiedPosition = Util::nullopt;
 		}
+		// use the commanding player's client number as the bot's user specified client number
+		// not all bot actions use this number, but it cannot hurt to set it
+		g_entities[ id ].botMind->userSpecifiedClientNum = ent->s.number;
 		level.team[ userTeam ].lastTacticId = id;
 		changedBots++;
 	} while ( ( changedBots < numBots && id != stopId ) );


### PR DESCRIPTION
Action `follow(500)` will make a bot roam in radius 500 around another player. `/tactic` saves the user's client number in the bot's mind. `/bot behavior` can optionally take an argument to specify who to follow. If it is not specified who to follow, the action fails.