### PR TITLE
cg_event.cpp: fix colour leak with rocketpod indicator

### DIFF
--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -90,7 +90,7 @@ static const struct {
 	{ "[hive]",        true,  true,  TEAM_ALIENS },
 
 	{ LONGFORM,        true,  false, TEAM_HUMANS }, // H spawn (human building explosion)
-	{ "^dR[turret]",   true,  true,  TEAM_HUMANS }, // rocket pod. FIXME: we need a rocket pod emoticon
+	{ "^dR^*[turret]", true,  true,  TEAM_HUMANS }, // rocket pod. FIXME: we need a rocket pod emoticon
 	{ "[turret]",      true,  true,  TEAM_HUMANS },
 	{ "[reactor]",     true,  true,  TEAM_HUMANS },
 


### PR DESCRIPTION
this fixes the blue colour of the rocket pod indicator leaking into the rest of the kill message (this only affected emoticon mode).