### PR TITLE
Activate ent

### DIFF
--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -2186,11 +2186,13 @@ static void ClientThink_real( gentity_t *self )
 		trap_Trace( &trace, client->ps.origin, nullptr, nullptr, point, self->s.number, MASK_SHOT, 0 );
 
 		ent = &g_entities[ trace.entityNum ];
+		bool activableTarget = ent->s.eType == entityType_t::ET_BUILDABLE || ent->s.eType == entityType_t::ET_MOVER;
 
 		if ( ent && ent->use &&
 		     ( !ent->buildableTeam   || ent->buildableTeam   == client->pers.team ) &&
 		     ( !ent->conditions.team || ent->conditions.team == client->pers.team ) &&
-		     Distance( self->s.origin, ent->s.origin ) < ENTITY_USE_RANGE )
+		     trace.fraction < 1.0f &&
+				 !( activableTarget && Distance( self->s.origin, ent->s.origin ) < ENTITY_USE_RANGE ) )
 		{
 			if ( g_debugEntities.Get() > 1 )
 			{


### PR DESCRIPTION
This allows mappers to make doors or buttons that can react to `+activate`, if the spawnflag 0x80 is set. Needs a way to test it actually work, though. @cu-kai you might be interested.