### PR TITLE
cg_event.cpp: add a messageSuicide to MOD_TELEFRAG

### DIFF
--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -528,6 +528,7 @@ static void CG_Obituary( entityState_t *ent )
 
 			case MOD_TELEFRAG:
 				message = G_( "%s%s ^*tried to invade %s%s%s^*'s personal space" );
+				messageSuicide = G_( "%s%s ^*ended up in the void" );
 				break;
 
 			case MOD_SLAP:


### PR DESCRIPTION
This fixes deaths caused by the `target_kill` logic entity being attributed to "noname" in the obituary.

Since there's no way you can telefrag yourself, this seems the most appropriate change rather than change the sgame logic (which remains unchanged since Tremulous).