### PR TITLE
gameplay: fill with 5 bots by default

### DIFF
--- a/dist/configs/config/server.cfg
+++ b/dist/configs/config/server.cfg
@@ -66,7 +66,7 @@ set g_teamForceBalance 2
 //set g_doWarmup 1
 //set g_warmup 20
 
-set g_bot_defaultFill 3
+set g_bot_defaultFill 5
 
 // following the first map, start this rotation
 // rotation is described in game/maprotation.cfg


### PR DESCRIPTION
Currently, the official server instance uses `bot fill 5` and I think the default configuration should be as close as possible as the official server. This PR improves on this point.

The impact of this setting is mostly (if not only) seen in the testing servers, which are the only ones to use the default configuration.
To me, it is obvious that 3 vs 3 is not representative of the desired gameplay in unvanquished. If it was, then many of the current games would be botless, as we frequently have more than 5 real players, yet there are usually still bots on the most played servers (@sweet235 's server).
And most of the maps are too big for teams of 3 players. Even in the 11 official maps, only 5 of them are small maps.
Imo, you need at least 4 people per team in most situations, so that: 2 can attack or build an outpost, 1 can rebuild, and last can cover the builder. Ofc, bots do not rebuild yet, but with tactics it's possible for a builder to ask a single bot to cover them, while keeping the 2 other bots in aggressive stances to keep pressure on enemy.

To be honest, I do not think "5" is the good number: this depends on maps, really.
In my (current) opinion, `bot fill 4` would be better, as it is (imo) more adapted (than fill or 3 or 5) to 5 of the official maps (antares, chasm, parpax, plat23, yocto), while the 6 remaining maps (forlorn, perseus, spacetracks, station15, thunder, vega) are much bigger and could use 5 or even more (especially for thunder).

Better bot fill values could be put in the rotation file, but this would only trigger on rotation changes, and would drop back to 3 for callvotes. It's also a PR that would affect a different repo, which is more annoying to do.

