### PR TITLE
Fix a navgen error handling bug

### DIFF
--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -1010,7 +1010,7 @@ bool NavmeshGenerator::Step()
 	if ( status.code != NavgenStatus::OK )
 	{
 		d_->status = status;
-		return true;
+		return false;
 	}
 
 	for ( int i = 0; i < ntiles; i++ )


### PR DESCRIPTION
Due to the wrong return there the error message was not logged and the cached failure file not written.