### PR TITLE
Fix random substitution of particles, fix #1509

### DIFF
--- a/src/cgame/cg_particles.cpp
+++ b/src/cgame/cg_particles.cpp
@@ -365,11 +365,12 @@ static particle_t *CG_SpawnNewParticle( baseParticle_t *bp, particleEjector_t *p
 				}
 			}
 
-			break;
+			return p;
 		}
 	}
 
-	return p;
+	Log::Notice( "MAX_PARTICLES hit" );
+	return nullptr;
 }
 
 /*
@@ -497,11 +498,12 @@ static particleEjector_t *CG_SpawnNewParticleEjector( baseParticleEjector_t *bpe
 				Log::Debug( "PE %s created", ps->class_->name );
 			}
 
-			break;
+			return pe;
 		}
 	}
 
-	return pe;
+	Log::Notice( "MAX_PARTICLE_EJECTORS hit" );
+	return nullptr;
 }
 
 /*
@@ -551,11 +553,12 @@ particleSystem_t *CG_SpawnNewParticleSystem( qhandle_t psHandle )
 				Log::Debug( "PS %s created", bps->name );
 			}
 
-			break;
+			return ps;
 		}
 	}
 
-	return ps;
+	Log::Notice( "MAX_PARTICLE_SYSTEMS hit" );
+	return nullptr;
 }
 
 /*


### PR DESCRIPTION
Fix random substitution of particles, fix:

- https://github.com/Unvanquished/Unvanquished/issues/1509

I noticed there was no error message for `MAX_PARTICLE_SYSTEMS` being hit. I noticed there was an error message for `MAX_TRAIL_SYSTEMS` being hit.

So I wanted to add such error message to debug #1509.

So I decided to copy-paste the `MAX_TRAIL_SYSTEMS` hit message and implement it for `MAX_PARTICLE_SYSTEMS` the cargo cult way.

So I discovered the particle code was not only not printing anything when `MAX_PARTICLE_SYSTEMS` was hit, but was also returning the particle system anyway, so the previous one before `MAX_PARTICLE_SYSTEMS` is hit.

After that we may want to increase `MAX_PARTICLE_SYSTEMS` anyway because with maps like dretchstorm with grenade spam this log message would be spammed a lot.

---

_Edit:_ In fact the code did not return an unitialized particle system or unitialized particle when `MAX_PARTICLE_SYSTEMS` or `MAX_PARTICLES`  was hit, but returned the last known particle system or particle instead. That explains 1. why the particles systems and particles were valid ones but were not the expected ones and 2. we did not experienced any crash.