### PR TITLE
remove unused `G_Physics()` `msec` argument

### DIFF
--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -2437,11 +2437,11 @@ void G_RunFrame( int levelTime )
 			case entityType_t::ET_BUILDABLE:
 				// TODO: Do buildables make any use of G_Physics' functionality apart from the call
 				//       to G_RunThink?
-				G_Physics( ent, msec );
+				G_Physics( ent );
 				continue;
 
 			case entityType_t::ET_CORPSE:
-				G_Physics( ent, msec );
+				G_Physics( ent );
 				continue;
 
 			case entityType_t::ET_MOVER:
@@ -2451,7 +2451,7 @@ void G_RunFrame( int levelTime )
 			default:
 				if ( ent->physicsObject )
 				{
-					G_Physics( ent, msec );
+					G_Physics( ent );
 					continue;
 				}
 				else if ( i < MAX_CLIENTS )

--- a/src/sgame/sg_physics.cpp
+++ b/src/sgame/sg_physics.cpp
@@ -92,7 +92,7 @@ G_Physics
 
 ================
 */
-void G_Physics( gentity_t *ent, int )
+void G_Physics( gentity_t *ent )
 {
 	vec3_t  origin;
 	trace_t tr;

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -256,7 +256,7 @@ void              G_namelog_update_name( gclient_t *client );
 void              G_namelog_cleanup();
 
 // sg_physcis.c
-void              G_Physics( gentity_t *ent, int msec );
+void              G_Physics( gentity_t *ent );
 
 // sg_session.c
 void              G_ReadSessionData( gclient_t *client );


### PR DESCRIPTION
sg_physics: remove unused `G_Physics()` `msec` argument

An older commit silenced a warning the very lazy way: [`b211d958`](https://github.com/Unvanquished/Unvanquished/commit/b211d95894b5482fb30d7e4f0bf9a724c7f60d96#diff-e26f1fb658bcb1ffffb7df1a23b7ddf2d5cdc264f687d9f660c43781bc79ea46L91), let's remove this unused variable entirely!
