### PR TITLE
Lesser autojump

### DIFF
--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -555,12 +555,6 @@ static bool BotShouldJump( gentity_t *self, const gentity_t *blocker, const glm:
 	trace_t trace;
 	const float TRACE_LENGTH = BOT_OBSTACLE_AVOID_RANGE;
 
-	//blocker is not on our team, so ignore
-	if ( G_Team( self ) != G_Team( blocker ) )
-	{
-		return false;
-	}
-
 	//already normalized
 
 	class_t pClass = static_cast<class_t>( self->client->ps.stats[STAT_CLASS] );

--- a/src/shared/bot_nav_shared.cpp
+++ b/src/shared/bot_nav_shared.cpp
@@ -134,6 +134,18 @@ static void ParseOption( Str::StringRef name, Str::StringRef value, Str::StringR
 			return;
 		}
 	}
+	else if ( Str::IsIEqual( name, "autojump" ) )
+	{
+		if ( floatValue < 0.f || 1.f < floatValue )
+		{
+			Log::Warn( "%s: incorrect value for autojump '%f': must be between 0 and 1", file, floatValue );
+		}
+		else if ( floatValue > 0.0f )
+		{
+			config.autojumpSecurity = floatValue;
+			return;
+		}
+	}
 	else
 	{
 		Log::Warn( "%s: unknown navgen setting '%s'", file, name );

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -49,7 +49,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 #define MIN_WALK_NORMAL 0.7f
 
 static const int NAVMESHSET_MAGIC = 'M'<<24 | 'S'<<16 | 'E'<<8 | 'T'; //'MSET';
-static const int NAVMESHSET_VERSION = 8; // Increment when navgen algorithm or data format changes
+static const int NAVMESHSET_VERSION = 9; // Increment when navgen algorithm or data format changes
 
 enum navPolyFlags
 {
@@ -85,8 +85,9 @@ struct NavgenConfig {
 	int excludeSky; // boolean - exclude surfaces with surfaceparm sky from navmesh generation
 	int filterGaps; // boolean - add new walkable spans so bots can walk over small gaps
 	int generatePatchTris; // boolean - generate triangles from the BSP's patches
+	float autojumpSecurity; // percentage - allow to use part of jump magnitude (with default gravity of 800) as stepsize. The result can not excess the agent's height, except if STEPSIZE is already doing it (then STEPSIZE will be used)
 
-	static NavgenConfig Default() { return { 2.0f, STEPSIZE, 1, 1, 1, 1 }; }
+	static NavgenConfig Default() { return { 2.0f, STEPSIZE, 1, 1, 1, 1, 0.5f }; }
 };
 
 struct NavgenMapIdentification


### PR DESCRIPTION
Port the "lesser auto-jump" feature from my betterai branch.

It has to be noted that this PR will enable more than just automatically jumping around geometry: it will *also* let bots jump over enemy structures, which includes the barricade.

Speaking about the barricade, I do have commits that properly handle this case, *but* this is out of scope. Simply put, the barricade needs to be considered an obstacle even for friends if it's high enough, otherwise bots will stuck on it. A simple way to see that is to put barricade in plat23's bases, on top of the slopes. This should make tyrant tyrant bots stuck (and overall should annoy any tyrant player a lot obviously).

It has to be said that there is a risk of seeing mantis (notably) doing their deadly head-dance with this change. To prevent this, if it is really desired to, requires to reinject the team test, or at least only ignore enemies.
Myself, I think the deadly head dancing is not a problem. If it is a problem, then players should also be prevented to do so.