### PR TITLE
Shuffle entity state bits to fix base beacons

### DIFF
--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -2505,7 +2505,7 @@ static void CG_PlayerUpgrades( centity_t *cent, refEntity_t *torso )
 	}
 
 	// creep below bloblocked players
-	if ( es->eFlags & EF_BLOBLOCKED )
+	if ( es->modelindex2 & PF_BLOBLOCKED )
 	{
 		vec3_t  temp, origin, up = { 0.0f, 0.0f, 1.0f };
 		trace_t tr;

--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -1431,15 +1431,6 @@ static void PlayerStateToEntityState( playerState_t *ps, entityState_t *s )
 		s->eFlags &= ~EF_DEAD;
 	}
 
-	if ( ps->stats[ STAT_STATE ] & SS_BLOBLOCKED )
-	{
-		s->eFlags |= EF_BLOBLOCKED;
-	}
-	else
-	{
-		s->eFlags &= ~EF_BLOBLOCKED;
-	}
-
 	if ( ps->externalEvent )
 	{
 		s->event = ps->externalEvent;
@@ -1494,6 +1485,15 @@ static void PlayerStateToEntityState( playerState_t *ps, entityState_t *s )
 	else
 	{
 		s->modelindex2 &= ~PF_JETPACK_ACTIVE;
+	}
+
+	if ( ps->stats[ STAT_STATE ] & SS_BLOBLOCKED )
+	{
+		s->modelindex2 |= PF_BLOBLOCKED;
+	}
+	else
+	{
+		s->modelindex2 &= ~PF_BLOBLOCKED;
 	}
 
 	// use misc field to store team/class info:

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -477,14 +477,17 @@ enum persEnum_t
 #define EF_FIRING3          BIT(17) // third fire
 #define EF_MOVER_STOP       BIT(18) // will push otherwise
 #define EF_CONNECTION       BIT(19) // draw a connection trouble sprite
-#define EF_BLOBLOCKED       BIT(20) // caught by a trapper
-#define EF_TYPING           BIT(21) // player is writting a message
+
+// overlaps with EF_BC_DYING!
+#define EF_TYPING           BIT(21) // player is writing a message
 
 // for beacons:
+#define EF_BC_BASE_OUTPOST  BIT(20) // base is an outpost
 #define EF_BC_DYING         BIT(21) // beacon is fading out
 #define EF_BC_ENEMY         BIT(22) // entity/base is from the enemy
 #define EF_BC_TAG_PLAYER    BIT(23) // entity is a player
-#define EF_BC_BASE_OUTPOST  BIT(24) // base is an outpost
+
+// EF_xxx can go up to BIT(23)
 
 #define EF_BC_TAG_RELEVANT  (EF_BC_ENEMY|EF_BC_TAG_PLAYER)   // relevant flags for tags
 #define EF_BC_BASE_RELEVANT (EF_BC_ENEMY|EF_BC_BASE_OUTPOST) // relevant flags for bases
@@ -495,6 +498,8 @@ enum persEnum_t
 // entityState_t->modelIndex2 "public flags" when used for client entities
 #define PF_JETPACK_ENABLED  BIT(0)
 #define PF_JETPACK_ACTIVE   BIT(1)
+#define PF_BLOBLOCKED       BIT(2) // caught by a trapper
+// PF_xxx can go up to BIT(MODELINDEX_BITS - 1)
 
 enum weaponMode_t
 {


### PR DESCRIPTION
EF_BC_BASE_OUTPOST was BIT(24) which is out of range for the eFlags netcode.

Fixes #2390. Though I must say it doesn't look so great -- the tent icon has terrible jaggies.