### PR TITLE
Ai fight range

### DIFF
--- a/src/sgame/sg_api.cpp
+++ b/src/sgame/sg_api.cpp
@@ -183,11 +183,6 @@ void trap_Trace( trace_t *results, const glm::vec3& start, const glm::vec3& mins
 	trap_Trace( results, &start[0], &mins[0], &maxs[0], &end[0], passEntityNum, contentmask, skipmask );
 }
 
-int trap_PointContents(const vec3_t point, int passEntityNum)
-{
-	return G_CM_PointContents( point, passEntityNum );
-}
-
 void trap_SetBrushModel(gentity_t *ent, const char *name)
 {
 	G_CM_SetBrushModel( ent, name );

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -799,6 +799,7 @@ AINodeStatus_t BotActionSay( gentity_t *self, AIGenericNode_t *node )
 // TODO: Move decision making out of these actions and into the rest of the behavior tree
 AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 {
+	bool canSprint = true;
 	team_t myTeam = ( team_t ) self->client->pers.team;
 	botMemory_t* mind = self->botMind;
 
@@ -886,7 +887,8 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 	BotAimAtEnemy( self );
 	glm::vec3 dummy;
 	//TODO when failing to handle obstacle, a different target should be taken
-	BotAvoidObstacles( self, dummy, false );
+	//  for now, at least avoid wasting stamina
+	canSprint = !BotAvoidObstacles( self, dummy, false );
 	BotMoveInDir( self, MOVE_FORWARD );
 
 	if ( inAttackRange )
@@ -932,7 +934,7 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 		BotStandStill( self );
 	}
 
-	BotSprint( self, true );
+	BotSprint( self, canSprint );
 
 	return STATUS_RUNNING;
 }

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -837,7 +837,8 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 	}
 
 	//aliens have radar so they will always 'see' the enemy if they are in radar range
-	if ( myTeam == TEAM_ALIENS && DistanceToGoalSquared( self ) <= Square( g_bot_aliensenseRange.Get() ) )
+	float goalDist = DistanceToGoalSquared( self );
+	if ( myTeam == TEAM_ALIENS && goalDist <= Square( g_bot_aliensenseRange.Get() ) )
 	{
 		mind->enemyLastSeen = level.time;
 	}
@@ -895,21 +896,21 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 	// We are human and we either are at fire range, or have
 	// a direct path to goal
 
-	if ( mind->skillLevel >= 3 && DistanceToGoalSquared( self ) < Square( MAX_HUMAN_DANCE_DIST )
-	        && ( DistanceToGoalSquared( self ) > Square( MIN_HUMAN_DANCE_DIST ) || mind->skillLevel < 5 )
+	if ( mind->skillLevel >= 3 && goalDist < Square( MAX_HUMAN_DANCE_DIST )
+	        && ( goalDist > Square( MIN_HUMAN_DANCE_DIST ) || mind->skillLevel < 5 )
 	        && self->client->ps.weapon != WP_PAIN_SAW && self->client->ps.weapon != WP_FLAMER )
 	{
 		BotMoveInDir( self, MOVE_BACKWARD );
 	}
-	else if ( DistanceToGoalSquared( self ) <= Square( MIN_HUMAN_DANCE_DIST ) ) //we wont hit this if skill < 5
+	else if ( goalDist <= Square( MIN_HUMAN_DANCE_DIST ) ) //we wont hit this if skill < 5
 	{
 		// We will be moving toward enemy, strafing to
 		// the result: we go around the enemy
 		BotAlternateStrafe( self );
 	}
-	else if ( DistanceToGoalSquared( self ) >= Square( MAX_HUMAN_DANCE_DIST ) && self->client->ps.weapon != WP_PAIN_SAW )
+	else if ( goalDist >= Square( MAX_HUMAN_DANCE_DIST ) && self->client->ps.weapon != WP_PAIN_SAW )
 	{
-		if ( DistanceToGoalSquared( self ) - Square( MAX_HUMAN_DANCE_DIST ) < 100 )
+		if ( goalDist - Square( MAX_HUMAN_DANCE_DIST ) < 100 )
 		{
 			BotStandStill( self );
 		}

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -826,12 +826,15 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 		return STATUS_FAILURE;
 	}
 
-	if ( WeaponIsEmpty( BG_GetPlayerWeapon( &self->client->ps ), &self->client->ps ) && myTeam == TEAM_HUMANS )
+	playerState_t const* ps = &self->client->ps;
+	weapon_t primaryWP = static_cast<weapon_t>( ps->weapon );
+	weapon_t equipedWP = BG_GetPlayerWeapon( ps );
+	if ( WeaponIsEmpty( equipedWP, ps ) && myTeam == TEAM_HUMANS )
 	{
 		G_ForceWeaponChange( self, WP_BLASTER );
 	}
 
-	if ( BG_GetPlayerWeapon( &self->client->ps ) == WP_HBUILD )
+	if ( equipedWP == WP_HBUILD )
 	{
 		G_ForceWeaponChange( self, WP_BLASTER );
 	}
@@ -898,7 +901,7 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 
 	if ( mind->skillLevel >= 3 && goalDist < Square( MAX_HUMAN_DANCE_DIST )
 	        && ( goalDist > Square( MIN_HUMAN_DANCE_DIST ) || mind->skillLevel < 5 )
-	        && self->client->ps.weapon != WP_PAIN_SAW && self->client->ps.weapon != WP_FLAMER )
+	        && primaryWP != WP_PAIN_SAW && primaryWP != WP_FLAMER )
 	{
 		BotMoveInDir( self, MOVE_BACKWARD );
 	}
@@ -908,7 +911,7 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 		// the result: we go around the enemy
 		BotAlternateStrafe( self );
 	}
-	else if ( goalDist >= Square( MAX_HUMAN_DANCE_DIST ) && self->client->ps.weapon != WP_PAIN_SAW )
+	else if ( goalDist >= Square( MAX_HUMAN_DANCE_DIST ) && primaryWP != WP_PAIN_SAW )
 	{
 		if ( goalDist - Square( MAX_HUMAN_DANCE_DIST ) < 100 )
 		{

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -885,7 +885,7 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 	BotAimAtEnemy( self );
 	BotMoveInDir( self, MOVE_FORWARD );
 
-	if ( inAttackRange || self->client->ps.weapon == WP_PAIN_SAW )
+	if ( inAttackRange )
 	{
 		BotFireWeaponAI( self );
 	}

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -884,6 +884,9 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 	// direct navmesh path and we are not at at weapon range (if human)
 
 	BotAimAtEnemy( self );
+	glm::vec3 dummy;
+	//TODO when failing to handle obstacle, a different target should be taken
+	BotAvoidObstacles( self, dummy, false );
 	BotMoveInDir( self, MOVE_FORWARD );
 
 	if ( inAttackRange )

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -740,7 +740,7 @@ AINodeStatus_t BotActionAlternateStrafe( gentity_t *self, AIGenericNode_t* )
 
 AINodeStatus_t BotActionClassDodge( gentity_t *self, AIGenericNode_t* )
 {
-	BotClassMovement( self, BotTargetInAttackRange( self, self->botMind->goal ) );
+	BotClassMovement( self, BotTargetInAttackRange( self, self->botMind->goal, BG_GetPlayerWeapon( &self->client->ps ) ) );
 	return STATUS_SUCCESS;
 }
 
@@ -869,8 +869,7 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 	}
 
 	// We have a valid visible target
-
-	bool inAttackRange = BotTargetInAttackRange( self, self->botMind->goal );
+	bool inAttackRange = BotTargetInAttackRange( self, self->botMind->goal, BG_GetPlayerWeapon( &self->client->ps ) );
 	self->botMind->enemyLastSeen = level.time;
 
 	if ( !( inAttackRange && myTeam == TEAM_HUMANS ) && !mind->nav().directPathToGoal )

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -841,7 +841,8 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 
 	//aliens have radar so they will always 'see' the enemy if they are in radar range
 	float goalDist = DistanceToGoalSquared( self );
-	if ( myTeam == TEAM_ALIENS && goalDist <= Square( g_bot_aliensenseRange.Get() ) )
+	if ( ( myTeam == TEAM_ALIENS && goalDist <= Square( g_bot_aliensenseRange.Get() ) )
+	  || ( myTeam == TEAM_HUMANS && goalDist <= Square( RADAR_RANGE ) && BG_InventoryContainsUpgrade( UP_RADAR, ps->stats ) ) )
 	{
 		mind->enemyLastSeen = level.time;
 	}

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -731,7 +731,7 @@ static bool BotFindSteerTarget( gentity_t *self, glm::vec3 &dir )
 // This function tries to detect obstacles and to find a way
 // around them. It always sets dir as the output value.
 // Returns true on error
-static bool BotAvoidObstacles( gentity_t *self, glm::vec3 &dir, bool ignoreGeometry )
+bool BotAvoidObstacles( gentity_t *self, glm::vec3 &dir, bool ignoreGeometry )
 {
 	dir = self->botMind->nav().glm_dir();
 	gentity_t const *blocker = BotGetPathBlocker( self, dir );

--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -226,7 +226,7 @@ static AIValue_t inAttackRange( gentity_t *self, const AIValue_t *params )
 
 	target = e.ent;
 
-	return AIBoxInt( BotTargetInAttackRange( self, target ) );
+	return AIBoxInt( BotTargetInAttackRange( self, target, BG_GetPlayerWeapon( &self->client->ps ) ) );
 }
 
 static AIValue_t isVisible( gentity_t *self, const AIValue_t *params )

--- a/src/sgame/sg_bot_public.h
+++ b/src/sgame/sg_bot_public.h
@@ -74,6 +74,7 @@ void G_BotFill( bool immediately );
 void G_BotRemoveObstacle( qhandle_t handle );
 void G_BotUpdateObstacles();
 std::string G_BotToString( gentity_t *bot );
+bool BotAvoidObstacles( gentity_t *self, glm::vec3 &dir, bool ignoreGeometry );
 
 const char BOT_DEFAULT_BEHAVIOR[] = "default";
 const char BOT_NAME_FROM_LIST[] = "*";

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -37,6 +37,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 static Cvar::Range<Cvar::Cvar<int>> g_bot_defaultSkill( "g_bot_defaultSkill", "Default skill value bots will have when added", Cvar::NONE, 5, 1, 9 );
 static Cvar::Cvar<int> g_bot_alienAimDelay = Cvar::Cvar<int>( "g_bot_alienAimDelay", "make bots of alien team slower to aim", Cvar::NONE, 250 );
 static Cvar::Cvar<int> g_bot_humanAimDelay = Cvar::Cvar<int>( "g_bot_humanAimDelay", "make bots of human team slower to aim", Cvar::NONE, 150 );
+static Cvar::Range<Cvar::Cvar<int>> g_bot_distanceAccuracy( "g_bot_distanceAccuracy", "maximum random offset a bot can have, in weapon range%", Cvar::NONE, 0, 0, 50 );
 
 //consider bot to be stuck if it does not move farther than this in some period of time
 constexpr float BOT_STUCK_RADIUS = 150.0f;
@@ -1292,7 +1293,7 @@ bool BotTargetInAttackRange( const gentity_t *self, botTarget_t target, weapon_t
 			break;
 		case WP_PAIN_SAW:
 			// Start running the saw when an alien is closeby, not literally in range
-			range = PAINSAW_RANGE + 60;
+			range = PAINSAW_RANGE;
 			secondaryRange = 0;
 			break;
 		case WP_FLAMER:
@@ -1375,6 +1376,13 @@ bool BotTargetInAttackRange( const gentity_t *self, botTarget_t target, weapon_t
 	bool allowed = hit->s.eType != entityType_t::ET_BUILDABLE || g_bot_attackStruct.Get();
 	float dist = glm::distance( muzzle, VEC2GLM( trace.endpos ) );
 	range = std::max( range, secondaryRange );
+
+	float blurrDist = ( SkillModifier( self->botMind->skillLevel ) * g_bot_distanceAccuracy.Get() ) / 2;
+	if ( random() <= 0.5 )
+	{
+		blurrDist = -blurrDist;
+	}
+	range = blurrDist;
 
 	return hitEnemy && allowed && dist <= range;
 }

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1209,7 +1209,7 @@ bool BotChangeGoalPos( gentity_t *self, const glm::vec3 &goal )
 	return BotChangeGoal( self, target );
 }
 
-bool BotTargetInAttackRange( const gentity_t *self, botTarget_t target )
+bool BotTargetInAttackRange( const gentity_t *self, botTarget_t target, weapon_t wp )
 {
 	ASSERT( target.targetsValidEntity() );
 
@@ -1224,7 +1224,7 @@ bool BotTargetInAttackRange( const gentity_t *self, botTarget_t target )
 	AngleVectors( VEC2GLM( self->client->ps.viewangles ), &forward, &right, &up );
 	muzzle = G_CalcMuzzlePoint( self, forward );
 	targetPos = target.getPos();
-	switch ( self->client->ps.weapon )
+	switch ( wp )
 	{
 		case WP_ABUILD:
 			range = ABUILDER_CLAW_RANGE;

--- a/src/sgame/sg_bot_util.h
+++ b/src/sgame/sg_bot_util.h
@@ -61,7 +61,7 @@ void  BotAimAtLocation( gentity_t *self, const glm::vec3 &target );
 bool BotEntityIsValidTarget( const gentity_t *ent );
 bool BotEntityIsValidEnemyTarget( const gentity_t *self, const gentity_t *enemy );
 bool BotTargetIsVisible( const gentity_t *self, botTarget_t target, int mask );
-bool BotTargetInAttackRange( const gentity_t *self, botTarget_t target );
+bool BotTargetInAttackRange( const gentity_t *self, botTarget_t target, weapon_t wp );
 void BotTargetToRouteTarget( const gentity_t *self, botTarget_t target, botRouteTarget_t *routeTarget );
 botTarget_t BotGetRoamTarget( const gentity_t *self );
 botTarget_t BotGetRetreatTarget( const gentity_t *self );

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -46,17 +46,31 @@ static bool TakesDamages( gentity_t const* ent )
 
 void G_ForceWeaponChange( gentity_t *ent, weapon_t weapon )
 {
+	if ( G_Team( ent ) != TEAM_HUMANS ) // only humans have several weapons
+	{
+		return;
+	}
 	playerState_t *ps = &ent->client->ps;
+
+	weapon_t prevWeapon = BG_GetPlayerWeapon( &ent->client->ps );
+	weapon_t newWeapon;
 
 	if ( weapon == WP_NONE || !BG_InventoryContainsWeapon( weapon, ps->stats ) )
 	{
 		// switch to the first non blaster weapon
-		ps->persistant[ PERS_NEWWEAPON ] = BG_PrimaryWeapon( ps->stats );
+		newWeapon = BG_PrimaryWeapon( ps->stats );
 	}
 	else
 	{
-		ps->persistant[ PERS_NEWWEAPON ] = weapon;
+		newWeapon = weapon;
 	}
+
+	if ( newWeapon == prevWeapon )
+	{
+		return;
+	}
+
+	ps->persistant[ PERS_NEWWEAPON ] = newWeapon;
 
 	// force this here to prevent flamer effect from continuing
 	ps->generic1 = WPM_NOTFIRING;


### PR DESCRIPTION
This PR notably fixes:

* the painsaw dance, when bots detect a building or an alien on the ceiling while equiped with a painsaw. This also happens with flamer, even if it's rarer for obvious reasons (longer range)
* bots literally cutting their way through friends (and killing said friends for no reason, this is very frustrating to be psawed by a bot while all aliens are far away)
* bots waiting to be at range of their target to be able to damage it, despite blaster being available (and an actual weapon)
* bots unable to jump over or steer around blockers to reach their target. This is not perfect though, if no path can be found they'll still walk endlessly against the obstacle, but this is still a net improvement over current situation

Note that the range handling is not perfect, bots could (and likely should) swap weapons a bit sooner, because weapon swapping takes time, and there is the aforementioned bad obstacle management. I still think this is a huge improvement.

The PR was tested against `eggs-master` 1.1 because this map made those problems very obvious and easy to reproduce.
I think it's ready for reviewing, but I won't merge it until I have run more extensive tests. There might even be some possible cleanup in there.