### PR TITLE
AI: less stubborn bots

### DIFF
--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -187,6 +187,10 @@ private:
 	//avoid relying on buttons to remember what AI was doing
 	bool wantSprinting = false;
 	bool exhausted = false;
+	int lastDistanceScan = INT_MIN;
+public:
+	//TODO this should be private
+	bool rescanMoveTarget( void );
 };
 
 navMeshStatus_t G_BotSetupNav( const botClass_t *botClass, qhandle_t *navHandle );

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -35,6 +35,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <glm/gtx/vector_angle.hpp>
 
 static Cvar::Range<Cvar::Cvar<int>> g_bot_defaultSkill( "g_bot_defaultSkill", "Default skill value bots will have when added", Cvar::NONE, 5, 1, 9 );
+static Cvar::Cvar<int> g_bot_rescanDelay( "g_bot_rescanDelay", "delay in ms between 2 scans for close buildings in some actions. Smaller delays can impact performances. MUST BE > 0.", Cvar::NONE, 5000 );
 
 static void ListTeamEquipment( gentity_t *self, unsigned int (&numUpgrades)[UP_NUM_UPGRADES], unsigned int (&numWeapons)[WP_NUM_WEAPONS] );
 static const int MIN_SKILL = 1;
@@ -2510,4 +2511,22 @@ glm::vec3 ProjectPointOntoVector( const glm::vec3 &point, const glm::vec3 &lineP
 	glm::vec3 pointRelative = point - linePoint1;
 	glm::vec3 lineDir = glm::normalize( linePoint2 - linePoint1 );
 	return linePoint1 + glm::dot( pointRelative, lineDir ) * lineDir;
+}
+
+bool botMemory_t::rescanMoveTarget( void )
+{
+	int delay = g_bot_rescanDelay.Get();
+	if ( delay <= 0 )
+	{
+		Log::Warn( "g_bot_rescanDelay have invalid value %d, using 5s instead.", delay );
+		g_bot_rescanDelay.Set( 5000 );
+		delay = 5000;
+	}
+	if ( level.time >= lastDistanceScan + delay )
+	{
+		lastDistanceScan = level.time;
+		return true;
+	}
+
+	return false;
 }


### PR DESCRIPTION
This PR allows bots to change their target if they detect a matching target closer than the original one.
There is a default setting of 5s between rescans.

To test this:

* place a telenode somewhere near a wall (and remove other ones)
* place an armory on the other side of the wall, so that the distance is very short. A navmesh between node and armoury is, ofc, required
* place a 2nd armory so that it's on the path between 1st arm and node, but have a "ghost distance"  higher than for the 1st armory
* add a human bot: it will try to go at first armory, but will change it's mind to use the closer one on the road

This PR is still a draft because of lack of documentation and insufficiently testing. Development tests were done on `eggs-master` 1.1 since this map have a perfect shape to demonstrate the feature.