### PR TITLE
cvar for custom aliensense range for bots

### DIFF
--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -823,7 +823,7 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 	}
 
 	//aliens have radar so they will always 'see' the enemy if they are in radar range
-	if ( myTeam == TEAM_ALIENS && DistanceToGoalSquared( self ) <= Square( ALIENSENSE_RANGE ) )
+	if ( myTeam == TEAM_ALIENS && DistanceToGoalSquared( self ) <= Square( g_bot_aliensenseRange.Get() ) )
 	{
 		self->botMind->enemyLastSeen = level.time;
 	}

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -959,7 +959,7 @@ gentity_t* BotFindBestEnemy( gentity_t *self )
 			continue;
 		}
 
-		if ( DistanceSquared( self->s.origin, target->s.origin ) > Square( ALIENSENSE_RANGE ) )
+		if ( DistanceSquared( self->s.origin, target->s.origin ) > Square( g_bot_aliensenseRange.Get() ) )
 		{
 			continue;
 		}
@@ -1003,7 +1003,7 @@ gentity_t* BotFindBestEnemy( gentity_t *self )
 gentity_t* BotFindClosestEnemy( gentity_t *self )
 {
 	gentity_t* closestEnemy = nullptr;
-	float minDistance = Square( ALIENSENSE_RANGE );
+	float minDistance = Square( g_bot_aliensenseRange.Get() );
 	gentity_t *target;
 
 	for ( target = g_entities; target < &g_entities[level.num_entities - 1]; target++ )

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -213,6 +213,7 @@ extern Cvar::Cvar<int> g_bot_chasetime;
 extern Cvar::Cvar<int> g_bot_reactiontime;
 extern Cvar::Cvar<bool> g_bot_infiniteFunds;
 extern Cvar::Cvar<bool> g_bot_infiniteMomentum;
+extern Cvar::Cvar<int> g_bot_aliensenseRange;
 extern Cvar::Modified<Cvar::Cvar<int>> g_bot_defaultFill;
 
 #endif // SG_EXTERN_H_

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -287,6 +287,7 @@ Cvar::Cvar<int> g_bot_chasetime("g_bot_chasetime", "bots stop chasing after x ms
 Cvar::Cvar<int> g_bot_reactiontime("g_bot_reactiontime", "bots' reaction time to enemies (milliseconds)", Cvar::NONE, 500);
 Cvar::Cvar<bool> g_bot_infiniteFunds("g_bot_infiniteFunds", "give bots unlimited funds", Cvar::NONE, false);
 Cvar::Cvar<bool> g_bot_infiniteMomentum("g_bot_infiniteMomentum", "allow bots to ignore momentum, but not other restrictions", Cvar::NONE, false);
+Cvar::Cvar<int> g_bot_aliensenseRange("g_bot_aliensenseRange", "custom aliensense range for bots", Cvar::NONE, ALIENSENSE_RANGE);
 
 //</bot stuff>
 


### PR DESCRIPTION
In the bot code, replace the hard-coded aliensense range by a cvar. This does affect human bots too, to some degree.

This is useful on small maps, where the aliensense range covers large parts of the map. The bots will pick their goal quite freely inside a sphere with the aliensense range as radius. Reducing the radius is desirable on some small maps.