### PR TITLE
Spiker rework

### DIFF
--- a/src/sgame/components/SpikerComponent.cpp
+++ b/src/sgame/components/SpikerComponent.cpp
@@ -168,7 +168,7 @@ bool SpikerComponent::SafeToShoot(glm::vec3 direction) {
 		trap_Trace( &trace, entity.oldEnt->s.origin, mins, maxs, &end[0], entity.oldEnt->num(), ma->clipmask, 0 );
 		gentity_t* hit = &g_entities[trace.entityNum];
 
-		if (hit && ( not use_experiments && G_OnSameTeam( entity.oldEnt, hit ) ) || ( use_experiments && G_Team( hit ) == TEAM_HUMANS ) ) {
+		if (hit && ( ( not use_experiments && G_OnSameTeam( entity.oldEnt, hit ) ) || ( use_experiments && G_Team( hit ) == TEAM_HUMANS ) ) ) {
 			return true;
 		}
 	}


### PR DESCRIPTION
This PR is a crude spiker rework.

There are 2 ideas in here:

1. only fire spikes that might hit an enemy, instead of spikes that might not hit a friend. This removes A LOT of friendly fire
2. number of fired spikes impact the cooldown time: the less spikes sent, the faster the spiker can shoot anew

It probably needs more work, notably a real spike count, but this should be enough to test if the idea is worth working on.

Fix #1722