### PR TITLE
cg_rocket_draw: support emoticons in map and author names

### DIFF
--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -3594,12 +3594,12 @@ static void CG_Rocket_DrawLoadingText()
 
 static void CG_Rocket_DrawLevelAuthors()
 {
-	Rocket_SetInnerRML( cg.mapAuthors.c_str(), RP_QUAKE );
+	Rocket_SetInnerRML( cg.mapAuthors.c_str(), RP_QUAKE | RP_EMOTICONS );
 }
 
 static void CG_Rocket_DrawLevelName()
 {
-	Rocket_SetInnerRML( cg.mapLongName.c_str(), RP_QUAKE );
+	Rocket_SetInnerRML( cg.mapLongName.c_str(), RP_QUAKE | RP_EMOTICONS );
 }
 
 static void CG_Rocket_DrawMOTD()


### PR DESCRIPTION
I first thought it was a bug, but maybe we prefer to keep map and author names text only.

The author name can be used elsewhere than a map a map loading screen, etc.

What's your thought about it?