### PR TITLE
Loop entities (almost) once in `CG_AddPacketEntities()`

### DIFF
--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -28,6 +28,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "cg_local.h"
 
+/* It is dynamically adjusted in CG_AddPacketEntities() to avoid looping
+over unused entities. It can be zero before the first frame starts adding
+entities, as none is added yet and none has to be removed yet. This should
+never reach the MAX_GENTITIES value. */
+int cg_highestActiveEntity = 0;
+
 static Cvar::Range<Cvar::Cvar<float>>
 	cg_drawDebugDistance("cg_drawDebugDistance", "draw a sphere around "
 			"yourself to give an idea of distances. Set this "
@@ -1318,10 +1324,17 @@ void CG_AddPacketEntities()
 
 	bool done[ MAX_GENTITIES ] = {};
 
+	int highest = 0;
+
 	// add each entity sent over by the server
 	for ( const entityState_t &ent : cg.snap->entities )
 	{
-		const unsigned num = ent.number;
+		const int num = ent.number;
+
+		/* This number may become cg_highestActiveEntity
+		to loop over the cg_entities array. */
+		ASSERT( num < MAX_GENTITIES );
+
 		centity_t *cent = &cg_entities[ num ];
 
 		if ( !cent->valid )
@@ -1334,9 +1347,22 @@ void CG_AddPacketEntities()
 		CG_AddCEntity( cent );
 
 		done[ num ] = true;
+
+		if ( num > highest )
+		{
+			highest = num;
+		}
 	}
-	
-	for ( unsigned num = 0; num < MAX_GENTITIES; num++ )
+
+	/* We assume cg_highestActiveEntity is never greater
+	than MAX_GENTITIES. cg_highestActiveEntity carries the
+	highest entity number used by an entity in the previous game frame.
+	This is not the amount of entities from the previous game frame.
+	A short lifetime entity with a small number will have to be removed
+	before a long lifetime entity with a high number is removed, so we
+	need to iterate all entities (valid or not) up to the previous highest
+	entity to be able to remove entities that should be removed. */
+	for ( int num = 0; num <= cg_highestActiveEntity; num++ )
 	{
 		if ( done[ num ] )
 		{
@@ -1352,6 +1378,20 @@ void CG_AddPacketEntities()
 
 		cent->valid = false;
 	}
+
+	if ( cg_debugPVS.Get() )
+	{
+		if ( highest > cg_highestActiveEntity )
+		{
+			Log::Debug("Highest entity in PVS went up: %u", highest);
+		}
+		else if ( highest < cg_highestActiveEntity )
+		{
+			Log::Debug("Highest entity in PVS went down: %u", highest);
+		}
+	}
+
+	cg_highestActiveEntity = highest;
 
 	//make an attempt at drawing bounding boxes of selected entity types
 	if ( cg_drawBBOX.Get() > 0 )

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1782,6 +1782,7 @@ enum altShader_t
 extern  cgs_t               cgs;
 extern  cg_t                cg;
 extern  centity_t           cg_entities[ MAX_GENTITIES ];
+extern int cg_highestActiveEntity;
 
 extern  weaponInfo_t        cg_weapons[ 32 ];
 extern  upgradeInfo_t       cg_upgrades[ 32 ];

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -757,6 +757,7 @@ struct centity_t
 	entityState_t  nextState; // from cg.nextFrame, if available
 	bool       interpolate; // true if next is valid to interpolate to
 	bool       currentValid; // true if cg.frame holds this entity
+	bool valid;
 
 	int            muzzleFlashTime; // move to playerEntity?
 	int            previousEvent;
@@ -818,8 +819,6 @@ struct centity_t
 
 	float                 radarVisibility;
 
-	bool              valid;
-	bool              oldValid;
 	int                   pvsEnterTime;
 
 	cbeacon_t             beacon;

--- a/src/cgame/cg_minimap.cpp
+++ b/src/cgame/cg_minimap.cpp
@@ -514,11 +514,10 @@ CG_MinimapDrawTeammates
 static void CG_MinimapDrawTeammates( const minimap_t* m )
 {
     int ownTeam = CG_MyTeam();
-    int i;
 
-    for ( i = 0; i < MAX_GENTITIES; i++ )
+    for ( int num = 0; num <= cg_highestActiveEntity; num++ )
     {
-        centity_t* mate = &cg_entities[i];
+        centity_t* mate = &cg_entities[ num ];
         playerEntity_t* state = &mate->pe;
 
         int clientNum = mate->currentState.clientNum;

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -1279,7 +1279,7 @@ static void CG_LoadClientInfo( clientInfo_t *ci )
 	// frames for this new model
 	clientNum = ci - cgs.clientinfo;
 
-	for ( int num = 0; num <= cg_highestActiveEntity; num++ )
+	for ( int num = 0; num < MAX_CLIENTS; num++ )
 	{
 		centity_t *cent = &cg_entities[ num ];
 		if ( cent->currentState.clientNum == clientNum &&

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -1279,12 +1279,13 @@ static void CG_LoadClientInfo( clientInfo_t *ci )
 	// frames for this new model
 	clientNum = ci - cgs.clientinfo;
 
-	for ( i = 0; i < MAX_GENTITIES; i++ )
+	for ( int num = 0; num <= cg_highestActiveEntity; num++ )
 	{
-		if ( cg_entities[ i ].currentState.clientNum == clientNum &&
-		     cg_entities[ i ].currentState.eType == entityType_t::ET_PLAYER )
+		centity_t *cent = &cg_entities[ num ];
+		if ( cent->currentState.clientNum == clientNum &&
+		     cent->currentState.eType == entityType_t::ET_PLAYER )
 		{
-			CG_ResetPlayerEntity( &cg_entities[ i ] );
+			CG_ResetPlayerEntity( cent );
 		}
 	}
 }
@@ -3489,16 +3490,14 @@ void CG_PlayerDisconnect( vec3_t org )
 
 centity_t *CG_GetLocation( vec3_t origin )
 {
-	int       i;
-	centity_t *eloc, *best;
 	float     bestlen, len;
 
-	best = nullptr;
+	centity_t *best = nullptr;
 	bestlen = 3.0f * 8192.0f * 8192.0f;
 
-	for ( i = MAX_CLIENTS; i < MAX_GENTITIES; i++ )
+	for ( int num = MAX_CLIENTS; num <= cg_highestActiveEntity; num++ )
 	{
-		eloc = &cg_entities[ i ];
+		centity_t *eloc = &cg_entities[ num ];
 
 		if ( !eloc->valid || eloc->currentState.eType != entityType_t::ET_LOCATION )
 		{


### PR DESCRIPTION
cg_ents: process entities only once in `CG_AddPacketEntities()`

1. Iterate all valid entities and process them.
2. Iterate all entities skipping already processed ones.

cgame: use dynamic `cg_maxEntities` when iterating entities

Instead of iterating entities to `MAX_GENTITIES`, iterate to `cg_maxEntities` which is the the limit above the highest entity in current scene.

cgame: use dynamic `cg_highestActiveEntity` when iterating entities

Instead of iterating entities to `MAX_GENTITIES,` iterate to `cg_highestActiveEntity` (included) which is the highest entity number from the previous frame.

cg_players: loop clients to `MAX_CLIENTS`

---

_Original message:_

By running the game on Orbit profiler after having tweaked the engine to run on 0 frametime and not be polluted by any idling code, and running the game with lowest graphics profile, this code was the functions reported to eat CPU cycles after the actual rendering by the OpenGL driver and the RmlUi code..

We recently increased `MAX_GENTITIES` if I'm right. This code iterated the entities four time, and two time up to the max.

It now iterates only once, to the max.

~~This is WIP, I kept the separate rewrite steps I've done if that can help reviewers to understand what I am doing, and verify step after step I'm not doing any mistakes.~~