### PR TITLE
Make alien bots follow upward navcons, if present

### DIFF
--- a/src/sgame/botlib/bot_nav.cpp
+++ b/src/sgame/botlib/bot_nav.cpp
@@ -192,6 +192,14 @@ static bool overOffMeshConnectionStart( const Bot_t *bot, rVec pos )
 	return false;
 }
 
+bool G_IsBotOverNavcon( int botClientNum )
+{
+	rVec spos;
+	Bot_t *bot = &agents[ botClientNum ];
+	GetEntPosition( botClientNum, spos );
+	return overOffMeshConnectionStart( bot, spos );
+}
+
 static void G_UpdatePathCorridor( Bot_t *bot, rVec spos, botRouteTargetInternal target )
 {
 	bot->corridor.movePosition( spos, bot->nav->query, &bot->nav->filter );
@@ -208,6 +216,24 @@ static void G_UpdatePathCorridor( Bot_t *bot, rVec spos, botRouteTargetInternal 
 	}
 
 	FindWaypoints( bot, bot->cornerVerts, bot->cornerFlags, bot->cornerPolys, &bot->numCorners, MAX_CORNERS );
+}
+
+bool G_BotPathNextCorner( int botClientNum, glm::vec3 &result )
+{
+	Bot_t *bot = &agents[ botClientNum ];
+	gentity_t *ent = &g_entities[ botClientNum ];
+	if ( bot->numCorners <= 0 )
+	{
+		return false;
+	}
+	dtPolyRef firstPoly = bot->corridor.getFirstPoly();
+	float corner[ 3 ] = { 0 };
+	bot->nav->query->closestPointOnPolyBoundary( firstPoly, ent->s.origin, corner );
+	float temp = corner[ 1 ];
+	corner[ 1 ] = corner[ 2 ];
+	corner[ 2 ] = temp;
+	result = VEC2GLM( corner );
+	return true;
 }
 
 void G_BotUpdatePath( int botClientNum, const botRouteTarget_t *target, botNavCmd_t *cmd )

--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -180,6 +180,7 @@ public:
 	glm::vec3 stuckPosition;
 
 	int spawnTime;
+	int lastNavconTime;
 
 	Util::optional< glm::vec3 > userSpecifiedPosition;
 	Util::optional< int > userSpecifiedClientNum;
@@ -194,7 +195,9 @@ navMeshStatus_t G_BotSetupNav( const NavgenConfig &config, const botClass_t *bot
 void G_BotShutdownNav();
 void G_BotSetNavMesh( int botClientNum, qhandle_t navHandle );
 bool G_BotFindRoute( int botClientNum, const botRouteTarget_t *target, bool allowPartial );
+bool G_BotPathNextCorner( int botClientNum, glm::vec3 &result );
 void G_BotUpdatePath( int botClientNum, const botRouteTarget_t *target, botNavCmd_t *cmd );
+bool G_IsBotOverNavcon( int botClientNum );
 bool G_BotNavTrace( int botClientNum, botTrace_t *botTrace, const glm::vec3& start, const glm::vec3& end );
 glm::vec3 ProjectPointOntoVector( const glm::vec3 &point, const glm::vec3 &linePoint1, const glm::vec3 &linePoint2 );
 

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1801,6 +1801,27 @@ void BotFireWeapon( weaponMode_t mode, usercmd_t *botCmdBuffer )
 		usercmdPressButton( botCmdBuffer->buttons, BTN_ATTACK3 );
 	}
 }
+
+static Cvar::Cvar<int> g_bot_upwardAttackMinHeight("g_bot_upwardAttackMinHeight", "minial height difference for bots to attack upwards.", Cvar::NONE, 100);
+
+// return true if an upward attack is started or in progress, false otherwise
+static bool BotAttackUpward( gentity_t *self )
+{
+	glm::vec3 ownPos = VEC2GLM( self->s.origin );
+	const gentity_t *targetEnt = self->botMind->goal.getTargetedEntity();
+	if ( !targetEnt )
+	{
+		return false;
+	}
+	glm::vec3 targetPos = VEC2GLM( targetEnt->s.origin );
+	if ( targetPos.z - ownPos.z > g_bot_upwardAttackMinHeight.Get() )
+	{
+		BotMoveUpward( self, targetPos );
+		return true;
+	}
+	return false;
+}
+
 void BotClassMovement( gentity_t *self, bool inAttackRange )
 {
 	botMemory_t *mind = self->botMind;
@@ -1829,20 +1850,36 @@ void BotClassMovement( gentity_t *self, bool inAttackRange )
 			botIsSmall = true;
 			break;
 		case PCL_ALIEN_LEVEL1:
+			if ( BotAttackUpward( self ) )
+			{
+				return;
+			}
 			botIsSmall = true;
 			break;
 		case PCL_ALIEN_LEVEL2:
 		case PCL_ALIEN_LEVEL2_UPG:
+			if ( BotAttackUpward( self ) )
+			{
+				return;
+			}
 			botIsSmall = true;
 			botIsJumper = self->botMind->botSkillSet[BOT_A_MARA_JUMP_ON_ATTACK];
 			break;
 		case PCL_ALIEN_LEVEL3:
+			if ( BotAttackUpward( self ) )
+			{
+				return;
+			}
 			break;
 		case PCL_ALIEN_LEVEL3_UPG:
 			if ( mind->goal.getTargetType() == entityType_t::ET_BUILDABLE && self->client->ps.ammo > 0 && inAttackRange )
 			{
 				// Don't move when sniping buildings as adv goon
 				BotStandStill( self );
+			}
+			else if ( BotAttackUpward( self ) )
+			{
+				return;
 			}
 			break;
 		case PCL_ALIEN_LEVEL4:

--- a/src/sgame/sg_bot_util.h
+++ b/src/sgame/sg_bot_util.h
@@ -121,6 +121,7 @@ void         G_BotNavCleanup();
 bool     FindRouteToTarget( gentity_t *self, botTarget_t target, bool allowPartial );
 bool         BotMoveToGoal( gentity_t *self );
 void         BotSetNavmesh( gentity_t  *ent, class_t newClass );
+void         BotMoveUpward( gentity_t *self, glm::vec3 target );
 
 // local navigation
 void     BotWalk( gentity_t *self, bool enable );


### PR DESCRIPTION
This makes it possible to place navcons that lead upwards. Mantis, marauder and dragoon will use special moves to follow them. Mantis and dragoon will leap, marauder will walljump.

There are two main reasons why this is useful:

- To make bots escape from pits, where they would converge otherwise
- To make bots attack the high ground

Two cases are handled: a bot moving peacefully to a point, and a bot attacking a target. These are the two main modes in which a bot can be. It is not enough to handle the peaceful case alone, since this would prevent a bot from doing the special move when it has spotted an enemy.

Two cvars are added to control this:

- `g_bot_upwardNavconMinHeight` sets a minimum height difference for the special moves to trigger, when moving peacefully
- `g_bot_upwardAttackMinHeight` does the same, but for fighting

All this is completely optional. If we don't want the peaceful case, we don't put navcons leading upwards. If we don't want the fighting case, we set `g_bot_upwardAttackMinHeight` to a big number.

I have tested this on my server for a while, and it seems to works well enough. Even if a bot fails at doing the special move, the unstick will kick in eventually and it will try again.

Of course, some care must be taken while placing the navcons. Currently, this does not take the map geometry into account. A cvar `g_bot_upwardLeapAngleCorr` allows to adjust the angle for mantis and dragoon leaps.