### PR TITLE
Crouching bots

### DIFF
--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -741,6 +741,27 @@ static bool BotAvoidObstacles( gentity_t *self, glm::vec3 &dir, bool ignoreGeome
 		return false;
 	}
 
+	// check for crouching
+	{
+		glm::vec3 playerMins;
+		glm::vec3 playerCMaxs;
+		trace_t trace;
+
+		class_t pClass = static_cast<class_t>( self->client->ps.stats[STAT_CLASS] );
+		BG_BoundingBox( pClass, &playerMins, nullptr, &playerCMaxs, nullptr, nullptr );
+
+		glm::vec3 origin = VEC2GLM( self->s.origin );
+		glm::vec3 end = origin + BOT_OBSTACLE_AVOID_RANGE * dir;
+
+		//make sure we are moving into a block
+		trap_Trace( &trace, origin, playerMins, playerCMaxs, end, self->s.number, MASK_PLAYERSOLID, 0 );
+		if ( trace.fraction >= 1.0f )
+		{
+			self->botMind->cmdBuffer.upmove = -127;
+			return false;
+		}
+	}
+
 	if ( BotShouldJump( self, blocker, dir ) )
 	{
 		BotJump( self );

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -78,6 +78,7 @@ static Cvar::Range<Cvar::Cvar<int>> msecPerFrame(
 	Cvar::NONE, 20, 1, 1500 );
 
 static Cvar::Cvar<int> frameToggle("g_bot_navgen_frame", "FOR INTERNAL USE", Cvar::NONE, 0);
+static Cvar::Cvar<bool> g_bot_autocrouch("g_bot_autocrouch", "wether bots should crouch when they detect an obstacle or not", Cvar::NONE, true);
 
 static NavmeshGenerator navgen;
 static std::vector<class_t> navgenQueue;
@@ -742,6 +743,7 @@ static bool BotAvoidObstacles( gentity_t *self, glm::vec3 &dir, bool ignoreGeome
 	}
 
 	// check for crouching
+	if ( g_bot_autocrouch.Get() )
 	{
 		glm::vec3 playerMins;
 		glm::vec3 playerCMaxs;

--- a/src/shared/bot_nav_shared.cpp
+++ b/src/shared/bot_nav_shared.cpp
@@ -173,7 +173,7 @@ static void ParseOption( Str::StringRef name, Str::StringRef value, Str::StringR
 // cellheight 2.5
 NavgenConfig ReadNavgenConfig( Str::StringRef mapName )
 {
-	NavgenConfig config = NavgenConfig::Default();
+	NavgenConfig config;
 	std::string path = Str::Format( "maps/%s.navcfg", mapName );
 	int f;
 	int len = BG_FOpenGameOrPakPath( path, f );
@@ -241,7 +241,7 @@ std::string GetNavmeshHeader( fileHandle_t f, const NavgenConfig& config, NavMes
 		return "Map is different version";
 	}
 
-	if ( 0 != memcmp( &header.config, &config, sizeof(NavgenConfig) ) )
+	if ( header.config != config )
 	{
 		return "Navgen config changed";
 	}

--- a/src/shared/bot_nav_shared.cpp
+++ b/src/shared/bot_nav_shared.cpp
@@ -146,6 +146,14 @@ static void ParseOption( Str::StringRef name, Str::StringRef value, Str::StringR
 			return;
 		}
 	}
+	else if ( Str::IsIEqual( name, "crouch" ) )
+	{
+		if ( !( boolValue & ~1 ) )
+		{
+			config.crouchSupport = boolValue;
+			return;
+		}
+	}
 	else
 	{
 		Log::Warn( "%s: unknown navgen setting '%s'", file, name );

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -79,16 +79,32 @@ enum navPolyAreas
 
 // Part of header which must contain 4-byte members only
 struct NavgenConfig {
-	float requestedCellHeight;
-	float stepSize;
-	int excludeCaulk; // boolean - exclude caulk surfaces
-	int excludeSky; // boolean - exclude surfaces with surfaceparm sky from navmesh generation
-	int filterGaps; // boolean - add new walkable spans so bots can walk over small gaps
-	int generatePatchTris; // boolean - generate triangles from the BSP's patches
-	float autojumpSecurity; // percentage - allow to use part of jump magnitude (with default gravity of 800) as stepsize. The result can not excess the agent's height, except if STEPSIZE is already doing it (then STEPSIZE will be used)
-	bool crouchSupport = true;
+	float requestedCellHeight = 2.f;
+	float stepSize = STEPSIZE;
+	float autojumpSecurity = 0.5f; // percentage - allow to use part of jump magnitude (with default gravity of 800) as stepsize. The result can not excess the agent's height, except if STEPSIZE is already doing it (then STEPSIZE will be used)
+	bool excludeCaulk = 1; // exclude caulk surfaces
+	bool excludeSky = 1; // exclude surfaces with surfaceparm sky from navmesh generation
+	bool filterGaps = 1; // add new walkable spans so bots can walk over small gaps
+	bool generatePatchTris = 1; // generate triangles from the BSP's patches
+	bool crouchSupport = true; // use crouchMaxs.z value instead of Maxs.z to compute paths
 
-	static NavgenConfig Default() { return { 2.0f, STEPSIZE, 1, 1, 1, 1, 0.5f }; }
+	bool operator==( NavgenConfig const& other ) const
+	{
+		return requestedCellHeight == other.requestedCellHeight
+			&& stepSize == other.stepSize
+			&& excludeCaulk == other.excludeCaulk
+			&& excludeSky == other.excludeSky
+			&& filterGaps == other.filterGaps
+			&& generatePatchTris == other.generatePatchTris
+			&& autojumpSecurity == other.autojumpSecurity
+			&& crouchSupport == other.crouchSupport
+			;
+	}
+
+	bool operator!=( NavgenConfig const& other ) const
+	{
+		return not ( *this == other );
+	}
 };
 
 struct NavgenMapIdentification

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -86,6 +86,7 @@ struct NavgenConfig {
 	int filterGaps; // boolean - add new walkable spans so bots can walk over small gaps
 	int generatePatchTris; // boolean - generate triangles from the BSP's patches
 	float autojumpSecurity; // percentage - allow to use part of jump magnitude (with default gravity of 800) as stepsize. The result can not excess the agent's height, except if STEPSIZE is already doing it (then STEPSIZE will be used)
+	bool crouchSupport = true;
 
 	static NavgenConfig Default() { return { 2.0f, STEPSIZE, 1, 1, 1, 1, 0.5f }; }
 };

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -49,7 +49,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 #define MIN_WALK_NORMAL 0.7f
 
 static const int NAVMESHSET_MAGIC = 'M'<<24 | 'S'<<16 | 'E'<<8 | 'T'; //'MSET';
-static const int NAVMESHSET_VERSION = 9; // Increment when navgen algorithm or data format changes
+static const int NAVMESHSET_VERSION = 10; // Increment when navgen algorithm or data format changes
 
 enum navPolyFlags
 {

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -86,7 +86,7 @@ struct NavgenConfig {
 	bool excludeSky = 1; // exclude surfaces with surfaceparm sky from navmesh generation
 	bool filterGaps = 1; // add new walkable spans so bots can walk over small gaps
 	bool generatePatchTris = 1; // generate triangles from the BSP's patches
-	bool crouchSupport = true; // use crouchMaxs.z value instead of Maxs.z to compute paths
+	bool crouchSupport = false; // use crouchMaxs.z value instead of Maxs.z to compute paths
 
 	bool operator==( NavgenConfig const& other ) const
 	{

--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -1028,7 +1028,7 @@ void NavmeshGenerator::StartGeneration( class_t species )
 	//radius of agent (BBox maxs[0] or BBox maxs[1])
 	float radius = dimensions->maxs[0];
 	//height of agent (BBox maxs[2] - BBox mins[2])
-	float height = dimensions->crouchMaxs[2] - dimensions->mins[2];
+	float height = ( config_.crouchSupport ? dimensions->crouchMaxs[2] : dimensions->maxs[2] ) - dimensions->mins[2];
 
 	const float cellSize = radius / 4.0f;
 

--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -1028,7 +1028,7 @@ void NavmeshGenerator::StartGeneration( class_t species )
 	//radius of agent (BBox maxs[0] or BBox maxs[1])
 	float radius = dimensions->maxs[0];
 	//height of agent (BBox maxs[2] - BBox mins[2])
-	float height = dimensions->maxs[2] - dimensions->mins[2];
+	float height = dimensions->crouchMaxs[2] - dimensions->mins[2];
 
 	const float cellSize = radius / 4.0f;
 


### PR DESCRIPTION
Allows bots to crouch when it would allow them to pass an obstacle.

This is placed before other tests since it's notably more reliable than jumping.
Note that all this part of the code needs a serious refactoring, that I'll do *after* all PRs concerning bot movements are merged. And after said refactoring, I shuold be able to bring back the wallwalking experiments, too.

Fix #1862 