### PR TITLE
increase MAX_CBEACONS to 1024

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -630,7 +630,7 @@ struct buildableCache_t
 
 //=================================================
 
-#define MAX_CBEACONS 50
+#define MAX_CBEACONS 1024
 
 // the point of keeping the beacon data separately from centities is
 // to be able to handle virtual beacons (client-side beacons) without


### PR DESCRIPTION
50 is not even enough to hold all players, since the max client value is 64. This is thus obviously not enough for PvE layouts or any game where builders put enough buildings around.

1024 can probably be "not enough", or it might be "too much", I just choose this value randomly.

Easy way to test is to load a PvE map, I did the test with eggs-master.