### PR TITLE
allow to disable obituaries

### DIFF
--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -102,8 +102,13 @@ static const struct {
 	{ "",              true,  false, TEAM_NONE },   // (MOD_REPLACE)
 };
 
+static Cvar::Cvar<bool> cg_showObituaries( "cg_showObituaries", "show obituaries in chat", Cvar::NONE, true );
 static void CG_Obituary( entityState_t *ent )
 {
+	if ( not cg_showObituaries.Get() )
+	{
+		return;
+	}
 	int          mod;
 	int          target, attacker, assistant;
 	int          attackerClass = -1;

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -105,7 +105,7 @@ static const struct {
 static Cvar::Cvar<bool> cg_showObituaries( "cg_showObituaries", "show obituaries in chat", Cvar::NONE, true );
 static void CG_Obituary( entityState_t *ent )
 {
-	if ( not cg_showObituaries.Get() )
+	if ( !cg_showObituaries.Get() )
 	{
 		return;
 	}


### PR DESCRIPTION
This allows to actually read the chat, instead of it being constantly flushed by the "foo killed bar" spam. Of course, it's disabled by default as people might enjoy it.