### PR TITLE
Firebomb cooldown

### DIFF
--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -3310,7 +3310,7 @@ static bool Cmd_Sell_conflictingUpgrades( gentity_t *ent, upgrade_t upgrade )
 	return sold;
 }
 
-Cvar::Cvar<int> g_firebombCooldown("g_firebombCooldown", "clients can buy firebombs every <g_firebombCooldown> milliseconds.", Cvar::NONE, 0);
+static Cvar::Cvar<int> g_firebombCooldown("g_firebombCooldown", "clients can buy firebombs every <g_firebombCooldown> milliseconds.", Cvar::NONE, 0);
 
 static bool Cmd_Buy_internal( gentity_t *ent, const char *s, bool sellConflicting, bool quiet )
 {

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -625,6 +625,7 @@ struct gclient_t
 	int        lastCombatTime; // time of last damage received/dealt from/to clients
 	int        lastAmmoRefillTime;
 	int        lastFuelRefillTime;
+	int        lastFirebombBuyTime;
 
 	unlagged_t unlaggedHist[ MAX_UNLAGGED_MARKERS ];
 	unlagged_t unlaggedBackup;


### PR DESCRIPTION
Add a cvar `g_firebombCooldown`, that is a time span in milliseconds. Clients can only buy a firebomb after at least this much time has passed since the previous buy. I set this to 2 seconds on my server right now.

I only did this after i have been convinced by multiple persons that we currently have a problem with firebomb spam. Some people (@illwieckz) can regularly be observed standing on armouries and throwing 10 firebombs in a fraction of a second. That makes my poor machine slow and my blind bots burn.