### PR TITLE
Cancel votes

### DIFF
--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -47,6 +47,7 @@ Cvar::Range<Cvar::Cvar<int>> g_killDelay(
 		"how many seconds a player needs to wait before the suicide (/kill) command take effect",
 		Cvar::NONE,
 		20, 0, 120 );
+static Cvar::Cvar<bool> g_voteAllowChange( "g_voteAllowChange", "allows players to change their mind (they might spam)", Cvar::NONE, false );
 
 /*
 ==================
@@ -2271,8 +2272,13 @@ static void Cmd_Vote_f( gentity_t *ent )
 
 	if ( ent->client->pers.voted & ( 1 << team ) )
 	{
-		trap_SendServerCommand( ent->num(), va( "print_tr %s %s", QQ( N_("$1$: vote canceled") ),  cmd ) );
-		G_Vote( ent, team, false );
+		if ( g_voteAllowChange.Get() )
+		{
+			trap_SendServerCommand( ent->num(), va( "print_tr %s %s", QQ( N_("$1$: vote canceled") ),  cmd ) );
+			G_Vote( ent, team, false );
+			return;
+		}
+		trap_SendServerCommand( ent->num(), va( "print_tr %s %s", QQ( N_("$1$: vote already cast") ),  cmd ) );
 		return;
 	}
 

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -2271,8 +2271,8 @@ static void Cmd_Vote_f( gentity_t *ent )
 
 	if ( ent->client->pers.voted & ( 1 << team ) )
 	{
-		trap_SendServerCommand( ent->num(),
-		                        va( "print_tr %s %s", QQ( N_("$1$: vote already cast") ),  cmd ) );
+		trap_SendServerCommand( ent->num(), va( "print_tr %s %s", QQ( N_("$1$: vote canceled") ),  cmd ) );
+		G_Vote( ent, team, false );
 		return;
 	}
 

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -2017,57 +2017,50 @@ void G_Vote( gentity_t *ent, team_t team, bool voting )
 		return;
 	}
 
-	if ( voting && (ent->client->pers.voted & ( 1 << team )) )
-	{
-		return;
-	}
-
-	if ( !voting && !( ent->client->pers.voted & ( 1 << team ) ) )
-	{
-		return;
-	}
-
-	ent->client->pers.voted |= 1 << team;
-
 	//TODO maybe refactor vote no/yes in one and only one variable and divide the NLOC by 2 ?
-
 	if ( voting )
 	{
+		if ( (ent->client->pers.voted & ( 1 << team )) )
+		{
+			return;
+		}
 		level.team[ team ].voted++;
-	}
-	else
-	{
-		level.team[ team ].voted--;
-	}
-
-	if ( ent->client->pers.voteYes & ( 1 << team ) )
-	{
-		if ( voting )
+		ent->client->pers.voted |= 1 << team;
+		if ( ent->client->pers.voteYes & ( 1 << team ) )
 		{
 			level.team[ team ].voteYes++;
-		}
-		else
-		{
-			level.team[ team ].voteYes--;
+			trap_SetConfigstring( CS_VOTE_YES + team, va( "%d", level.team[ team ].voteYes ) );
 		}
 
-		trap_SetConfigstring( CS_VOTE_YES + team,
-		                      va( "%d", level.team[ team ].voteYes ) );
-	}
-
-	if ( ent->client->pers.voteNo & ( 1 << team ) )
-	{
-		if ( voting )
+		if ( ent->client->pers.voteNo & ( 1 << team ) )
 		{
 			level.team[ team ].voteNo++;
+			trap_SetConfigstring( CS_VOTE_NO + team, va( "%d", level.team[ team ].voteNo ) );
 		}
-		else
-		{
-			level.team[ team ].voteNo--;
-		}
+		return;
+	}
 
-		trap_SetConfigstring( CS_VOTE_NO + team,
-		                      va( "%d", level.team[ team ].voteNo ) );
+	if ( !( ent->client->pers.voted & ( 1 << team ) ) )
+	{
+		return;
+	}
+
+	ent->client->pers.voted &= ~( 1 << team );
+	level.team[ team ].voted--;
+	bool wasYes = ent->client->pers.voteYes & ( 1 << team );
+	bool wasNo  = ent->client->pers.voteNo  & ( 1 << team );
+	ent->client->pers.voteYes &= ~( 1 << team );
+	ent->client->pers.voteNo  &= ~( 1 << team );
+
+	if ( wasYes )
+	{
+		level.team[ team ].voteYes--;
+		trap_SetConfigstring( CS_VOTE_YES + team, va( "%d", level.team[ team ].voteYes ) );
+	}
+	if ( wasNo )
+	{
+		level.team[ team ].voteNo--;
+		trap_SetConfigstring( CS_VOTE_NO + team, va( "%d", level.team[ team ].voteNo ) );
 	}
 }
 


### PR DESCRIPTION
This PR does 3 things:

1. it makes the G_Vote function less convoluted
2. fixing the vote cancellation system while we're at it
3. allows players to change their mind (i.e. because of a typo or because they were talked into a different point of view)

fix #1941 
fix #1940 as "good enough" since then admins can immediately change their mind (if they allowed that beforehand, but if they're admins...)