### PR TITLE
Implement `common/outside`

### DIFF
--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -245,6 +245,11 @@ static bool SkipSurface( const NavgenConfig *config, const dshader_t *shader ) {
 		return true;
 	}
 
+	if ( !Q_stricmp( shader->shader, "textures/common/outside" ) )
+	{
+		return true;
+	}
+
 	return false;
 }
 


### PR DESCRIPTION
Implement `common/outside` material.

See PR on data side for more explanations:

- https://github.com/UnvanquishedAssets/tex-common_src.dpkdir/pull/6

To not draw navmesh on the surface, the navgen is expected to actually recognize the `textures/common/outside` name the same way it already recognizes `textures/common/caulk`, which was probably an early attempt to exclude some surfaces that are usually not seen within maps. I see no reason to waste a precious surfaceparm for that.

I also created special `SkipContent` and `SkipSurface` functions to be usable on both brushes and patches without omitting stuff. Even if some skip conditions doesn't make much sense (like a caulked patch), a mapper can still do nonsensical things (like a caulked patch) so we better be sure we filter everything.