### PR TITLE
bots: Delete useless warning

### DIFF
--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -281,7 +281,6 @@ bool G_BotAdd( const char *name, team_t team, int skill, const char *behavior, b
 
 	if ( clientNum < 0 )
 	{
-		Log::Warn( "no more slots for bot" );
 		return false;
 	}
 	gentity_t *bot = &g_entities[ clientNum ];


### PR DESCRIPTION
It's spammy. There are two calls to G_BotAdd(): One in sg_admin.cpp and another when running the bot fill code. The sg_admin codepath already warns when a bot cannot be added. The bot fill code path shouldn't care if a bot can't be added.

Fixes #1812