### PR TITLE
Bring back the flee skills merge (3/3)

### DIFF
--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -108,12 +108,9 @@ enum bot_skill
 
 	// situation awareness and survival
 	BOT_B_PAIN, // basic awareness: notice an enemy if it bites you, or shoots at you
-	BOT_A_MARA_JUMP_ON_FLEE,
-	BOT_A_LEAP_ON_FLEE, // mantis
-	BOT_A_POUNCE_ON_FLEE, // dragoon and adv dragoon
-	BOT_A_TYRANT_CHARGE_ON_FLEE,
+	BOT_A_FAST_FLEE,
+	BOT_H_FAST_FLEE,
 	BOT_A_SAFE_BARBS, // don't barb yourself as adv goon
-	BOT_H_RUN_ON_FLEE, // when fleeing, RUN
 	BOT_H_BUY_MODERN_ARMOR, // if this is disabled, bot will buy the second-to-last unlocked armor, and will never buy battlesuit
 	BOT_H_PREFER_ARMOR, // prefer to buy armor rather than guns
 	BOT_H_MEDKIT, // knows the medkit even exist

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -981,16 +981,18 @@ bool BotMoveToGoal( gentity_t *self )
 	weaponMode_t wpm = WPM_NONE;
 	int magnitude = 0;
 	const playerState_t& ps  = self->client->ps;
+	if ( ( G_Team( self ) == TEAM_HUMANS && self->botMind->skillSet[BOT_H_FAST_FLEE] )
+			|| ( G_Team( self ) == TEAM_ALIENS && self->botMind->skillSet[BOT_A_FAST_FLEE] ) )
+	{
+		return true;
+	}
 	switch ( ps.stats [ STAT_CLASS ] )
 	{
 		case PCL_HUMAN_NAKED:
 		case PCL_HUMAN_LIGHT:
 		case PCL_HUMAN_MEDIUM:
 		case PCL_HUMAN_BSUIT:
-			if ( self->botMind->skillSet[BOT_H_RUN_ON_FLEE] )
-			{
-				BotSprint( self, true );
-			}
+			BotSprint( self, true );
 			break;
 		//those classes do not really have capabilities allowing them to be
 		//significantly faster while fleeing (except jumps, but that also
@@ -1000,7 +1002,7 @@ bool BotMoveToGoal( gentity_t *self )
 		case PCL_ALIEN_LEVEL0:
 			break;
 		case PCL_ALIEN_LEVEL1:
-			if ( self->botMind->skillSet[BOT_A_LEAP_ON_FLEE] && ps.weaponCharge <= 50 ) // I don't remember why 50
+			if ( ps.weaponCharge <= 50 ) // I don't remember why 50
 			{
 				wpm = WPM_SECONDARY;
 				magnitude = LEVEL1_POUNCE_MINPITCH;
@@ -1014,31 +1016,28 @@ bool BotMoveToGoal( gentity_t *self )
 			// a lot of maneuverability
 			int msec = level.time - level.previousTime;
 			constexpr float jumpChance = 0.2f; // chance per second
-			if ( self->botMind->skillSet[BOT_A_MARA_JUMP_ON_FLEE] && (jumpChance / 1000.0f) * msec > random() )
+			if ( (jumpChance / 1000.0f) * msec > random() )
 			{
 				BotJump( self );
 			}
 			break;
 		}
 		case PCL_ALIEN_LEVEL3:
-			if ( self->botMind->skillSet[BOT_A_POUNCE_ON_FLEE] && ps.weaponCharge < LEVEL3_POUNCE_TIME )
+			if ( ps.weaponCharge < LEVEL3_POUNCE_TIME )
 			{
 				wpm = WPM_SECONDARY;
 				magnitude = LEVEL3_POUNCE_JUMP_MAG;
 			}
 		break;
 		case PCL_ALIEN_LEVEL3_UPG:
-			if ( self->botMind->skillSet[BOT_A_POUNCE_ON_FLEE] && ps.weaponCharge < LEVEL3_POUNCE_TIME_UPG )
+			if ( ps.weaponCharge < LEVEL3_POUNCE_TIME_UPG )
 			{
 				wpm = WPM_SECONDARY;
 				magnitude = LEVEL3_POUNCE_JUMP_MAG_UPG;
 			}
 			break;
 		case PCL_ALIEN_LEVEL4:
-			if ( self->botMind->skillSet[BOT_A_TYRANT_CHARGE_ON_FLEE] )
-			{
-				wpm = WPM_SECONDARY;
-			}
+			wpm = WPM_SECONDARY;
 		break;
 	}
 	if ( wpm != WPM_NONE )

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -84,8 +84,8 @@ static bool G_SkillPreferred( Str::StringRef behavior )
 	return G_GetPreferredSkillset().find( behavior ) != G_GetPreferredSkillset().end();
 }
 
-// aliens have 84 points to spend max, but we give them a bit less for balancing
-static int skillsetBudgetAliens = 80;
+// aliens have 67 points to spend max, but we give them a bit less for balancing
+static int skillsetBudgetAliens = 63;
 // humans have 48 points to spend max
 static int skillsetBudgetHumans = 48;
 
@@ -175,14 +175,14 @@ static const std::vector<botSkillTreeElement_t> movement_skills = {
 static const std::vector<botSkillTreeElement_t> survival_skills = {
 	// aliens
 	{ "safe-barbs",         BOT_A_SAFE_BARBS,            3, pred_alien, {} },
-	{ "a-fast-flee",        BOT_A_FAST_FLEE,             4, pred_always, {} },
+	{ "a-fast-flee",        BOT_A_FAST_FLEE,             7, pred_alien, {} },
 
 
 	// humans
 	{ "buy-modern-armor",   BOT_H_BUY_MODERN_ARMOR, 10, pred_human, {
 		{ "prefer-armor", BOT_H_PREFER_ARMOR, 5, pred_human, {} },
 	}},
-	{ "h-fast-flee",        BOT_H_FAST_FLEE,    4, pred_always, {} },
+	{ "h-fast-flee",        BOT_H_FAST_FLEE,    5, pred_human, {} },
 	{ "medkit",             BOT_H_MEDKIT,       8, pred_human, {} },
 };
 

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -174,17 +174,15 @@ static const std::vector<botSkillTreeElement_t> movement_skills = {
 
 static const std::vector<botSkillTreeElement_t> survival_skills = {
 	// aliens
-	{ "mara-flee-jump",     BOT_A_MARA_JUMP_ON_FLEE,     4, pred_alien, {} },
-	{ "mantis-flee-jump",   BOT_A_LEAP_ON_FLEE,          3, pred_alien, {} },
-	{ "goon-flee-jump",     BOT_A_POUNCE_ON_FLEE,        4, pred_alien, {} },
-	{ "tyrant-flee-run",    BOT_A_TYRANT_CHARGE_ON_FLEE, 4, pred_alien, {} },
 	{ "safe-barbs",         BOT_A_SAFE_BARBS,            3, pred_alien, {} },
+	{ "a-fast-flee",        BOT_A_FAST_FLEE,             4, pred_always, {} },
+
 
 	// humans
 	{ "buy-modern-armor",   BOT_H_BUY_MODERN_ARMOR, 10, pred_human, {
 		{ "prefer-armor", BOT_H_PREFER_ARMOR, 5, pred_human, {} },
 	}},
-	{ "flee-run",           BOT_H_RUN_ON_FLEE,  5, pred_human, {} },
+	{ "h-fast-flee",        BOT_H_FAST_FLEE,    4, pred_always, {} },
 	{ "medkit",             BOT_H_MEDKIT,       8, pred_human, {} },
 };
 

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -84,7 +84,7 @@ static bool G_SkillPreferred( Str::StringRef behavior )
 	return G_GetPreferredSkillset().find( behavior ) != G_GetPreferredSkillset().end();
 }
 
-// aliens have 67 points to spend max, but we give them a bit less for balancing
+// aliens have 71 points to spend max, but we give them a bit less for balancing
 static int skillsetBudgetAliens = 63;
 // humans have 48 points to spend max
 static int skillsetBudgetHumans = 48;


### PR DESCRIPTION
(This PR is about the last two commits) This brings back the changes from https://github.com/Unvanquished/Unvanquished/pull/2489 with some fixes so it doesn't break the balancing.

This serie of PR is documented in https://forums.unvanquished.net/viewtopic.php?t=2406&sid=8b972857d4e739c578b73a0718baf6e8

Based on https://github.com/Unvanquished/Unvanquished/pull/2442. I unfortunately don't have time to test out the balancing implications of this PR, but the PR number 2 seemed fine in my experience and this change is fairly small.

Next PR in the series: https://github.com/Unvanquished/Unvanquished/pull/2635, that should bring no balancing change