### PR TITLE
change datagrid background colour

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/shared/datagrid.rcss
+++ b/pkg/unvanquished_src.dpkdir/ui/shared/datagrid.rcss
@@ -15,7 +15,7 @@ datagridheader {
 
 /* Alternate colours of each row */
 datagridrow:nth-child(even) {
-	background-color: #333333;
+	background-color: #444444;
 }
 datagridrow:nth-child(odd) {
 	background-color: #222222;


### PR DESCRIPTION
fix #1989 server list background uses #333333 which is used by unv's color codes

The colour is probably a bit too bright, but this would solve the aforementioned issue.