### PR TITLE
use menu background when chatting

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/ingame_chat.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/ingame_chat.rml
@@ -2,7 +2,7 @@
 	<head>
 	<link type="text/rcss" href="/ui/shared/basics.rcss" />
 	<style>
-		body {
+		.chat {
 			position: absolute;
 			top: 50%;
 			width: 100%;
@@ -17,9 +17,13 @@
 		}
 	</style>
 	<script src="lua/util.lua"></script>
+	<link type="text/rcss" href="menu.rcss" />
 	</head>
 	<body id="ingame_chat" onkeydown="detectEscape(event, document)" onshow='document:GetElementById("chatfield"):Focus()' >
-	<div>
+	<img class="gradient black" src="/ui/assets/background/black" />
+	<img class="circles" src="/ui/assets/background/circles1" />
+	<img class="circles" src="/ui/assets/background/circles2" />
+	<div class="chat">
 		<chatType/>
 		<chatfield id="chatfield" onfocus='Events.pushevent("setChatCommand", event)' />
 	</div>


### PR DESCRIPTION
fix #2578 

![2023-04-13](https://user-images.githubusercontent.com/1316300/231621155-e78de961-07bd-45d2-9aa3-704ed37f19b5.png)

Screen could probably be darkened too, but that's better than current situation I guess?