### PR TITLE
Add debug commands to make skilltree maintenance easier (6/?)

### DIFF
--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -470,6 +470,8 @@ static const struct cg_cmd_t
 	{ "destroy",          0,                       0                },
 	{ "destroyTestPS",    CG_DestroyTestPS_f,      0                },
 	{ "destroyTestTS",    CG_DestroyTestTS_f,      0                },
+	{ "devbotcountskillpoints", 0,                 0                },
+	{ "devbotgraphskilltree", 0,                   0                },
 	{ "devteam",          0,                       0                },
 	{ "follow",           0,                       CG_CompleteName  },
 	{ "follownext",       0,                       0                },

--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -472,6 +472,7 @@ static const struct cg_cmd_t
 	{ "destroyTestTS",    CG_DestroyTestTS_f,      0                },
 	{ "devbotcountskillpoints", 0,                 0                },
 	{ "devbotgraphskilltree", 0,                   0                },
+	{ "devbotlistskills", 0,                       0                },
 	{ "devteam",          0,                       0                },
 	{ "follow",           0,                       CG_CompleteName  },
 	{ "follownext",       0,                       0                },

--- a/src/sgame/sg_bot_public.h
+++ b/src/sgame/sg_bot_public.h
@@ -75,6 +75,9 @@ void G_BotRemoveObstacle( qhandle_t handle );
 void G_BotUpdateObstacles();
 std::string G_BotToString( gentity_t *bot );
 
+std::string G_BotPrintSkillGraph(team_t team, int skillLevel);
+int G_BotCountSkillPoints(team_t team);
+
 const char BOT_DEFAULT_BEHAVIOR[] = "default";
 const char BOT_NAME_FROM_LIST[] = "*";
 

--- a/src/sgame/sg_bot_public.h
+++ b/src/sgame/sg_bot_public.h
@@ -77,6 +77,7 @@ std::string G_BotToString( gentity_t *bot );
 
 std::string G_BotPrintSkillGraph(team_t team, int skillLevel);
 int G_BotCountSkillPoints(team_t team);
+std::string G_BotListSkillset();
 
 const char BOT_DEFAULT_BEHAVIOR[] = "default";
 const char BOT_NAME_FROM_LIST[] = "*";

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -482,3 +482,29 @@ int G_BotCountSkillPoints(team_t team)
 
 	return total;
 }
+
+// This function is used for debug only
+std::string G_BotListSkillset()
+{
+	std::vector<std::string> skillNames;
+	for (const auto &skill : skillTree)
+	{
+		skillNames.push_back(skill.name);
+	}
+
+	std::sort( skillNames.begin(), skillNames.end() );
+
+	bool first = true;
+	std::string output;
+	for (const auto &skillName : skillNames)
+	{
+		if (!first)
+		{
+			output += ", ";
+		}
+
+		output += skillName;
+		first = false;
+	}
+	return output;
+}

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -127,8 +127,8 @@ static void G_SetSkillsetBudgetAliens( int val )
 
 void G_InitSkilltreeCvars()
 {
-	static Cvar::Callback<Cvar::Cvar<std::string>> g_skillset_disabledSkills(
-		"g_skillset_disabledSkills",
+	static Cvar::Callback<Cvar::Cvar<std::string>> g_bot_skillset_disabledSkills(
+		"g_bot_skillset_disabledSkills",
 		"Skills that will not be selected randomly for bots, example: " QQ("mantis-attack-jump, prefer-armor"),
 		Cvar::NONE,
 		"",
@@ -143,15 +143,15 @@ void G_InitSkilltreeCvars()
 		G_SetBaseSkillset
 		);
 
-	static Cvar::Callback<Cvar::Cvar<int>> g_bot_skillsetBudgetAliens(
-		"g_bot_skillsetBudgetAliens",
+	static Cvar::Callback<Cvar::Cvar<int>> g_bot_skillset_budgetAliens(
+		"g_bot_skillset_budgetAliens",
 		"How many skillpoint for bot aliens' random skills. Base skill costs are also removed from this sum",
 		Cvar::NONE,
 		skillsetBudgetAliens,
 		G_SetSkillsetBudgetAliens
 		);
-	static Cvar::Callback<Cvar::Cvar<int>> g_bot_skillsetBudgetHumans(
-		"g_bot_skillsetBudgetHumans",
+	static Cvar::Callback<Cvar::Cvar<int>> g_bot_skillset_budgetHumans(
+		"g_bot_skillset_budgetHumans",
 		"How many skillpoint for bot humans' random skills. Base skill costs are also removed from this sum",
 		Cvar::NONE,
 		skillsetBudgetHumans,

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -127,8 +127,8 @@ static void G_SetSkillsetBudgetAliens( int val )
 
 void G_InitSkilltreeCvars()
 {
-	static Cvar::Callback<Cvar::Cvar<std::string>> g_disabledSkillset(
-		"g_disabledSkillset",
+	static Cvar::Callback<Cvar::Cvar<std::string>> g_skillset_disabledSkills(
+		"g_skillset_disabledSkills",
 		"Skills that will not be selected randomly for bots, example: " QQ("mantis-attack-jump, prefer-armor"),
 		Cvar::NONE,
 		"",

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -26,6 +26,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "sg_bot_util.h"
 #include "../shared/parse.h"
 
+static std::array<std::set<std::string>, 9> baseSkillset;
+static std::set<std::string> disabledSkillset;
+
 static void G_UpdateSkillsets()
 {
 	for ( int i = 0; i < level.maxclients; i++ )
@@ -50,38 +53,59 @@ static std::set<std::string> G_ParseSkillsetList( Str::StringRef skillsCsv )
 	return skills;
 }
 
-static std::set<std::string>& G_GetDisabledSkillset()
+static std::set<std::pair<int, std::string>> G_ParseSkillsetListWithLevels( Str::StringRef skillsCsv )
 {
-	static std::set<std::string> disabledSkillset;
-	return disabledSkillset;
+	std::set<std::pair<int, std::string>> skills;
+
+	for (Parse_WordListSplitter i(skillsCsv); *i; ++i)
+	{
+		// Try to read a "n:skillname" pair where n represents a single digit
+		if ( strnlen(*i, 3) < 3 || !Str::cisdigit( (*i)[0] ) || (*i)[1] != ':' )
+		{
+			Log::Warn("Invalid \"int:skill\" pair: " QQ("%s"), *i);
+			continue;
+		}
+		int number = (*i)[0] - '0';
+		std::string skillName = *i + 2; // skip the first two character
+		skills.insert( { number, std::move(skillName) } );
+	}
+
+	return skills;
 }
 
 static void G_SetDisabledSkillset( Str::StringRef skillsCsv )
 {
-	G_GetDisabledSkillset() = G_ParseSkillsetList( skillsCsv );
+	disabledSkillset = G_ParseSkillsetList( skillsCsv );
 	G_UpdateSkillsets();
 }
 
 static bool G_SkillDisabled( Str::StringRef behavior )
 {
-	return G_GetDisabledSkillset().find( behavior ) != G_GetDisabledSkillset().end();
+	return disabledSkillset.find( behavior ) != disabledSkillset.end();
 }
 
-static std::set<std::string>& G_GetPreferredSkillset()
+static void G_SetBaseSkillset( Str::StringRef skillsCsv )
 {
-	static std::set<std::string> preferredSkillset;
-	return preferredSkillset;
-}
-
-static void G_SetPreferredSkillset( Str::StringRef skillsCsv )
-{
-	G_GetPreferredSkillset() = G_ParseSkillsetList( skillsCsv );
+	std::set<std::pair<int, std::string>> skills = G_ParseSkillsetListWithLevels( skillsCsv );
+	for ( int skillLevel = 1; skillLevel <= 9; skillLevel++ )
+	{
+		std::set<std::string> level;
+		for ( auto &skill : skills )
+		{
+			if (skill.first <= skillLevel)
+			{
+				level.insert(skill.second);
+			}
+		}
+		baseSkillset[skillLevel - 1] = std::move(level);
+	}
 	G_UpdateSkillsets();
 }
 
-static bool G_SkillPreferred( Str::StringRef behavior )
+static bool G_IsBaseSkillAtLevel( int skillLevel, Str::StringRef behavior )
 {
-	return G_GetPreferredSkillset().find( behavior ) != G_GetPreferredSkillset().end();
+	ASSERT( skillLevel >= 1 && skillLevel <= 9 );
+	return baseSkillset[skillLevel - 1].find( behavior ) != baseSkillset[skillLevel - 1].end();
 }
 
 // aliens have 71 points to spend max, but we give them a bit less for balancing
@@ -105,28 +129,30 @@ void G_InitSkilltreeCvars()
 {
 	static Cvar::Callback<Cvar::Cvar<std::string>> g_disabledSkillset(
 		"g_disabledSkillset",
-		"Disabled skills for bots, example: " QQ("mantis-attack-jump, prefer-armor"),
+		"Skills that will not be selected randomly for bots, example: " QQ("mantis-attack-jump, prefer-armor"),
 		Cvar::NONE,
 		"",
 		G_SetDisabledSkillset
 		);
-	static Cvar::Callback<Cvar::Cvar<std::string>> g_preferredSkillset(
-		"g_preferredSkillset",
-		"Preferred skills for bots, example: " QQ("mantis-attack-jump, prefer-armor"),
+
+	static Cvar::Callback<Cvar::Cvar<std::string>> g_bot_skillset_baseSkills(
+		"g_bot_skillset_baseSkills",
+		"Preferred skills for bots depending on levels, this is a level:skillName key:value list, example: " QQ("6:mantis-attack-jump, 3:prefer-armor"),
 		Cvar::NONE,
 		"",
-		G_SetPreferredSkillset
+		G_SetBaseSkillset
 		);
-	static Cvar::Callback<Cvar::Cvar<int>> g_skillsetBudgetAliens(
-		"g_skillsetBudgetAliens",
-		"the skillset budget for aliens.",
+
+	static Cvar::Callback<Cvar::Cvar<int>> g_bot_skillsetBudgetAliens(
+		"g_bot_skillsetBudgetAliens",
+		"How many skillpoint for bot aliens' random skills. Base skill costs are also removed from this sum",
 		Cvar::NONE,
 		skillsetBudgetAliens,
 		G_SetSkillsetBudgetAliens
 		);
-	static Cvar::Callback<Cvar::Cvar<int>> g_skillsetBudgetHumans(
-		"g_skillsetBudgetHumans",
-		"the skillset budget for humans.",
+	static Cvar::Callback<Cvar::Cvar<int>> g_bot_skillsetBudgetHumans(
+		"g_bot_skillsetBudgetHumans",
+		"How many skillpoint for bot humans' random skills. Base skill costs are also removed from this sum",
 		Cvar::NONE,
 		skillsetBudgetHumans,
 		G_SetSkillsetBudgetHumans
@@ -218,14 +244,22 @@ static bool SkillIsAvailable(const botSkillTreeElement_t &skill, team_t team, sk
 }
 
 // Note: this function modifies possible_choices to remove the one we just chose.
-static Util::optional<botSkillTreeElement_t> ChooseOneSkill(team_t team, skillSet_t skillSet, std::vector<botSkillTreeElement_t> &possible_choices, std::mt19937_64& rng)
+static Util::optional<botSkillTreeElement_t> ChooseOneSkill(team_t team, skillSet_t skillSet, std::vector<botSkillTreeElement_t> &possible_choices, std::mt19937_64& rng, int skillLevel)
 {
 	int total_skill_points = 0;
-	for (const auto &skill : possible_choices)
+	for (auto skill = possible_choices.begin(); skill != possible_choices.end(); skill++)
 	{
-		if (SkillIsAvailable(skill, team, skillSet))
+		// force base skills to be selected first (if the the skill is for the correct team)
+		if (G_IsBaseSkillAtLevel(skillLevel, skill->name) && (skill->allowed_teams == TEAM_NONE || skill->allowed_teams == team))
 		{
-			total_skill_points += skill.cost;
+			// force this to be selected first
+			botSkillTreeElement_t choice = *skill;
+			possible_choices.erase(skill);
+			return choice;
+		}
+		if (SkillIsAvailable(*skill, team, skillSet))
+		{
+			total_skill_points += skill->cost;
 		}
 	}
 
@@ -289,21 +323,19 @@ std::vector<botSkillTreeElement_t> BotPickSkillset(std::string seed, int skillLe
 	while (true)
 	{
 		Util::optional<botSkillTreeElement_t> new_skill =
-			ChooseOneSkill(team, skillSet, possible_choices, rng);
+			ChooseOneSkill(team, skillSet, possible_choices, rng, skillLevel);
 		if ( !new_skill )
 		{
 			// no skill left to unlock
 			break;
 		}
 
-		bool preferred = G_SkillPreferred( new_skill->name );
+		skill_points -= new_skill->cost;
 
-		if ( !preferred )
-		{
-			skill_points -= new_skill->cost;
-		}
+		// force base skills to always be selected, no matter the cost
+		bool isBaseSkill = G_IsBaseSkillAtLevel( skillLevel, new_skill->name );
 
-		if ( skill_points < 0 && !preferred )
+		if ( skill_points < 0 && !isBaseSkill )
 		{
 			// we don't have money to spend anymore, we are done
 			continue;

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -2292,6 +2292,11 @@ static void Cmd_BotSaveSkillTree_f( gentity_t * )
 	}
 }
 
+static void Cmd_BotListSkills_f( gentity_t * )
+{
+	Log::Notice( "Skillset skills: %s", G_BotListSkillset( static_cast<team_t>( team ) ) );
+}
+
 /*
 =================
 Cmd_Ignite_f
@@ -4215,6 +4220,7 @@ static const commands_t cmds[] =
 	{ "deconstruct",     CMD_TEAM | CMD_ALIVE,                Cmd_Deconstruct_f      },
 	{ "devbotcountskillpoints", CMD_CHEAT,                    Cmd_BotCountSkillPoints_f },
 	{ "devbotgraphskilltree", CMD_CHEAT,                      Cmd_BotSaveSkillTree_f },
+	{ "devbotlistskills", CMD_CHEAT,                          Cmd_BotListSkills_f },
 	{ "devteam",         CMD_CHEAT,                           Cmd_Devteam_f          },
 	{ "follow",          CMD_SPEC,                            Cmd_Follow_f           },
 	{ "follownext",      CMD_SPEC,                            Cmd_FollowCycle_f      },


### PR DESCRIPTION
I've split the first part of this PR into a separate one, https://github.com/Unvanquished/Unvanquished/pull/2722. This PR also depends on #2697. Only the last three commits of this PR are from this PR.

This introduces two new commands, `/devbotcountskillpoints` and `/devbotgraphskilltree`. The first just prints a message with the total cost of (reachable) skills in the tree for each team, and the second saves a `.dot` graph file that can be converted to an image. For example one can do: `dot -Tpng ~/.local/share/unvanquished/game/bot-skilltree-human.dot > result.png && eog result.png`.

This also refactors the skilltree implementation, making the above possible even though it makes it a bit less flexible (extra complexities like {having two conflicting skills that can't be selected at the same time} could be probably be brought back if desired, but for now we don't use those). This should bring no balancing change.

Previous PR in this series: https://github.com/Unvanquished/Unvanquished/pull/2697