### PR TITLE
spawn suicide when blocked by geometry

### DIFF
--- a/src/sgame/components/SpawnerComponent.cpp
+++ b/src/sgame/components/SpawnerComponent.cpp
@@ -40,6 +40,7 @@ void SpawnerComponent::Think(int timeDelta) {
 	if (blocker) {
 		if (!blocker->oldEnt) {
 			logger.Warn("Spawn blocking entity has oldEnt == nullptr");
+			Entities::Kill(entity, nullptr, MOD_SUICIDE);
 			return;
 		}
 
@@ -135,7 +136,7 @@ Entity* SpawnerComponent::CheckSpawnPointHelper(
 
 	// Check for a clear line towards the spawn location.
 	trap_Trace(
-		&tr, &spawnerOrigin[0], nullptr, nullptr, &spawnPoint[0], spawnerNumber, MASK_SHOT, 0
+		&tr, &spawnerOrigin[0], nullptr, nullptr, &spawnPoint[0], spawnerNumber, MASK_PLAYERSOLID, 0
 	);
 
 	if (tr.entityNum != ENTITYNUM_NONE) {


### PR DESCRIPTION
This can happen when loading layouts or maps which were built for a version where the spawner was smaller.

fix #2515 