### PR TITLE
some string rework for translation

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1167,32 +1167,27 @@ static void SetMapInfoFromArenaInfo( arenaInfo_t arenaInfo )
 {
 	cg.mapLongName = arenaInfo.longName;
 
-	if ( arenaInfo.authors.size() != 0 )
+	if ( !arenaInfo.authors.empty() )
 	{
-		if ( arenaInfo.authors.size() == 1 )
+		std::string authorNames;
+
+		for ( std::string &author: arenaInfo.authors )
 		{
-			cg.mapAuthors = Str::Format( _( "by %s"), arenaInfo.authors[ 0 ] );
-		}
-		else
-		{
-			std::string first_authors;
-			for ( std::string &author : arenaInfo.authors )
+			if ( author == arenaInfo.authors.front() )
 			{
-				if ( &author == &arenaInfo.authors.back() )
-				{
-					break;
-				}
-
-				if ( &author != &arenaInfo.authors.front() )
-				{
-					first_authors += ", ";
-				}
-
-				first_authors += author;
+				authorNames = author;
 			}
-
-			cg.mapAuthors = Str::Format( _( "by %s and %s"), first_authors, arenaInfo.authors.back() );
+			else if ( author == arenaInfo.authors.back() )
+			{
+				authorNames = Str::Format( "%s and %s", authorNames, author );
+			}
+			else
+			{
+				authorNames = Str::Format( "%s, %s", authorNames, author );
+			}
 		}
+
+		cg.mapAuthors = Str::Format( _( "by %s"), authorNames );
 	}
 }
 

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -1178,6 +1178,11 @@ static void CG_CenterPrintTR_f()
 	CG_CenterPrint( TranslateText_Internal( false, 1 ), 1.0f );
 }
 
+static void CG_CenterPrintTR_plural_f()
+{
+	CG_CenterPrint( TranslateText_Internal( true, 1 ), 1.0f );
+}
+
 /*
 =================
 CG_CenterPrintTR_Delay_f
@@ -1350,6 +1355,7 @@ static const consoleCommand_t svcommands[] =
 	{ "cpd",              CG_CenterPrint_Delay_f  },
 	{ "cpd_tr",           CG_CenterPrintTR_Delay_f},
 	{ "cp_tr",            CG_CenterPrintTR_f      },
+	{ "cp_tr_p",          CG_CenterPrintTR_plural_f },
 	{ "cs",               CG_ConfigStringModified },
 	{ "map_restart",      CG_MapRestart           },
 	{ "pmove_params",     CG_PmoveParams_f        },

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -115,12 +115,20 @@ static const char *CG_KeyNameForCommand( const char *command )
 
 			for ( Keyboard::Key key : binding.keys )
 			{
-				if ( !keyNames.empty() )
+				if ( keyNames.empty() )
 				{
-					keyNames += va( " %s ", _("or") );
+					keyNames = CG_KeyDisplayName( key );
 				}
-				keyNames += CG_KeyDisplayName( key );
+				else if ( key == binding.keys.back() )
+				{
+					keyNames = Str::Format( _("%s or %s"), keyNames, CG_KeyDisplayName( key ) );
+				}
+				else
+				{
+					keyNames = Str::Format( _("%s, %s"), keyNames, CG_KeyDisplayName( key ) );
+				}
 			}
+
 			if ( keyNames.empty() )
 			{
 				keyNames = Str::Format( _( "\"%s\" (unbound)" ), _( binding.humanName ) );

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -130,7 +130,7 @@ static const char *CG_KeyNameForCommand( const char *command )
 		}
 	}
 
-	return "(⚠  BUG)"; // shouldn't happen: if it does, BUG
+	return "(⚠ BUG)"; // shouldn't happen: if it does, BUG
 }
 
 #define MAX_TUTORIAL_TEXT 4096

--- a/src/cgame/rocket/rocket_keys.cpp
+++ b/src/cgame/rocket/rocket_keys.cpp
@@ -322,15 +322,25 @@ std::string CG_KeyBinding( const char* bind, int team )
 
 	if ( keys.empty() )
 	{
-		return "Unbound";
+		return _( "Unbound" );
 	}
 
-	std::string keyNames = CG_KeyDisplayName( keys[0] );
+	std::string keyNames;
 
-	for ( size_t i = 1; i < keys.size(); i++ )
+	for ( Keyboard::Key key : keys )
 	{
-		keyNames += " or ";
-		keyNames += CG_KeyDisplayName( keys[i] );
+		if ( key == keys.front() )
+		{
+			keyNames = CG_KeyDisplayName( key );
+		}
+		else if ( key == keys.back() )
+		{
+			keyNames = Str::Format( _("%s or %s"), keyNames, CG_KeyDisplayName( key ) );
+		}
+		else
+		{
+			keyNames = Str::Format( _("%s, %s"), keyNames, CG_KeyDisplayName( key ) );
+		}
 	}
 
 	return keyNames;

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -1151,7 +1151,8 @@ const char *ClientConnect( int clientNum, bool firstTime )
 			if ( !G_ClientIsLagging( level.clients + i ) )
 			{
 				G_LogPrintf( "Duplicate GUID: %i", i );
-				trap_SendServerCommand( i, "cp \"Your GUID is not secure\"" );
+				trap_SendServerCommand( i, "cp_tr "
+					QQ( N_("Your GUID is not secure") ) );
 				G_LogPrintf( "FailedConnecting: %i [%s] (%s) \"%s^*\" \"%s^*\"",
 				             clientNum, client->pers.ip.str[0] ? client->pers.ip.str : "127.0.0.1", client->pers.guid,
 				             client->pers.netname,

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -841,17 +841,19 @@ const char *ClientUserinfoChanged( int clientNum, bool forceName )
 		     level.time - client->pers.namelog->nameChangeTime <=
 		     g_minNameChangePeriod.Get() * 1000 )
 		{
-			trap_SendServerCommand( ent->num(), va(
-			                          "print_tr %s %g", QQ( N_("Name change spam protection (g_minNameChangePeriod = $1$)") ),
-			                          g_minNameChangePeriod.Get() ) );
+			trap_SendServerCommand( ent->num(), va("print_tr %s %s %g",
+				QQ( N_("Name change spam protection ($1$ = $2$)") ),
+				"g_minNameChangePeriod",
+				g_minNameChangePeriod.Get() ) );
 			revertName = true;
 		}
 		else if ( !forceName && g_maxNameChanges.Get() > 0 &&
 		          client->pers.namelog->nameChanges >= g_maxNameChanges.Get() )
 		{
-			trap_SendServerCommand( ent->num(), va(
-			                          "print_tr %s %d", QQ( N_("Maximum name changes reached (g_maxNameChanges = $1$)") ),
-			                          g_maxNameChanges.Get() ) );
+			trap_SendServerCommand( ent->num(), va("print_tr %s %s %d",
+				QQ( N_("Maximum name changes reached ($1$ = $2$)") ),
+				"g_maxNameChanges",
+				g_maxNameChanges.Get() ) );
 			revertName = true;
 		}
 		else if ( !forceName && client->pers.namelog->muted )

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -2356,9 +2356,13 @@ void G_RunFrame( int levelTime )
 			}
 		}
 
+		// We may de-hardcode this value.
 		if ( level.pausedTime > 120000 )
 		{
-			trap_SendServerCommand( -1, "print_tr \"" N_("Server: The game has been unpaused automatically (2 minute max)") "\"" );
+			// FIXME: This assumes plural.
+			trap_SendServerCommand( -1, va( "print_tr_p %s %d",
+				QQ( N_("Server: The game has been unpaused automatically ($1$ minutes max)") ),
+				2 ) );
 			trap_SendServerCommand( -1, "cp \"The game has been unpaused!\"" );
 			level.pausedTime = 0;
 		}

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -1992,7 +1992,8 @@ void CheckExitRules()
 	{
 		// nobody wins because the teams are empty after x amount of game time
 		level.lastWin = TEAM_NONE;
-		trap_SendServerCommand( -1, "print \"Empty teams skip map time exceeded.\n\"" );
+		trap_SendServerCommand( -1, "print_tr "
+			QQ( N_("Empty teams skip map time exceeded.") ) );
 		trap_SetConfigstring( CS_WINNER, "Stalemate" );
 		LogExit( "Timelimit hit." );
 		G_MapLog_Result( 't' );

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -1933,7 +1933,7 @@ void CheckExitRules()
 		if ( level.matchTime >= level.timelimit * 60000 )
 		{
 			level.lastWin = TEAM_NONE;
-			trap_SendServerCommand( -1, "print_tr \"" N_("Timelimit hit") "\"" );
+			trap_SendServerCommand( -1, "print_tr " QQ( N_("Timelimit hit") ) );
 			trap_SetConfigstring( CS_WINNER, "Stalemate" );
 			G_notify_sensor_end( TEAM_NONE );
 			LogExit( "Timelimit hit." );
@@ -1965,7 +1965,7 @@ void CheckExitRules()
 	{
 		//humans win
 		level.lastWin = TEAM_HUMANS;
-		trap_SendServerCommand( -1, "print_tr \"" N_("Humans win") "\"" );
+		trap_SendServerCommand( -1, "print_tr " QQ( N_("Humans win") ) );
 		trap_SetConfigstring( CS_WINNER, "Humans Win" );
 		G_notify_sensor_end( TEAM_HUMANS );
 		LogExit( "Humans win." );
@@ -1979,7 +1979,7 @@ void CheckExitRules()
 	{
 		//aliens win
 		level.lastWin = TEAM_ALIENS;
-		trap_SendServerCommand( -1, "print_tr \"" N_("Aliens win") "\"" );
+		trap_SendServerCommand( -1, "print_tr " QQ( N_("Aliens win") ) );
 		trap_SetConfigstring( CS_WINNER, "Aliens Win" );
 		G_notify_sensor_end( TEAM_ALIENS );
 		LogExit( "Aliens win." );

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -1943,13 +1943,16 @@ void CheckExitRules()
 		else if ( level.matchTime >= ( level.timelimit - 5 ) * 60000 &&
 		          level.timelimitWarning < TW_IMMINENT )
 		{
-			trap_SendServerCommand( -1, "cp \"5 minutes remaining!\"" );
+			trap_SendServerCommand( -1, va( "cp_tr_p %s %d",
+				QQ( N_("$1$ minutes remaining!" ) ),
+				5 ) );
 			level.timelimitWarning = TW_IMMINENT;
 		}
 		else if ( level.matchTime >= ( level.timelimit - 1 ) * 60000 &&
 		          level.timelimitWarning < TW_PASSED )
 		{
-			trap_SendServerCommand( -1, "cp \"1 minute remaining!\"" );
+			trap_SendServerCommand( -1, "cp_tr "
+				QQ( N_("1 minute remaining!") ) );
 			level.timelimitWarning = TW_PASSED;
 		}
 	}
@@ -2338,7 +2341,8 @@ void G_RunFrame( int levelTime )
 		while ( ptime3000 > 3000 )
 		{
 			ptime3000 -= 3000;
-			trap_SendServerCommand( -1, "cp \"The game has been paused. Please wait.\"" );
+			trap_SendServerCommand( -1, "cp_tr "
+				QQ( N_("The game has been paused. Please wait.") ) );
 
 			if ( level.pausedTime >= 110000  && level.pausedTime <= 119000 )
 			{
@@ -2363,7 +2367,8 @@ void G_RunFrame( int levelTime )
 			trap_SendServerCommand( -1, va( "print_tr_p %s %d",
 				QQ( N_("Server: The game has been unpaused automatically ($1$ minutes max)") ),
 				2 ) );
-			trap_SendServerCommand( -1, "cp \"The game has been unpaused!\"" );
+			trap_SendServerCommand( -1, "cp_tr "
+				QQ( N_("The game has been unpaused!") ) );
 			level.pausedTime = 0;
 		}
 


### PR DESCRIPTION
_Question:_ can we assume any “`(%s)`” will never have any translation variant? I know for example that English “`%s:`” is actually translated to “`%s :`” in French (French typography requires a non-breakable thin space before double-punctuation like “`;`” and “`:`”). If we assume “`(%s)`” will never have any translation variant we can exclude more strings or parts of strings to be translated.

I actually split things like “`Vote failed (reason1)`” and “`Vote failed (reason2)`” into “`Vote failed`”, “`(reason1)`”, “`(reason2)`”. I see no reason to translate the same string many times. And if we can exclude the parenthesis, we would also be able to simplify some “`reason`” string or even remove some from translatable strings.

_Note:_ I now consider that we can split such strings because Weblate displays by default strings that are in the same context, so there is no real context issue to fear about.