### PR TITLE
print a warning on missing shader/model/sound/particle system, etc. and skip broken light flare entities

### DIFF
--- a/src/sgame/sg_spawn.cpp
+++ b/src/sgame/sg_spawn.cpp
@@ -1170,7 +1170,7 @@ void G_SpawnFakeEntities()
 	level.fakeLocation->r.svFlags = SVF_BROADCAST;
 
 	level.fakeLocation->nextPathSegment = level.locationHead;
-	level.fakeLocation->s.generic1 = G_LocationIndex( "" );
+	level.fakeLocation->s.generic1 = 0;
 	level.locationHead = level.fakeLocation;
 
 	G_SetOrigin( level.fakeLocation, VEC2GLM( level.fakeLocation->s.origin ) );

--- a/src/sgame/sg_spawn_gfx.cpp
+++ b/src/sgame/sg_spawn_gfx.cpp
@@ -137,6 +137,12 @@ static void findEmptySpot( glm::vec3 const& origin, float radius, glm::vec3& spo
 
 void SP_gfx_light_flare( gentity_t *self )
 {
+	if ( !self->shaderKey )
+	{
+		Log::Warn( "Light flare entity %d at (%d, %d, %d) has no shader", self->num(), self->s.origin[0], self->s.origin[1], self->s.origin[2] );
+		return;
+	}
+
 	self->s.eType = entityType_t::ET_LIGHTFLARE;
 	self->s.modelindex = G_ShaderIndex( self->shaderKey );
 	VectorCopy( self->activatedPosition, self->s.origin2 );

--- a/src/sgame/sg_utils.cpp
+++ b/src/sgame/sg_utils.cpp
@@ -146,22 +146,50 @@ static int G_FindConfigstringIndex( const char *name, int start, int max, bool c
 
 int G_ParticleSystemIndex( const char *name )
 {
-	return G_FindConfigstringIndex( name, CS_PARTICLE_SYSTEMS, MAX_GAME_PARTICLE_SYSTEMS, true );
+	int i = G_FindConfigstringIndex( name, CS_PARTICLE_SYSTEMS, MAX_GAME_PARTICLE_SYSTEMS, true );
+
+	if ( !i )
+	{
+		Log::Warn( "Missing particle system: %s", name );
+	}
+
+	return i;
 }
 
 int G_ShaderIndex( const char *name )
 {
-	return G_FindConfigstringIndex( name, CS_SHADERS, MAX_GAME_SHADERS, true );
+	int i = G_FindConfigstringIndex( name, CS_SHADERS, MAX_GAME_SHADERS, true );
+
+	if ( !i )
+	{
+		Log::Warn( "Missing shader: %s", name );
+	}
+
+	return i;
 }
 
 int G_ModelIndex( const char *name )
 {
-	return G_FindConfigstringIndex( name, CS_MODELS, MAX_MODELS, true );
+	int i = G_FindConfigstringIndex( name, CS_MODELS, MAX_MODELS, true );
+
+	if ( !i )
+	{
+		Log::Warn( "Missing model: %s", name );
+	}
+
+	return i;
 }
 
 int G_SoundIndex( const char *name )
 {
-	return G_FindConfigstringIndex( name, CS_SOUNDS, MAX_SOUNDS, true );
+	int i = G_FindConfigstringIndex( name, CS_SOUNDS, MAX_SOUNDS, true );
+
+	if ( !i )
+	{
+		Log::Warn( "Missing sound: %s", name );
+	}
+
+	return i;
 }
 
 /**
@@ -172,17 +200,38 @@ int G_SoundIndex( const char *name )
  */
 int G_GradingTextureIndex( const char *name )
 {
-	return G_FindConfigstringIndex( name, CS_GRADING_TEXTURES+1, MAX_GRADING_TEXTURES-1, true );
+	int i = G_FindConfigstringIndex( name, CS_GRADING_TEXTURES+1, MAX_GRADING_TEXTURES-1, true );
+
+	if ( !i )
+	{
+		Log::Warn( "Missing grading texture: %s", name );
+	}
+
+	return i;
 }
 
 int G_ReverbEffectIndex( const char *name )
 {
-	return G_FindConfigstringIndex( name, CS_REVERB_EFFECTS+1, MAX_REVERB_EFFECTS-1, true );
+	int i = G_FindConfigstringIndex( name, CS_REVERB_EFFECTS+1, MAX_REVERB_EFFECTS-1, true );
+
+	if ( !i )
+	{
+		Log::Warn( "Missing reverb effect: %s", name );
+	}
+
+	return i;
 }
 
 int G_LocationIndex( const char *name )
 {
-	return G_FindConfigstringIndex( name, CS_LOCATIONS, MAX_LOCATIONS, true );
+	int i = G_FindConfigstringIndex( name, CS_LOCATIONS, MAX_LOCATIONS, true );
+
+	if ( !i )
+	{
+		Log::Warn( "Missing location: %s", name );
+	}
+
+	return i;
 }
 
 /*


### PR DESCRIPTION
There are multiple ways to have some stuff missing without getting any warning.

Right now I got a but, it's a regression in the nexus6 map after [I released 1.2.2](https://forums.unvanquished.net/viewtopic.php?p=19199#p19199). It happens that nexus6 1.2.2 is now built from source, and source had a mistake, a light flare entity in a wall (wrong, but not the cause of the regression) that does not have any shader set (the cause of the regression).

Surprinsingly, the game was drawing the fallback texture without printing any warning about the missing texture.

This PR adds warnings to many missing stuff.

It also prevents to produce the invalid light flare entity if such entity misses the required texture, meaning maps using broken light flare entity without texture would print a warning _and_ will render correctly.