### PR TITLE
fix an unused variable warning in `parse.cpp`

### DIFF
--- a/src/shared/parse.cpp
+++ b/src/shared/parse.cpp
@@ -555,7 +555,7 @@ static int Parse_ReadEscapeCharacter( script_t *script, char *ch )
 
 				int val = 0;
 
-				for ( ;; script->script_p++ )
+				while ( true )
 				{
 					c = *script->script_p;
 
@@ -565,6 +565,8 @@ static int Parse_ReadEscapeCharacter( script_t *script, char *ch )
 					else { break; }
 
 					val = ( val << 4 ) + c;
+
+					script->script_p++;
 				}
 
 				script->script_p--;
@@ -585,7 +587,7 @@ static int Parse_ReadEscapeCharacter( script_t *script, char *ch )
 
 				int val = 0;
 
-				for ( ;; script->script_p++ )
+				while ( true )
 				{
 					c = *script->script_p;
 
@@ -593,6 +595,8 @@ static int Parse_ReadEscapeCharacter( script_t *script, char *ch )
 					else { break; }
 
 					val = val * 10 + c;
+
+					script->script_p++;
 				}
 
 				script->script_p--;

--- a/src/shared/parse.cpp
+++ b/src/shared/parse.cpp
@@ -497,7 +497,7 @@ Parse_ReadEscapeCharacter
 */
 static int Parse_ReadEscapeCharacter( script_t *script, char *ch )
 {
-	int c, val, i;
+	int c, val;
 
 	//step over the leading '\\'
 	script->script_p++;
@@ -553,7 +553,7 @@ static int Parse_ReadEscapeCharacter( script_t *script, char *ch )
 			{
 				script->script_p++;
 
-				for ( i = 0, val = 0;; i++, script->script_p++ )
+				for ( val = 0;; script->script_p++ )
 				{
 					c = *script->script_p;
 
@@ -581,7 +581,7 @@ static int Parse_ReadEscapeCharacter( script_t *script, char *ch )
 			{
 				if ( *script->script_p < '0' || *script->script_p > '9' ) { Parse_ScriptError( script, "unknown escape char" ); }
 
-				for ( i = 0, val = 0;; i++, script->script_p++ )
+				for ( val = 0;; script->script_p++ )
 				{
 					c = *script->script_p;
 

--- a/src/shared/parse.cpp
+++ b/src/shared/parse.cpp
@@ -497,7 +497,7 @@ Parse_ReadEscapeCharacter
 */
 static int Parse_ReadEscapeCharacter( script_t *script, char *ch )
 {
-	int c, val;
+	int c;
 
 	//step over the leading '\\'
 	script->script_p++;
@@ -553,7 +553,9 @@ static int Parse_ReadEscapeCharacter( script_t *script, char *ch )
 			{
 				script->script_p++;
 
-				for ( val = 0;; script->script_p++ )
+				int val = 0;
+
+				for ( ;; script->script_p++ )
 				{
 					c = *script->script_p;
 
@@ -581,7 +583,9 @@ static int Parse_ReadEscapeCharacter( script_t *script, char *ch )
 			{
 				if ( *script->script_p < '0' || *script->script_p > '9' ) { Parse_ScriptError( script, "unknown escape char" ); }
 
-				for ( val = 0;; script->script_p++ )
+				int val = 0;
+
+				for ( ;; script->script_p++ )
 				{
 					c = *script->script_p;
 


### PR DESCRIPTION
Fix an unused variable warning in `parse.cpp`:

```
src/shared/parse.cpp:500:14: warning: variable 'i' set but not used [-Wunused-but-set-variable]
        int c, val, i;
                    ^
```

Also deobfuscate the code a bit, this file is incredibly convoluted!