### PR TITLE
Question: cg_main: do not apply MSVC workaround on not MSVC compilers

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1252,10 +1252,23 @@ void CG_Init( int serverMessageNum, int clientNum, const glconfig_t& gl, const G
 	// clear everything
 	// reset cgs in-place to avoid creating a huge struct on stack (caused a stack overflow)
 	// this is equivalent to cgs = cgs_t()
+#ifdef _MSC_VER
+	/* Use a C++11 braced initializer instead of a bracket initializer when
+	zeroing a struct. This works around a bug in how MSVC generates implicit
+	default constructors. */
 	cgs.~cgs_t();
-	new(&cgs) cgs_t{}; // Using {} instead of () to work around MSVC bug
+	new(&cgs) cgs_t{};
 	cg.~cg_t();
 	new(&cg) cg_t{};
+#else
+	/* The MSVC workaround is known to crash ICC, there is no reason to apply
+	MSVC workarounds on non-MSVC compilers. */
+	cgs.~cgs_t();
+	new(&cgs) cgs_t();
+	cg.~cg_t();
+	new(&cg) cg_t();
+#endif
+
 	for ( centity_t& ent : cg_entities) { ent = {}; }
 
 	CG_UpdateLoadingStep( LOAD_START );


### PR DESCRIPTION
This is mostly a question, I was toying with some compilers and I noticed this exact code in `cg_main.cpp` was crashing ICC, actually the two occurrences of the `new(&something) something{};` form:

```c++
	cgs.~cgs_t();
	new(&cgs) cgs_t{}; // Using {} instead of () to work around MSVC bug
	cg.~cg_t();
	new(&cg) cg_t{};
```

```
[ 81%] Building CXX object CMakeFiles/cgame-native-dll.dir/src/cgame/cg_main.cpp.o
icpc: command line warning #10148: option '-march=x86-64' not supported
"": internal error: ** The compiler has encountered an unexpected problem.
** Segmentation violation signal raised. **
Access violation or stack overflow. Please contact Intel Support for assistance.
icpc: error #10106: Fatal error in /opt/intel/oneapi/compiler/2023.1.0/linux/bin/intel64/../../bin/intel64/mcpcom, terminated by segmentation violation
compilation aborted for src/cgame/cg_main.cpp (code 1)
gmake[3]: *** [CMakeFiles/cgame-native-dll.dir/build.make:272 : CMakeFiles/cgame-native-dll.dir/src/cgame/cg_main.cpp.o] Error 1
```

Though even if ICC is the least of our concern, I'm surprised we apply an MSVC workaround to all non-MSVC compilers.

This MSVC workaround was implemented in faee5bae3576085e01775e61cb3b754e08fbc6ae

Interestingly there are two other occurrences in engine code in `cl_main.cpp` but ICC doesn't crash with them:

```c++
	cl.~clientActive_t();
	new(&cl) clientActive_t{}; // Using {} instead of () to work around MSVC bug
```

```c++
	clc.~clientConnection_t();
	new(&clc) clientConnection_t{}; // Using {} instead of () to work around MSVC bug
```

So basically, I find this curious…

- Can the ICC crash reveal a bug in our code somewhere else?
- Is ICC stupid? 
- Should the workaround be fine on any compiler?
- Should we implement a kind of macro we would allow us to do something like `ZERO(cgs, cgs_t)` and hide the magic, eventually using per-compiler code?