### PR TITLE
cgame,sgame: request and resend `pmoveParams` when client is ready

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1399,6 +1399,9 @@ void CG_Init( int serverMessageNum, int clientNum, const glconfig_t& gl, const G
 	CG_ShaderStateChanged();
 
 	trap_Cvar_Set( "ui_winner", "" ); // Clear the previous round's winner.
+
+	// Request server to resend pmoveParams.
+	trap_SendClientCommand( "client_ready" );
 }
 
 /*

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -2842,6 +2842,11 @@ static void Cmd_Class_f( gentity_t *ent )
 	}
 }
 
+static void Cmd_ClientReady_f( gentity_t *ent )
+{
+	G_SendClientPmoveParams( ent->num() );
+}
+
 static void Cmd_Deconstruct_f( gentity_t *ent )
 {
 	// Check for valid build weapon.
@@ -4810,6 +4815,7 @@ static const commands_t cmds[] =
 	{ "callteamvote",    CMD_MESSAGE | CMD_TEAM,              Cmd_CallVote_f         },
 	{ "callvote",        CMD_MESSAGE,                         Cmd_CallVote_f         },
 	{ "class",           CMD_TEAM,                            Cmd_Class_f            },
+	{ "client_ready",    0,                                   Cmd_ClientReady_f      },
 	{ "damage",          CMD_CHEAT | CMD_ALIVE,               Cmd_Damage_f           },
 	{ "deconstruct",     CMD_TEAM | CMD_ALIVE,                Cmd_Deconstruct_f      },
 	{ "devteam",         CMD_CHEAT,                           Cmd_Devteam_f          },


### PR DESCRIPTION
Previously, `clientParams` was only sent on client connect, but the client needs the server to resend them after reloading the game with `vid_restart`.

Fixes #2653:

- https://github.com/Unvanquished/Unvanquished/issues/2653