### PR TITLE
rmlui: implement web custom tags and b, i, em and ul/li standard tags, make use of them

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/help_gameplay.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/help_gameplay.rml
@@ -19,11 +19,13 @@
 				<translate>In this section you will find a summary of major gameplay elements to know to become a successful player.</translate>
 				<br />
 				<br />
-				<!-- FIXME: use a proper list (ul+li isn't supported as of now) -->
-				<translate>Feel free to join us in the community and developer chats!</translate><br />
-				&nbsp;&nbsp;&nbsp;• <translate>We are chatting on IRC and Matrix in <b>#unvanquished</b> and <b>#unvanquished-dev</b> on Libera.Chat</translate><br />
-				&nbsp;&nbsp;&nbsp;• <translate>Discuss news in the forum, <b>forums.unvanquished.net</b></translate><br />
-				&nbsp;&nbsp;&nbsp;• <translate>Discover more about the game in the wiki, <b>wiki.unvanquished.net</b></translate>
+				<translate>More can be found on our website and other community places!</translate>
+				<ul>
+					<li><translate>Chat with players and developers on Libera.Chat IRC, Matrix or Discord: <web dest="chat" /></translate></li>
+					<li><translate>Discuss news in the forums: <web dest="forums" /></translate></li>
+					<li><translate>Discover more about the game in the wiki: <web dest="wiki" /></translate></li>
+				</ul>
+				<translate>Please report bugs on: <web dest="bugs" /></translate>
 			</panel>
 			<tab>
 				<img class="emoticon" src="/emoticons/tyrant" />

--- a/pkg/unvanquished_src.dpkdir/ui/menu.rcss
+++ b/pkg/unvanquished_src.dpkdir/ui/menu.rcss
@@ -144,3 +144,15 @@ body.ingame .black2 {
 	top: 13%;
 	opacity: 0.6;
 }
+
+.devmsg {
+	position: absolute;
+	bottom: 1em;
+	left: 1em;
+	color: rgba(255, 0, 0, 200);
+}
+
+.devmsg web {
+	font-weight: normal;
+	color: rgba(255, 0, 0, 200);
+}

--- a/pkg/unvanquished_src.dpkdir/ui/menu_ingame.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/menu_ingame.rml
@@ -12,7 +12,7 @@
 		<img class="circles" src="/ui/assets/background/circles2" />
 		<img class="black2" src="/ui/assets/background/black2" />
 
-		<div style="position: absolute; bottom: 1em; left: 1em; color: rgba(255, 0, 0, 200);"><translate>This is a beta version of Unvanquished. Please report any issue you may find at https://bugs.unvanquished.net</translate></div>
+		<div class="devmsg"><translate>This is a beta version of Unvanquished. Please report any issue you may find at <web dest="bugs" /></translate></div>
 
 		<sidebar>
 				<!-- HACK: Using shared/window.rml as a stylesheet rather than a template -->

--- a/pkg/unvanquished_src.dpkdir/ui/menu_main.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/menu_main.rml
@@ -15,7 +15,7 @@
 		<img class="fog" src="/ui/assets/background/fog" />
 		<img class="logo" src="/ui/assets/logos/fuzzy_blue" />
 
-		<div style="position: absolute; bottom: 1em; left: 1em; color: rgba(255, 0, 0, 200);"><translate>This is a beta version of Unvanquished. Please report any issue you may find at https://bugs.unvanquished.net</translate></div>
+		<div class="devmsg"><translate>This is a beta version of Unvanquished. Please report any issue you may find at <web dest="bugs" /></translate></div>
 
 		<sidebar>
 				<!-- HACK: Add some extra spacing atop the main menu -->

--- a/pkg/unvanquished_src.dpkdir/ui/shared/basics.rcss
+++ b/pkg/unvanquished_src.dpkdir/ui/shared/basics.rcss
@@ -62,6 +62,10 @@ indent {
 	margin-left: 1.5em;
 }
 
+web {
+	color: #ffffff;
+}
+
 /* #### Links #### */
 /* Inline */
 ilink {

--- a/pkg/unvanquished_src.dpkdir/ui/shared/basics.rcss
+++ b/pkg/unvanquished_src.dpkdir/ui/shared/basics.rcss
@@ -45,6 +45,18 @@ h3 {
 	height: 1.3em; /* Same as input boxes */
 }
 
+b {
+	font-weight: bold;
+}
+
+i {
+	font-style: italic;
+}
+
+em {
+	font-style: italic;
+}
+
 indent {
 	display: block;
 	margin-left: 1.5em;

--- a/pkg/unvanquished_src.dpkdir/ui/shared/basics.rcss
+++ b/pkg/unvanquished_src.dpkdir/ui/shared/basics.rcss
@@ -57,6 +57,26 @@ em {
 	font-style: italic;
 }
 
+/* For now, render ordered list
+as unordered list as a fallback. */
+ul, ol {
+	display: table;
+	margin: 1em 0em;
+}
+
+li {
+	display: table-row;
+}
+
+li-bullet {
+	display: table-cell;
+	width: .6em;
+}
+
+li-content {
+	display: table-cell;
+}
+
 indent {
 	display: block;
 	margin-left: 1.5em;

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -75,6 +75,41 @@ void Rocket_UpdateLanguage()
 		hudContext->Update();
 	updateLanguage = false;
 }
+
+class WebElement : public Rml::Element
+{
+public:
+	WebElement(const Rml::String& tag) : Rml::Element(tag) {}
+
+private:
+	const std::unordered_map<std::string, std::string> webUrls = {
+		{ "bugs", "bugs.unvanquished.net" },
+		{ "chat", "unvanquished.net/chat" },
+		{ "forums", "forums.unvanquished.net" },
+		{ "wiki", "wiki.unvanquished.net" },
+	};
+
+	void OnAttributeChange( const Rml::ElementAttributes& changed_attributes ) override
+	{
+		Rml::Element::OnAttributeChange( changed_attributes );
+
+		if ( changed_attributes.find( "dest" ) != changed_attributes.end() )
+		{
+			const Rml::String dest = GetAttribute< Rml::String >( "dest",  "" );
+
+			if ( webUrls.find( dest ) != webUrls.end() )
+			{
+				SetInnerRML( webUrls.at( dest ) );
+			}
+			else
+			{
+				Log::Warn( "Unknown \"dest\" attribute in web RML tag" );
+				SetInnerRML( "⚠ BUG" );
+			}
+		}
+	}
+};
+
 class TranslateElement : public Rml::Element
 {
 public:
@@ -3781,6 +3816,7 @@ void CG_Rocket_RegisterElements()
 	RegisterElement<BeaconOwnerElement>( "beacon_owner" );
 	RegisterElement<PredictedMineEfficiencyElement>( "predictedMineEfficiency" );
 	RegisterElement<BarbsHudElement>( "barbs" );
+	RegisterElement<WebElement>( "web" );
 	RegisterElement<TranslateElement>( "translate" );
 	RegisterElement<SpawnQueueElement>( "spawnPos" );
 	RegisterElement<NumSpawnsElement>( "numSpawns" );

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -76,6 +76,29 @@ void Rocket_UpdateLanguage()
 	updateLanguage = false;
 }
 
+// Standard HTML
+
+class LiElement : public Rml::Element
+{
+public:
+	LiElement(const Rml::String& tag) : Rml::Element(tag) {}
+
+private:
+	void OnUpdate() override
+	{
+		if ( !done )
+		{
+			SetInnerRML( va( "<li-bullet>• </li-bullet><li-content>%s</li-content>",
+				GetInnerRML().c_str() ) );
+			done = true;
+		}
+	}
+
+	bool done = false;
+};
+
+// Game-specific RML
+
 class WebElement : public Rml::Element
 {
 public:
@@ -3787,6 +3810,10 @@ void CG_Rocket_RegisterElements()
 		Rocket_RegisterElement( elementRenderCmdList[ i ].name );
 	}
 
+	// Standard HTML
+	RegisterElement<LiElement>( "li" );
+
+	// Game-specific RML
 	RegisterElement<AmmoHudElement>( "ammo" );
 	RegisterElement<ClipsHudElement>( "clips" );
 	RegisterElement<FpsHudElement>( "fps" );


### PR DESCRIPTION
- Introduce `web` tag for common Unvanquished urls, to be used this way: `Discuss news in the forums: <web forums />`, this will be displayed this way: `Discuss news in the forums: forums.unvanquished.net`. This makes the strings translatable without translating the URL itself. The day we implement hyperlinks, we would have nothing to translate. If we want to change an URL, we would have nothing to translate. And we don't have to put any styling code in the translatable string.

- Implement `b`, `i`, `em` and even `ul/li` standard tags.

Make use of all that niceness.

[![rmlui](https://dl.illwieckz.net/b/unvanquished/wip/rmlui/unvanquished_2023-07-24_062320_000.png)](https://dl.illwieckz.net/b/unvanquished/wip/rmlui/unvanquished_2023-07-24_062320_000.png)