### PR TITLE
WIP: cg_predict: introduce cg_predict cvar

### DIFF
--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -36,6 +36,10 @@ static  pmove_t   cg_pmove;
 static BoundedVector<centity_t *, MAX_GENTITIES> cg_solidEntities;
 static BoundedVector<centity_t *, MAX_GENTITIES> cg_triggerEntities;
 
+static Cvar::Range<Cvar::Cvar<int>> cg_predict( "cg_predict",
+	"number of backup commands for prediction",
+	Cvar::NONE, CMD_BACKUP, 0, CMD_BACKUP );
+
 /*
 ====================
 CG_BuildSolidList
@@ -804,7 +808,7 @@ void CG_PredictPlayerState()
 		stateIndex = cg.stateHead;
 	}
 
-	for ( cmdNum = current - CMD_BACKUP + 1; cmdNum <= current; cmdNum++ )
+	for ( cmdNum = current - cg_predict.Get() + 1; cmdNum <= current; cmdNum++ )
 	{
 		// get the command
 		trap_GetUserCmd( cmdNum, &cg_pmove.cmd );


### PR DESCRIPTION
The idea is to configure the client for an amount of backup commands to use to do client-side prediction.

The default is `64`, like original value. But instead of having to choice between no prediction at all and prediction with `64` command backups that eats hundreds of fps, one may chose do less precise prediction and save hundreds of fps.

This work-in-progress, see this discussion for details:

- https://github.com/DaemonEngine/Daemon/issues/846

A second patch could be added to drop the boolean `cg_nopredict` and replace any `if ( cg_nopredict.Get() )` with `if ( !cg_predict.Get() )`, people would then disable prediction by setting `cg_predict` to `0`.