### PR TITLE
Increase flamer direct damage and floor fire chance.

### DIFF
--- a/pkg/unvanquished_src.dpkdir/configs/missiles/flamer.attr.cfg
+++ b/pkg/unvanquished_src.dpkdir/configs/missiles/flamer.attr.cfg
@@ -1,5 +1,5 @@
 // attributes
-damage             5
+damage             8
 meansOfDeath       MOD_FLAMER
 
 splashDamage       10

--- a/src/shared/bg_gameplay.cpp
+++ b/src/shared/bg_gameplay.cpp
@@ -154,7 +154,7 @@ const float LEVEL1_SLOW_MOD = 0.75f;
 
 const float FLAMER_DAMAGE_MAXDST_MOD = 0.5f;
 const float FLAMER_SPLASH_MINDST_MOD = 0.5f;
-const float FLAMER_LEAVE_FIRE_CHANCE = 0.1f;
+const float FLAMER_LEAVE_FIRE_CHANCE = 0.2f;
 
 const int   PRIFLE_DAMAGE_FULL_TIME = 0;
 const int   PRIFLE_DAMAGE_HALF_LIFE = 0;


### PR DESCRIPTION
This is a compromise between its original stats and its current state after nerfs in 4957493 (adjusted in c3027e0).

See https://github.com/Unvanquished/gameplay/issues/69 for the discussion leading to this; note that the range nerf discussed therein is *not* included here.