### PR TITLE
Do not try to print `nullptr` in error message

### DIFF
--- a/src/sgame/sg_spawn_position.cpp
+++ b/src/sgame/sg_spawn_position.cpp
@@ -102,7 +102,9 @@ void SP_pos_location( gentity_t *self )
 	}
 
 	self->nextPathSegment = level.locationHead;
-	self->s.generic1 = G_LocationIndex(message);
+
+	self->s.generic1 = message ? G_LocationIndex( message ) : 0;
+
 	level.locationHead = self;
 
 	G_SetOrigin( self, VEC2GLM( self->s.origin ) );

--- a/src/sgame/sg_utils.cpp
+++ b/src/sgame/sg_utils.cpp
@@ -150,7 +150,7 @@ int G_ParticleSystemIndex( const char *name )
 
 	if ( !i )
 	{
-		Log::Warn( "Missing particle system: %s", name );
+		Log::Warn( "Missing particle system: %s", name ? name : "<nullptr>" );
 	}
 
 	return i;
@@ -162,7 +162,7 @@ int G_ShaderIndex( const char *name )
 
 	if ( !i )
 	{
-		Log::Warn( "Missing shader: %s", name );
+		Log::Warn( "Missing shader: %s", name ? name : "<nullptr>" );
 	}
 
 	return i;
@@ -174,7 +174,7 @@ int G_ModelIndex( const char *name )
 
 	if ( !i )
 	{
-		Log::Warn( "Missing model: %s", name );
+		Log::Warn( "Missing model: %s", name ? name : "<nullptr>" );
 	}
 
 	return i;
@@ -186,7 +186,7 @@ int G_SoundIndex( const char *name )
 
 	if ( !i )
 	{
-		Log::Warn( "Missing sound: %s", name );
+		Log::Warn( "Missing sound: %s", name ? name : "<nullptr>" );
 	}
 
 	return i;
@@ -204,7 +204,7 @@ int G_GradingTextureIndex( const char *name )
 
 	if ( !i )
 	{
-		Log::Warn( "Missing grading texture: %s", name );
+		Log::Warn( "Missing grading texture: %s", name ? name : "<nullptr>" );
 	}
 
 	return i;
@@ -216,7 +216,7 @@ int G_ReverbEffectIndex( const char *name )
 
 	if ( !i )
 	{
-		Log::Warn( "Missing reverb effect: %s", name );
+		Log::Warn( "Missing reverb effect: %s", name ? name : "<nullptr>" );
 	}
 
 	return i;
@@ -228,7 +228,7 @@ int G_LocationIndex( const char *name )
 
 	if ( !i )
 	{
-		Log::Warn( "Missing location: %s", name );
+		Log::Warn( "Missing location: %s", name ? name : "<nullptr>" );
 	}
 
 	return i;


### PR DESCRIPTION
Necessary change after:

- https://github.com/Unvanquished/Unvanquished/pull/2648

When loading chasm map I got this:

```
Warn: Assertion failure at src/common/String.cpp:37 (AssertOnTinyFormatError): "reason == """ expected: "tinyformat: Null char* pointer passed for string parameter", actual:  
Thread 39 "daemon" received signal SIGTRAP, Trace/breakpoint trap.
0x00007fffaa80e2bd in Str::AssertOnTinyFormatError (reason="\"tinyformat: Null char* pointer passed for string parameter\"") at src/common/String.cpp:37
37	            ASSERT_EQ(reason, "");
```
