### PR TITLE
cg_main: fix navgen messages by copying translated string

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1129,10 +1129,10 @@ static void GenerateNavmeshes()
 		return;
 	}
 
-	const char* message = _("Generating bot navigation meshes");
+	const std::string message = _("Generating bot navigation meshes");
 	cg.navmeshLoadingFraction = 0;
 	cg.loadingNavmesh = true;
-	Q_strncpyz( cg.loadingText, message, sizeof(cg.loadingText) );
+	Q_strncpyz( cg.loadingText, message.c_str(), sizeof(cg.loadingText) );
 	trap_UpdateScreen();
 
 	NavmeshGenerator navgen;


### PR DESCRIPTION
Fix navgen messages by copying translated string, otherwise we may reuse a pointer that can contain other data.

Fixes #2666:

- https://github.com/Unvanquished/Unvanquished/issues/2666