### PR TITLE
 scoreboard shows number of players per team (improved)

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/ingame_scoreboard.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/ingame_scoreboard.rml
@@ -155,7 +155,7 @@
 	<inlinecvar cvar="ui_winner" class="winner" />
 
 	<half>
-		<teamname><translate>Aliens</translate> (<playerscount team="aliens"/>)</teamname>
+		<teamname><translate>Aliens</translate> (<playerCount team="aliens"/>)</teamname>
 		<teambox class="alien">
 			<datagrid source="playerList.aliens" id="aliens">
 				<col fields="num" formatter="GearOrReady"></col>
@@ -168,7 +168,7 @@
 	</half>
 
 	<half>
-		<teamname><translate>Humans</translate> (<playerscount team="humans"/>)</teamname>
+		<teamname><translate>Humans</translate> (<playerCount team="humans"/>)</teamname>
 		<teambox class="human">
 			<datagrid source="playerList.humans" id="humans">
 				<col fields="num" formatter="GearOrReady"></col>

--- a/pkg/unvanquished_src.dpkdir/ui/ingame_scoreboard.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/ingame_scoreboard.rml
@@ -157,6 +157,7 @@
 	<half>
 		<teamname><translate>Aliens</translate></teamname>
 		<teambox class="alien">
+			<playerscount team="aliens"/>
 			<datagrid source="playerList.aliens" id="aliens">
 				<col fields="num" formatter="GearOrReady"></col>
 				<col fields="num" formatter="PlayerName">Name</col>
@@ -170,6 +171,7 @@
 	<half>
 		<teamname><translate>Humans</translate></teamname>
 		<teambox class="human">
+			<playerscount team="humans"/>
 			<datagrid source="playerList.humans" id="humans">
 				<col fields="num" formatter="GearOrReady"></col>
 				<col fields="num" formatter="PlayerName">Name</col>

--- a/pkg/unvanquished_src.dpkdir/ui/ingame_scoreboard.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/ingame_scoreboard.rml
@@ -155,9 +155,8 @@
 	<inlinecvar cvar="ui_winner" class="winner" />
 
 	<half>
-		<teamname><translate>Aliens</translate></teamname>
+		<teamname><translate>Aliens</translate> (<playerscount team="aliens"/>)</teamname>
 		<teambox class="alien">
-			<playerscount team="aliens"/>
 			<datagrid source="playerList.aliens" id="aliens">
 				<col fields="num" formatter="GearOrReady"></col>
 				<col fields="num" formatter="PlayerName">Name</col>
@@ -169,9 +168,8 @@
 	</half>
 
 	<half>
-		<teamname><translate>Humans</translate></teamname>
+		<teamname><translate>Humans</translate> (<playerscount team="humans"/>)</teamname>
 		<teambox class="human">
-			<playerscount team="humans"/>
 			<datagrid source="playerList.humans" id="humans">
 				<col fields="num" formatter="GearOrReady"></col>
 				<col fields="num" formatter="PlayerName">Name</col>

--- a/pkg/unvanquished_src.dpkdir/ui/ingame_scoreboard.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/ingame_scoreboard.rml
@@ -180,8 +180,7 @@
 		</teambox>
 	</half>
 
-
-	<teamname><translate>Spectators</translate></teamname>
+	<teamname><translate>Spectators</translate> (<playerCount team="spectators"/>)</teamname>
 	<teambox class="spec">
 		<datasource  source="playerList.spectators" fields="num" formatter="PlayerName" />
 	</teambox>

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1167,6 +1167,7 @@ struct cg_t
 	int      scoresRequestTime;
 	int      numScores;
 	int      teamScores[ 2 ];
+	int teamPlayerCount[ NUM_TEAMS ];
 	score_t  scores[ MAX_CLIENTS ];
 	bool showScores;
 	char     killerName[ MAX_NAME_LENGTH ];

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -2505,7 +2505,7 @@ public:
 
 		team_t team = BG_PlayableTeamFromString( teamname.c_str() );
 
-		SetText( va( "Player count: %d", cg.teamPlayerCount[ team ] ) );
+		SetText( va( "%d", cg.teamPlayerCount[ team ] ) );
 	}
 };
 

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -2504,19 +2504,8 @@ public:
 		std::string teamname = GetAttribute< Rml::String >( "team", "" );
 
 		team_t team = BG_PlayableTeamFromString( teamname.c_str() );
-		size_t count = 0;
 
-		for ( int i = 0; i < cg.numScores; ++i )
-		{
-			score_t const& score = cg.scores[ i ];
-
-			if ( score.team == team )
-			{
-				++count;
-			}
-		}
-
-		SetText( va( "Player count: %zu", count ) );
+		SetText( va( "Player count: %d", cg.teamPlayerCount[ team ] ) );
 	}
 };
 

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -2490,10 +2490,10 @@ private:
 	int spawns_;
 };
 
-class PlayersCountElement : public TextHudElement
+class PlayerCountElement : public TextHudElement
 {
 public:
-	PlayersCountElement( const Rml::String& tag ) :
+	PlayerCountElement( const Rml::String& tag ) :
 			TextHudElement( tag, ELEMENT_GAME )
 			{}
 
@@ -3784,5 +3784,5 @@ void CG_Rocket_RegisterElements()
 	RegisterElement<TranslateElement>( "translate" );
 	RegisterElement<SpawnQueueElement>( "spawnPos" );
 	RegisterElement<NumSpawnsElement>( "numSpawns" );
-	RegisterElement<PlayersCountElement>( "playerscount" );
+	RegisterElement<PlayerCountElement>( "playerCount" );
 }

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -2490,6 +2490,35 @@ private:
 	int spawns_;
 };
 
+class PlayersCountElement : public TextHudElement
+{
+public:
+	PlayersCountElement( const Rml::String& tag ) :
+			TextHudElement( tag, ELEMENT_GAME )
+			{}
+
+	void DoOnUpdate() override
+	{
+		//there is probably a better way to do that, maybe reusing value
+		//cached in some struct?
+		std::string teamname = GetAttribute< Rml::String >( "team", "" );
+
+		team_t team = BG_PlayableTeamFromString( teamname.c_str() );
+		size_t count = 0;
+
+		for ( int i = 0; i < cg.numScores; ++i )
+		{
+			score_t const& score = cg.scores[ i ];
+
+			if ( score.team == team )
+			{
+				++count;
+			}
+		}
+
+		SetText( va( "Player count: %zu", count ) );
+	}
+};
 
 static void CG_Rocket_DrawPlayerHealth()
 {
@@ -3766,4 +3795,5 @@ void CG_Rocket_RegisterElements()
 	RegisterElement<TranslateElement>( "translate" );
 	RegisterElement<SpawnQueueElement>( "spawnPos" );
 	RegisterElement<NumSpawnsElement>( "numSpawns" );
+	RegisterElement<PlayersCountElement>( "playerscount" );
 }

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -52,6 +52,7 @@ static void CG_ParseScores()
 	cg.teamScores[ 1 ] = atoi( CG_Argv( 2 ) );
 
 	memset( cg.scores, 0, sizeof( cg.scores ) );
+	memset( cg.teamPlayerCount, 0, sizeof( cg.teamPlayerCount ) );
 
 	for ( i = 0; i < cg.numScores; i++ )
 	{
@@ -71,6 +72,8 @@ static void CG_ParseScores()
 		cgs.clientinfo[ cg.scores[ i ].client ].score = cg.scores[ i ].score;
 
 		cg.scores[ i ].team = cgs.clientinfo[ cg.scores[ i ].client ].team;
+
+		cg.teamPlayerCount[ cg.scores[ i ].team ]++;
 	}
 
 	cg.scoreInvalidated = true;


### PR DESCRIPTION
Improvement over:

- https://github.com/Unvanquished/Unvanquished/pull/2630

The main change is that it reuse an existing loop to compute player count, to only do it once per frame.

It also lists spectator count.

I renamed the tag `playerCount` because I thought the wording was more consistent with other things.

![unvanquished_2023-05-03_144853_000](https://user-images.githubusercontent.com/2311649/235921681-2c773121-0b8a-4f10-8aaf-2e4e679d838e.jpg)
