### PR TITLE
cg_ents: use `trap_S_UpdateEntityPositionVelocity` to set position and velocity in one call

### DIFF
--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -264,8 +264,7 @@ void CG_SetEntitySoundPosition( centity_t *cent )
 	}
 	else
 	{
-		trap_S_UpdateEntityPosition( cent->currentState.number, cent->lerpOrigin );
-		trap_S_UpdateEntityVelocity( cent->currentState.number, cent->currentState.pos.trDelta );
+		trap_S_UpdateEntityPositionVelocity( cent->currentState.number, cent->lerpOrigin, cent->currentState.pos.trDelta );
 	}
 }
 


### PR DESCRIPTION
Use `trap_S_UpdateEntityPositionVelocity` to set position and velocity in one call.

Game sidecar of:

- https://github.com/DaemonEngine/Daemon/pull/853