### PR TITLE
Add option to disable marks, disable marks in `lowest` graphics profile

### DIFF
--- a/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
@@ -20,5 +20,6 @@ seta cg_shadows 1
 seta cg_playerShadows 1
 seta cg_buildableShadows 0
 seta cg_bounceParticles 1
+seta cg_marks on
 seta cg_motionblur 0.05
 vid_restart

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
@@ -20,5 +20,6 @@ seta cg_shadows 1
 seta cg_playerShadows 0
 seta cg_buildableShadows 0
 seta cg_bounceParticles 1
+seta cg_marks on
 seta cg_motionblur 0
 vid_restart

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
@@ -20,5 +20,6 @@ seta cg_shadows 0
 seta cg_playerShadows 0
 seta cg_buildableShadows 0
 seta cg_bounceParticles 0
+seta cg_marks off
 seta cg_motionblur 0
 vid_restart

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
@@ -20,5 +20,6 @@ seta cg_shadows 1
 seta cg_playerShadows 1
 seta cg_buildableShadows 1
 seta cg_bounceParticles 1
+seta cg_marks on
 seta cg_motionblur 0
 vid_restart

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
@@ -20,5 +20,6 @@ seta cg_shadows 1
 seta cg_playerShadows 1
 seta cg_buildableShadows 1
 seta cg_bounceParticles 1
+seta cg_marks on
 seta cg_motionblur 0.05
 vid_restart

--- a/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
@@ -224,8 +224,12 @@
 					<input cvar="r_ssao" type="checkbox" />
 					<p><translate>Simulate dark corners.</translate>&nbsp;<translate>Experimental.</translate></p>
 				</row>
-
-				<h2><translate>Particles</translate></h2>
+				<row>
+					<h3><translate>Marks</translate></h3>
+					<input cvar="cg_marks" type="checkbox" />
+					<p><translate>Draw marks (such as bullet holes or creep) on surfaces
+</translate></p>
+				</row>
 				<row>
 					<h3><translate>Particle physics</translate></h3>
 					<input cvar="cg_bounceParticles" type="checkbox" />


### PR DESCRIPTION
- Add option to disable marks
- Disable marks in `lowest` graphics profile

Marks are very costly:

- https://github.com/Unvanquished/Unvanquished/issues/2663

Now I'm looking for a proper title for part where both particles and marks can be tweaked.