### PR TITLE
Bots use beacons to locate enemy buildables

### DIFF
--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -855,6 +855,9 @@ static void BeaconAutoTag( gentity_t *self, int timePassed )
 
 	if ( !( client = self->client ) ) return;
 
+	// You can use noclip to inspect a team's tag beacons without changing them
+	if ( client->noclip ) return;
+
 	team = (team_t)client->pers.team;
 
 	BG_GetClientViewOrigin( &self->client->ps, viewOrigin );

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -162,7 +162,7 @@ void AIDestroyValue( AIValue_t v )
 	}
 }
 
-// Closest alive, but (unlike the botMind->closestBuildings) not necessarily active building
+// Closest alive, but not necessarily active building
 static botEntityAndDistance_t ClosestBuilding(gentity_t *self, bool alignment)
 {
 	botEntityAndDistance_t result;
@@ -207,6 +207,7 @@ botEntityAndDistance_t AIEntityToGentity( gentity_t *self, AIEntity_t e )
 		return ClosestBuilding( self, true );
 
 	case E_ENEMYBUILDING:
+		// TODO use closestBuildings so the bot is not omniscient? Or add a non-cheating alternative
 		return ClosestBuilding( self, false );
 
 	case E_GOAL:

--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -149,6 +149,9 @@ struct botMemory_t
 
 	botEntityAndDistance_t bestEnemy;
 	botEntityAndDistance_t closestDamagedBuilding;
+
+	// For allied buildable types: closest alive and active buildable
+	// For enemy buildable types: closest alive buildable with a tag beacon
 	botEntityAndDistance_t closestBuildings[ BA_NUM_BUILDABLES ];
 
 	AIBehaviorTree_t *behaviorTree;

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -793,6 +793,8 @@ void BotFindClosestBuildings( gentity_t *self )
 		self->botMind->closestBuildings[ i ].distance = std::numeric_limits<float>::max();
 	}
 
+	auto alliedTag = G_Team( self ) == TEAM_ALIENS ? &gentity_t::alienTag : &gentity_t::humanTag;
+
 	for ( testEnt = &g_entities[MAX_CLIENTS]; testEnt < &g_entities[level.num_entities]; testEnt++ )
 	{
 		float newDist;
@@ -814,10 +816,23 @@ void BotFindClosestBuildings( gentity_t *self )
 			continue;
 		}
 
-		// skip buildings that are currently building or aren't powered
-		if ( !testEnt->powered || !testEnt->spawned )
+		if ( G_OnSameTeam( self, testEnt ) )
 		{
-			continue;
+			// skip buildings that are currently building or aren't powered
+			if ( !testEnt->powered || !testEnt->spawned )
+			{
+				continue;
+			}
+		}
+		else
+		{
+			// skip enemy buildings without tag beacons
+			// FIXME: the bot should not magically know about the death of enemy structures and hence
+			// should be able to target a beacon whose corresponding buildable is already dead.
+			if ( nullptr == testEnt->*alliedTag )
+			{
+				continue;
+			}
 		}
 
 		newDist = Distance( self->s.origin, testEnt->s.origin );

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -781,41 +781,6 @@ Entity Querys
 =======================
 */
 
-gentity_t* BotFindBuilding( gentity_t *self, int buildingType, int range )
-{
-	float minDistance = -1;
-	gentity_t* closestBuilding = nullptr;
-	float newDistance;
-	float rangeSquared = Square( range );
-	gentity_t *target = &g_entities[MAX_CLIENTS];
-	int i;
-
-	for ( i = MAX_CLIENTS; i < level.num_entities; i++, target++ )
-	{
-		if ( !target->inuse )
-		{
-			continue;
-		}
-		if ( target->s.eType == entityType_t::ET_BUILDABLE &&
-		     target->s.modelindex == buildingType &&
-		     target->powered && target->spawned &&
-		     Entities::IsAlive( target ) )
-		{
-			newDistance = DistanceSquared( self->s.origin, target->s.origin );
-			if ( range && newDistance > rangeSquared )
-			{
-				continue;
-			}
-			if ( newDistance < minDistance || minDistance == -1 )
-			{
-				minDistance = newDistance;
-				closestBuilding = target;
-			}
-		}
-	}
-	return closestBuilding;
-}
-
 void BotFindClosestBuildings( gentity_t *self )
 {
 	gentity_t *testEnt;

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -793,7 +793,7 @@ void BotFindClosestBuildings( gentity_t *self )
 		self->botMind->closestBuildings[ i ].distance = std::numeric_limits<float>::max();
 	}
 
-	for ( testEnt = &g_entities[MAX_CLIENTS]; testEnt < &g_entities[level.num_entities - 1]; testEnt++ )
+	for ( testEnt = &g_entities[MAX_CLIENTS]; testEnt < &g_entities[level.num_entities]; testEnt++ )
 	{
 		float newDist;
 		// ignore entities that aren't in use
@@ -915,7 +915,7 @@ gentity_t* BotFindBestEnemy( gentity_t *self )
 	bool  hasRadar = ( team == TEAM_ALIENS ) ||
 	                     ( team == TEAM_HUMANS && BG_InventoryContainsUpgrade( UP_RADAR, self->client->ps.stats ) );
 
-	for ( target = g_entities; target < &g_entities[level.num_entities - 1]; target++ )
+	for ( target = g_entities; target < &g_entities[level.num_entities]; target++ )
 	{
 		float newScore;
 
@@ -971,7 +971,7 @@ gentity_t* BotFindClosestEnemy( gentity_t *self )
 	float minDistance = Square( g_bot_aliensenseRange.Get() );
 	gentity_t *target;
 
-	for ( target = g_entities; target < &g_entities[level.num_entities - 1]; target++ )
+	for ( target = g_entities; target < &g_entities[level.num_entities]; target++ )
 	{
 		float newDistance;
 		//ignore entities that arnt in use

--- a/src/sgame/sg_bot_util.h
+++ b/src/sgame/sg_bot_util.h
@@ -46,7 +46,6 @@ int        FindBots( int *botEntityNumbers, int maxBots, team_t team );
 gentity_t* BotFindClosestEnemy( gentity_t *self );
 gentity_t* BotFindBestEnemy( gentity_t *self );
 void       BotFindClosestBuildings( gentity_t *self );
-gentity_t* BotFindBuilding( gentity_t *self, int buildingType, int range );
 bool   BotTeamateHasWeapon( gentity_t *self, int weapon );
 void       BotSearchForEnemy( gentity_t *self );
 void       BotPain( gentity_t *self, gentity_t *attacker, int damage );


### PR DESCRIPTION
Implement #2641 (the easy alternative <aoeu>#</aoeu>1).

Specifically, this is just for the `closestBuildings` array. There are other ways bots can locate buildables such as BotFindClosestEnemy (which requires being within sense range) that don't depend on this.

I noticed that due to their lower mobility, human bots can take several minutes to find the enemy base on plat23. So I imagine that on larger maps, it could be quite a long time before bots find the enemy base via random roaming. In case this is a problem, what if we give each team one freebie beacon at the start of the game pointing to the enemy's main buildable? It could be useful for flesh-and-blood players too to get oriented a bit quicker in an unfamiliar map. What do you think? 