### PR TITLE
fix draw votes using the wrong cvar for time

### DIFF
--- a/src/sgame/sg_votes.cpp
+++ b/src/sgame/sg_votes.cpp
@@ -398,7 +398,7 @@ static std::unordered_map<std::string, VoteDefinition> voteInfo = {
 	{"allowbuild",        { true,  V_TEAM,   T_PLAYER,   false,  true,  qtrinary::qno,    &g_denyVotesPercent,        VOTE_ALWAYS,  nullptr,             nullptr,                   &HandleAllowbuildVote } },
 	{"extend",            { true,  V_PUBLIC, T_OTHER,    false,  false, qtrinary::qno,    &g_extendVotesTime ,        VOTE_REMAIN,  &g_extendVotesTime,  nullptr,                   &HandleExtendVote } },
 	{"admitdefeat",       { true,  V_TEAM,   T_NONE,     false,  true,  qtrinary::qno,    &g_admitDefeatVotesPercent, VOTE_ALWAYS,  nullptr,             nullptr,                   &HandleAdmitDefeatVote } },
-	{"draw",              { true,  V_PUBLIC, T_NONE,     false,  true,  qtrinary::qyes,   &g_drawVotesPercent,        VOTE_AFTER,   &g_drawVotesPercent, &g_drawVoteReasonRequired, &HandleDrawVote } },
+	{"draw",              { true,  V_PUBLIC, T_NONE,     false,  true,  qtrinary::qyes,   &g_drawVotesPercent,        VOTE_AFTER,   &g_drawVotesAfter,   &g_drawVoteReasonRequired, &HandleDrawVote } },
 	{"map_restart",       { true,  V_PUBLIC, T_NONE,     false,  true,  qtrinary::qno,    &g_mapVotesPercent,         VOTE_ALWAYS,  nullptr,             nullptr,                   &HandleMapRestart } },
 	{"map",               { true,  V_PUBLIC, T_OTHER,    false,  true,  qtrinary::qmaybe, &g_mapVotesPercent,         VOTE_BEFORE,  &g_mapVotesBefore,   nullptr,                   &HandleMapVote } },
 	{"layout",            { true,  V_PUBLIC, T_OTHER,    false,  true,  qtrinary::qno,    &g_mapVotesPercent,         VOTE_BEFORE,  &g_mapVotesBefore,   nullptr,                   &HandleLayoutVote } },


### PR DESCRIPTION
This fixes the vote handler using the `g_drawVotesPercent` instead of `g_drawVotesAfter` when calling the "draw" vote.