### PR TITLE
cg_main: do not capture mouse on loading screen

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1201,6 +1201,8 @@ void CG_Init( int serverMessageNum, int clientNum, const glconfig_t& gl, const G
 {
 	const char *s;
 
+	Rocket_SetActiveContext( KEYCATCH_UI );
+
 	CG_UpdateLoadingStep( LOAD_START );
 
 	// get the rendering configuration from the client system
@@ -1350,6 +1352,8 @@ void CG_Init( int serverMessageNum, int clientNum, const glconfig_t& gl, const G
 
 	// Request server to resend pmoveParams.
 	trap_SendClientCommand( "client_ready" );
+
+	Rocket_SetActiveContext( 0 );
 }
 
 /*

--- a/src/cgame/rocket/rocket.cpp
+++ b/src/cgame/rocket/rocket.cpp
@@ -647,11 +647,6 @@ public:
 private:
     void Update()
     {
-        if ( menuContext )
-        {
-			CG_Rocket_EnableCursor( show_cursor && focus );
-        }
-
         MouseMode mode;
 
         if ( !focus )
@@ -660,6 +655,7 @@ private:
         }
         else if ( show_cursor )
         {
+            CG_Rocket_EnableCursor( menuContext );
             mode = MouseMode::CustomCursor;
         }
         else
@@ -668,7 +664,6 @@ private:
         }
 
         trap_SetMouseMode( mode );
-
     }
 
     bool show_cursor = true;


### PR DESCRIPTION
There may be better ways to do this (why it is captured to begin with?).

There may also be other places where to do something like this (server connection screen, map download screen…).

One may also want to capture the mouse when the game is fullscreen as a hack to hide the system cursor when loading map in fullscreen, but that should be done after this.

The current code captures the mouse when loading maps to hide the system cursor, but that also captures the mouse move, and centers the mouse pointer… which is very bad and give birth to a full load of bugs when the game is windowed and especially not in foreground.