### PR TITLE
fix several other voting issues following refactoring

### DIFF
--- a/src/sgame/sg_votes.cpp
+++ b/src/sgame/sg_votes.cpp
@@ -396,7 +396,7 @@ static std::unordered_map<std::string, VoteDefinition> voteInfo = {
 	{"unmute",            { false, V_PUBLIC, T_PLAYER,   false,  true,  qtrinary::qno,    &g_denyVotesPercent,        VOTE_ALWAYS,  nullptr,             nullptr,                   &HandleUnmuteVote } },
 	{"denybuild",         { true,  V_TEAM,   T_PLAYER,   true,   true,  qtrinary::qyes,   &g_denyVotesPercent,        VOTE_ALWAYS,  nullptr,             nullptr,                   &HandleDenybuildVote } },
 	{"allowbuild",        { true,  V_TEAM,   T_PLAYER,   false,  true,  qtrinary::qno,    &g_denyVotesPercent,        VOTE_ALWAYS,  nullptr,             nullptr,                   &HandleAllowbuildVote } },
-	{"extend",            { true,  V_PUBLIC, T_OTHER,    false,  false, qtrinary::qno,    &g_extendVotesTime ,        VOTE_REMAIN,  &g_extendVotesTime,  nullptr,                   &HandleExtendVote } },
+	{"extend",            { true,  V_PUBLIC, T_OTHER,    false,  false, qtrinary::qno,    &g_extendVotesPercent,      VOTE_REMAIN,  &g_extendVotesTime,  nullptr,                   &HandleExtendVote } },
 	{"admitdefeat",       { true,  V_TEAM,   T_NONE,     false,  true,  qtrinary::qno,    &g_admitDefeatVotesPercent, VOTE_ALWAYS,  nullptr,             nullptr,                   &HandleAdmitDefeatVote } },
 	{"draw",              { true,  V_PUBLIC, T_NONE,     false,  true,  qtrinary::qyes,   &g_drawVotesPercent,        VOTE_AFTER,   &g_drawVotesAfter,   &g_drawVoteReasonRequired, &HandleDrawVote } },
 	{"map_restart",       { true,  V_PUBLIC, T_NONE,     false,  true,  qtrinary::qno,    &g_mapVotesPercent,         VOTE_ALWAYS,  nullptr,             nullptr,                   &HandleMapRestart } },

--- a/src/sgame/sg_votes.cpp
+++ b/src/sgame/sg_votes.cpp
@@ -357,10 +357,10 @@ static bool HandleFillBotsHumanVote( gentity_t* ent, team_t team, std::string& c
 	}
 
 	Com_sprintf( level.team[ team ].voteString, sizeof( level.team[ team ].voteString ),
-	             "bot fill humans %d", num );
+	             "bot fill %d h", num );
 	Com_sprintf( level.team[ team ].voteDisplayString,
 	             sizeof( level.team[ team ].voteDisplayString ),
-	             N_( "Fill each team with bots to %d" ), num );
+	             N_( "Fill the human team with bots to %d" ), num );
 	return true;
 }
 
@@ -379,10 +379,10 @@ static bool HandleFillBotsAliensVote( gentity_t* ent, team_t team, std::string& 
 	}
 
 	Com_sprintf( level.team[ team ].voteString, sizeof( level.team[ team ].voteString ),
-	             "bot fill aliens %d", num );
+	             "bot fill %d a", num );
 	Com_sprintf( level.team[ team ].voteDisplayString,
 	             sizeof( level.team[ team ].voteDisplayString ),
-	             N_( "Fill each team with bots to %d" ), num );
+	             N_( "Fill the alien team with bots to %d" ), num );
 	return true;
 }
 


### PR DESCRIPTION
Companion to #2687

This fixes the vote handler using the `g_extendVotestime` instead of `g_extendVotesPercent` when calling the "extend" vote.

I have also fixed fillbots_{humans|aliens} not working, and made the vote text more descriptive.