### PR TITLE
Fix crash with TurrentComponent targeting

### DIFF
--- a/src/sgame/components/TurretComponent.h
+++ b/src/sgame/components/TurretComponent.h
@@ -114,7 +114,7 @@ class TurretComponent: public TurretComponentBase {
 		glm::vec3 RelativeAnglesToDirection(const glm::vec3 relativeAngles) const;
 
 		/** An entity target that the turret can track. */
-		gentity_t* target;
+		GentityRef target;
 
 		/** The attack range of the turret, used for checking whether a target can be hit. */
 		float range;


### PR DESCRIPTION
This reportedly crashes when a targeted player leaves the team. Likely a regression in 59fb1ff18fd32aade0e79bb6d8a7f92202c71335.

Fixes #2692.