### PR TITLE
Add wall climbing for dretch and mantis bots

### DIFF
--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -177,6 +177,7 @@ public:
 
 	int spawnTime;
 	int lastNavconTime;
+	int lastWallclimbActivationTime;
 
 	Util::optional< glm::vec3 > userSpecifiedPosition;
 	Util::optional< int > userSpecifiedClientNum;

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -844,6 +844,8 @@ static constexpr int WALLCLIMB_MAX_TIME = 3000;
 static Cvar::Cvar<int> g_bot_upwardNavconMinHeight("g_bot_upwardNavconMinHeight", "minimal height difference for bots to use special upward movement.", Cvar::NONE, 100);
 static Cvar::Cvar<int> g_bot_upwardLeapAngleCorr("g_bot_upwardLeapAngleCorr", "is added to the angle for mantis and dragoon when leaping upward (in degrees).", Cvar::NONE, 20);
 
+// could use BG_ClassHasAbility( pcl, SCA_WALLCLIMBER ) to check if calling
+// this is a good idea
 static void BotClimbToGoal( gentity_t *self )
 {
 	glm::vec3 ownPos = VEC2GLM( self->s.origin );

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -830,6 +830,15 @@ Global Bot Navigation
 =========================
 */
 
+
+// HACK:
+// Set an upper bound on how long a bot will have the wall climb activated,
+// in order to prevent looping on strange wall geometries.
+// This works well in practice, as recast limits the navcon distance.
+// There are at least to cleaner ways to handle this:
+// - Calculate the required time when a bot activates the wall climb
+// - Disable the wall climb once a bot has reached the higher level navmesh
+// Both are non-trivial, because a bot might choose a new goal while wall climbing.
 static constexpr int WALLCLIMB_MAX_TIME = 3000;
 
 static Cvar::Cvar<int> g_bot_upwardNavconMinHeight("g_bot_upwardNavconMinHeight", "minimal height difference for bots to use special upward movement.", Cvar::NONE, 100);


### PR DESCRIPTION
Make dretch and mantis bots able to follow upward navcons by using the alien wall climb. This works as follows: if a dretch or mantis bot is over an upward navcon, it enables the wall climb and goes up. Additionally, it saves the current time in its mind.

3 seconds after encountering the navcon, it will disable the wall climb. This has been observed to be useful if a particularly difficult wall geometry makes a bot loop on a wall. It will fall down eventually.

This can be seen in action on my server on the map thunder, near the default alien base.