### PR TITLE
Don't grab cursor during loading if windowed

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1201,6 +1201,13 @@ void CG_Init( int serverMessageNum, int clientNum, const glconfig_t& gl, const G
 {
 	const char *s;
 
+	bool fullscreen;
+	if ( Cvar::ParseCvarValue( Cvar::GetValue( "r_fullscreen" ), fullscreen ) && !fullscreen )
+	{
+		// ungrab the mouse while loading in windowed mode
+		trap_SetMouseMode( MouseMode::SystemCursor );
+	}
+
 	CG_UpdateLoadingStep( LOAD_START );
 
 	// get the rendering configuration from the client system


### PR DESCRIPTION
Enhanced version of #2688 that doesn't show the cursor in full-screen mode.

According to my tests, the game already issues an appropriate call to trap_SetMouseMode when the loading ends (Deltas if focused or SystemCursor if not), so additional calls at the end of CG_Init are not needed.