### PR TITLE
Add base skills for each skill level (5/?)

### DIFF
--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -157,6 +157,9 @@ void G_InitSkilltreeCvars()
 		skillsetBudgetHumans,
 		G_SetSkillsetBudgetHumans
 		);
+
+	G_SetDisabledSkillset(g_bot_skillset_disabledSkills.Get());
+	G_SetBaseSkillset(g_bot_skillset_baseSkills.Get());
 }
 
 struct botSkillTreeElement_t {

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -143,15 +143,15 @@ void G_InitSkilltreeCvars()
 		G_SetBaseSkillset
 		);
 
-	static Cvar::Callback<Cvar::Cvar<int>> g_skillsetBudgetAliens(
-		"g_skillsetBudgetAliens",
+	static Cvar::Callback<Cvar::Cvar<int>> g_skillset_budgetAliens(
+		"g_skillset_budgetAliens",
 		"How many skillpoint for bot aliens' random skills. Base skill costs are also removed from this sum",
 		Cvar::NONE,
 		skillsetBudgetAliens,
 		G_SetSkillsetBudgetAliens
 		);
-	static Cvar::Callback<Cvar::Cvar<int>> g_skillsetBudgetHumans(
-		"g_skillsetBudgetHumans",
+	static Cvar::Callback<Cvar::Cvar<int>> g_skillset_budgetHumans(
+		"g_skillset_budgetHumans",
 		"How many skillpoint for bot humans' random skills. Base skill costs are also removed from this sum",
 		Cvar::NONE,
 		skillsetBudgetHumans,

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -127,31 +127,31 @@ static void G_SetSkillsetBudgetAliens( int val )
 
 void G_InitSkilltreeCvars()
 {
-	static Cvar::Callback<Cvar::Cvar<std::string>> g_skillset_disabledSkills(
-		"g_skillset_disabledSkills",
+	static Cvar::Callback<Cvar::Cvar<std::string>> g_bot_skillset_disabledSkills(
+		"g_bot_skillset_disabledSkills",
 		"Skills that will not be selected randomly for bots, example: " QQ("mantis-attack-jump, prefer-armor"),
 		Cvar::NONE,
 		"",
 		G_SetDisabledSkillset
 		);
 
-	static Cvar::Callback<Cvar::Cvar<std::string>> g_skillset_baseSkills(
-		"g_skillset_baseSkills",
+	static Cvar::Callback<Cvar::Cvar<std::string>> g_bot_skillset_baseSkills(
+		"g_bot_skillset_baseSkills",
 		"Preferred skills for bots depending on levels, this is a level:skillName key:value list, example: " QQ("6:mantis-attack-jump, 3:prefer-armor"),
 		Cvar::NONE,
 		"",
 		G_SetBaseSkillset
 		);
 
-	static Cvar::Callback<Cvar::Cvar<int>> g_skillset_budgetAliens(
-		"g_skillset_budgetAliens",
+	static Cvar::Callback<Cvar::Cvar<int>> g_bot_skillset_budgetAliens(
+		"g_bot_skillset_budgetAliens",
 		"How many skillpoint for bot aliens' random skills. Base skill costs are also removed from this sum",
 		Cvar::NONE,
 		skillsetBudgetAliens,
 		G_SetSkillsetBudgetAliens
 		);
-	static Cvar::Callback<Cvar::Cvar<int>> g_skillset_budgetHumans(
-		"g_skillset_budgetHumans",
+	static Cvar::Callback<Cvar::Cvar<int>> g_bot_skillset_budgetHumans(
+		"g_bot_skillset_budgetHumans",
 		"How many skillpoint for bot humans' random skills. Base skill costs are also removed from this sum",
 		Cvar::NONE,
 		skillsetBudgetHumans,

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -127,8 +127,8 @@ static void G_SetSkillsetBudgetAliens( int val )
 
 void G_InitSkilltreeCvars()
 {
-	static Cvar::Callback<Cvar::Cvar<std::string>> g_disabledSkillset(
-		"g_disabledSkillset",
+	static Cvar::Callback<Cvar::Cvar<std::string>> g_skillset_disabledSkills(
+		"g_skillset_disabledSkills",
 		"Skills that will not be selected randomly for bots, example: " QQ("mantis-attack-jump, prefer-armor"),
 		Cvar::NONE,
 		"",


### PR DESCRIPTION
This PR is based on https://github.com/Unvanquished/Unvanquished/pull/2722, only the last 3 commits are from this PR.

This PR adds a baseline of skill for each skill level, allowing for several modes of operation:
* Pure random, which is the current
* Pure deterministic, for which you can set `g_skillset_budgetHumans` and `g_skillset_budgetAliens` to 0 and write the `g_skillset_baseSkills` list
* A mixed mode, where the base skills are selected first, and the leftover skill points (if any)

You can even have some skills mandatory at some skill levels and forbidden from the random part by putting them in the `g_skillset_disabledSkills` list.

This also renames the skilltree cvars so that that they are all under the `g_skilltree_` namespace, to make them easier to find.

---

This PR doesn't do any balancing or behavior change, but it should make switching the default mode to e.g. a deterministic one as "simple" as actually writting the skill lists and testing it for balancing.