### PR TITLE
sg_cmds: silence clang warning for bitwise instead of logical operators

### DIFF
--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -2497,10 +2497,11 @@ static bool Cmd_Sell_upgrades( gentity_t *ent )
 
 static bool Cmd_Sell_armour( gentity_t *ent )
 {
-	return Cmd_Sell_upgradeItem( ent, UP_LIGHTARMOUR ) |
-	       Cmd_Sell_upgradeItem( ent, UP_MEDIUMARMOUR ) |
-	       Cmd_Sell_upgradeItem( ent, UP_BATTLESUIT ) |
-	       Cmd_Sell_upgradeItem( ent, UP_RADAR );
+	bool sold = Cmd_Sell_upgradeItem( ent, UP_LIGHTARMOUR );
+	sold |= Cmd_Sell_upgradeItem( ent, UP_MEDIUMARMOUR );
+	sold |= Cmd_Sell_upgradeItem( ent, UP_BATTLESUIT );
+	sold |= Cmd_Sell_upgradeItem( ent, UP_RADAR );
+	return sold;
 }
 
 static bool Cmd_Sell_internal( gentity_t *ent, const char *s )
@@ -2591,7 +2592,9 @@ static bool Cmd_Sell_internal( gentity_t *ent, const char *s )
 	}
 	else if ( !Q_stricmp( s, "all" ) )
 	{
-		return Cmd_Sell_weapons( ent ) | Cmd_Sell_upgrades( ent );
+		bool sold = Cmd_Sell_weapons( ent );
+		sold |= Cmd_Sell_upgrades( ent );
+		return sold;
 	}
 	else
 	{


### PR DESCRIPTION
Fixes #2652:

- https://github.com/Unvanquished/Unvanquished/issues/2652