### PR TITLE
Make bots calculate the required wall climb time

### DIFF
--- a/src/sgame/botlib/bot_nav.cpp
+++ b/src/sgame/botlib/bot_nav.cpp
@@ -264,7 +264,7 @@ void G_BotUpdatePath( int botClientNum, const botRouteTarget_t *target, botNavCm
 
 		cmd->havePath = !bot->needReplan;
 
-		bool overNavconStart = false;
+		bool usingNavcon = false;
 
 		if ( overOffMeshConnectionStart( bot, spos ) )
 		{
@@ -274,14 +274,14 @@ void G_BotUpdatePath( int botClientNum, const botRouteTarget_t *target, botNavCm
 			// numCorners is guaranteed to be >= 1 here
 			dtPolyRef con = bot->cornerPolys[ bot->numCorners - 1 ];
 
-			overNavconStart = true;
-
 			if ( bot->corridor.moveOverOffmeshConnection( con, refs, start, end, bot->nav->query ) )
 			{
 				bot->offMesh = true;
 				bot->offMeshPoly = con;
 				bot->offMeshEnd = end;
 				bot->offMeshStart = start;
+
+				usingNavcon = true;
 			}
 		}
 
@@ -325,11 +325,11 @@ void G_BotUpdatePath( int botClientNum, const botRouteTarget_t *target, botNavCm
 			recast2quake( cmd->tpos );
 		}
 
-		// when the bot is over an offmesh connection:
+		// when the bot is using an offmesh connection:
 		// save some characteristics about the connection in its mind, for later use
 		// this happens quite rarely, so we can afford a square root for the
 		// distance here
-		if ( overNavconStart )
+		if ( usingNavcon )
 		{
 			gentity_t *self = &g_entities[ botClientNum ];
 			self->botMind->lastNavconTime = level.time;

--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -177,7 +177,7 @@ public:
 
 	int spawnTime;
 	int lastNavconTime;
-	int lastWallclimbActivationTime;
+	int lastNavconDistance;
 
 	Util::optional< glm::vec3 > userSpecifiedPosition;
 	Util::optional< int > userSpecifiedClientNum;

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -830,19 +830,17 @@ Global Bot Navigation
 =========================
 */
 
-
-// HACK:
-// Set an upper bound on how long a bot will have the wall climb activated,
-// in order to prevent looping on strange wall geometries.
-// This works well in practice, as recast limits the navcon distance.
-// There are at least to cleaner ways to handle this:
-// - Calculate the required time when a bot activates the wall climb
-// - Disable the wall climb once a bot has reached the higher level navmesh
-// Both are non-trivial, because a bot might choose a new goal while wall climbing.
-static constexpr int WALLCLIMB_MAX_TIME = 3000;
-
 static Cvar::Cvar<int> g_bot_upwardNavconMinHeight("g_bot_upwardNavconMinHeight", "minimal height difference for bots to use special upward movement.", Cvar::NONE, 100);
 static Cvar::Cvar<int> g_bot_upwardLeapAngleCorr("g_bot_upwardLeapAngleCorr", "is added to the angle for mantis and dragoon when leaping upward (in degrees).", Cvar::NONE, 20);
+
+static int wallclimbStopTime( gentity_t *self )
+{
+	// experiments suggest an appropriate value of 4 milliseconds per distance
+	// unit, add 500 milliseconds as safety margin
+	// if the bot is moving downwards from the navcon start, lastNavconDistance
+	// will be negative
+	return self->botMind->lastNavconTime + self->botMind->lastNavconDistance * 4 + 500;
+}
 
 // could use BG_ClassHasAbility( pcl, SCA_WALLCLIMBER ) to check if calling
 // this is a good idea
@@ -867,7 +865,7 @@ void BotMoveUpward( gentity_t *self, glm::vec3 nextCorner )
 		BotClimbToGoal( self );
 		break;
 	case PCL_ALIEN_LEVEL1:
-		if ( level.time - self->botMind->lastWallclimbActivationTime < WALLCLIMB_MAX_TIME )
+		if ( level.time < wallclimbStopTime( self ) )
 		{
 			BotClimbToGoal( self );
 			return;
@@ -912,15 +910,9 @@ void BotMoveUpward( gentity_t *self, glm::vec3 nextCorner )
 static bool BotTryMoveUpward( gentity_t *self )
 {
 	int selfClientNum = self->client->num();
-	bool overNavcon = G_IsBotOverNavcon( selfClientNum );
 	glm::vec3 ownPos = VEC2GLM( self->s.origin );
 	glm::vec3 nextCorner;
 	bool hasNextCorner = G_BotPathNextCorner( selfClientNum, nextCorner );
-
-	if ( overNavcon )
-	{
-		self->botMind->lastNavconTime = level.time;
-	}
 
 	if ( !hasNextCorner )
 	{
@@ -928,9 +920,20 @@ static bool BotTryMoveUpward( gentity_t *self )
 	}
 
 	// if not trying to move upward
-	if ( nextCorner.z - ownPos.z < g_bot_upwardNavconMinHeight.Get() && level.time - self->botMind->lastWallclimbActivationTime > WALLCLIMB_MAX_TIME )
+	if ( nextCorner.z - ownPos.z < g_bot_upwardNavconMinHeight.Get() )
 	{
-		return false;
+		switch ( self->client->ps.stats [ STAT_CLASS ] )
+		{
+		case PCL_ALIEN_LEVEL0:
+		case PCL_ALIEN_LEVEL1:
+			if ( level.time > wallclimbStopTime( self ) )
+			{
+				return false;
+			}
+			break;
+		default:
+			return false;
+		}
 	}
 
 	int diff = level.time - self->botMind->lastNavconTime;
@@ -938,15 +941,8 @@ static bool BotTryMoveUpward( gentity_t *self )
 	switch ( self->client->ps.stats [ STAT_CLASS ] )
 	{
 	case PCL_ALIEN_LEVEL0:
-		self->botMind->lastWallclimbActivationTime = self->botMind->lastNavconTime;
-		if ( diff < 0 || diff > WALLCLIMB_MAX_TIME )
-		{
-			return false;
-		}
-		break;
 	case PCL_ALIEN_LEVEL1:
-		self->botMind->lastWallclimbActivationTime = self->botMind->lastNavconTime;
-		if ( diff < 0 || diff > WALLCLIMB_MAX_TIME )
+		if ( level.time > wallclimbStopTime( self ) )
 		{
 			return false;
 		}
@@ -1020,6 +1016,10 @@ bool BotMoveToGoal( gentity_t *self )
 	if ( G_Team( self ) != targetTeam )
 	{
 		BotTryMoveUpward( self );
+		return true;
+	}
+	else if ( BotTryMoveUpward( self ) )
+	{
 		return true;
 	}
 

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -833,7 +833,7 @@ Global Bot Navigation
 static Cvar::Cvar<int> g_bot_upwardNavconMinHeight("g_bot_upwardNavconMinHeight", "minimal height difference for bots to use special upward movement.", Cvar::NONE, 100);
 static Cvar::Cvar<int> g_bot_upwardLeapAngleCorr("g_bot_upwardLeapAngleCorr", "is added to the angle for mantis and dragoon when leaping upward (in degrees).", Cvar::NONE, 20);
 
-static int wallclimbStopTime( gentity_t *self )
+static int WallclimbStopTime( gentity_t *self )
 {
 	// experiments suggest an appropriate value of 4 milliseconds per distance
 	// unit, add 500 milliseconds as safety margin
@@ -865,7 +865,7 @@ void BotMoveUpward( gentity_t *self, glm::vec3 nextCorner )
 		BotClimbToGoal( self );
 		break;
 	case PCL_ALIEN_LEVEL1:
-		if ( level.time < wallclimbStopTime( self ) )
+		if ( level.time < WallclimbStopTime( self ) )
 		{
 			BotClimbToGoal( self );
 			return;
@@ -926,7 +926,7 @@ static bool BotTryMoveUpward( gentity_t *self )
 		{
 		case PCL_ALIEN_LEVEL0:
 		case PCL_ALIEN_LEVEL1:
-			if ( level.time > wallclimbStopTime( self ) )
+			if ( level.time > WallclimbStopTime( self ) )
 			{
 				return false;
 			}
@@ -942,7 +942,7 @@ static bool BotTryMoveUpward( gentity_t *self )
 	{
 	case PCL_ALIEN_LEVEL0:
 	case PCL_ALIEN_LEVEL1:
-		if ( level.time > wallclimbStopTime( self ) )
+		if ( level.time > WallclimbStopTime( self ) )
 		{
 			return false;
 		}


### PR DESCRIPTION
Previously, we made dretch and mantis bots activate the wall climb for exactly 3 seconds. This is an awkward limit, and even too short in some rare cases. We do want to disable the wall climb as soon as possible, as this makes bot movements easier to predict.

This PR calculates the required climb time when a bot is over a navcon start. In this case, it will save the distance to its goal in its mind. By looking at this distance, it can later decide when to disable the wall climb.

There is one other improvement: Detection of a navcon start was duplicated. It is now only done in one place, and not in the behavior tree execution. This improves performance. It also improves reliability of all bot upward movements (as the code can now never miss a navcon start).

Beside that, this makes the wall climb code easier to understand.