### PR TITLE
Glm extract

### DIFF
--- a/src/sgame/BaseClustering.cpp
+++ b/src/sgame/BaseClustering.cpp
@@ -127,7 +127,7 @@ namespace BaseClustering {
 
 			// Trace from mean buildable's origin towards cluster center, so that the beacon does
 			// not spawn inside a wall. Then use MoveTowardsRoom on the trace results.
-			trace_t tr = G_RayTrace( VEC2GLM( mean->s.origin ), center, 0, MASK_SOLID, 0);
+			trace_t tr = G_PointTrace( VEC2GLM( mean->s.origin ), center, 0, MASK_SOLID, 0);
 			Beacon::MoveTowardsRoom(tr.endpos);
 
 			// Prepare beacon flags.

--- a/src/sgame/BaseClustering.cpp
+++ b/src/sgame/BaseClustering.cpp
@@ -127,8 +127,7 @@ namespace BaseClustering {
 
 			// Trace from mean buildable's origin towards cluster center, so that the beacon does
 			// not spawn inside a wall. Then use MoveTowardsRoom on the trace results.
-			trace_t tr;
-			trap_Trace(&tr, mean->s.origin, nullptr, nullptr, &center[0], 0, MASK_SOLID, 0);
+			trace_t tr = G_RayTrace( VEC2GLM( mean->s.origin ), center, 0, MASK_SOLID, 0);
 			Beacon::MoveTowardsRoom(tr.endpos);
 
 			// Prepare beacon flags.

--- a/src/sgame/Beacon.cpp
+++ b/src/sgame/Beacon.cpp
@@ -300,7 +300,7 @@ namespace Beacon //this should eventually become a class
 		for ( i = 0; i < numvecs; i++ )
 		{
 			VectorMA( origin, 500, vecs[ i ], end );
-			trap_Trace( &tr, origin, nullptr, nullptr, end, 0, MASK_SOLID, 0 );
+			tr = G_RayTrace( origin, end, 0, MASK_SOLID, 0 );
 			VectorAdd( accumulator, tr.endpos, accumulator );
 		}
 
@@ -642,8 +642,7 @@ namespace Beacon //this should eventually become a class
 
 		// Do a trace for bounding boxes under the reticle first, they are prefered
 		{
-			trace_t tr;
-			trap_Trace( &tr, begin, nullptr, nullptr, end, skip, mask, 0 );
+			trace_t tr = G_RayTrace( begin, end, skip, mask, 0 );
 			if ( EntityTaggable( tr.entityNum, team, true ) )
 			{
 				reticleEnt = g_entities + tr.entityNum;
@@ -676,8 +675,7 @@ namespace Beacon //this should eventually become a class
 
 			// LOS
 			{
-				trace_t tr;
-				trap_Trace( &tr, begin, nullptr, nullptr, ent->r.currentOrigin, skip, mask, 0 );
+				trace_t tr = G_RayTrace( begin, ent->r.currentOrigin, skip, mask, 0 );
 				if( tr.entityNum != i )
 					continue;
 			}

--- a/src/sgame/Beacon.cpp
+++ b/src/sgame/Beacon.cpp
@@ -300,7 +300,7 @@ namespace Beacon //this should eventually become a class
 		for ( i = 0; i < numvecs; i++ )
 		{
 			VectorMA( origin, 500, vecs[ i ], end );
-			tr = G_RayTrace( origin, end, 0, MASK_SOLID, 0 );
+			tr = G_PointTrace( origin, end, 0, MASK_SOLID, 0 );
 			VectorAdd( accumulator, tr.endpos, accumulator );
 		}
 
@@ -642,7 +642,7 @@ namespace Beacon //this should eventually become a class
 
 		// Do a trace for bounding boxes under the reticle first, they are prefered
 		{
-			trace_t tr = G_RayTrace( begin, end, skip, mask, 0 );
+			trace_t tr = G_PointTrace( begin, end, skip, mask, 0 );
 			if ( EntityTaggable( tr.entityNum, team, true ) )
 			{
 				reticleEnt = g_entities + tr.entityNum;
@@ -675,7 +675,7 @@ namespace Beacon //this should eventually become a class
 
 			// LOS
 			{
-				trace_t tr = G_RayTrace( begin, ent->r.currentOrigin, skip, mask, 0 );
+				trace_t tr = G_PointTrace( begin, ent->r.currentOrigin, skip, mask, 0 );
 				if( tr.entityNum != i )
 					continue;
 			}

--- a/src/sgame/components/TurretComponent.cpp
+++ b/src/sgame/components/TurretComponent.cpp
@@ -187,7 +187,7 @@ bool TurretComponent::TargetCanBeHit() {
 	glm::vec3 traceStart   = VEC2GLM(entity.oldEnt->s.pos.trBase);
 	glm::vec3 traceEnd     = traceStart + range * aimDirection;
 
-	trace_t tr = G_RayTrace( traceStart, traceEnd, entity.oldEnt->num(), MASK_SHOT, 0 );
+	trace_t tr = G_PointTrace( traceStart, traceEnd, *entity.oldEnt, MASK_SHOT, 0 );
 
 	return (tr.entityNum == target->num());
 }
@@ -235,7 +235,7 @@ void TurretComponent::SetBaseDirection() {
 	glm::vec3 traceStart     = VEC2GLM(entity.oldEnt->s.pos.trBase);
 	glm::vec3 traceEnd       = traceStart + MINIMUM_CLEARANCE * torsoDirection;
 
-	trace_t tr = G_RayTrace( traceStart, traceEnd, entity.oldEnt->num(), MASK_SHOT, 0 );
+	trace_t tr = G_PointTrace( traceStart, traceEnd, *entity.oldEnt, MASK_SHOT, 0 );
 
 	// TODO: Check the presence of a PhysicsComponent to decide whether the obstacle is permanent.
 	if (tr.entityNum == ENTITYNUM_WORLD ||

--- a/src/sgame/components/TurretComponent.cpp
+++ b/src/sgame/components/TurretComponent.cpp
@@ -187,9 +187,7 @@ bool TurretComponent::TargetCanBeHit() {
 	glm::vec3 traceStart   = VEC2GLM(entity.oldEnt->s.pos.trBase);
 	glm::vec3 traceEnd     = traceStart + range * aimDirection;
 
-	trace_t tr;
-	trap_Trace(&tr, &traceStart[0], nullptr, nullptr, &traceEnd[0], entity.oldEnt->num(),
-	           MASK_SHOT, 0);
+	trace_t tr = G_RayTrace( traceStart, traceEnd, entity.oldEnt->num(), MASK_SHOT, 0 );
 
 	return (tr.entityNum == target->num());
 }
@@ -237,9 +235,7 @@ void TurretComponent::SetBaseDirection() {
 	glm::vec3 traceStart     = VEC2GLM(entity.oldEnt->s.pos.trBase);
 	glm::vec3 traceEnd       = traceStart + MINIMUM_CLEARANCE * torsoDirection;
 
-	trace_t tr;
-	trap_Trace(&tr, &traceStart[0], nullptr, nullptr, &traceEnd[0], entity.oldEnt->num(),
-	           MASK_SHOT, 0);
+	trace_t tr = G_RayTrace( traceStart, traceEnd, entity.oldEnt->num(), MASK_SHOT, 0 );
 
 	// TODO: Check the presence of a PhysicsComponent to decide whether the obstacle is permanent.
 	if (tr.entityNum == ENTITYNUM_WORLD ||

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -2219,7 +2219,7 @@ static void ClientThink_real( gentity_t *self )
 
 		AngleVectors( client->ps.viewangles, view, nullptr, nullptr );
 		VectorMA( viewpoint, range1, view, point );
-		trace = G_RayTrace( &viewpoint[0], point, self->s.number, MASK_SHOT, 0 );
+		trace = G_PointTrace( &viewpoint[0], point, *self, MASK_SHOT, 0 );
 
 		ent = &g_entities[ trace.entityNum ];
 		bool activableTarget = ent->s.eType == entityType_t::ET_BUILDABLE || ent->s.eType == entityType_t::ET_MOVER;

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -2219,7 +2219,7 @@ static void ClientThink_real( gentity_t *self )
 
 		AngleVectors( client->ps.viewangles, view, nullptr, nullptr );
 		VectorMA( viewpoint, range1, view, point );
-		trap_Trace( &trace, &viewpoint[0], nullptr, nullptr, point, self->s.number, MASK_SHOT, 0 );
+		trace = G_RayTrace( &viewpoint[0], point, self->s.number, MASK_SHOT, 0 );
 
 		ent = &g_entities[ trace.entityNum ];
 		bool activableTarget = ent->s.eType == entityType_t::ET_BUILDABLE || ent->s.eType == entityType_t::ET_MOVER;

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -5397,7 +5397,7 @@ bool G_admin_builder( gentity_t *ent )
 	glm::vec3 end = start + 1000.f * forward;
 
 	//TODO there are many occurrences of trap_Trace without mins/maxs, a specialized API is likely needed
-	tr = G_RayTrace( start, end, ent->s.number, MASK_PLAYERSOLID, 0 );
+	tr = G_PointTrace( start, end, *ent, MASK_PLAYERSOLID, 0 );
 	traceEnt = &g_entities[ tr.entityNum ];
 
 	if ( tr.fraction < 1.0f && ( traceEnt->s.eType == entityType_t::ET_BUILDABLE ) )

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -5397,7 +5397,7 @@ bool G_admin_builder( gentity_t *ent )
 	glm::vec3 end = start + 1000.f * forward;
 
 	//TODO there are many occurrences of trap_Trace without mins/maxs, a specialized API is likely needed
-	trap_Trace( &tr, &start[0], nullptr, nullptr, &end[0], ent->s.number, MASK_PLAYERSOLID, 0 );
+	tr = G_RayTrace( start, end, ent->s.number, MASK_PLAYERSOLID, 0 );
 	traceEnt = &g_entities[ tr.entityNum ];
 
 	if ( tr.fraction < 1.0f && ( traceEnt->s.eType == entityType_t::ET_BUILDABLE ) )

--- a/src/sgame/sg_api.cpp
+++ b/src/sgame/sg_api.cpp
@@ -171,14 +171,28 @@ bool trap_EntityContact(const vec3_t mins, const vec3_t maxs, const gentity_t *e
 	return G_CM_EntityContact( mins, maxs, ent, traceType_t::TT_AABB );
 }
 
-trace_t G_RayTrace( glm::vec3 const& start, glm::vec3 const& end, int entityNum, int contentmask, int skipmask )
+trace_t G_PointTrace( glm::vec3 const& start, glm::vec3 const& end, const gentity_t& skipEntity, int contentmask, int skipmask )
+{
+	trace_t tr;
+	G_CM_Trace( &tr, &start[0], nullptr, nullptr, &end[0], skipEntity.num(), contentmask, skipmask, traceType_t::TT_AABB );
+	return tr;
+}
+
+trace_t G_PointTrace( vec3_t const start, vec3_t const end, const gentity_t& skipEntity, int contentmask, int skipmask )
+{
+	trace_t tr;
+	G_CM_Trace( &tr, start, nullptr, nullptr, end, skipEntity.num(), contentmask, skipmask, traceType_t::TT_AABB );
+	return tr;
+}
+
+trace_t G_PointTrace( glm::vec3 const& start, glm::vec3 const& end, int entityNum, int contentmask, int skipmask )
 {
 	trace_t tr;
 	G_CM_Trace( &tr, &start[0], nullptr, nullptr, &end[0], entityNum, contentmask, skipmask, traceType_t::TT_AABB );
 	return tr;
 }
 
-trace_t G_RayTrace( vec3_t const start, vec3_t const end, int entityNum, int contentmask, int skipmask )
+trace_t G_PointTrace( vec3_t const start, vec3_t const end, int entityNum, int contentmask, int skipmask )
 {
 	trace_t tr;
 	G_CM_Trace( &tr, start, nullptr, nullptr, end, entityNum, contentmask, skipmask, traceType_t::TT_AABB );

--- a/src/sgame/sg_api.cpp
+++ b/src/sgame/sg_api.cpp
@@ -171,6 +171,20 @@ bool trap_EntityContact(const vec3_t mins, const vec3_t maxs, const gentity_t *e
 	return G_CM_EntityContact( mins, maxs, ent, traceType_t::TT_AABB );
 }
 
+trace_t G_RayTrace( glm::vec3 const& start, glm::vec3 const& end, int entityNum, int contentmask, int skipmask )
+{
+	trace_t tr;
+	G_CM_Trace( &tr, &start[0], nullptr, nullptr, &end[0], entityNum, contentmask, skipmask, traceType_t::TT_AABB );
+	return tr;
+}
+
+trace_t G_RayTrace( vec3_t const start, vec3_t const end, int entityNum, int contentmask, int skipmask )
+{
+	trace_t tr;
+	G_CM_Trace( &tr, start, nullptr, nullptr, end, entityNum, contentmask, skipmask, traceType_t::TT_AABB );
+	return tr;
+}
+
 void trap_Trace( trace_t *results, const vec3_t start, const vec3_t mins, const vec3_t maxs,
                  const vec3_t end, int passEntityNum, int contentmask, int skipmask )
 {

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1439,7 +1439,7 @@ bool BotTargetIsVisible( const gentity_t *self, botTarget_t target, int mask )
 		return false;
 	}
 
-	trace = G_RayTrace( muzzle, targetPos, self->num(), mask, 0 );
+	trace = G_PointTrace( muzzle, targetPos, *self, mask, 0 );
 
 	if ( trace.surfaceFlags & SURF_NOIMPACT )
 	{
@@ -1972,7 +1972,7 @@ void BotFireWeaponAI( gentity_t *self )
 	muzzle = G_CalcMuzzlePoint( self, forward );
 	glm::vec3 targetPos = BotGetIdealAimLocation( self, self->botMind->goal, 0 );
 
-	trace = G_RayTrace( muzzle, targetPos, ENTITYNUM_NONE, MASK_SHOT, 0 );
+	trace = G_PointTrace( muzzle, targetPos, ENTITYNUM_NONE, MASK_SHOT, 0 );
 	distance = glm::distance( muzzle, VEC2GLM( trace.endpos ) );
 	bool readyFire = self->client->ps.IsWeaponReady();
 	glm::vec3 target = self->botMind->goal.getPos();

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1439,7 +1439,7 @@ bool BotTargetIsVisible( const gentity_t *self, botTarget_t target, int mask )
 		return false;
 	}
 
-	trap_Trace( &trace, &muzzle[0], nullptr, nullptr, &targetPos[0], self->num(), mask, 0 );
+	trace = G_RayTrace( muzzle, targetPos, self->num(), mask, 0 );
 
 	if ( trace.surfaceFlags & SURF_NOIMPACT )
 	{
@@ -1972,7 +1972,7 @@ void BotFireWeaponAI( gentity_t *self )
 	muzzle = G_CalcMuzzlePoint( self, forward );
 	glm::vec3 targetPos = BotGetIdealAimLocation( self, self->botMind->goal, 0 );
 
-	trap_Trace( &trace, &muzzle[0], nullptr, nullptr, &targetPos[0], ENTITYNUM_NONE, MASK_SHOT, 0 );
+	trace = G_RayTrace( muzzle, targetPos, ENTITYNUM_NONE, MASK_SHOT, 0 );
 	distance = glm::distance( muzzle, VEC2GLM( trace.endpos ) );
 	bool readyFire = self->client->ps.IsWeaponReady();
 	glm::vec3 target = self->botMind->goal.getPos();

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -468,7 +468,7 @@ static bool ATrapper_CheckTarget( gentity_t *self, GentityRef target, int range 
 		return false;
 	}
 
-	trace = G_RayTrace( self->s.pos.trBase, target->s.pos.trBase, self->num(), MASK_SHOT, 0 );
+	trace = G_PointTrace( self->s.pos.trBase, target->s.pos.trBase, *self, MASK_SHOT, 0 );
 
 	if ( trace.contents & CONTENTS_SOLID ) // can we see the target?
 	{
@@ -1085,7 +1085,7 @@ gentity_t *G_GetDeconstructibleBuildable( gentity_t *ent )
 	BG_GetClientViewOrigin( &ent->client->ps, viewOrigin );
 	AngleVectors( ent->client->ps.viewangles, forward, nullptr, nullptr );
 	VectorMA( viewOrigin, BUILDER_DECONSTRUCT_RANGE, forward, end );
-	trace = G_RayTrace( viewOrigin, end, ent->num(), MASK_PLAYERSOLID, 0 );
+	trace = G_PointTrace( viewOrigin, end, *ent, MASK_PLAYERSOLID, 0 );
 	buildable = &g_entities[ trace.entityNum ];
 
 	// Check if target is valid.
@@ -1558,7 +1558,7 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 
 	BG_PositionBuildableRelativeToPlayer( ps, mins, maxs, trap_Trace, entity_origin, angles, &tr1 );
 	trap_Trace( &tr2, entity_origin, mins, maxs, entity_origin, ENTITYNUM_NONE, MASK_PLAYERSOLID, 0 );
-	tr3 = G_RayTrace( ps->origin, entity_origin, ent->num(), MASK_PLAYERSOLID, 0 );
+	tr3 = G_PointTrace( ps->origin, entity_origin, *ent, MASK_PLAYERSOLID, 0 );
 
 	VectorCopy( entity_origin, origin );
 	*groundEntNum = tr1.entityNum;

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -468,8 +468,7 @@ static bool ATrapper_CheckTarget( gentity_t *self, GentityRef target, int range 
 		return false;
 	}
 
-	trap_Trace( &trace, self->s.pos.trBase, nullptr, nullptr, target->s.pos.trBase, self->num(),
-	            MASK_SHOT, 0 );
+	trace = G_RayTrace( self->s.pos.trBase, target->s.pos.trBase, self->num(), MASK_SHOT, 0 );
 
 	if ( trace.contents & CONTENTS_SOLID ) // can we see the target?
 	{
@@ -1086,7 +1085,7 @@ gentity_t *G_GetDeconstructibleBuildable( gentity_t *ent )
 	BG_GetClientViewOrigin( &ent->client->ps, viewOrigin );
 	AngleVectors( ent->client->ps.viewangles, forward, nullptr, nullptr );
 	VectorMA( viewOrigin, BUILDER_DECONSTRUCT_RANGE, forward, end );
-	trap_Trace( &trace, viewOrigin, nullptr, nullptr, end, ent->num(), MASK_PLAYERSOLID, 0 );
+	trace = G_RayTrace( viewOrigin, end, ent->num(), MASK_PLAYERSOLID, 0 );
 	buildable = &g_entities[ trace.entityNum ];
 
 	// Check if target is valid.
@@ -1559,7 +1558,7 @@ itemBuildError_t G_CanBuild( gentity_t *ent, buildable_t buildable, int /*distan
 
 	BG_PositionBuildableRelativeToPlayer( ps, mins, maxs, trap_Trace, entity_origin, angles, &tr1 );
 	trap_Trace( &tr2, entity_origin, mins, maxs, entity_origin, ENTITYNUM_NONE, MASK_PLAYERSOLID, 0 );
-	trap_Trace( &tr3, ps->origin, nullptr, nullptr, entity_origin, ent->num(), MASK_PLAYERSOLID, 0 );
+	tr3 = G_RayTrace( ps->origin, entity_origin, ent->num(), MASK_PLAYERSOLID, 0 );
 
 	VectorCopy( entity_origin, origin );
 	*groundEntNum = tr1.entityNum;

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -2248,7 +2248,7 @@ static void Cmd_Ignite_f( gentity_t *player )
 	BG_GetClientViewOrigin( &player->client->ps, viewOrigin );
 	AngleVectors( player->client->ps.viewangles, forward, nullptr, nullptr );
 	VectorMA( viewOrigin, 1000, forward, end );
-	trace = G_RayTrace( viewOrigin, end, player->num(), MASK_PLAYERSOLID, 0 );
+	trace = G_PointTrace( viewOrigin, end, *player, MASK_PLAYERSOLID, 0 );
 
 	if ( trace.entityNum == ENTITYNUM_WORLD ) {
 		G_SpawnFire( trace.endpos, trace.plane.normal, player );
@@ -4080,7 +4080,7 @@ static void Cmd_Beacon_f( gentity_t *ent )
 	VectorMA( origin, 65536, forward, end );
 
 	G_UnlaggedOn( ent, origin, 65536 );
-	tr = G_RayTrace( origin, end, ent->num(), MASK_PLAYERSOLID, 0 );
+	tr = G_PointTrace( origin, end, *ent, MASK_PLAYERSOLID, 0 );
 	G_UnlaggedOff( );
 
 	// Evaluate flood limit.

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -2248,7 +2248,7 @@ static void Cmd_Ignite_f( gentity_t *player )
 	BG_GetClientViewOrigin( &player->client->ps, viewOrigin );
 	AngleVectors( player->client->ps.viewangles, forward, nullptr, nullptr );
 	VectorMA( viewOrigin, 1000, forward, end );
-	trap_Trace( &trace, viewOrigin, nullptr, nullptr, end, player->num(), MASK_PLAYERSOLID, 0 );
+	trace = G_RayTrace( viewOrigin, end, player->num(), MASK_PLAYERSOLID, 0 );
 
 	if ( trace.entityNum == ENTITYNUM_WORLD ) {
 		G_SpawnFire( trace.endpos, trace.plane.normal, player );
@@ -4080,7 +4080,7 @@ static void Cmd_Beacon_f( gentity_t *ent )
 	VectorMA( origin, 65536, forward, end );
 
 	G_UnlaggedOn( ent, origin, 65536 );
-	trap_Trace( &tr, origin, nullptr, nullptr, end, ent->num(), MASK_PLAYERSOLID, 0 );
+	tr = G_RayTrace( origin, end, ent->num(), MASK_PLAYERSOLID, 0 );
 	G_UnlaggedOff( );
 
 	// Evaluate flood limit.

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -930,10 +930,7 @@ Test for a LOS between two entities
 */
 bool G_IsVisible( gentity_t *start, gentity_t *end, int contents )
 {
-	trace_t trace;
-
-	trap_Trace( &trace, start->s.pos.trBase, nullptr, nullptr, end->s.pos.trBase,
-	            start->num(), contents, 0 );
+	trace_t trace = G_RayTrace( start->s.pos.trBase, end->s.pos.trBase, start->num(), contents, 0 );
 
 	return trace.fraction >= 1.0f || trace.entityNum == end->num();
 }

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -930,7 +930,7 @@ Test for a LOS between two entities
 */
 bool G_IsVisible( gentity_t *start, gentity_t *end, int contents )
 {
-	trace_t trace = G_RayTrace( start->s.pos.trBase, end->s.pos.trBase, start->num(), contents, 0 );
+	trace_t trace = G_PointTrace( start->s.pos.trBase, end->s.pos.trBase, *start, contents, 0 );
 
 	return trace.fraction >= 1.0f || trace.entityNum == end->num();
 }

--- a/src/sgame/sg_missile.cpp
+++ b/src/sgame/sg_missile.cpp
@@ -530,8 +530,7 @@ void G_RunMissile( gentity_t *ent )
 		}
 		else
 		{
-			trap_Trace( &tr, ent->r.currentOrigin, nullptr, nullptr, origin,
-			            passent, ent->clipmask, 0 );
+			tr = G_RayTrace( ent->r.currentOrigin, origin, passent, ent->clipmask, 0 );
 
 			if ( tr.fraction < 1.0f )
 			{

--- a/src/sgame/sg_missile.cpp
+++ b/src/sgame/sg_missile.cpp
@@ -530,7 +530,7 @@ void G_RunMissile( gentity_t *ent )
 		}
 		else
 		{
-			tr = G_RayTrace( ent->r.currentOrigin, origin, passent, ent->clipmask, 0 );
+			tr = G_PointTrace( ent->r.currentOrigin, origin, passent, ent->clipmask, 0 );
 
 			if ( tr.fraction < 1.0f )
 			{

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -342,6 +342,8 @@ void              G_UpdateZaps( int msec );
 void              G_ClearPlayerZapEffects( gentity_t *player );
 void              G_FireWeapon( gentity_t *self, weapon_t weapon, weaponMode_t weaponMode );
 void              G_FireUpgrade( gentity_t *self, upgrade_t upgrade );
+trace_t G_RayTrace( glm::vec3 const& start, glm::vec3 const& end, int entityNum, int contentmask, int skipmask );
+trace_t G_RayTrace( vec3_t const start, vec3_t const end, int entityNum, int contentmask, int skipmask );
 
 // CombatFeedback.cpp
 namespace CombatFeedback

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -342,8 +342,11 @@ void              G_UpdateZaps( int msec );
 void              G_ClearPlayerZapEffects( gentity_t *player );
 void              G_FireWeapon( gentity_t *self, weapon_t weapon, weaponMode_t weaponMode );
 void              G_FireUpgrade( gentity_t *self, upgrade_t upgrade );
-trace_t G_RayTrace( glm::vec3 const& start, glm::vec3 const& end, int entityNum, int contentmask, int skipmask );
-trace_t G_RayTrace( vec3_t const start, vec3_t const end, int entityNum, int contentmask, int skipmask );
+trace_t G_PointTrace( glm::vec3 const& start, glm::vec3 const& end, gentity_t const& skipEntity, int contentmask, int skipmask );
+// old compat interfaces, try to avoid using them
+trace_t G_PointTrace( vec3_t const start, vec3_t const end, gentity_t const& skipEntity, int contentmask, int skipmask );
+trace_t G_PointTrace( glm::vec3 const& start, glm::vec3 const& end, int skipEntity, int contentmask, int skipmask );
+trace_t G_PointTrace( vec3_t const start, vec3_t const end, int skipEntity, int contentmask, int skipmask );
 
 // CombatFeedback.cpp
 namespace CombatFeedback

--- a/src/sgame/sg_spawn_gfx.cpp
+++ b/src/sgame/sg_spawn_gfx.cpp
@@ -119,11 +119,11 @@ static void findEmptySpot( glm::vec3 const& origin, float radius, glm::vec3& spo
 
 				glm::vec3 test = origin + delta;
 
-				trace_t trace = G_RayTrace( test, test, ENTITYNUM_NONE, MASK_SOLID, 0 );
+				trace_t trace = G_PointTrace( test, test, ENTITYNUM_NONE, MASK_SOLID, 0 );
 
 				if ( !trace.allsolid )
 				{
-					trace = G_RayTrace( test, origin, ENTITYNUM_NONE, MASK_SOLID, 0 );
+					trace = G_PointTrace( test, origin, ENTITYNUM_NONE, MASK_SOLID, 0 );
 					delta *= trace.fraction;
 					total += delta;
 				}

--- a/src/sgame/sg_spawn_gfx.cpp
+++ b/src/sgame/sg_spawn_gfx.cpp
@@ -119,12 +119,11 @@ static void findEmptySpot( glm::vec3 const& origin, float radius, glm::vec3& spo
 
 				glm::vec3 test = origin + delta;
 
-				trace_t trace;
-				trap_Trace( &trace, &test[0], nullptr, nullptr, &test[0], ENTITYNUM_NONE, MASK_SOLID, 0 );
+				trace_t trace = G_RayTrace( test, test, ENTITYNUM_NONE, MASK_SOLID, 0 );
 
 				if ( !trace.allsolid )
 				{
-					trap_Trace( &trace, &test[0], nullptr, nullptr, &origin[0], ENTITYNUM_NONE, MASK_SOLID, 0 );
+					trace = G_RayTrace( test, origin, ENTITYNUM_NONE, MASK_SOLID, 0 );
 					delta *= trace.fraction;
 					total += delta;
 				}

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -355,7 +355,7 @@ static void G_WideTrace( trace_t *tr, gentity_t *ent, const float range,
 	// The range is reduced according to the former trace so we don't hit something behind the
 	// current target.
 	VectorMA( muzzle, Distance( muzzle, tr->endpos ) + halfDiagonal, forward, end );
-	*tr = G_RayTrace( muzzle, end, ent->s.number, CONTENTS_SOLID, 0 );
+	*tr = G_PointTrace( muzzle, end, *ent, CONTENTS_SOLID, 0 );
 
 	// In case we hit a different target, which can happen if two potential targets are close,
 	// switch to it, so we will end up with the target we were looking at.
@@ -506,12 +506,12 @@ static void FireBullet( gentity_t *self, float spread, float damage, meansOfDeat
 	if ( self->client )
 	{
 		G_UnlaggedOn( self, muzzle, 8192 * 16 );
-		tr = G_RayTrace( muzzle, end, self->s.number, MASK_SHOT, 0 );
+		tr = G_PointTrace( muzzle, end, *self, MASK_SHOT, 0 );
 		G_UnlaggedOff();
 	}
 	else
 	{
-		tr = G_RayTrace( muzzle, end, self->s.number, MASK_SHOT, 0 );
+		tr = G_PointTrace( muzzle, end, *self, MASK_SHOT, 0 );
 	}
 
 	if ( tr.surfaceFlags & SURF_NOIMPACT )
@@ -598,7 +598,7 @@ static void ShotgunPattern( vec3_t origin, vec3_t origin2, int seed, gentity_t *
 		VectorMA( end, r, right, end );
 		VectorMA( end, u, up, end );
 
-		tr = G_RayTrace( origin, end, self->s.number, MASK_SHOT, 0 );
+		tr = G_PointTrace( origin, end, *self, MASK_SHOT, 0 );
 		traceEnt = &g_entities[ tr.entityNum ];
 
 		traceEnt->Damage((float)SHOTGUN_DMG, self, VEC2GLM( tr.endpos ),
@@ -904,7 +904,7 @@ void G_CheckCkitRepair( gentity_t *self )
 	AngleVectors( self->client->ps.viewangles, forward, nullptr, nullptr );
 	VectorMA( viewOrigin, 100, forward, end );
 
-	tr = G_RayTrace( viewOrigin, end, self->s.number, MASK_PLAYERSOLID, 0 );
+	tr = G_PointTrace( viewOrigin, end, *self, MASK_PLAYERSOLID, 0 );
 	traceEnt = &g_entities[ tr.entityNum ];
 
 	if ( tr.fraction < 1.0f && traceEnt->spawned && traceEnt->s.eType == entityType_t::ET_BUILDABLE &&
@@ -1148,7 +1148,7 @@ static void FindZapChainTargets( zap_t *zap )
 				&& distance <= LEVEL2_AREAZAP_CHAIN_RANGE )
 		{
 			// world-LOS check: trace against the world, ignoring other BODY entities
-			tr = G_RayTrace( ent->s.origin, enemy->s.origin, ent->s.number, CONTENTS_SOLID, 0 );
+			tr = G_PointTrace( ent->s.origin, enemy->s.origin, *ent, CONTENTS_SOLID, 0 );
 
 			if ( tr.entityNum == ENTITYNUM_NONE )
 			{

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -355,7 +355,7 @@ static void G_WideTrace( trace_t *tr, gentity_t *ent, const float range,
 	// The range is reduced according to the former trace so we don't hit something behind the
 	// current target.
 	VectorMA( muzzle, Distance( muzzle, tr->endpos ) + halfDiagonal, forward, end );
-	trap_Trace( tr, muzzle, nullptr, nullptr, end, ent->s.number, CONTENTS_SOLID, 0 );
+	*tr = G_RayTrace( muzzle, end, ent->s.number, CONTENTS_SOLID, 0 );
 
 	// In case we hit a different target, which can happen if two potential targets are close,
 	// switch to it, so we will end up with the target we were looking at.
@@ -506,12 +506,12 @@ static void FireBullet( gentity_t *self, float spread, float damage, meansOfDeat
 	if ( self->client )
 	{
 		G_UnlaggedOn( self, muzzle, 8192 * 16 );
-		trap_Trace( &tr, muzzle, nullptr, nullptr, end, self->s.number, MASK_SHOT, 0 );
+		tr = G_RayTrace( muzzle, end, self->s.number, MASK_SHOT, 0 );
 		G_UnlaggedOff();
 	}
 	else
 	{
-		trap_Trace( &tr, muzzle, nullptr, nullptr, end, self->s.number, MASK_SHOT, 0 );
+		tr = G_RayTrace( muzzle, end, self->s.number, MASK_SHOT, 0 );
 	}
 
 	if ( tr.surfaceFlags & SURF_NOIMPACT )
@@ -598,7 +598,7 @@ static void ShotgunPattern( vec3_t origin, vec3_t origin2, int seed, gentity_t *
 		VectorMA( end, r, right, end );
 		VectorMA( end, u, up, end );
 
-		trap_Trace( &tr, origin, nullptr, nullptr, end, self->s.number, MASK_SHOT, 0 );
+		tr = G_RayTrace( origin, end, self->s.number, MASK_SHOT, 0 );
 		traceEnt = &g_entities[ tr.entityNum ];
 
 		traceEnt->Damage((float)SHOTGUN_DMG, self, VEC2GLM( tr.endpos ),
@@ -904,7 +904,7 @@ void G_CheckCkitRepair( gentity_t *self )
 	AngleVectors( self->client->ps.viewangles, forward, nullptr, nullptr );
 	VectorMA( viewOrigin, 100, forward, end );
 
-	trap_Trace( &tr, viewOrigin, nullptr, nullptr, end, self->s.number, MASK_PLAYERSOLID, 0 );
+	tr = G_RayTrace( viewOrigin, end, self->s.number, MASK_PLAYERSOLID, 0 );
 	traceEnt = &g_entities[ tr.entityNum ];
 
 	if ( tr.fraction < 1.0f && traceEnt->spawned && traceEnt->s.eType == entityType_t::ET_BUILDABLE &&
@@ -1148,8 +1148,7 @@ static void FindZapChainTargets( zap_t *zap )
 				&& distance <= LEVEL2_AREAZAP_CHAIN_RANGE )
 		{
 			// world-LOS check: trace against the world, ignoring other BODY entities
-			trap_Trace( &tr, ent->s.origin, nullptr, nullptr,
-			            enemy->s.origin, ent->s.number, CONTENTS_SOLID, 0 );
+			tr = G_RayTrace( ent->s.origin, enemy->s.origin, ent->s.number, CONTENTS_SOLID, 0 );
 
 			if ( tr.entityNum == ENTITYNUM_NONE )
 			{

--- a/src/shared/bg_local.h
+++ b/src/shared/bg_local.h
@@ -52,8 +52,5 @@ extern  pmove_t *pm;
 #define pm_waterfriction     (1.125f)
 #define pm_spectatorfriction (5.0f)
 
-void            PM_ClipVelocity( const vec3_t in, const vec3_t normal, vec3_t out );
-void            PM_AddTouchEnt( int entityNum );
-
 //==================================================================
 #endif /* BG_LOCAL_H_ */

--- a/src/shared/bg_pmove.cpp
+++ b/src/shared/bg_pmove.cpp
@@ -118,7 +118,7 @@ static void PM_AddEvent( int newEvent )
 PM_AddTouchEnt
 ===============
 */
-void PM_AddTouchEnt( int entityNum )
+static void PM_AddTouchEnt( int entityNum )
 {
 	int i;
 
@@ -303,7 +303,7 @@ PM_ClipVelocity
 Slide off of the impacting surface
 ==================
 */
-void PM_ClipVelocity( const vec3_t in, const vec3_t normal, vec3_t out )
+static void PM_ClipVelocity( const vec3_t in, const vec3_t normal, vec3_t out )
 {
 	float t = -DotProduct( in, normal );
 	VectorMA( in, t, normal, out );

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -38,10 +38,13 @@ template<typename T>
 inline glm::vec3 VEC2GLM( const T& v ) {
 	return glm::vec3( v[0], v[1], v[2] );
 }
+
+#if 0
 // A specialised version to warn about useless VEC2GLM mistakes
 DEPRECATED inline glm::vec3 VEC2GLM( glm::vec3 v ) {
 	return v;
 }
+#endif
 
 #include "engine/qcommon/q_shared.h"
 


### PR DESCRIPTION
some safe commits extracted from #2547 .
Goal is to reduce possible git conflicts considering how long this is taking to me to debug that annoying NaN problem. It's likely I could get other "safe" commits from there, but it would trigger git conflicts, so I'd rather avoid it.
I also have other commits starting to instrument the code to hunt the NaN, not sure this should be added there as well.
If there could be an easy way to detect NaN usage (like signals or exceptions, or at least aborts) it would really be great, but for now I could not find anything usable.