### PR TITLE
make the skillset feature opt-out

### DIFF
--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -127,6 +127,41 @@ enum bot_skill
 
 using skillSet_t = std::bitset<BOT_NUM_SKILLS>;
 
+class botSkillTreeElement_t {
+public:
+	Str::StringRef name;
+	bot_skill skill;
+	int cost;
+	// function that determines if this skill is available
+	std::function<bool(const gentity_t *self, skillSet_t existing_skills)> predicate;
+	// skills that are unlocked once you unlock this one
+	std::vector<botSkillTreeElement_t> unlocked_skills;
+
+	botSkillTreeElement_t(
+			Str::StringRef name_,
+			bot_skill skill_,
+			int cost_,
+			std::function<bool(const gentity_t *, skillSet_t )> pred,
+			std::vector<botSkillTreeElement_t> unlocked
+			)
+	:name( name_ ), skill( skill_ ), cost( cost_ ), predicate( pred ), unlocked_skills( unlocked )
+	{
+		m_all_skills.emplace( *this );
+	}
+
+	bool operator<( botSkillTreeElement_t const& other ) const //allows sorting by name to use std::set
+	{
+		return name < other.name;
+	}
+
+	static std::set<botSkillTreeElement_t> const& allSkills()
+	{
+		return m_all_skills;
+	}
+private:
+	static std::set<botSkillTreeElement_t> m_all_skills;
+};
+
 #define MAX_NODE_DEPTH 20
 struct AIBehaviorTree_t;
 struct AIGenericNode_t;

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -133,15 +133,10 @@ void G_InitSkilltreeCvars()
 		);
 }
 
-struct botSkillTreeElement_t {
-	Str::StringRef name;
-	bot_skill skill;
-	int cost;
-	// function that determines if this skill is available
-	std::function<bool(const gentity_t *self, skillSet_t existing_skills)> predicate;
-	// skills that are unlocked once you unlock this one
-	std::vector<botSkillTreeElement_t> unlocked_skills;
-};
+// HACK: avoiding
+// false-positive
+// git conflicts
+std::set<botSkillTreeElement_t> botSkillTreeElement_t::m_all_skills;
 
 static bool pred_always(const gentity_t *self, skillSet_t existing_skills)
 {

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -39,7 +39,7 @@ static Cvar::Range<Cvar::Cvar<int>> g_bot_defaultSkill( "g_bot_defaultSkill", "D
 // Those comments are just
 // a hackish way to prevent
 // git conflicts.
-static Cvar::Cvar<std::string> g_bot_fixedSkills( "g_bot_fixedSkills", "if not empty, this cvars disables the skillset randomness. It's built of key:value pairs, where key is a level number and value is the name of a skill.", Cvar::NONE, "" );
+static Cvar::Cvar<std::string> g_bot_fixedSkills( "g_bot_fixedSkills", "if not empty, this cvars disables the skillset randomness. It's built of key:value pairs, where key is a level number and value is the name of a skill.", Cvar::NONE, "1:prefer-armor 1:medkit 3:strafe-attack 5:aim-barbs 5:feels-pain 5:a-fast-flee 5:h-fast-flee 5:small-attack-jump 5:mara-attack-jump 5:mantis-attack-jump 5:goon-attack-jump 5:tyrant-attack-run 5:buy-modern-armor 7:aim-head 7:predict-aim 7:safe-barbs" );
 
 static void ListTeamEquipment( gentity_t *self, unsigned int (&numUpgrades)[UP_NUM_UPGRADES], unsigned int (&numWeapons)[WP_NUM_WEAPONS] );
 static const int MIN_SKILL = 1;


### PR DESCRIPTION
This works by adding a cvar named: g_bot_defaultSkill

If this cvar is empty, which is the default, behavior won't change. Otherwise, it must be filled with "key:value" pairs, separated by a space (' ').
When a bot is added that have a skill >= key, then it gets the "value" skill automatically.
There are sanity checks that prevents non-existing skills to be tried to be added.

In a reasonable futur, I'd like to add a "/bot listSkills" command that will list all available skills. This could be then used to build a GUI that helps building the cvar.