### PR TITLE
Revert "Rotate bounding box correctly in G_CM_LinkEntity"

### DIFF
--- a/src/sgame/sg_cm_world.cpp
+++ b/src/sgame/sg_cm_world.cpp
@@ -444,16 +444,16 @@ void G_CM_LinkEntity( gentity_t *gEnt )
 	// set the abs box
 	if ( gEnt->r.bmodel && ( angles[ 0 ] || angles[ 1 ] || angles[ 2 ] ) )
 	{
-		glm::mat3 matrix = RotationMatrix( VEC2GLM( angles ) );
+		// expand for rotation
+		float max;
 
-		glm::vec3 mins = matrix * VEC2GLM( gEnt->r.mins );
-		glm::vec3 maxs = matrix * VEC2GLM( gEnt->r.maxs );
+		max = RadiusFromBounds( gEnt->r.mins, gEnt->r.maxs );
 
-		glm::vec3 absmin = glm::min(mins, maxs) + VEC2GLM(origin);
-		glm::vec3 absmax = glm::max(mins, maxs) + VEC2GLM(origin);
-
-		VectorCopy(absmin, gEnt->r.absmin);
-		VectorCopy(absmax, gEnt->r.absmax);
+		for ( int i = 0; i < 3; i++ )
+		{
+			gEnt->r.absmin[ i ] = origin[ i ] - max;
+			gEnt->r.absmax[ i ] = origin[ i ] + max;
+		}
 	}
 	else
 	{


### PR DESCRIPTION
This reverts commit ec4df1d0139e70e99b5251245c160dc697b45f8d.

Said commit introduces the regression which is talked about in https://github.com/Unvanquished/Unvanquished/issues/2706#issuecomment-1565340318

I only did quick testing (that I described in aforementioned discussion), and would appreciate if @cu-kai or @sweet235 could test it on more situations.

Just as a reminder:
`mission-one`, `/setviewpos -3950 2193 3; noclip; devteam a`