### PR TITLE
Ai aim mod config

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/server_setup.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/server_setup.rml
@@ -244,7 +244,14 @@
 				<input cvar="g_bot_buy" type="checkbox" />
 				<h3> Human bots purchase equipment </h3>
 			</row>
-
+			<row>
+				<input type="range" min="0" max="2000" step="10" cvar="g_bot_humanAimDelay"/>
+				<h3> Aim speed modifier (higher is slower)</h3>
+				<p class="inline">
+					Current: <inlinecvar cvar="g_bot_humanAimDelay" type="number" format="%.0f"/> msecs
+					<ilink onclick='Events.pushevent("exec reset g_bot_humanAimDelay", event)'> (reset) </ilink>
+				</p>
+			</row>
 			<h2> Individually </h2>
 			<h3> Primary Weapons </h3>
 			<row>
@@ -321,6 +328,14 @@
 			<row>
 				<input cvar="g_bot_evolve" type="checkbox" />
 				<h3> Alien bots morph </h3>
+			</row>
+			<row>
+				<input type="range" min="0" max="2000" step="10" cvar="g_bot_alienAimDelay"/>
+				<h3> Aim speed modifier (higher is slower)</h3>
+				<p class="inline">
+					Current: <inlinecvar cvar="g_bot_alienAimDelay" type="number" format="%.0f"/> msecs
+					<ilink onclick='Events.pushevent("exec reset g_bot_alienAimDelay", event)'> (reset) </ilink>
+				</p>
 			</row>
 
 			<h2> Individually </h2>

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -31,6 +31,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <glm/gtx/norm.hpp>
 
+//NOTE: kept as constant to let compiler optimise Square( MAX_HUMAN_DANCE_DIST );
+//how far away we can be before we stop going forward when fighting an alien
+constexpr float MAX_HUMAN_DANCE_DIST = 300.0f;
+
+//NOTE: kept as constant to let compiler optimise Square( MIN_HUMAN_DANCE_DIST );
+//how far away we can be before we try to go around an alien when fighting an alien
+constexpr float MIN_HUMAN_DANCE_DIST = 100.0f;
+
 /*
 ======================
 g_bot_ai.c

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -34,6 +34,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <glm/geometric.hpp>
 #include <glm/gtx/norm.hpp>
 
+//trace distance to trigger AI obstacled avoiding procedures.
+//this is a constant as fiddling with this value will impact both
+//server performance and efficiency of AI obstacle procedures.
+constexpr float BOT_OBSTACLE_AVOID_RANGE = 20.0f;
+
 //tells if all navmeshes loaded successfully
 // Only G_BotNavInit and G_BotNavCleanup should set it
 navMeshStatus_t navMeshLoaded = navMeshStatus_t::UNINITIALIZED;
@@ -517,7 +522,6 @@ static const gentity_t* BotGetPathBlocker( gentity_t *self, const glm::vec3 &dir
 {
 	glm::vec3 playerMins, playerMaxs;
 	trace_t trace;
-	const float TRACE_LENGTH = BOT_OBSTACLE_AVOID_RANGE;
 
 	if ( !( self && self->client ) )
 	{
@@ -532,7 +536,7 @@ static const gentity_t* BotGetPathBlocker( gentity_t *self, const glm::vec3 &dir
 	playerMaxs[2] += STEPSIZE;
 
 	glm::vec3 origin = VEC2GLM( self->s.origin );
-	glm::vec3 end = origin + TRACE_LENGTH * dir;
+	glm::vec3 end = origin + BOT_OBSTACLE_AVOID_RANGE * dir;
 
 	trap_Trace( &trace, origin, playerMins, playerMaxs, end, self->s.number, MASK_PLAYERSOLID, 0 );
 	if ( ( trace.fraction < 1.0f && trace.plane.normal[ 2 ] < MIN_WALK_NORMAL ) || g_entities[ trace.entityNum ].s.eType == entityType_t::ET_BUILDABLE )
@@ -553,7 +557,6 @@ static bool BotShouldJump( gentity_t *self, const gentity_t *blocker, const glm:
 	glm::vec3 playerMaxs;
 	float jumpMagnitude;
 	trace_t tr1, tr2;
-	const float TRACE_LENGTH = BOT_OBSTACLE_AVOID_RANGE;
 
 	//already normalized
 
@@ -565,7 +568,7 @@ static bool BotShouldJump( gentity_t *self, const gentity_t *blocker, const glm:
 
 	//Log::Debug(vtos(self->movedir));
 	glm::vec3 origin = VEC2GLM( self->s.origin );
-	glm::vec3 end = origin + TRACE_LENGTH * dir;
+	glm::vec3 end = origin + BOT_OBSTACLE_AVOID_RANGE * dir;
 
 	//make sure we are moving into a block
 	trap_Trace( &tr1, origin, playerMins, playerMaxs, end, self->s.number, MASK_PLAYERSOLID, 0 );

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -36,6 +36,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 static Cvar::Range<Cvar::Cvar<int>> g_bot_defaultSkill( "g_bot_defaultSkill", "Default skill value bots will have when added", Cvar::NONE, 5, 1, 9 );
 
+//consider bot to be stuck if it does not move farther than this in some period of time
+constexpr float BOT_STUCK_RADIUS = 150.0f;
+
 static void ListTeamEquipment( gentity_t *self, unsigned int (&numUpgrades)[UP_NUM_UPGRADES], unsigned int (&numWeapons)[WP_NUM_WEAPONS] );
 static const int MIN_SKILL = 1;
 static const int MAX_SKILL = 9;

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -35,6 +35,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <glm/gtx/vector_angle.hpp>
 
 static Cvar::Range<Cvar::Cvar<int>> g_bot_defaultSkill( "g_bot_defaultSkill", "Default skill value bots will have when added", Cvar::NONE, 5, 1, 9 );
+static Cvar::Cvar<int> g_bot_alienAimDelay = Cvar::Cvar<int>( "g_bot_alienAimDelay", "make bots of alien team slower to aim", Cvar::NONE, 250 );
+static Cvar::Cvar<int> g_bot_humanAimDelay = Cvar::Cvar<int>( "g_bot_humanAimDelay", "make bots of human team slower to aim", Cvar::NONE, 150 );
 
 //consider bot to be stuck if it does not move farther than this in some period of time
 constexpr float BOT_STUCK_RADIUS = 150.0f;
@@ -1534,7 +1536,7 @@ glm::vec3 BotGetIdealAimLocation( gentity_t *self, const botTarget_t &target, in
 
 static int BotGetAimTime( gentity_t *self )
 {
-	int baseTime = G_Team( self ) == TEAM_ALIENS ? 250 : 150;
+	int baseTime = G_Team( self ) == TEAM_ALIENS ? g_bot_alienAimDelay.Get() : g_bot_humanAimDelay.Get();
 	if ( self->botMind->skillSet[BOT_B_FAST_AIM] )
 	{
 		baseTime = baseTime * 3 / 5;

--- a/src/sgame/sg_bot_util.h
+++ b/src/sgame/sg_bot_util.h
@@ -142,25 +142,4 @@ bool  BotFindRandomPointInRadius( int botClientNum, const glm::vec3 &origin, glm
 
 bool  BotPathIsWalkable( const gentity_t *self, botTarget_t target );
 
-//configurable constants
-//For a reference of how far a number represents, take a look at tremulous.h
-
-//how long our traces are for obstacle avoidence
-#define BOT_OBSTACLE_AVOID_RANGE 20.0f
-
-//at what hp do we use medkit?
-#define BOT_USEMEDKIT_HP 50
-
-//used for clamping distance to heal structure when deciding whether to go heal
-#define MAX_HEAL_DIST 2000.0f
-
-//how far away we can be before we stop going forward when fighting an alien
-#define MAX_HUMAN_DANCE_DIST 300.0f
-
-//how far away we can be before we try to go around an alien when fighting an alien
-#define MIN_HUMAN_DANCE_DIST 100.0f
-
-//consider bot to be stuck if it does not move farther than this in some period of time
-constexpr float BOT_STUCK_RADIUS = 150;
-
 #endif


### PR DESCRIPTION
This allows server owners to modify per faction aim speed modifier, to adapt the overall AI balancing to their taste.