### PR TITLE
Invalidate GentityRef on player death

### DIFF
--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -1501,6 +1501,11 @@ void ClientSpawn( gentity_t *ent, gentity_t *spawn, const vec3_t origin, const v
 	bool evolving = ent == spawn;
 	ClientSpawnCBSE(ent, evolving);
 
+	if ( !evolving )
+	{
+		++ent->generation; // invalidate GentityRef's
+	}
+
 	index = ent->num();
 	client = ent->client;
 

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -129,6 +129,8 @@ class Entity;
 // Replacement for gentity_t* that can detect the case where an entity has been recycled.
 // operator bool checks that the entity is non-null and has not been freed since the reference
 // was formed.
+// For a player entity, we increment the generation number when it spawns or dies. It does
+// not increment upon evolve/armor change, although the CBSE entity is reallocated in that case.
 template<typename T>
 struct GentityRef_impl
 {


### PR DESCRIPTION
The existing behavior is to be invalidated only when the client disconnects. The existing behavior turned out to be good enough to prevent some crashes (by using GentityRef instead of gentity_t *), but I always intended it to be invalidated on player death.