### PR TITLE
human bots see an enemy: they shoot at it

### DIFF
--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -806,6 +806,8 @@ static bool TargetInOffmeshAttackRange( gentity_t *self )
 		return distSquare < Square( ( 100 * 8192 ) / CHAINGUN_SPREAD );
 	case WP_MACHINEGUN:
 		return distSquare < Square( ( 50 * 8192 ) / RIFLE_SPREAD );
+	case WP_FLAMER:
+		return distSquare < Square( 250 ); // determined by trial and error
 	default:
 		return true;
 	}

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -788,6 +788,29 @@ AINodeStatus_t BotActionSay( gentity_t *self, AIGenericNode_t *node )
 	return STATUS_SUCCESS;
 }
 
+// Check if a human bot should switch to blaster to attack an offmesh target.
+// TODO: Add different ranges for buildings vs moving targets.
+//       If the target can move, we could allow a higher range for spready guns.
+// This function has a small overlap with BotTargetInAttackRange.
+static bool TargetInOffmeshAttackRange( gentity_t *self )
+{
+	float distSquare = DistanceToGoalSquared( self );
+	switch ( BG_PrimaryWeapon( self->client->ps.stats ) )
+	{
+	case WP_HBUILD:
+	case WP_PAIN_SAW:
+		return false;
+	case WP_SHOTGUN:
+		return distSquare < Square( ( 50 * 8192 ) / SHOTGUN_SPREAD );
+	case WP_CHAINGUN:
+		return distSquare < Square( ( 100 * 8192 ) / CHAINGUN_SPREAD );
+	case WP_MACHINEGUN:
+		return distSquare < Square( ( 50 * 8192 ) / RIFLE_SPREAD );
+	default:
+		return true;
+	}
+}
+
 // TODO: Move decision making out of these actions and into the rest of the behavior tree
 AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 {
@@ -813,7 +836,12 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 		return STATUS_SUCCESS;
 	}
 
-	if ( !mind->nav().havePath )
+	if ( !mind->nav().havePath && !mind->hasOffmeshGoal )
+	{
+		return STATUS_FAILURE;
+	}
+
+	if ( mind->hasOffmeshGoal && !BotTargetIsVisible( self, self->botMind->goal, MASK_OPAQUE ) )
 	{
 		return STATUS_FAILURE;
 	}
@@ -861,6 +889,47 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 	}
 
 	// We have a valid visible target
+
+	if ( mind->hasOffmeshGoal )
+	{
+		// The target is visible, but not on the navmesh
+		ASSERT( G_Team( self ) == TEAM_HUMANS );
+		if ( !BotTargetIsVisible( self, self->botMind->goal, MASK_SHOT ) )
+		{
+			return STATUS_SUCCESS;
+		}
+		bool inRange = TargetInOffmeshAttackRange( self );
+		bool couldChangeToPrimary = BG_GetPlayerWeapon( &self->client->ps ) == WP_BLASTER && !WeaponIsEmpty( BG_PrimaryWeapon( self->client->ps.stats ), &self->client->ps );
+		if ( !inRange && BG_GetPlayerWeapon( &self->client->ps ) != WP_BLASTER )
+		{
+			G_ForceWeaponChange( self, WP_BLASTER );
+		}
+		else if ( inRange && couldChangeToPrimary )
+		{
+			G_ForceWeaponChange( self, WP_NONE );
+		}
+
+		// check if the target has moved onto the navmesh
+		if ( mind->nav().directPathToGoal )
+		{
+			// target is on a navmesh now, switch to primary weapon if we have
+			// the blaster selected (the onmesh target code below assumes this)
+			if ( couldChangeToPrimary )
+			{
+				G_ForceWeaponChange( self, WP_NONE );
+			}
+			self->botMind->setHasOffmeshGoal( false );
+		}
+		else
+		{
+			BotAimAtEnemy( self );
+			BotStandStill( self );
+			BotFireWeaponAI( self );
+			return STATUS_RUNNING;
+		}
+	}
+
+	// The target is visible, and on the navmesh
 
 	bool inAttackRange = BotTargetInAttackRange( self, self->botMind->goal );
 	self->botMind->enemyLastSeen = level.time;

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -891,7 +891,12 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 	}
 
 	// We have a valid visible target
-	bool couldChangeToPrimary = G_Team( self ) == TEAM_HUMANS && BG_GetPlayerWeapon( &self->client->ps ) == WP_BLASTER && !WeaponIsEmpty( BG_PrimaryWeapon( self->client->ps.stats ), &self->client->ps );
+	bool couldChangeToPrimary = false;
+	if ( G_Team( self ) == TEAM_HUMANS )
+	{
+		weapon_t primaryWeapon = BG_PrimaryWeapon( self->client->ps.stats );
+		couldChangeToPrimary = BG_GetPlayerWeapon( &self->client->ps ) == WP_BLASTER && primaryWeapon != WP_HBUILD && !WeaponIsEmpty( primaryWeapon, &self->client->ps );
+	}
 
 	if ( mind->hasOffmeshGoal )
 	{

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -843,7 +843,7 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 		return STATUS_FAILURE;
 	}
 
-	if ( mind->hasOffmeshGoal && !BotTargetIsVisible( self, self->botMind->goal, MASK_OPAQUE ) )
+	if ( mind->hasOffmeshGoal && !BotTargetIsVisible( self, self->botMind->goal, MASK_SHOT ) )
 	{
 		return STATUS_FAILURE;
 	}

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -891,6 +891,7 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 	}
 
 	// We have a valid visible target
+	bool couldChangeToPrimary = G_Team( self ) == TEAM_HUMANS && BG_GetPlayerWeapon( &self->client->ps ) == WP_BLASTER && !WeaponIsEmpty( BG_PrimaryWeapon( self->client->ps.stats ), &self->client->ps );
 
 	if ( mind->hasOffmeshGoal )
 	{
@@ -901,7 +902,6 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 			return STATUS_SUCCESS;
 		}
 		bool inRange = TargetInOffmeshAttackRange( self );
-		bool couldChangeToPrimary = BG_GetPlayerWeapon( &self->client->ps ) == WP_BLASTER && !WeaponIsEmpty( BG_PrimaryWeapon( self->client->ps.stats ), &self->client->ps );
 		if ( !inRange && BG_GetPlayerWeapon( &self->client->ps ) != WP_BLASTER )
 		{
 			G_ForceWeaponChange( self, WP_BLASTER );
@@ -914,12 +914,6 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 		// check if the target has moved onto the navmesh
 		if ( mind->nav().directPathToGoal )
 		{
-			// target is on a navmesh now, switch to primary weapon if we have
-			// the blaster selected (the onmesh target code below assumes this)
-			if ( couldChangeToPrimary )
-			{
-				G_ForceWeaponChange( self, WP_NONE );
-			}
 			self->botMind->setHasOffmeshGoal( false );
 		}
 		else
@@ -932,6 +926,14 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 	}
 
 	// The target is visible, and on the navmesh
+
+	// switch to primary weapon if we have the blaster selected, and the primary
+	// weapon is not empty
+	if ( couldChangeToPrimary )
+	{
+		ASSERT( G_Team( self ) == TEAM_HUMANS );
+		G_ForceWeaponChange( self, WP_NONE );
+	}
 
 	bool inAttackRange = BotTargetInAttackRange( self, self->botMind->goal );
 	self->botMind->enemyLastSeen = level.time;

--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -179,6 +179,9 @@ public:
 	int lastNavconTime;
 	int lastNavconDistance;
 
+	void setHasOffmeshGoal( bool val ) { hasOffmeshGoal = val; }
+	bool hasOffmeshGoal;
+
 	Util::optional< glm::vec3 > userSpecifiedPosition;
 	Util::optional< int > userSpecifiedClientNum;
 private:

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1173,6 +1173,8 @@ void BotTargetToRouteTarget( const gentity_t *self, botTarget_t target, botRoute
 	routeTarget->polyExtents[ 1 ] += self->r.maxs[ 1 ] + 10;
 }
 
+static Cvar::Cvar<bool> g_bot_offmeshAttack("g_bot_offmeshAttack", "if bots will attack offmesh enemies", Cvar::NONE, true);
+
 bool BotChangeGoal( gentity_t *self, botTarget_t target )
 {
 	if ( !target.isValid() )
@@ -1182,11 +1184,21 @@ bool BotChangeGoal( gentity_t *self, botTarget_t target )
 
 	if ( !FindRouteToTarget( self, target, false ) )
 	{
+		// TODO: allow adv marauder and adv goon to pick offmesh targets,
+		// if they are in zap/barb range
+		if ( G_Team( self) == TEAM_HUMANS && BotTargetIsVisible( self, target, MASK_SHOT ) && G_Team( target.getTargetedEntity() ) == TEAM_ALIENS && g_bot_offmeshAttack.Get() )
+		{
+			self->botMind->goal = target;
+			self->botMind->m_nav.directPathToGoal = false;
+			self->botMind->hasOffmeshGoal = true;
+			return true;
+		}
 		return false;
 	}
 
 	self->botMind->goal = target;
 	self->botMind->m_nav.directPathToGoal = false;
+	self->botMind->hasOffmeshGoal = false;
 	return true;
 }
 


### PR DESCRIPTION
I am convinced that currently, bots will only pick an enemy as target if the enemy's position can be projected downwards onto the navmesh. This does affect human bots in particular. Build some alien building over an unreachable navmesh part, or over no navmesh part: they will not attack it.

This PR relaxes this condition. Human bots are allowed to pick a target that is not over the navmesh. They will stand still and fire at it, as long as it is visible. Human bots can always do that reasonably, as they have the blaster for targets too far away for the primary weapon. If the target is not a building, and moves onto the navmesh, they proceed as usual.

Here is a video illustrating the problem: https://unvanquished.greboca.com/F-A-I-L.html . That place is not reachable for human bots. So the aliens were perfectly safe there. With this PR, a human bot will fire at them if it sees them.

Recently, I spent some time making alien bots go to previously unreachable places (with navcons provided). This PR makes human bots shoot at previously unseen places, for symmetry.

Edit:
That video is a bad example, as human bots might not see the aliens there because of the reactor. I hope you get the idea though.