### PR TITLE
Quote() constness and cleanup

### DIFF
--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -492,7 +492,7 @@ char *ConcatArgsPrintable( int start )
 	static char line[ MAX_STRING_CHARS ];
 	int         len;
 	char        arg[ MAX_STRING_CHARS + 2 ];
-	char        *printArg;
+	const char *printArg;
 
 	len = 0;
 	c = trap_Argc();

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -316,7 +316,9 @@ bool              G_IsPlayableTeam( team_t team );
 bool              G_IsPlayableTeam( int team );
 team_t            G_IterateTeams( team_t team );
 std::string G_EscapeServerCommandArg( Str::StringRef str );
-char *Quote( Str::StringRef str );
+// WARNING: this function can only be called BUFFERSIZE times by the same function,
+// or bad things will happen!
+const char *Quote( Str::StringRef str );
 float             G_Distance( gentity_t *ent1, gentity_t *ent2 );
 float G_DistanceToBBox( const vec3_t origin, gentity_t* ent );
 int BG_FOpenGameOrPakPath( Str::StringRef filename, fileHandle_t &handle );

--- a/src/sgame/sg_utils.cpp
+++ b/src/sgame/sg_utils.cpp
@@ -943,15 +943,17 @@ std::string G_EscapeServerCommandArg( Str::StringRef str )
 // Escape a command for used in server commands (sent from client to server)
 // Difference from Cmd::Escape and normal command parsing is that newlines are allowed
 // (for commands that have multi-line output)
-char *Quote( Str::StringRef str )
+// WARNING: this function can only be called BUFFERSIZE times by the same function,
+// or bad things will happen!
+const char *Quote( Str::StringRef str )
 {
-	static char buffer[ 4 ][ MAX_STRING_CHARS ];
+	int constexpr BUFFERSIZE = 256; // must be a power of 2
+	static std::string buffer[BUFFERSIZE];
 	static int index = -1;
 
-	index = ( index + 1 ) & 3;
-	Q_strncpyz( buffer[ index ], G_EscapeServerCommandArg( str ).c_str(), sizeof( buffer[ index ] ) );
-
-	return buffer[ index ];
+	index = ( index + 1 ) & ( BUFFERSIZE - 1 );
+	buffer[index] = G_EscapeServerCommandArg( str );
+	return buffer[index].c_str();
 }
 
 // TODO: Add LocationComponent


### PR DESCRIPTION
Quote() function iterates over 4 buffers for no reason. Get rid of that.
Also use a std::string to store the cached data, which prevents to meet too long strings.
Last, make it's returned value const, as it should.