### PR TITLE
Make bot skill levels fully configurable (rewrite of #2697)

### DIFF
--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -383,12 +383,8 @@ skillSet_t BotPickSkillset(std::string seed, int skillLevel, team_t team)
 	return skillSet;
 }
 
-std::pair<std::string, skillSet_t> BotDetermineSkills(gentity_t *bot, int skillLevel)
+static std::string SkillSetToString( skillSet_t skillSet, const std::string &separator )
 {
-	std::string seed = bot->client->pers.netname;
-
-	skillSet_t skillSet = BotPickSkillset( seed, skillLevel, G_Team( bot ));
-
 	std::vector<std::string> skillNames;
 
 	for ( const botSkillTreeElement_t &s : skillTree )
@@ -406,9 +402,16 @@ std::pair<std::string, skillSet_t> BotDetermineSkills(gentity_t *bot, int skillL
 	{
 		if (!skill_list.empty())
 		{
-			skill_list.append(" ");
+			skill_list.append( separator );
 		}
 		skill_list.append( skill_ );
 	}
-	return { skill_list, skillSet };
+	return skill_list;
+}
+
+std::pair<std::string, skillSet_t> BotDetermineSkills(gentity_t *bot, int skillLevel)
+{
+	std::string seed = bot->client->pers.netname;
+	skillSet_t skillSet = BotPickSkillset( seed, skillLevel, G_Team( bot ));
+	return { SkillSetToString( skillSet, " " ), skillSet };
 }

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -104,28 +104,28 @@ static void G_SetSkillsetBudgetAliens( int val )
 void G_InitSkilltreeCvars()
 {
 	static Cvar::Callback<Cvar::Cvar<std::string>> g_disabledSkillset(
-		"g_disabledSkillset",
+		"g_bot_skillset_disabledSkills",
 		"Disabled skills for bots, example: " QQ("mantis-attack-jump, prefer-armor"),
 		Cvar::NONE,
 		"",
 		G_SetDisabledSkillset
 		);
 	static Cvar::Callback<Cvar::Cvar<std::string>> g_preferredSkillset(
-		"g_preferredSkillset",
+		"g_bot_skillset_preferredSkills",
 		"Preferred skills for bots, example: " QQ("mantis-attack-jump, prefer-armor"),
 		Cvar::NONE,
 		"",
 		G_SetPreferredSkillset
 		);
 	static Cvar::Callback<Cvar::Cvar<int>> g_skillsetBudgetAliens(
-		"g_skillsetBudgetAliens",
+		"g_bot_skillset_budgetAliens",
 		"the skillset budget for aliens.",
 		Cvar::NONE,
 		skillsetBudgetAliens,
 		G_SetSkillsetBudgetAliens
 		);
 	static Cvar::Callback<Cvar::Cvar<int>> g_skillsetBudgetHumans(
-		"g_skillsetBudgetHumans",
+		"g_bot_skillset_budgetHumans",
 		"the skillset budget for humans.",
 		Cvar::NONE,
 		skillsetBudgetHumans,


### PR DESCRIPTION
Since there has been no response on #2697 for a while, I have fixed the issues with it here. This is the one to make bot skill levels hard-codable with `set g_bot_baseSkills 3:movement 5:mantis-attack-jump` etc.

Since I heard something about issues with dependent skills, I added a warning message about unmet dependencies. You can force-set skills without meeting the dependencies, but there will be a warning like `^3Warn: Base skillset for level 4 includes mantis-attack-jump, but includes none of its dependencies: movement`. This is because some skills might fail to do anything due to being locked behind a test for a dependency.

Additionally you will get a warning anywhere a skill name is misspelled.