### PR TITLE
bots: human use medkit when go for heal

### DIFF
--- a/pkg/unvanquished_src.dpkdir/bots/default_humans.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/default_humans.bt
@@ -40,6 +40,10 @@ selector
 						condition baseRushScore < 0.75
 						selector
 						{
+							decorator return( STATUS_FAILURE )
+							{
+								action activateUpgrade( UP_MEDKIT )
+							}
 							decorator timer( 3000 )
 							{
 								action heal
@@ -73,6 +77,10 @@ selector
 			condition healScore > 0.25
 			selector
 			{
+				decorator return( STATUS_FAILURE )
+				{
+					action activateUpgrade( UP_MEDKIT )
+				}
 				decorator timer( 3000 )
 				{
 					action heal


### PR DESCRIPTION
This commit makes humans use their medkit pre-emptively when needing to heal. This will reduce their time camping on medistation at the very least.