### PR TITLE
sg_admin.cpp: improve the ban list

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -4176,6 +4176,7 @@ static int ban_out( void *ban, char *str )
 	char          date[ 11 ];
 	g_admin_ban_t *b = ( g_admin_ban_t * ) ban;
 	char          *made = b->made;
+	bool          active;
 
 	if ( !str )
 	{
@@ -4194,35 +4195,41 @@ static int ban_out( void *ban, char *str )
 
 	date[ i ] = 0;
 
-	if ( !b->expires || b->expires - t > 0 )
+	active = ( !b->expires || b->expires - t > 0 );
+
+	if ( active )
 	{
 		G_admin_duration( b->expires ? b->expires - t : -1,
-						  time, sizeof( time ),
-						  duration, sizeof( duration ) );
+		                  time, sizeof( time ),
+		                  duration, sizeof( duration ) );
+		d_color = ( !b->expires ? Color::Red : Color::White );
 	}
 	else
 	{
 		*time = 0;
-		Q_strncpyz( duration, "expired", sizeof( duration ) );
-		d_color = Color::Cyan;
+		Q_strncpyz( duration, "(expired)", sizeof( duration ) );
+		d_color = Color::Green;
 	}
 
-	Com_sprintf( str, MAX_STRING_CHARS, "%s"
-	             "         %s\\__ %s%s%-*s %s%-15s ^7%-8s %s"
-	             "          %s\\__ %s:^* %s",
-	             b->name,
-	             Color::ToString( G_ADMIN_BAN_IS_WARNING( b ) ? Color::Yellow : Color::Red ).c_str(),
-	             Color::ToString( d_color ).c_str(),
-	             time,
-	             MAX_DURATION_LENGTH - 1,
-	             duration,
-	             Color::ToString( ( strchr( b->ip.str, '/' ) ) ? Color::Red : Color::White ).c_str(),
+	Com_sprintf( str, MAX_STRING_CHARS, 
+	             "^3------------------------------\n"
+	             "    Name:     %s\n"
+	             "    IP:       %s%s\n"
+	             "    Admin:    %s\n"
+	             "    Reason:   ^3%s\n"
+	             "    Date:     ^3%s\n"
+	             "    Details:  %s%s%s%s%s%s",
+	             b->name, 
+	             Color::ToString( ( strchr( b->ip.str, '/' ) ) ? Color::Red : Color::Yellow ).c_str(),
 	             b->ip.str,
-	             date,
 	             b->banner,
+	             b->reason,
+	             date, 
 	             Color::ToString( G_ADMIN_BAN_IS_WARNING( b ) ? Color::Yellow : Color::Red ).c_str(),
-	             G_ADMIN_BAN_IS_WARNING( b ) ? "WARNING" : "BAN",
-	             b->reason );
+	             G_ADMIN_BAN_IS_WARNING( b ) ? "WARNING " : "BAN ",
+	             ( ( active && b->expires ) ? "^7- expiring in " : "^7- " ),
+	             Color::ToString( d_color ).c_str(),
+	             time, duration );
 
 	return b->id;
 }

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -511,7 +511,7 @@ g_admin_command_t *g_admin_commands = nullptr;
 std::vector<g_admin_vote_t> g_admin_votes;
 
 /* ent must be non-nullptr */
-#define G_ADMIN_NAME( ent ) ( ent->client->pers.netname ) // prefer netname at all times
+#define G_ADMIN_NAME( ent ) ( ent->client->pers.admin ? ent->client->pers.admin->name : ent->client->pers.netname )
 
 const char *G_admin_name( gentity_t *ent )
 {
@@ -572,8 +572,8 @@ void G_admin_action( const char *action, const char *translation,
 	char qAdminStealthName[ MAX_NAME_LENGTH ];
 
 	// quote only has a limited buffer, so cache these values here.
-	Q_strncpyz( qAdminNetName, Quote( G_admin_name( admin ) ), sizeof( qAdminNetName ) );
-	Q_strncpyz( qAdminTaggedName, Quote( va( "%s%s", cloakTags[ G_admin_stealthed( admin ) ], G_admin_name( admin ) ) ), sizeof( qAdminTaggedName ) );
+	Q_strncpyz( qAdminNetName, Quote( G_user_name( admin, "console" ) ), sizeof( qAdminNetName ) );
+	Q_strncpyz( qAdminTaggedName, Quote( va( "%s%s", cloakTags[ G_admin_stealthed( admin ) ], G_user_name( admin, "console" ) ) ), sizeof( qAdminTaggedName ) );
 	Q_strncpyz( qAdminAdminName, Quote( ( admin ) 
 	                                    ? ( admin->client->pers.admin ? admin->client->pers.admin->name : qAdminNetName )
 	                                    : "console" ), sizeof( qAdminAdminName ) );


### PR DESCRIPTION
This PR changes the ban list to the same style as used on Bunker (Tremulous) and as previously discussed in #2196.

I have attached a screenshot of what the new banlist will look like.
![Screenshot_20230629_125311](https://github.com/Unvanquished/Unvanquished/assets/13281185/fcf1e75d-199b-40a7-9efb-453acab59b0f)

Furthermore, I also reverted a change I made in #2735 which changed the behaviour of `G_ADMIN_NAME` and more appropriately used `G_user_name` instead.

If nobody objects, I would like to store the level of the admin who created the ban to include this on the list. I haven't made that change yet as it will break compatibility with any existing admin.dat which contains bans.