### PR TITLE
bot skills h-fast-flee and a-fast-flee: invert condition

### DIFF
--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -1029,8 +1029,8 @@ bool BotMoveToGoal( gentity_t *self )
 	weaponMode_t wpm = WPM_NONE;
 	int magnitude = 0;
 	const playerState_t& ps  = self->client->ps;
-	if ( ( G_Team( self ) == TEAM_HUMANS && self->botMind->skillSet[BOT_H_FAST_FLEE] )
-			|| ( G_Team( self ) == TEAM_ALIENS && self->botMind->skillSet[BOT_A_FAST_FLEE] ) )
+	if ( ( G_Team( self ) == TEAM_HUMANS && !self->botMind->skillSet[BOT_H_FAST_FLEE] )
+			|| ( G_Team( self ) == TEAM_ALIENS && !self->botMind->skillSet[BOT_A_FAST_FLEE] ) )
 	{
 		return true;
 	}


### PR DESCRIPTION
~~I'll ommit the rant about testing pull requests.~~
Well, there has been a mistake in the past. Currently the bot skills `h-fast-flee` and `a-fast-flee` are _inverted_. A bot "flees" if it tries to reach a healing buildable (medistation, booster or any other alien buildable). The fast flee skills are supposed the trigger faster moving. That means that human bots are supposed to sprint, and alien bots are supposed to do what makes their class faster.

You can test this by adding a single bot to a game, waiting until it is out of base, and then `/slap <bot> 90 1`. Replace 90 by something close to but below the bot's current health.