### PR TITLE
Warn cleanup

### DIFF
--- a/src/cgame/rocket/rocket.cpp
+++ b/src/cgame/rocket/rocket.cpp
@@ -638,9 +638,9 @@ public:
         }
     }
 
-    void SetFocus(bool focus)
+    void SetFocus(bool focus_)
     {
-        this->focus = focus;
+        focus = focus_;
         Update();
     }
 

--- a/src/cgame/rocket/rocketFormControlInput.h
+++ b/src/cgame/rocket/rocketFormControlInput.h
@@ -182,7 +182,7 @@ private:
 		}
 	}
 
-	void SetCvarValueAndFlags( const Rml::String& cvar, Rml::String value )
+	void SetCvarValueAndFlags( const Rml::String& cvar_, Rml::String value )
 	{
 		if ( type == "range" )
 		{
@@ -193,8 +193,8 @@ private:
 				value.erase( point ); // for compatibility with integer cvars
 			}
 		}
-		Cvar::SetValue( cvar.c_str(), value.c_str() );
-		Cvar::AddFlags( cvar.c_str(), Cvar::USER_ARCHIVE );
+		Cvar::SetValue( cvar_.c_str(), value.c_str() );
+		Cvar::AddFlags( cvar_.c_str(), Cvar::USER_ARCHIVE );
 	}
 
 	Rml::String cvar;

--- a/src/cgame/rocket/rocketKeyBinder.h
+++ b/src/cgame/rocket/rocketKeyBinder.h
@@ -203,7 +203,7 @@ protected:
 		trap_Key_SetBinding( newKey, team, cmd.c_str() );
 	}
 
-	int GetTeam( Rml::String team )
+	int GetTeam( Rml::String team_ )
 	{
 		static const struct {
 			int team;
@@ -217,13 +217,13 @@ protected:
 
 		for ( const auto& teamLabel : labels )
 		{
-			if ( team == teamLabel.label )
+			if ( team_ == teamLabel.label )
 			{
 				return teamLabel.team;
 			}
 		}
 
-		Log::Warn( "Team %s not found", team.c_str() );
+		Log::Warn( "Team %s not found", team_.c_str() );
 		return -1;
 	}
 

--- a/src/sgame/components/BuildableComponent.h
+++ b/src/sgame/components/BuildableComponent.h
@@ -48,7 +48,7 @@ class BuildableComponent: public BuildableComponentBase {
 		void Think(int timeDelta);
 
 		lifecycle_t GetState() { return state; }
-		void SetState(lifecycle_t state) { this->state = state; }
+		void SetState(lifecycle_t state_) { state = state_; }
 
 		/**
 		 * @return Whether the buildable is currently marked for deconstruction.
@@ -80,8 +80,8 @@ class BuildableComponent: public BuildableComponentBase {
 		 */
 		bool Active() const { return state == CONSTRUCTED && Powered(); }
 
-		void SetAimAngles(const glm::vec3 aimAngles) { this->aimAngles = aimAngles; }
-		glm::vec3 AimAngles() const { return this->aimAngles; }
+		void SetAimAngles(const glm::vec3 aimAngles) { m_aimAngles = aimAngles; }
+		glm::vec3 AimAngles() const { return m_aimAngles; }
 
 		/**
 		 * Protect current animation from being disrupted by selected, less important animations.
@@ -103,7 +103,7 @@ class BuildableComponent: public BuildableComponentBase {
 		bool marked;
 		int  markTime;
 
-		glm::vec3 aimAngles; /**< Aim angles relative to world. */
+		glm::vec3 m_aimAngles; /**< Aim angles relative to world. */
 
 		int protectAnimationUntil;
 

--- a/src/sgame/components/DeferredFreeingComponent.cpp
+++ b/src/sgame/components/DeferredFreeingComponent.cpp
@@ -28,8 +28,8 @@ DeferredFreeingComponent::DeferredFreeingComponent(Entity &entity)
 	: DeferredFreeingComponentBase(entity), freeTime(DONT_FREE)
 {}
 
-void DeferredFreeingComponent::HandleFreeAt(int freeTime) {
-	this->freeTime = freeTime;
+void DeferredFreeingComponent::HandleFreeAt(int freeTime_) {
+	freeTime = freeTime_;
 }
 
 int DeferredFreeingComponent::GetFreeTime() {

--- a/src/sgame/components/HealthComponent.cpp
+++ b/src/sgame/components/HealthComponent.cpp
@@ -241,13 +241,13 @@ Util::optional<glm::vec3> direction, int flags, meansOfDeath_t meansOfDeath) {
 	}
 }
 
-void HealthComponent::SetHealth(float health) {
-	health = Math::Clamp(health, FLT_EPSILON, maxHealth);
+void HealthComponent::SetHealth(float health_) {
+	health_ = Math::Clamp(health_, FLT_EPSILON, maxHealth);
 
-	healthLogger.Debug("Changing health: %3.1f → %3.1f.", this->health, health);
+	healthLogger.Debug("Changing health: %3.1f → %3.1f.", health, health_);
 
-	ScaleDamageAccounts(health - this->health);
-	HealthComponent::health = health;
+	ScaleDamageAccounts(health_ - health);
+	HealthComponent::health = health_;
 }
 
 void HealthComponent::SetMaxHealth(float maxHealth, bool scaleHealth) {

--- a/src/sgame/components/IgnitableComponent.cpp
+++ b/src/sgame/components/IgnitableComponent.cpp
@@ -60,8 +60,8 @@ void IgnitableComponent::HandlePrepareNetCode() {
 	}
 }
 
-void IgnitableComponent::HandleIgnite(gentity_t* fireStarter) {
-	if (!fireStarter) {
+void IgnitableComponent::HandleIgnite(gentity_t* fireStarter_) {
+	if (!fireStarter_) {
 		// TODO: Find out why this happens.
 		fireLogger.Notice("Received ignite message with no fire starter.");
 	}
@@ -75,13 +75,13 @@ void IgnitableComponent::HandleIgnite(gentity_t* fireStarter) {
 	// Start burning on initial ignition.
 	if (!onFire) {
 		onFire = true;
-		this->fireStarter = fireStarter;
+		fireStarter = fireStarter_;
 
 		fireLogger.Notice("Ignited.");
 	} else {
-		if (alwaysOnFire && !this->fireStarter) {
+		if (alwaysOnFire && !fireStarter) {
 			// HACK: Igniting an alwaysOnFire entity will initialize the fire starter.
-			this->fireStarter = fireStarter;
+			fireStarter = fireStarter_;
 
 			fireLogger.Debug("Firestarter set.");
 		} else {

--- a/src/sgame/components/ThinkingComponent.cpp
+++ b/src/sgame/components/ThinkingComponent.cpp
@@ -33,7 +33,7 @@ void ThinkingComponent::Think() {
 		int timeDelta = time - record.timestamp;
 
 		int thisFrameExecutionLateness = timeDelta - record.period;
-		int nextFrameExecutionLateness = timeDelta + averageFrameTime - record.period;
+		int nextFrameExecutionLateness = timeDelta - record.period + averageFrameTime;
 
 		switch (record.scheduler) {
 			case SCHEDULER_AFTER:

--- a/src/sgame/components/ThinkingComponent.h
+++ b/src/sgame/components/ThinkingComponent.h
@@ -52,10 +52,9 @@ class ThinkingComponent: public ThinkingComponentBase {
 		};
 
 		std::vector<thinkRecord_t> thinkers;
-
-		bool iteratingThinkers;
 		std::vector<thinkRecord_t> newThinkers; /**< Used for adding thinkers during iteration over them. */
 
+		bool iteratingThinkers;
 		bool unregisterActiveThinker;
 
 		float averageFrameTime; /**< Smoothed out average frame time for predictions. */

--- a/src/sgame/components/TurretComponent.cpp
+++ b/src/sgame/components/TurretComponent.cpp
@@ -31,8 +31,8 @@ void TurretComponent::HandlePrepareNetCode() {
 	VectorCopy(relativeAimAngles, entity.oldEnt->s.angles2);
 }
 
-void TurretComponent::SetRange(float range) {
-	this->range = range;
+void TurretComponent::SetRange(float range_) {
+	range = range_;
 }
 
 Entity* TurretComponent::GetTarget() {
@@ -194,14 +194,14 @@ bool TurretComponent::TargetCanBeHit() {
 	return (tr.entityNum == target->num());
 }
 
-bool TurretComponent::TargetValid(Entity& target, bool newTarget) {
-	if (!target.Get<ClientComponent>() ||
-	    target.Get<SpectatorComponent>() ||
-	    Entities::IsDead(target) ||
-	    (target.oldEnt->flags & FL_NOTARGET) ||
-	    !Entities::OnOpposingTeams(entity, target) ||
-	    G_Distance(entity.oldEnt, target.oldEnt) > range ||
-	    !trap_InPVS(entity.oldEnt->s.origin, target.oldEnt->s.origin)) {
+bool TurretComponent::TargetValid(Entity& target_, bool newTarget) {
+	if (!target_.Get<ClientComponent>() ||
+	    target_.Get<SpectatorComponent>() ||
+	    Entities::IsDead(target_) ||
+	    (target_.oldEnt->flags & FL_NOTARGET) ||
+	    !Entities::OnOpposingTeams(entity, target_) ||
+	    G_Distance(entity.oldEnt, target_.oldEnt) > range ||
+	    !trap_InPVS(entity.oldEnt->s.origin, target_.oldEnt->s.origin)) {
 
 		if (!newTarget) {
 			turretLogger.Verbose("Target lost: Out of range or eliminated.");
@@ -211,7 +211,7 @@ bool TurretComponent::TargetValid(Entity& target, bool newTarget) {
 	}
 
 	// New targets require a line of sight.
-	if (G_LineOfFire(entity.oldEnt, target.oldEnt)) {
+	if (G_LineOfFire(entity.oldEnt, target_.oldEnt)) {
 		lastLineOfSightToTarget = level.time;
 	} else if (newTarget) {
 		return false;

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -747,13 +747,13 @@ static g_admin_cmd_t *G_admin_cmd( const char *cmd )
 
 static g_admin_level_t *G_admin_level( const int l )
 {
-	g_admin_level_t *level;
+	g_admin_level_t *level_;
 
-	for ( level = g_admin_levels; level; level = level->next )
+	for ( level_ = g_admin_levels; level_; level_ = level_->next )
 	{
-		if ( level->level == l )
+		if ( level_->level == l )
 		{
-			return level;
+			return level_;
 		}
 	}
 
@@ -1205,31 +1205,31 @@ static void admin_readconfig_int( const char **cnf, int *v )
 static void admin_default_levels()
 {
 	g_admin_level_t *l;
-	int             level = 0;
+	int level_ = 0;
 
 	l = g_admin_levels = (g_admin_level_t*) BG_Alloc( sizeof( g_admin_level_t ) );
-	l->level = level++;
+	l->level = level_++;
 	Q_strncpyz( l->name, "^4Unknown Player", sizeof( l->name ) );
 	Q_strncpyz( l->flags,
 	            "listplayers admintest adminhelp time register",
 	            sizeof( l->flags ) );
 
 	l = l->next = (g_admin_level_t*) BG_Alloc( sizeof( g_admin_level_t ) );
-	l->level = level++;
+	l->level = level_++;
 	Q_strncpyz( l->name, "^5Server Regular", sizeof( l->name ) );
 	Q_strncpyz( l->flags,
 	            "listplayers admintest adminhelp time register unregister",
 	            sizeof( l->flags ) );
 
 	l = l->next = (g_admin_level_t*) BG_Alloc( sizeof( g_admin_level_t ) );
-	l->level = level++;
+	l->level = level_++;
 	Q_strncpyz( l->name, "^6Team Manager", sizeof( l->name ) );
 	Q_strncpyz( l->flags,
 	            "listplayers admintest adminhelp time putteam spec999 register unregister bot listbots",
 	            sizeof( l->flags ) );
 
 	l = l->next = (g_admin_level_t*) BG_Alloc( sizeof( g_admin_level_t ) );
-	l->level = level++;
+	l->level = level_++;
 	Q_strncpyz( l->name, "^2Junior Admin", sizeof( l->name ) );
 	Q_strncpyz( l->flags,
 	            "listplayers admintest adminhelp time putteam spec999 warn kick mute ADMINCHAT "
@@ -1237,7 +1237,7 @@ static void admin_default_levels()
 	            sizeof( l->flags ) );
 
 	l = l->next = (g_admin_level_t*) BG_Alloc( sizeof( g_admin_level_t ) );
-	l->level = level++;
+	l->level = level_++;
 	Q_strncpyz( l->name, "^3Senior Admin", sizeof( l->name ) );
 	Q_strncpyz( l->flags,
 	            "listplayers admintest adminhelp time putteam spec999 warn kick mute showbans ban "
@@ -1245,7 +1245,7 @@ static void admin_default_levels()
 	            sizeof( l->flags ) );
 
 	l = l->next = (g_admin_level_t*) BG_Alloc( sizeof( g_admin_level_t ) );
-	l->level = level++;
+	l->level = level_++;
 	Q_strncpyz( l->name, "^1Server Operator", sizeof( l->name ) );
 	Q_strncpyz( l->flags,
 	            "ALLFLAGS -IMMUTABLE -INCOGNITO",
@@ -1256,7 +1256,7 @@ static void admin_default_levels()
 void G_admin_authlog( gentity_t *ent )
 {
 	char            aflags[ MAX_ADMIN_FLAGS * 2 ];
-	g_admin_level_t *level;
+	g_admin_level_t *level_;
 	int             levelNum = 0;
 
 	if ( !ent )
@@ -1269,11 +1269,11 @@ void G_admin_authlog( gentity_t *ent )
 		levelNum = ent->client->pers.admin->level;
 	}
 
-	level = G_admin_level( levelNum );
+	level_ = G_admin_level( levelNum );
 
 	Com_sprintf( aflags, sizeof( aflags ), "%s %s",
 	             ent->client->pers.admin->flags,
-	             ( level ) ? level->flags : "" );
+	             ( level_ ) ? level_->flags : "" );
 
 	G_LogPrintf( "AdminAuth: %i \"%s^*\" \"%s^*\" [%d] (%s): %s",
 	             ent->num(), ent->client->pers.netname,
@@ -5185,7 +5185,7 @@ bool G_admin_flaglist( gentity_t *ent )
 bool G_admin_flag( gentity_t *ent )
 {
 	g_admin_admin_t *admin = nullptr;
-	g_admin_level_t *level = nullptr;
+	g_admin_level_t *level_ = nullptr;
 	gentity_t       *vic = nullptr;
 	char            command[ MAX_ADMIN_CMD_LEN ];
 	char            name[ MAX_NAME_LENGTH ];
@@ -5220,15 +5220,15 @@ bool G_admin_flag( gentity_t *ent )
 		}
 
 		id = atoi( name + 1 );
-		level = G_admin_level( id );
+		level_ = G_admin_level( id );
 
-		if ( !level )
+		if ( !level_ )
 		{
 			ADMP( va( "%s %s %d", QQ( N_("^3$1$: admin level $2$ does not exist") ), command, id ) );
 			return false;
 		}
 
-		Com_sprintf( adminname, sizeof( adminname ), "admin level %d", level->level );
+		Com_sprintf( adminname, sizeof( adminname ), "admin level %d", level_->level );
 	}
 	else
 	{
@@ -5254,17 +5254,17 @@ bool G_admin_flag( gentity_t *ent )
 
 	if( trap_Argc() < 3 )
 	{
-		if ( !level )
+		if ( !level_ )
 		{
-			level = G_admin_level( admin->level );
+			level_ = G_admin_level( admin->level );
 			ADMP( va( "%s %s %s %s", QQ( N_("^3$1$:^* flags for $2$^* are '^3$3$^*'") ),
 			          command, Quote( admin->name ), Quote( admin->flags ) ) );
 		}
 
-		if ( level )
+		if ( level_ )
 		{
 			ADMP( va( "%s %s %d %s", QQ( N_("^3$1$:^* admin level $2$ flags are '$3$'") ),
-			          command, level->level, Quote( level->flags ) ) );
+			          command, level_->level, Quote( level_->flags ) ) );
 		}
 
 		return true;
@@ -5318,10 +5318,10 @@ bool G_admin_flag( gentity_t *ent )
 		return false;
 	}
 
-	if ( level )
+	if ( level_ )
 	{
-		flagPtr = level->flags;
-		flagSize = sizeof( level->flags );
+		flagPtr = level_->flags;
+		flagSize = sizeof( level_->flags );
 	}
 	else
 	{
@@ -5795,7 +5795,7 @@ bool G_admin_l1( gentity_t *ent )
 
 bool G_admin_register( gentity_t *ent )
 {
-	int level = 1;
+	int level_ = 1;
 
 	if ( !ent )
 	{
@@ -5804,7 +5804,7 @@ bool G_admin_register( gentity_t *ent )
 
 	if ( ent->client->pers.admin && ent->client->pers.admin->level != 0 )
 	{
-		level = ent->client->pers.admin->level;
+		level_ = ent->client->pers.admin->level;
 	}
 
 	if ( G_IsUnnamed( ent->client->pers.netname ) )
@@ -5815,7 +5815,7 @@ bool G_admin_register( gentity_t *ent )
 
 	trap_SendConsoleCommand( va( "setlevel %d %d;",
 	                         ent->num(),
-	                         level ) );
+	                         level_ ) );
 
 	AP( va( "print_tr %s %s", QQ( N_("^3register:^* $1$^* is now a protected name") ),
 	        Quote( ent->client->pers.netname ) ) );

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -102,15 +102,15 @@ static void G_SetBaseSkillset( Str::StringRef skillsCsv )
 	std::vector<std::pair<int, bot_skill>> skills = G_ParseSkillsetListWithLevels( skillsCsv );
 	for ( int skillLevel = 1; skillLevel <= 9; skillLevel++ )
 	{
-		skillSet_t level{};
+		skillSet_t level_{};
 		for ( auto &skill : skills )
 		{
 			if (skill.first <= skillLevel)
 			{
-				level.set( skill.second );
+				level_.set( skill.second );
 			}
 		}
-		baseSkillset[ skillLevel - 1 ] = level;
+		baseSkillset[ skillLevel - 1 ] = level_;
 	}
 
 	CheckBaseSkillset();
@@ -439,10 +439,10 @@ static void CheckBaseSkillset()
 		// Find the lowest level the skill is in and see if it has unset dependencies
 		for ( int l = 1; l <= 9; l++ )
 		{
-			const skillSet_t &level = baseSkillset[ l - 1 ];
-			if ( level[ skill.skill ] )
+			const skillSet_t &level_ = baseSkillset[ l - 1 ];
+			if ( level_[ skill.skill ] )
 			{
-				if ( skill.prerequisite.any() && ( skill.prerequisite & level ).none() )
+				if ( skill.prerequisite.any() && ( skill.prerequisite & level_ ).none() )
 				{
 					std::string deps = SkillSetToString( skill.prerequisite, " / " );
 					Log::Warn( "Base skillset for level %d includes %s, but includes none of its dependencies: %s",

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -829,7 +829,6 @@ struct level_locals_t
 		int              queuedBudget;
 		int              kills;
 		spawnQueue_t     spawnQueue;
-		bool             locked;
 		float            momentum;
 		int              layoutBuildPoints;
 		int              botFillTeamSize;
@@ -837,12 +836,13 @@ struct level_locals_t
 		int              lastTeamStatus;
 		int              lastTacticId;
 		int              lastTacticTime;
+		bool             locked;
 	} team[ NUM_TEAMS ];
 
 	struct {
 		int synchronous;
-		bool fixed;
 		int msec;
+		bool fixed;
 		bool accurate;
 		bool initialized;
 	} pmoveParams;
@@ -857,16 +857,13 @@ struct commands_t
 
 struct zap_t
 {
-	bool  used;
-
+	gentity_t *effectChannel;
 	gentity_t *creator;
 	gentity_t *targets[ LEVEL2_AREAZAP_MAX_TARGETS ];
-	int       numTargets;
 	float     distances[ LEVEL2_AREAZAP_MAX_TARGETS ];
-
+	int       numTargets;
 	int       timeToLive;
-
-	gentity_t *effectChannel;
+	bool  used;
 };
 
 #endif // SG_STRUCT_H_

--- a/src/sgame/sg_utils.cpp
+++ b/src/sgame/sg_utils.cpp
@@ -997,14 +997,14 @@ glm::vec3 G_CalcMuzzlePoint( const gentity_t *self, const glm::vec3 &forward )
 	return glm::floor( muzzlePoint + 0.5f );
 }
 
-bool gentity_t::Damage( float amount, gentity_t* source,
+bool gentity_t::Damage( float amount_, gentity_t* source,
 		Util::optional<glm::vec3> location,
 		Util::optional<glm::vec3> direction,
-		int flags, meansOfDeath_t meansOfDeath )
+		int flags_, meansOfDeath_t meansOfDeath )
 {
 	if ( s.eType != entityType_t::ET_MOVER )
 	{
-		return entity->Damage( amount, source, location, direction, flags, meansOfDeath );
+		return entity->Damage( amount_, source, location, direction, flags_, meansOfDeath );
 	}
 
 	// it seems returning true allows to signal caller a change
@@ -1019,9 +1019,9 @@ bool gentity_t::Damage( float amount, gentity_t* source,
 
 	if ( pain )
 	{
-		pain( this, source, amount );
+		pain( this, source, amount_ );
 	}
-	health -= amount;
+	health -= amount_;
 	if ( health <= 0 && die )
 	{
 		die( this, nullptr, source, 0 );

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -575,15 +575,15 @@ static void ShotgunPattern( vec3_t origin, vec3_t origin2, int seed, gentity_t *
 	int       i;
 	float     r, u, a;
 	vec3_t    end;
-	vec3_t    forward, right, up;
+	vec3_t    forward_, right_, up_;
 	trace_t   tr;
 	gentity_t *traceEnt;
 
 	// derive the right and up vectors from the forward vector, because
 	// the client won't have any other information
-	VectorNormalize2( origin2, forward );
-	PerpendicularVector( right, forward );
-	CrossProduct( forward, right, up );
+	VectorNormalize2( origin2, forward_ );
+	PerpendicularVector( right_, forward_ );
+	CrossProduct( forward_, right_, up_ );
 
 	// generate the "random" spread pattern
 	for ( i = 0; i < SHOTGUN_PELLETS; i++ )
@@ -594,15 +594,15 @@ static void ShotgunPattern( vec3_t origin, vec3_t origin2, int seed, gentity_t *
 		u = sinf( r ) * a;
 		r = cosf( r ) * a;
 
-		VectorMA( origin, SHOTGUN_RANGE, forward, end );
-		VectorMA( end, r, right, end );
+		VectorMA( origin, SHOTGUN_RANGE, forward_, end );
+		VectorMA( end, r, right_, end );
 		VectorMA( end, u, up, end );
 
 		trap_Trace( &tr, origin, nullptr, nullptr, end, self->s.number, MASK_SHOT, 0 );
 		traceEnt = &g_entities[ tr.entityNum ];
 
 		traceEnt->Damage((float)SHOTGUN_DMG, self, VEC2GLM( tr.endpos ),
-		                         VEC2GLM( forward ), 0, (meansOfDeath_t)MOD_SHOTGUN);
+		                         VEC2GLM( forward_ ), 0, (meansOfDeath_t)MOD_SHOTGUN);
 	}
 }
 
@@ -890,7 +890,7 @@ BUILD GUN
 
 void G_CheckCkitRepair( gentity_t *self )
 {
-	vec3_t    viewOrigin, forward, end;
+	vec3_t    viewOrigin, forward_, end;
 	trace_t   tr;
 	gentity_t *traceEnt;
 
@@ -901,8 +901,8 @@ void G_CheckCkitRepair( gentity_t *self )
 	}
 
 	BG_GetClientViewOrigin( &self->client->ps, viewOrigin );
-	AngleVectors( self->client->ps.viewangles, forward, nullptr, nullptr );
-	VectorMA( viewOrigin, 100, forward, end );
+	AngleVectors( self->client->ps.viewangles, forward_, nullptr, nullptr );
+	VectorMA( viewOrigin, 100, forward_, end );
 
 	trap_Trace( &tr, viewOrigin, nullptr, nullptr, end, self->s.number, MASK_PLAYERSOLID, 0 );
 	traceEnt = &g_entities[ tr.entityNum ];
@@ -1390,7 +1390,7 @@ void G_ChargeAttack( gentity_t *self, gentity_t *victim )
 {
 	int    damage;
 	int    i;
-	vec3_t forward;
+	vec3_t forward_;
 
 	if ( !self->client || self->client->ps.weaponCharge <= 0 ||
 	     !( self->client->ps.stats[ STAT_STATE ] & SS_CHARGING ) ||
@@ -1404,8 +1404,8 @@ void G_ChargeAttack( gentity_t *self, gentity_t *victim )
 		return;
 	}
 
-	VectorSubtract( victim->s.origin, self->s.origin, forward );
-	VectorNormalize( forward );
+	VectorSubtract( victim->s.origin, self->s.origin, forward_ );
+	VectorNormalize( forward_ );
 
 	// For buildables, track the last MAX_TRAMPLE_BUILDABLES_TRACKED buildables
 	//  hit, and do not do damage if the current buildable is in that list
@@ -1427,7 +1427,7 @@ void G_ChargeAttack( gentity_t *self, gentity_t *victim )
 
 	damage = LEVEL4_TRAMPLE_DMG * self->client->ps.weaponCharge / LEVEL4_TRAMPLE_DURATION;
 
-	victim->Damage((float)damage, self, VEC2GLM( victim->s.origin ), VEC2GLM( forward ),
+	victim->Damage((float)damage, self, VEC2GLM( victim->s.origin ), VEC2GLM( forward_ ),
 	                       DAMAGE_NO_LOCDAMAGE, MOD_LEVEL4_TRAMPLE);
 
 	SendMeleeHitEvent( self, victim, nullptr );
@@ -1556,14 +1556,14 @@ void G_WeightAttack( gentity_t *self, gentity_t *victim )
 Set muzzle location relative to pivoting eye.
 ===============
 */
-void G_CalcMuzzlePoint( const gentity_t *self, const vec3_t forward, const vec3_t, const vec3_t, vec3_t muzzlePoint )
+void G_CalcMuzzlePoint( const gentity_t *self, const vec3_t forward_, const vec3_t, const vec3_t, vec3_t muzzlePoint )
 {
 	vec3_t normal;
 
 	VectorCopy( self->client->ps.origin, muzzlePoint );
 	BG_GetClientNormal( &self->client->ps, normal );
 	VectorMA( muzzlePoint, self->client->ps.viewheight, normal, muzzlePoint );
-	VectorMA( muzzlePoint, 1, forward, muzzlePoint );
+	VectorMA( muzzlePoint, 1, forward_, muzzlePoint );
 	// snap to integer coordinates for more efficient network bandwidth usage
 	SnapVector( muzzlePoint );
 }

--- a/src/shared/Clustering.h
+++ b/src/shared/Clustering.h
@@ -258,8 +258,8 @@ namespace Clustering {
 			 * @brief Set laxity, a factor that scales the allowed deviation from the average edge
 			 *        length when splitting the minimum spanning tree into cluster spanning trees.
 			 */
-			void SetLaxity(float laxity = 1.0) {
-				this->laxity = laxity;
+			void SetLaxity(float laxity_ = 1.0) {
+				this->laxity = laxity_;
 				dirtyClusters = true;
 			}
 


### PR DESCRIPTION
Those commits reduce useless padding and fix many -Wshadow warning in unv's codebase.
This does *not* enable to add `-Werror=shadow` to CI since RmlUI and daemon are full of shadow problems.

I removed shadowing by appending a `_` to names, usually to function parameters, as this is already done in various places in the code.