### PR TITLE
add g_bot_medistatDistance to fine tune medistation queing prevention code

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/server_setup.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/server_setup.rml
@@ -245,6 +245,14 @@
 				<h3> Human bots purchase equipment </h3>
 			</row>
 			<row>
+				<input type="range" min="0" max="20000" step="100" cvar="g_bot_medistatDistance"/>
+				<h3> busy medistation detection distance</h3>
+				<p class="inline">
+					Current: <inlinecvar cvar="g_bot_medistatDistance" type="number" format="%.0f"/> Qu
+					<ilink onclick='Events.pushevent("exec reset g_bot_medistatDistance", event)'> (reset) </ilink>
+				</p>
+			</row>
+			<row>
 				<input type="range" min="0" max="2000" step="10" cvar="g_bot_humanAimDelay"/>
 				<h3> Aim speed modifier (higher is slower)</h3>
 				<p class="inline">

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -39,6 +39,7 @@ constexpr float MAX_HUMAN_DANCE_DIST = 300.0f;
 //how far away we can be before we try to go around an alien when fighting an alien
 constexpr float MIN_HUMAN_DANCE_DIST = 100.0f;
 
+static Cvar::Cvar<int> g_bot_medistatDistance( "g_bot_medistatDistance", "Distance at which bots will detect the busyness of a medistation", Cvar::NONE, 200 );
 /*
 ======================
 g_bot_ai.c
@@ -1387,7 +1388,7 @@ static AINodeStatus_t BotActionReachHealH( gentity_t *self )
 	// (It would be nice to allow the BT to check for the failure cause.
 	//  How? That's a good question)
 	if ( medistation->target && medistation->target.get() != self
-	     && dist2 > Square( 200 ) )
+	     && dist2 > Square( g_bot_medistatDistance.Get() ) )
 	{
 		return STATUS_FAILURE;
 	}


### PR DESCRIPTION
Making the distance configurable with a cvar, and implementing a GUI for it while at it.

The intent is that server admins can workaround the buggy limitation which #1598 introduced over the feature I implemented in betterai mod.

![2023-07-06](https://github.com/Unvanquished/Unvanquished/assets/1316300/cdf19fcb-ef37-407a-9d49-3360f7440eeb)
