### PR TITLE
fix crash if using BotActionFollow on a disconnected client

### DIFF
--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -442,6 +442,17 @@ void G_BotThink( gentity_t *self )
 	//hacky ping fix
 	self->client->ps.ping = rand() % 50 + 50;
 
+	//reset the user specified client number if the client disconnected
+	if ( self->botMind->userSpecifiedClientNum )
+	{
+		int userSpecifiedClientNum = *self->botMind->userSpecifiedClientNum;
+		gentity_t *ent = &g_entities[ userSpecifiedClientNum ];
+		if ( !ent->client || ent->client->pers.connected == CON_DISCONNECTED )
+		{
+			self->botMind->userSpecifiedClientNum = Util::nullopt;
+		}
+	}
+
 	if ( !self->botMind->behaviorTree )
 	{
 		Log::Warn( "NULL behavior tree" );


### PR DESCRIPTION
A bot's mind can contain an optional user-specified client number. Currently, the only bot action using this number is the function `BotActionFollow`, which makes a bot roam in some radius around a player (or another bot). This is done along these lines: https://github.com/Unvanquished/Unvanquished/blob/master/src/sgame/sg_bot_ai.cpp#L1220

It turns out this results in an sgame crash if the corresponding client disconnected. Oops.

Fix this by resetting the client number if the client disconnected.