### PR TITLE
dretch and mantis bots: attack enemies while wall climbing

### DIFF
--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -855,11 +855,12 @@ static void BotMaybeAttackWhileClimbing( gentity_t *self )
 	BG_BoundingBox( static_cast<class_t>( ownClass ), &playerMins, &playerMaxs, nullptr, nullptr, nullptr );
 
 	glm::vec3 origin = VEC2GLM( self->s.origin );
-	glm::vec3 dir = glm::vec3( 0.0f, 0.0f, 1.0f );
+	glm::vec3 forward, right, up;
+	AngleVectors( VEC2GLM( self->client->ps.viewangles ), &forward, &right, &up );
 	auto range = ownClass == PCL_ALIEN_LEVEL0 ? LEVEL0_BITE_RANGE : LEVEL1_CLAW_RANGE;
 
 	trace_t trace;
-	glm::vec3 end = origin + range * dir;
+	glm::vec3 end = origin + range * forward;
 	trap_Trace( &trace, origin, playerMins, playerMaxs, end, self->s.number, MASK_PLAYERSOLID, 0 );
 
 	if ( trace.fraction < 1.0f )

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -845,6 +845,48 @@ static int WallclimbStopTime( gentity_t *self )
 	return self->botMind->lastNavconTime + self->botMind->lastNavconDistance * 4 + 500;
 }
 
+// check if a wall climbing bot is running into an attackable human entity, if so: attack it
+static void BotMaybeAttackWhileClimbing( gentity_t *self )
+{
+	ASSERT( self->botMind->lastNavconDistance > 0 );
+
+	int ownClass = self->client->ps.stats[ STAT_CLASS ];
+	glm::vec3 playerMins, playerMaxs;
+	BG_BoundingBox( static_cast<class_t>( ownClass ), &playerMins, &playerMaxs, nullptr, nullptr, nullptr );
+
+	glm::vec3 origin = VEC2GLM( self->s.origin );
+	glm::vec3 dir = glm::vec3( 0.0f, 0.0f, 1.0f );
+	auto range = ownClass == PCL_ALIEN_LEVEL0 ? LEVEL0_BITE_RANGE : LEVEL1_CLAW_RANGE;
+
+	trace_t trace;
+	glm::vec3 end = origin + range * dir;
+	trap_Trace( &trace, origin, playerMins, playerMaxs, end, self->s.number, MASK_PLAYERSOLID, 0 );
+
+	if ( trace.fraction < 1.0f )
+	{
+		gentity_t const* hit = &g_entities[ trace.entityNum ];
+		bool hitEnemy = not ( G_OnSameTeam( self, hit ) || G_Team( hit ) == TEAM_NONE );
+
+		if ( hitEnemy )
+		{
+			int distanceExtension = 30;  // roughly corresponds to 100 milliseconds
+			// upper bound for extensions, in case a bot loops on a wall:
+			int extendedDistance = std::max( self->botMind->lastNavconDistance + distanceExtension, 4000 );
+
+			if ( ownClass == PCL_ALIEN_LEVEL0 && G_DretchCanDamageEntity( self, hit ) )
+			{
+				self->botMind->lastNavconDistance = extendedDistance;
+			}
+			else if ( ownClass == PCL_ALIEN_LEVEL1 )
+			{
+				usercmd_t *botCmdBuffer = &self->botMind->cmdBuffer;
+				BotFireWeapon( WPM_PRIMARY, botCmdBuffer );
+				self->botMind->lastNavconDistance = extendedDistance;
+			}
+		}
+	}
+}
+
 // could use BG_ClassHasAbility( pcl, SCA_WALLCLIMBER ) to check if calling
 // this is a good idea
 static void BotClimbToGoal( gentity_t *self )
@@ -855,6 +897,7 @@ static void BotClimbToGoal( gentity_t *self )
 	self->botMind->cmdBuffer.upmove = -127;
 	self->botMind->cmdBuffer.forwardmove = 127;
 	self->botMind->cmdBuffer.rightmove = 0;
+	BotMaybeAttackWhileClimbing( self );
 }
 
 void BotMoveUpward( gentity_t *self, glm::vec3 nextCorner )


### PR DESCRIPTION
Fix https://github.com/Unvanquished/Unvanquished/issues/2729 regarding enemy players and buildables. Wall climbing dretch and mantis perform an upward trace while wall climbing. If that trace hits an enemy, they will attack and increase the time limit for the wall climb, until about 10 seconds have passed.

If a wall climbing bot is blocked by one of its own team's buildables, there is still not much we can do. But the team should notice eventually and remove the buildable.

