### PR TITLE
bots: invert check if a healing source is horizontally placed

### DIFF
--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -246,7 +246,7 @@ botEntityAndDistance_t BotGetHealTarget( const gentity_t *self )
 		// We skip buildings on roof or walls as bots can't wallwalk.
 		// Unless it's a booster, as boosters are often put on walls
 		// and have a large area of effect.
-		if ( candidate.ent && ( glm::dot( VEC2GLM(candidate.ent->s.origin2), up ) <= MIN_WALK_NORMAL || buildable == BA_A_BOOSTER ) )
+		if ( candidate.ent && ( glm::dot( VEC2GLM(candidate.ent->s.origin2), up ) >= MIN_WALK_NORMAL || buildable == BA_A_BOOSTER ) )
 		{
 			return candidate;
 		}

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -246,6 +246,9 @@ botEntityAndDistance_t BotGetHealTarget( const gentity_t *self )
 		// We skip buildings on roof or walls as bots can't wallwalk.
 		// Unless it's a booster, as boosters are often put on walls
 		// and have a large area of effect.
+		// TODO:
+		// - The dot product is used to simply extract z component, maybe remove it
+		// - Maybe check if the building is over the navmesh
 		if ( candidate.ent && ( glm::dot( VEC2GLM(candidate.ent->s.origin2), up ) >= MIN_WALK_NORMAL || buildable == BA_A_BOOSTER ) )
 		{
 			return candidate;


### PR DESCRIPTION
Current code tries to prevent alien bots from picking a building to heal at, if this building is on walls or ceilings (except booster). This is reasonable, as this would make the bot stuck doing strange jumps in most cases. However, the current check is _inverted_, meaning that bots will _only_ pick such bad healing targets.

Please do not ask me why current code uses the dot product with a vector `(0,0,1)` to extract the vertical coordinate of a vector. I have no idea at all.

I have tried this with the default eggs on plat23. More tests could not hurt.