### PR TITLE
improve bot lcannon handling: do not always charge to the target's full health

### DIFF
--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -121,6 +121,7 @@ enum bot_skill
 	BOT_A_AIM_HEAD,
 	BOT_A_AIM_BARBS, // precisely target barbs
 	BOT_H_PREDICTIVE_AIM, // predict where to aim depending on weapon and enemy speed
+	BOT_H_LCANNON_TRICKS,
 
 	BOT_NUM_SKILLS
 };

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -154,7 +154,7 @@ void G_InitSkilltreeCvars()
 		Cvar::NONE,
 		"1:movement 1:fighting 1:feels-pain 1:buy-modern-armor 1:medkit "
 		"3:strafe-attack "
-		"5:aim-barbs 5:mantis-attack-jump 5:small-attack-jump 5:mara-attack-jump 5:goon-attack-jump 5:tyrant-attack-run 5:a-fast-flee 5:h-fast-flee 5:prefer-armor "
+		"5:aim-barbs 5:mantis-attack-jump 5:small-attack-jump 5:mara-attack-jump 5:goon-attack-jump 5:tyrant-attack-run 5:a-fast-flee 5:h-fast-flee 5:prefer-armor 5:lcannon-tricks "
 		"7:aim-head 7:predict-aim 7:safe-barbs "
 		, // unused: fast-aim
 		G_SetBaseSkillset
@@ -245,6 +245,7 @@ static const std::vector<botSkillTreeElement_t> skillTree =
 	////
 
 	{ "fast-aim",           BOT_B_FAST_AIM,                8,  TEAM_NONE,   needs_one_of({BOT_B_BASIC_FIGHT}) },
+	{ "lcannon-tricks",     BOT_H_LCANNON_TRICKS,          3,  TEAM_HUMANS, needs_one_of({BOT_B_BASIC_FIGHT}) },
 
 	// aliens
 	{ "aim-head",           BOT_A_AIM_HEAD,                10, TEAM_ALIENS, needs_one_of({BOT_B_BASIC_FIGHT}) },

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -2130,7 +2130,7 @@ void BotFireWeaponAI( gentity_t *self )
 				}
 				else
 				{
-					if ( botTarget->client && level.time - botTarget->client->lastCombatTime < 4000 )
+					if ( self->botMind->skillSet[ BOT_H_LCANNON_TRICKS ] && botTarget->client && level.time - botTarget->client->lastCombatTime < 4000 )
 					{
 						// assume we know the target's health because we heard it cry
 						targetMaxHP *= Entities::HealthFraction( botTarget );

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -2130,10 +2130,18 @@ void BotFireWeaponAI( gentity_t *self )
 				}
 				else
 				{
+					if ( botTarget->client && level.time - botTarget->client->lastCombatTime < 4000 )
+					{
+						// assume we know the target's health because we heard it cry
+						targetMaxHP *= Entities::HealthFraction( botTarget );
+					}
 					float dmgRatio = targetMaxHP / LCANNON_DAMAGE;
 					float chargeMax = static_cast<float>( LCANNON_CHARGE_TIME_MAX );
 					float charge = chargeMax * std::min( dmgRatio, 0.95f );
-					if ( self->client->ps.weaponCharge < charge )
+					bool isFarAway = DistanceToGoalSquared( self ) > Square( 100 );
+					// stop charging and fire if the desired charge is reached, or if the target is very close and
+					// some minimum charge is reached (the target is most likely attacking us)
+					if ( self->client->ps.weaponCharge < charge && ( isFarAway || self->client->ps.weaponCharge < 0.4f ) )
 					{
 						BotFireWeapon( WPM_PRIMARY, botCmdBuffer );
 					}


### PR DESCRIPTION
Recently, human bots using lcannon are extremely easy to kill with big aliens. The reason is that they are too easy to predict. This is surprising, as they are quite deadly against small aliens.

How to easily kill even a skill 9 lcannon bot: use a dragoon. Notice that the bot will _always_ charge its lcannon up to the dragoon's 200 HP. This will trigger the beep. As soon as you hear the beep, pounce upwards to fly in a nice parabola (one quite safe direction is tangential to some small circle around the bot on the floor). The bot will likely not hit you. After that, you have enough time to get close the bot and hit it once. You are in no danger at all until you hear the beep again. Repeat until the bot is dead. You can learn to do this without being hit in a few minutes.

Compare this to trying to kill a prifle or chaingun bot. Good luck with that.

This PR adds two small improvements to lcannon handling:

- If you have been hit by a human in the last 4 seconds, we can assume the bot heard you cry and can thus estimate your health. Make the bot only charge up to your actual health in this case. This might make it shoot before the beep. 
- If you go very near the bot, you are likely attacking it. Allow the bot to release the shot if you are closer than 100 units (and the charge is above 40%).