### PR TITLE
command revert: remove beacons, and maybe reduce team's spawn counter

### DIFF
--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -2682,6 +2682,17 @@ void G_BuildLogRevert( int id )
 										 ent->num(), BG_Buildable( ent->s.modelindex )->name );
 						}
 
+						Beacon::DetachTags( ent );
+						switch ( ent->s.modelindex )
+						{
+						case BA_H_SPAWN:
+						case BA_A_SPAWN:
+							level.team[G_Team( ent )].numSpawns--;
+							break;
+						default:
+							break;
+						}
+
 						// Revert resources
 						G_FreeBudget( ent->buildableTeam, BG_Buildable( ent->s.modelindex )->buildPoints, 0 );
 						momentumChange[ log->buildableTeam ] -= log->momentumEarned;


### PR DESCRIPTION
The admin command `revert` is arguably the most important command, especially when you have new players around during a serious game. It has two bugs:

- When reverting the construction of a building, its beacon will persist.
- When reverting the construction of a spawn, the team's spawn counter is not changed. Thus the game cannot end anymore. (This is a bad one)

Fix both. A beacon for the enemy team might remain until the enemy team looks again.