### PR TITLE
Revert "Increase painsaw "range" for bot calculations"

### DIFF
--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1306,8 +1306,7 @@ bool BotTargetInAttackRange( const gentity_t *self, botTarget_t target )
 			secondaryRange = 0;
 			break;
 		case WP_PAIN_SAW:
-			// Start running the saw when an alien is closeby, not literally in range
-			range = PAINSAW_RANGE + 60;
+			range = PAINSAW_RANGE;
 			secondaryRange = 0;
 			break;
 		case WP_FLAMER:


### PR DESCRIPTION
This reverts commit 3145e8e7860a6d54fc5c00c92672c3919ef50c32. Currently, painsaw bots will stop 60 units short of an alien building to attack. Removing the number 60 in the code fixes this.