### PR TITLE
bots avoid ground flames

### DIFF
--- a/src/sgame/botlib/bot_nav.cpp
+++ b/src/sgame/botlib/bot_nav.cpp
@@ -239,7 +239,7 @@ bool G_BotPathNextCorner( int botClientNum, glm::vec3 &result )
 	return true;
 }
 
-static Cvar::Cvar<int> g_bot_cornerNearDistance("g_bot_cornerNearDistance", "maximal distance to a bot's next navigation corner to be considered near.", Cvar::NONE, 100);
+static Cvar::Cvar<int> g_bot_cornerNearDistance("g_bot_cornerNearDistance", "maximal distance to a bot's next navigation corner to be considered near", Cvar::NONE, 100);
 
 bool G_BotCloseToPathCorner( int botClientNum )
 {
@@ -252,6 +252,7 @@ bool G_BotCloseToPathCorner( int botClientNum )
 	glm::vec3 ownPos = VEC2GLM( self->s.origin );
 	glm::vec3 nextCorner = VEC2GLM( &bot->cornerVerts[ 0 ] );
 	std::swap( nextCorner.y, nextCorner.z );
+	recast2quake( &nextCorner[ 0 ] );
 	float distanceSquared = glm::distance2( ownPos, nextCorner );
 	if ( distanceSquared > Square( g_bot_cornerNearDistance.Get() ) )
 	{

--- a/src/sgame/components/HealthComponent.cpp
+++ b/src/sgame/components/HealthComponent.cpp
@@ -146,6 +146,10 @@ Util::optional<glm::vec3> direction, int flags, meansOfDeath_t meansOfDeath) {
 	// TODO: Add a message to update combat timers.
 	if (client && source->client && entity.oldEnt != source) {
 		client->lastCombatTime = entity.oldEnt->client->lastCombatTime = level.time;
+		if ( meansOfDeath == MOD_BURN )
+		{
+			client->lastGroundFlameDamageTime = entity.oldEnt->client->lastGroundFlameDamageTime = level.time;
+		}
 	}
 
 	if (client) {

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -400,6 +400,8 @@ Bot Thinks
 =======================
 */
 
+static Cvar::Cvar<bool> g_bot_jumpOverFire("g_bot_jumpOverFire", "if bots should jump over ground flames", Cvar::NONE, true);
+
 void G_BotThink( gentity_t *self )
 {
 	char buf[MAX_STRING_CHARS];
@@ -469,6 +471,13 @@ void G_BotThink( gentity_t *self )
 
 	self->botMind->willSprint( false ); //let the BT decide that
 	self->botMind->behaviorTree->run( self, ( AIGenericNode_t * ) self->botMind->behaviorTree );
+
+	// jump if damaged by ground flames, and if not close to a corner that will
+	// make us turn (we might miss it and thus go back)
+	if ( g_bot_jumpOverFire.Get() && level.time - self->client->lastGroundFlameDamageTime < 200 && !G_BotCloseToPathCorner( self->num() ) )
+	{
+		BotJump( self );
+	}
 
 	// if we were nudged...
 	VectorAdd( self->client->ps.velocity, nudge, self->client->ps.velocity );

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -400,7 +400,7 @@ Bot Thinks
 =======================
 */
 
-static Cvar::Cvar<bool> g_bot_jumpOverFire("g_bot_jumpOverFire", "if bots should jump over ground flames", Cvar::NONE, true);
+static Cvar::Cvar<bool> g_bot_jumpOverFire("g_bot_jumpOverFire", "whether bots should jump over ground flames", Cvar::NONE, true);
 
 void G_BotThink( gentity_t *self )
 {

--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -197,6 +197,7 @@ void G_BotShutdownNav();
 void G_BotSetNavMesh( int botClientNum, qhandle_t navHandle );
 bool G_BotFindRoute( int botClientNum, const botRouteTarget_t *target, bool allowPartial );
 bool G_BotPathNextCorner( int botClientNum, glm::vec3 &result );
+bool G_BotCloseToPathCorner( int botClientNum );
 void G_BotUpdatePath( int botClientNum, const botRouteTarget_t *target, botNavCmd_t *cmd );
 bool G_IsBotOverNavcon( int botClientNum );
 bool G_BotNavTrace( int botClientNum, botTrace_t *botTrace, const glm::vec3& start, const glm::vec3& end );

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -630,6 +630,7 @@ struct gclient_t
 	int        lastAmmoRefillTime;
 	int        lastFuelRefillTime;
 	int        lastLockWarnTime; // used for the entity locking system
+	int        lastGroundFlameDamageTime;
 
 	unlagged_t unlaggedHist[ MAX_UNLAGGED_MARKERS ];
 	unlagged_t unlaggedBackup;


### PR DESCRIPTION
There are frequent complaints about alien bots dying in ground flames. Currently, they simply ignore them. That makes them appear quite suicidal. This can be exploited by human players to gain lots of funds.

This PR eases this problem by making the bots jump when they are damaged by ground flames. This already helps a lot. The jump is not done if the bot is close to its next path corner. This is because, by jumping, the bot might miss the corner and turn around to go back into the flames.