### PR TITLE
Fix ADMBP buffer overflows

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -5911,6 +5911,11 @@ void G_admin_buffer_begin()
 
 void G_admin_buffer_end( gentity_t *ent )
 {
+	if ( !g_bfb.empty() && g_bfb.back() == '\n' )
+	{
+		g_bfb.pop_back();
+	}
+
 	G_admin_print_raw( ent, G_EscapeServerCommandArg( g_bfb ) );
 }
 

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -5925,8 +5925,8 @@ static inline void G_admin_buffer_print_raw( gentity_t *ent, Str::StringRef m, b
 		}
 	}
 
-	// Ensure we don't overflow client buffers. Allow for surrounding quotes and each needed escaping backslash
-	if ( g_bfb.size() + m.size() + bfbNaughtyCharacters + additionalNaughtyCharacters + 2 >= MAX_MESSAGE_SIZE )
+	// Ensure we don't overflow client buffers. Allow for 'print' command, surrounding quotes and each needed escaping backslash
+	if ( strlen("print ") + g_bfb.size() + m.size() + bfbNaughtyCharacters + additionalNaughtyCharacters + 2 >= MAX_MESSAGE_SIZE)
 	{
 		G_admin_buffer_end( ent );
 		G_admin_buffer_begin();


### PR DESCRIPTION
The 'print' command's length was not accounted for so overflows could happen if the buffer's length landed on a number from 1016 to 1021.