### PR TITLE
Fix bot painsaw range issues

### DIFF
--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -886,8 +886,11 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 	BotAimAtEnemy( self );
 	BotMoveInDir( self, MOVE_FORWARD );
 
-	if ( inAttackRange || self->client->ps.weapon == WP_PAIN_SAW )
+	if ( inAttackRange || ( self->client->ps.weapon == WP_PAIN_SAW &&
+	                        self->botMind->goal.getTargetedEntity()->client &&
+	                        goalDist < Square( PAINSAW_RANGE + 60 ) ) )
 	{
+		// If we have the saw and are near an enemy player target, fire even if not in range
 		BotFireWeaponAI( self );
 	}
 

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -837,7 +837,8 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 	}
 
 	//aliens have radar so they will always 'see' the enemy if they are in radar range
-	if ( myTeam == TEAM_ALIENS && DistanceToGoalSquared( self ) <= Square( g_bot_aliensenseRange.Get() ) )
+	float goalDist = DistanceToGoalSquared( self );
+	if ( myTeam == TEAM_ALIENS && goalDist <= Square( g_bot_aliensenseRange.Get() ) )
 	{
 		self->botMind->enemyLastSeen = level.time;
 	}
@@ -899,21 +900,21 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 	// We are human and we either are at fire range, or have
 	// a direct path to goal
 
-	if ( self->botMind->skillLevel >= 3 && DistanceToGoalSquared( self ) < Square( MAX_HUMAN_DANCE_DIST )
-	        && ( DistanceToGoalSquared( self ) > Square( MIN_HUMAN_DANCE_DIST ) || self->botMind->skillLevel < 5 )
+	if ( mind->skillLevel >= 3 && goalDist < Square( MAX_HUMAN_DANCE_DIST )
+	        && ( goalDist > Square( MIN_HUMAN_DANCE_DIST ) || mind->skillLevel < 5 )
 	        && self->client->ps.weapon != WP_PAIN_SAW && self->client->ps.weapon != WP_FLAMER )
 	{
 		BotMoveInDir( self, MOVE_BACKWARD );
 	}
-	else if ( DistanceToGoalSquared( self ) <= Square( MIN_HUMAN_DANCE_DIST ) ) //we wont hit this if skill < 5
+	else if ( goalDist <= Square( MIN_HUMAN_DANCE_DIST ) ) //we wont hit this if skill < 5
 	{
 		// We will be moving toward enemy, strafing to
 		// the result: we go around the enemy
 		BotAlternateStrafe( self );
 	}
-	else if ( DistanceToGoalSquared( self ) >= Square( MAX_HUMAN_DANCE_DIST ) && self->client->ps.weapon != WP_PAIN_SAW )
+	else if ( goalDist >= Square( MAX_HUMAN_DANCE_DIST ) && self->client->ps.weapon != WP_PAIN_SAW )
 	{
-		if ( DistanceToGoalSquared( self ) - Square( MAX_HUMAN_DANCE_DIST ) < 100 )
+		if ( goalDist - Square( MAX_HUMAN_DANCE_DIST ) < 100 )
 		{
 			BotStandStill( self );
 		}

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1291,8 +1291,7 @@ bool BotTargetInAttackRange( const gentity_t *self, botTarget_t target )
 			secondaryRange = 0;
 			break;
 		case WP_PAIN_SAW:
-			// Start running the saw when an alien is closeby, not literally in range
-			range = PAINSAW_RANGE + 60;
+			range = PAINSAW_RANGE;
 			secondaryRange = 0;
 			break;
 		case WP_FLAMER:


### PR DESCRIPTION
Fix the bug reported by @sweet235 in #2767. But also implement one of the ideas of #2539 which is to stop bots from *always* firing the painsaw, even when there are no enemies around, which can lead to friendly fire.

Includes one refactoring commit from #2539.

