### PR TITLE
Make human bots go to the nearest armoury when out of ammo

### DIFF
--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1510,7 +1510,8 @@ AINodeStatus_t BotActionBuy( gentity_t *self, AIGenericNode_t *node )
 		}
 
 		//we have every upgrade we want to buy
-		if ( numContain == numUpgrades )
+		if ( numContain == numUpgrades
+			 && ( !WeaponIsEmpty( BG_PrimaryWeapon( self->client->ps.stats ), &self->client->ps ) || !g_bot_resupply.Get() ) )
 		{
 			return STATUS_FAILURE;
 		}

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1192,12 +1192,13 @@ bool BotChangeGoal( gentity_t *self, botTarget_t target )
 
 	if ( g_bot_resupply.Get()
 		 && G_Team( self ) == TEAM_HUMANS
+		 && target.targetsValidEntity()
 		 && G_Team( target.getTargetedEntity() ) == TEAM_ALIENS
 		 && WeaponIsEmpty( BG_PrimaryWeapon( self->client->ps.stats ), &self->client->ps ) )
 	{
 		botTarget_t closestArmoury;
 		closestArmoury = self->botMind->closestBuildings[ BA_H_ARMOURY ].ent;
-		if ( FindRouteToTarget( self, closestArmoury, false) )
+		if ( closestArmoury.isValid() && closestArmoury.targetsValidEntity() && FindRouteToTarget( self, closestArmoury, false) )
 		{
 			// human bot has no ammo and can get it at the armoury: do not pick
 			// enemies as targets

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1190,6 +1190,21 @@ bool BotChangeGoal( gentity_t *self, botTarget_t target )
 		return false;
 	}
 
+	if ( g_bot_resupply.Get()
+		 && G_Team( self ) == TEAM_HUMANS
+		 && G_Team( target.getTargetedEntity() ) == TEAM_ALIENS
+		 && WeaponIsEmpty( BG_PrimaryWeapon( self->client->ps.stats ), &self->client->ps ) )
+	{
+		botTarget_t closestArmoury;
+		closestArmoury = self->botMind->closestBuildings[ BA_H_ARMOURY ].ent;
+		if ( FindRouteToTarget( self, closestArmoury, false) )
+		{
+			// human bot has no ammo and can get it at the armoury: do not pick
+			// enemies as targets
+			return false;
+		}
+	}
+
 	if ( !FindRouteToTarget( self, target, false ) )
 	{
 		// TODO: allow adv marauder and adv goon to pick offmesh targets,

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -198,6 +198,8 @@ extern Cvar::Cvar<bool> g_bot_jetpack; //can't be really used, yet
 extern Cvar::Cvar<bool> g_bot_grenade;
 extern Cvar::Cvar<bool> g_bot_firebomb;
 
+extern Cvar::Cvar<bool> g_bot_resupply;
+
 // bot evolution cvars
 extern Cvar::Cvar<bool> g_bot_evolve;
 extern Cvar::Cvar<bool> g_bot_builder;

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -274,6 +274,8 @@ Cvar::Cvar<bool> g_bot_jetpack("g_bot_jetpack", "whether bots buy the Jetpack", 
 Cvar::Cvar<bool> g_bot_grenade("g_bot_grenade", "whether bots buy the Grenade", Cvar::NONE, false);
 Cvar::Cvar<bool> g_bot_firebomb("g_bot_firebomb", "whether bots buy the Firebomb", Cvar::NONE, false);
 
+Cvar::Cvar<bool> g_bot_resupply("g_bot_resupply", "whether human bots visit an armoury when out of ammo", Cvar::NONE, true);
+
 // bot evolution cvars
 Cvar::Cvar<bool> g_bot_evolve("g_bot_evolve", "whether bots can evolve", Cvar::NONE, true);
 Cvar::Cvar<bool> g_bot_builder("g_bot_builder", "whether bots use non-advanced Granger", Cvar::NONE, false);


### PR DESCRIPTION
Currently, we never make human bots decide to pick up new ammo. When out of ammo, they continue to fight with the blaster. Even after their current enemy target is killed or lost, they will pick new enemy targets to attack with the blaster. Usually, this results in their sudden demise.

Why do not we see blaster bots all the time? Usually, there is an armoury next to a medistation. When low on health, they go there and trigger the automatic refill. The other reason is the purchase of better equipment (might be just a grenade/firebomb) at the nearest armoury.

This PR  makes the bot fight the current enemy target with the blaster, once out of ammo. But it does not allow human bots to choose new enemy targets after that, if the nearest armoury is reachable. Instead, the existing buy action is triggered, even when the bot has everything it wants to buy. This results in ammo refill.

Two drawbacks of this approach:
- This only considers the nearest armoury. However, the existing buy action has the same restriction
- This does not allow for energy weapon refill at the reactor or drills