### PR TITLE
fix bug in bot behavior function percentClips

### DIFF
--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -153,7 +153,7 @@ static AIValue_t haveUpgrade( gentity_t *self, const AIValue_t *params )
 // Only used to reduce duplicated code.
 static AIValue_t Ratio( int current, int max, bool infiniteAmmo )
 {
-	if ( max == 0 || infiniteAmmo )
+	if ( infiniteAmmo )
 	{
 		return AIBoxFloat( 1.f );
 	}
@@ -164,6 +164,7 @@ static AIValue_t Ratio( int current, int max, bool infiniteAmmo )
 static AIValue_t percentAmmoClip( gentity_t *self, const AIValue_t* )
 {
 	ASSERT( self && self->client );
+	ASSERT( wpa->maxAmmo > 0 );
 	playerState_t const& ps = self->client->ps;
 	weaponAttributes_t const* wpa = BG_Weapon( BG_PrimaryWeapon( ps.stats ) );
 
@@ -177,6 +178,10 @@ static AIValue_t percentClips( gentity_t *self, const AIValue_t* )
 	playerState_t const& ps = self->client->ps;
 	weaponAttributes_t const* wpa = BG_Weapon( BG_PrimaryWeapon( ps.stats ) );
 
+	if ( wpa->maxClips == 0 )
+	{
+		return AIBoxFloat( 0.f );
+	}
 	return Ratio( ps.clips, wpa->maxClips, wpa->infiniteAmmo );
 }
 


### PR DESCRIPTION
For weapons without multiple clips (lgun, chaingun, flamer, lcannon), the behavior tree function `percentClips` returns 1.0. This is inconsistent with the rest of the codebase, which has 0 (for example: https://github.com/Unvanquished/Unvanquished/blob/master/pkg/unvanquished_src.dpkdir/configs/weapon/lgun.attr.cfg#L13). Fix this by returning 0.0 instead of 1.0.

Notice that this number does never count the current clip, but rather gives the number of times a weapon can be reloaded.
