### PR TITLE
human weapons: refill the current clip too

### DIFF
--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -1083,9 +1083,8 @@ void CG_EntityEvent( centity_t *cent, vec3_t position )
 			break;
 
 		case EV_AMMO_REFILL:
-		case EV_CLIPS_REFILL:
 		case EV_FUEL_REFILL:
-			// TODO: Add different sounds for EV_AMMO_REFILL, EV_CLIPS_REFILL, EV_FUEL_REFILL
+			// TODO: Add different sounds for EV_AMMO_REFILL, EV_FUEL_REFILL
 			trap_S_StartSound( nullptr, es->number, soundChannel_t::CHAN_AUTO, cgs.media.itemFillSound );
 			break;
 

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -137,6 +137,11 @@ static bool CanUseAmmoRefill( gentity_t *self )
 		return false;
 	}
 
+	if ( ps->weapon == WP_BLASTER )
+	{
+		return false; // don't allow refill if they have the blaster equipped
+	}
+
 	if ( wa->maxClips == 0 )
 	{
 		// clipless weapons can be refilled whenever they lack ammo
@@ -187,7 +192,7 @@ bool G_RefillAmmo( gentity_t *self, bool triggerEvent )
 		}
 	}
 
-	G_ForceWeaponChange( self, (weapon_t) self->client->ps.stats[ STAT_WEAPON ] );
+	G_ForceWeaponChange( self, (weapon_t) self->client->ps.weapon );
 
 	return true;
 }

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -178,7 +178,6 @@ bool G_RefillAmmo( gentity_t *self, bool triggerEvent )
 
 		if ( triggerEvent )
 		{
-			G_AddEvent( self, EV_CLIPS_REFILL, 0 );
 			G_AddEvent( self, EV_AMMO_REFILL, 0 );
 		}
 	}

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -187,7 +187,7 @@ bool G_RefillAmmo( gentity_t *self, bool triggerEvent )
 		}
 	}
 
-	G_ForceWeaponChange( self, (weapon_t) self->client->ps.weapon );
+	G_ForceWeaponChange( self, (weapon_t) self->client->ps.stats[ STAT_WEAPON ] );
 
 	return true;
 }

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -142,9 +142,9 @@ static bool CanUseAmmoRefill( gentity_t *self )
 		// clipless weapons can be refilled whenever they lack ammo
 		return ( ps->ammo != wa->maxAmmo );
 	}
-	else if ( ps->clips != wa->maxClips )
+	else if ( ps->clips != wa->maxClips || ps->ammo != wa->maxAmmo )
 	{
-		// clip weapons have to miss a clip to be refillable
+		// clip weapons can be refilled whenever they lack ammo or clips
 		return true;
 	}
 	else
@@ -169,10 +169,12 @@ bool G_RefillAmmo( gentity_t *self, bool triggerEvent )
 	if ( BG_Weapon( self->client->ps.stats[ STAT_WEAPON ] )->maxClips > 0 )
 	{
 		GiveMaxClips( self );
+		GiveFullClip( self );
 
 		if ( triggerEvent )
 		{
 			G_AddEvent( self, EV_CLIPS_REFILL, 0 );
+			G_AddEvent( self, EV_AMMO_REFILL, 0 );
 		}
 	}
 	else

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -130,32 +130,15 @@ static bool CanUseAmmoRefill( gentity_t *self )
 	}
 
 	ps = &self->client->ps;
-	wa = BG_Weapon( ps->stats[ STAT_WEAPON ] );
+	// This is the *currently equipped* weapon, so you don't get refill while wielding blaster
+	wa = BG_Weapon( ps->weapon );
 
 	if ( wa->infiniteAmmo )
 	{
 		return false;
 	}
 
-	if ( ps->weapon == WP_BLASTER )
-	{
-		return false; // don't allow refill if they have the blaster equipped
-	}
-
-	if ( wa->maxClips == 0 )
-	{
-		// clipless weapons can be refilled whenever they lack ammo
-		return ( ps->ammo != wa->maxAmmo );
-	}
-	else if ( ps->clips != wa->maxClips || ps->ammo != wa->maxAmmo )
-	{
-		// clip weapons can be refilled whenever they lack ammo or clips
-		return true;
-	}
-	else
-	{
-		return false;
-	}
+	return ps->clips != wa->maxClips || ps->ammo != wa->maxAmmo;
 }
 
 /**

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -187,6 +187,8 @@ bool G_RefillAmmo( gentity_t *self, bool triggerEvent )
 		}
 	}
 
+	G_ForceWeaponChange( self, (weapon_t) self->client->ps.weapon );
+
 	return true;
 }
 

--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -1324,7 +1324,6 @@ static constexpr const char *const eventnames[] =
   "EV_MGTURRET_SPINUP", // turret spinup sound should play
 
   "EV_AMMO_REFILL",     // ammo for clipless weapon has been refilled
-  "EV_CLIPS_REFILL",    // weapon clips have been refilled
   "EV_FUEL_REFILL",     // jetpack fuel has been refilled
 
   "EV_HIT", // notify client of a hit

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -760,8 +760,7 @@ enum entity_event_t
 
   EV_MGTURRET_SPINUP, // turret spinup sound should play
 
-  EV_AMMO_REFILL,     // ammo for clipless weapon has been refilled
-  EV_CLIPS_REFILL,    // weapon clips have been refilled
+  EV_AMMO_REFILL,     // ammo has been refilled
   EV_FUEL_REFILL,     // jetpack fuel has been refilled
 
   EV_HIT, // notify client of a hit


### PR DESCRIPTION
At the armoury (or maybe reactor or drill), do not only give a player's clip weapon the maximum number of clips, but fill the current clip too. Current behavior is to only give the maximum number of clips.

I suppose the current behavior was implemented after noticing that one can circumvent the reload time when being close to an armoury.  You have to stop shooting for a short while to trigger the refill, but the reload time is noticably longer.

Turns out that you cannot host even the most slightly modded server without every player you know complaining about this. At each (complete or non-disciplined) refill, a player has to camp near the armoury for the reload time. This is conceived as very annoying. So I have been doing this on my server since I forgot when.

In the end, any serious player will learn how to circumvent the reload time anyway. One way is to simply buy the current weapon again. If you have a bind for that, I guess are you are already doing this. You can even use `p_weapon` and `vstr` to make a refill bind just like Tremulous had it.

Recently (in https://github.com/Unvanquished/Unvanquished/pull/2781), I ran into the problem of making human bots camp for the reload time when refilling ammo. I considered to make them buy the same weapon again instead. But then I decided to open this PR.