### PR TITLE
Fix alien HUD being drawn for spectators

### DIFF
--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -1782,27 +1782,6 @@ void ClientSpawn( gentity_t *ent, gentity_t *spawn, const vec3_t origin, const v
 	{
 		MoveClientToIntermission( ent );
 	}
-	else
-	{
-		// fire the targets of the spawn point
-		if ( !spawn && spawnPoint )
-		{
-			G_EventFireEntity( spawnPoint, ent, ON_SPAWN );
-		}
-
-		// select the highest weapon number available, after any
-		// spawn given items have fired
-		client->ps.weapon = 1;
-
-		for ( i = WP_NUM_WEAPONS - 1; i > WP_NONE; i-- )
-		{
-			if ( BG_InventoryContainsWeapon( i, client->ps.stats ) )
-			{
-				client->ps.weapon = i;
-				break;
-			}
-		}
-	}
 
 	// run a client frame to drop exactly to the floor,
 	// initialize animations and other things

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -527,7 +527,6 @@ static const entityCallEventDescription_t gentityEventDescriptions[] =
 		{ "onFree",      ON_FREE      },
 		{ "onReach",     ON_REACH     },
 		{ "onReset",     ON_RESET     },
-		{ "onSpawn",     ON_SPAWN     },
 		{ "onTouch",     ON_TOUCH     },
 		{ "onUse",       ON_USE       },
 		{ "target",      ON_DEFAULT   },

--- a/src/sgame/sg_entities.h
+++ b/src/sgame/sg_entities.h
@@ -193,8 +193,6 @@ enum gentityCallEvent_t
 	ON_ENABLE,
 	ON_DISABLE,
 
-	ON_SPAWN
-
 };
 
 enum initEntityStyle_t


### PR DESCRIPTION
This fixes the alien HUD being inappropriately drawn at various times, e.g. for spectators after a map_restart.

Also remove the onSpawn event type for BSP entities. This seems to be a remnant of Q3; you can't spawn from a map entity in Unvanquished.