### PR TITLE
Select class to spawn as in behavior tree

### DIFF
--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -608,6 +608,14 @@ void G_BotIntermissionThink( gclient_t *client )
 	client->readyToExit = true;
 }
 
+void G_BotSelectSpawnClass( gentity_t *self )
+{
+	if ( self->botMind->behaviorTree && self->botMind->behaviorTree->classSelectionTree )
+	{
+		BotEvaluateNode( self, self->botMind->behaviorTree->classSelectionTree );
+	}
+}
+
 // Initialization happens whenever someone first tries to add a bot.
 // Assuming the meshes already exist, this incurs some delay (a few tenths of a second), but on
 // servers bots are normally added at the beginning of the round so it shouldn't be noticeable.

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -502,6 +502,38 @@ static bool EvalConditionExpression( gentity_t *self, AIExpType_t *exp )
 	return false;
 }
 
+AINodeStatus_t BotSpawnNode( gentity_t *self, AIGenericNode_t *node )
+{
+	if ( !( self->client->ps.pm_flags & PMF_QUEUED ) )
+	{
+		return STATUS_FAILURE;
+	}
+
+	const AISpawnNode_t *spawn = reinterpret_cast<AISpawnNode_t *>( node );
+
+	switch ( G_Team( self ) )
+	{
+	case TEAM_ALIENS:
+		if ( G_AlienCheckSpawnClass( static_cast<class_t>( spawn->selection) ) )
+		{
+			self->client->pers.classSelection = static_cast<class_t>( spawn->selection );
+			return STATUS_SUCCESS;
+		}
+		break;
+	case TEAM_HUMANS:
+		if ( G_HumanCheckSpawnWeapon( static_cast<weapon_t>( spawn->selection ) ) )
+		{
+			self->client->pers.humanItemSelection = static_cast<weapon_t>( spawn->selection );
+			return STATUS_SUCCESS;
+		}
+		break;
+	default:
+		break;
+	}
+
+	return STATUS_FAILURE;
+}
+
 /*
 ======================
 BotConditionNode

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -558,7 +558,16 @@ This should always be used instead of the node->run function pointer
 */
 AINodeStatus_t BotEvaluateNode( gentity_t *self, AIGenericNode_t *node )
 {
-	AINodeStatus_t status = node->run( self, node );
+	AINodeStatus_t status;
+	if ( node->type == AINode_t::ACTION_NODE && !Entities::IsAlive( self ) )
+	{
+		// don't allow actions while dead
+		status = STATUS_FAILURE;
+	}
+	else
+	{
+		status = node->run( self, node );
+	}
 
 	// reset the current node if it finishes
 	// we do this so we can re-pathfind on the next entrance

--- a/src/sgame/sg_bot_ai.h
+++ b/src/sgame/sg_bot_ai.h
@@ -72,6 +72,7 @@ enum AINodeStatus_t
 // behavior tree node types
 enum AINode_t
 {
+	SPAWN_NODE,
 	SELECTOR_NODE,
 	ACTION_NODE,
 	CONDITION_NODE,
@@ -104,6 +105,7 @@ struct AIBehaviorTree_t
 	AINodeRunner run;
 	char name[ MAX_QPATH ];
 	AIGenericNode_t *root;
+	AIGenericNode_t *classSelectionTree; // extra BT for deciding the starting class with spawnAs
 };
 
 // operations used in condition nodes
@@ -181,6 +183,13 @@ struct AIUnaryOp_t
 	AIExpType_t expType;
 	AIOpType_t  opType;
 	AIExpType_t *exp;
+};
+
+struct AISpawnNode_t
+{
+	AINode_t type;
+	AINodeRunner run;
+	int selection; // class_t or weapon_t depending on team
 };
 
 struct AIConditionNode_t
@@ -272,5 +281,8 @@ AINodeStatus_t BotActionResetStuckTime( gentity_t *self, AIGenericNode_t *node )
 AINodeStatus_t BotActionGesture( gentity_t *self, AIGenericNode_t* );
 AINodeStatus_t BotActionStayHere( gentity_t *self, AIGenericNode_t* );
 AINodeStatus_t BotActionFollow( gentity_t *self, AIGenericNode_t* );
+
+// class selection node "spawnAs"
+AINodeStatus_t BotSpawnNode( gentity_t *self, AIGenericNode_t *node );
 
 #endif

--- a/src/sgame/sg_bot_public.h
+++ b/src/sgame/sg_bot_public.h
@@ -53,6 +53,7 @@ void G_BotDelAllBots();
 void G_BotThink( gentity_t *self );
 void G_BotSpectatorThink( gentity_t *self );
 void G_BotIntermissionThink( gclient_t *client );
+void G_BotSelectSpawnClass( gentity_t *self );
 void G_BotListNames( gentity_t *ent );
 bool G_BotClearNames();
 int  G_BotAddNames(team_t team, int arg, int last);

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -2038,6 +2038,57 @@ bool G_AlienEvolve( gentity_t *ent, class_t newClass, bool report, bool dryRun )
 	return true;
 }
 
+bool G_AlienCheckSpawnClass( class_t newClass, int reportToClientNum )
+{
+	if ( newClass != PCL_ALIEN_BUILDER0 &&
+	     newClass != PCL_ALIEN_BUILDER0_UPG &&
+	     newClass != PCL_ALIEN_LEVEL0 )
+	{
+		if ( reportToClientNum >= 0 )
+		{
+			G_TriggerMenuArgs( reportToClientNum, MN_A_CLASSNOTSPAWN, newClass );
+		}
+		return false;
+	}
+
+	if ( BG_ClassDisabled( newClass ) )
+	{
+		if ( reportToClientNum >= 0 )
+		{
+			G_TriggerMenuArgs( reportToClientNum, MN_A_CLASSNOTALLOWED, newClass );
+		}
+		return false;
+	}
+
+	if ( !BG_ClassUnlocked( newClass ) )
+	{
+		if ( reportToClientNum >= 0 )
+		{
+			G_TriggerMenuArgs( reportToClientNum, MN_A_CLASSLOCKED, newClass );
+		}
+		return false;
+	}
+
+	return true;
+}
+
+bool G_HumanCheckSpawnWeapon( weapon_t weapon, int reportToClientNum )
+{
+	weapon_t birthWeapons[] = { WP_HBUILD, WP_MACHINEGUN };
+	auto end = std::end( birthWeapons );
+
+	if ( BG_WeaponDisabled( weapon ) || end == std::find( std::begin( birthWeapons ), end, weapon ) )
+	{
+		if ( reportToClientNum >= 0 )
+		{
+			G_TriggerMenu( reportToClientNum, MN_H_SPAWNITEMNOTALLOWED );
+		}
+		return false;
+	}
+
+	return true;
+}
+
 /*
 =================
 Cmd_Class_f
@@ -2056,32 +2107,8 @@ static bool Cmd_Class_spawn_internal( gentity_t *ent, const char *s, bool report
 
 	if ( team == TEAM_ALIENS )
 	{
-		if ( newClass != PCL_ALIEN_BUILDER0 &&
-		     newClass != PCL_ALIEN_BUILDER0_UPG &&
-		     newClass != PCL_ALIEN_LEVEL0 )
+		if ( !G_AlienCheckSpawnClass( newClass, report ? clientNum : -1 ) )
 		{
-			if ( report )
-			{
-				G_TriggerMenuArgs( clientNum, MN_A_CLASSNOTSPAWN, newClass );
-			}
-			return false;
-		}
-
-		if ( BG_ClassDisabled( newClass ) )
-		{
-			if ( report )
-			{
-				G_TriggerMenuArgs( clientNum, MN_A_CLASSNOTALLOWED, newClass );
-			}
-			return false;
-		}
-
-		if ( !BG_ClassUnlocked( newClass ) )
-		{
-			if ( report )
-			{
-				G_TriggerMenuArgs( clientNum, MN_A_CLASSLOCKED, newClass );
-			}
 			return false;
 		}
 

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -1068,21 +1068,23 @@ static void G_SpawnClients( team_t team )
 	if ( G_GetSpawnQueueLength( sq ) > 0 && numSpawns > 0 )
 	{
 		clientNum = G_PeekSpawnQueue( sq );
+		if ( clientNum < 0 )
+		{
+			return;
+		}
+
 		ent = &g_entities[ clientNum ];
 
 		if ( ( spawn = G_SelectUnvanquishedSpawnPoint( team,
 		               ent->client->pers.lastDeathLocation,
 		               spawn_origin, spawn_angles ) ) )
 		{
-			clientNum = G_PopSpawnQueue( sq );
-
-			if ( clientNum < 0 )
+			if ( ent->r.svFlags & SVF_BOT )
 			{
-				return;
+				G_BotSelectSpawnClass( ent );
 			}
 
-			ent = &g_entities[ clientNum ];
-
+			G_PopSpawnQueue( sq );
 			ent->client->sess.spectatorState = SPECTATOR_NOT;
 			ClientUserinfoChanged( clientNum, false );
 			ClientSpawn( ent, spawn, spawn_origin, spawn_angles );

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -168,6 +168,8 @@ bool          G_CheckStopVote( team_t );
 bool          G_RoomForClassChange( gentity_t *ent, class_t pcl, vec3_t newOrigin );
 bool          G_ScheduleSpawn( gclient_t *client, class_t class_, weapon_t humanItem = WP_NONE );
 bool          G_AlienEvolve( gentity_t *ent, class_t newClass, bool report, bool dryRun );
+bool G_AlienCheckSpawnClass( class_t newClass, int reportToClientNum = -1 );
+bool G_HumanCheckSpawnWeapon( weapon_t weapon, int reportToClientNum = -1 );
 void              ScoreboardMessage( gentity_t *client );
 void              ClientCommand( int clientNum );
 void              G_ClearRotationStack();


### PR DESCRIPTION
With an optional `selectClass { ... }` prelude in the behavior tree, a bot can choose to spawn with a different class/weapon. The logic there parses and executes the same way as the normal BT. There's an example in the code comments.

Also I added the `numOurBuildings` function for BTs just so I could write a simplistic example. I think @sweet235 would be able to use it though, if porting the random builder logic from C++ to BT.