### PR TITLE
Documentation for trap_Trace

### DIFF
--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -211,8 +211,12 @@ void CG_Trace( trace_t *result, const vec3_t start, const vec3_t mins, const vec
 
 	CM_BoxTrace( &t, start, end, mins, maxs, 0, mask, skipmask, traceType_t::TT_AABB );
 	t.entityNum = t.fraction != 1.0 ? ENTITYNUM_WORLD : ENTITYNUM_NONE;
-	// check all other solid models
-	CG_ClipMoveToEntities( start, mins, maxs, end, skipNumber, mask, skipmask, &t, traceType_t::TT_AABB );
+
+	if ( !t.allsolid )
+	{
+		// check all other solid models
+		CG_ClipMoveToEntities( start, mins, maxs, end, skipNumber, mask, skipmask, &t, traceType_t::TT_AABB );
+	}
 
 	*result = t;
 }

--- a/src/sgame/components/SpikerComponent.cpp
+++ b/src/sgame/components/SpikerComponent.cpp
@@ -161,6 +161,7 @@ bool SpikerComponent::SafeToShoot(glm::vec3 direction) {
 	glm::vec3 end = VEC2GLM( entity.oldEnt->s.origin ) + (SPIKE_RANGE * direction);
 
 	// Test once with normal and once with inflated missile bounding box.
+	// FIXME: relies on wonky entityNum behavior (see trap_Trace comment)
 	for (float traceSize : {missileSize, missileSize * SAFETY_TRACE_INFLATION}) {
 		mins[0] = mins[1] = mins[2] = -traceSize;
 		maxs[0] = maxs[1] = maxs[2] =  traceSize;

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -1636,6 +1636,7 @@ static void G_UnlaggedDetectCollisions( gentity_t *ent )
 
 	G_UnlaggedOn( ent, ent->client->oldOrigin, range );
 
+	// FIXME: uses wonky entityNum behavior (see trap_Trace comment)
 	trap_Trace( &tr, ent->client->oldOrigin, ent->r.mins, ent->r.maxs,
 	            ent->client->ps.origin, ent->s.number, MASK_PLAYERSOLID, 0 );
 

--- a/src/sgame/sg_api.cpp
+++ b/src/sgame/sg_api.cpp
@@ -171,6 +171,26 @@ bool trap_EntityContact(const vec3_t mins, const vec3_t maxs, const gentity_t *e
 	return G_CM_EntityContact( mins, maxs, ent, traceType_t::TT_AABB );
 }
 
+// Traces against the world and all entities. See the comments on struct trace_t (q_shared.h) for
+// a general explanation of trace semantics. The difference with CM_* trace functions is that those
+// only trace against the world or a single BSP model, whereas trap_Trace checks everything in one
+// call.
+// Parameters:
+//     start / end: beginning and end points of the trace
+//     mins / maxs: bounding box extents (may be nullptr for a point trace)
+//     contentmask: collide with brushes/entities having any of these content flags
+//     skipmask: ignore brushes/entities having any of these content flags
+//     passEntityNum: if not ENTITYNUM_NONE, ignore the entity of this number and any entities owned by it
+//
+// `results` is populated according to the trace_t documentation, except there is one additional
+// field, entityNum. entityNum can be either one of two things:
+//   * an entity hit by the trace
+//   * an entity other than ENTITYNUM_WORLD that caused the startsolid flag to be set
+// If a trace both starts overlapping a non-world entity, and hits a different entity,
+// then entityNum may correspond to either one at random (higher entity numbers would overwrite
+// lower ones). TODO: fix wonky entityNum behavior by making it always correspond to the hit entity
+// (thus ignoring collisions that set startsolid but not allsolid). Some callers must be fixed that
+// rely on this behavior; create a new API if necessary.
 void trap_Trace( trace_t *results, const vec3_t start, const vec3_t mins, const vec3_t maxs,
                  const vec3_t end, int passEntityNum, int contentmask, int skipmask )
 {

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1989,7 +1989,7 @@ void BotFireWeaponAI( gentity_t *self )
 	muzzle = G_CalcMuzzlePoint( self, forward );
 	glm::vec3 targetPos = BotGetIdealAimLocation( self, self->botMind->goal, 0 );
 
-	trap_Trace( &trace, &muzzle[0], nullptr, nullptr, &targetPos[0], ENTITYNUM_NONE, MASK_SHOT, 0 );
+	trap_Trace( &trace, &muzzle[0], nullptr, nullptr, &targetPos[0], self->num(), MASK_SHOT, 0 );
 	distance = glm::distance( muzzle, VEC2GLM( trace.endpos ) );
 	bool readyFire = self->client->ps.IsWeaponReady();
 	glm::vec3 target = self->botMind->goal.getPos();

--- a/src/sgame/sg_cm_world.cpp
+++ b/src/sgame/sg_cm_world.cpp
@@ -754,25 +754,10 @@ static void G_CM_ClipMoveToEntities( moveclip_t *clip )
 	int            i, num;
 	int            touchlist[ MAX_GENTITIES ];
 	gentity_t *touch;
-	int            passOwnerNum;
 	trace_t        trace;
 	clipHandle_t   clipHandle;
 
 	num = G_CM_AreaEntities( clip->boxmins, clip->boxmaxs, touchlist, MAX_GENTITIES );
-
-	if ( clip->passEntityNum != ENTITYNUM_NONE )
-	{
-		passOwnerNum = g_entities[ clip->passEntityNum ].r.ownerNum;
-
-		if ( passOwnerNum == ENTITYNUM_NONE )
-		{
-			passOwnerNum = -1;
-		}
-	}
-	else
-	{
-		passOwnerNum = -1;
-	}
 
 	for ( i = 0; i < num; i++ )
 	{
@@ -794,11 +779,6 @@ static void G_CM_ClipMoveToEntities( moveclip_t *clip )
 			if ( touch->r.ownerNum == clip->passEntityNum )
 			{
 				continue; // don't clip against own missiles
-			}
-
-			if ( touch->r.ownerNum == passOwnerNum )
-			{
-				continue; // don't clip against other missiles from our owner
 			}
 		}
 

--- a/src/sgame/sg_cm_world.cpp
+++ b/src/sgame/sg_cm_world.cpp
@@ -810,16 +810,10 @@ static void G_CM_ClipMoveToEntities( moveclip_t *clip )
 
 		if ( trace.allsolid )
 		{
-			clip->trace.allsolid = true;
+			clip->trace = trace;
 			trace.entityNum = touch->num();
 		}
-		else if ( trace.startsolid )
-		{
-			clip->trace.startsolid = true;
-			trace.entityNum = touch->num();
-		}
-
-		if ( trace.fraction < clip->trace.fraction )
+		else if ( trace.fraction < clip->trace.fraction )
 		{
 			bool oldStart;
 
@@ -829,6 +823,11 @@ static void G_CM_ClipMoveToEntities( moveclip_t *clip )
 			trace.entityNum = touch->num();
 			clip->trace = trace;
 			clip->trace.startsolid |= oldStart;
+		}
+		else if ( trace.startsolid )
+		{
+			clip->trace.startsolid = true;
+			trace.entityNum = touch->num();
 		}
 	}
 }

--- a/src/sgame/sg_cm_world.cpp
+++ b/src/sgame/sg_cm_world.cpp
@@ -869,7 +869,7 @@ void G_CM_Trace( trace_t *results, const vec3_t start, const vec3_t mins2, const
 	CM_BoxTrace( &clip.trace, start, end, mins, maxs, 0, contentmask, skipmask, type );
 	clip.trace.entityNum = clip.trace.fraction == 1.0 ? ENTITYNUM_NONE : ENTITYNUM_WORLD;
 
-	if ( clip.trace.fraction == 0 )
+	if ( clip.trace.allsolid )
 	{
 		*results = clip.trace;
 		return; // blocked immediately by the world

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -317,6 +317,11 @@ bool G_FindFuel( gentity_t *self )
 ================
 Trace a bounding box against entities, but not the world
 Also check there is a line of sight between the start and end point
+FIXME: does not work correctly if width or height is big enough that the trace box
+is not contained inside the attacking player's bounding box. The trace protrudes in the +z
+direction for painsaw and all primary attacks of marauder and larger aliens. This means
+if an enemy is standing on your head with these weapons the trace does not hit although
+it should be in range.
 ================
 */
 static void G_WideTrace(


### PR DESCRIPTION
Document `trap_Trace`, the sgame's extension of tracing functions. (The main tracing documentation for the engine is added in https://github.com/DaemonEngine/Daemon/pull/931). Unfortunately the extra field `entityNum` filled in by the gamelogic has bad and inconsistent semantics.

I found a lot of places which have bugs due to using tracing APIs incorrectly. This is mostly because the engine's trace API is very hard to understand without documentation.  I made comments on some of them, as well as on places which may work correctly but rely on the questionable entityNum semantics.

An area that needs more investigation is whether the attack traces work correctly when playing with high latency. When unlagged is activated, the other clients' positions are temporarily changed to their past positions, so it is possible that they overlap the attacking player. There is some code that tries to avoid prevent this but it never corrects the overlap for more than one other client, so clearly it won't always work.

I added a `trace` command which prints the results of a trap_Trace call for debugging.

Also there are some minor bugfixes and cleanups related to tracing. I didn't touch any of the major bugs.