### PR TITLE
Fix bugs with missile tracing

### DIFF
--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -794,7 +794,7 @@ void G_InitDamageLocations()
 
 // TODO: Move to HealthComponent.
 void G_SelectiveDamage( gentity_t *targ, gentity_t * /*inflictor*/, gentity_t *attacker,
-                        vec3_t dir, vec3_t point, int damage, int dflags, int mod, int team )
+                        const vec3_t dir, const vec3_t point, int damage, int dflags, int mod, int team )
 {
 	if ( targ->client && ( team != targ->client->pers.team ) )
 	{
@@ -809,7 +809,7 @@ void G_SelectiveDamage( gentity_t *targ, gentity_t * /*inflictor*/, gentity_t *a
  * @param origin
  * @return true if the inflictor can directly damage the target.
  */
-bool G_CanDamage( gentity_t *targ, vec3_t origin )
+bool G_CanDamage( gentity_t *targ, const vec3_t origin )
 {
 	vec3_t  dest;
 	trace_t tr;
@@ -873,7 +873,7 @@ bool G_CanDamage( gentity_t *targ, vec3_t origin )
 	return false;
 }
 
-bool G_SelectiveRadiusDamage( vec3_t origin, gentity_t *attacker, float damage,
+bool G_SelectiveRadiusDamage( const vec3_t origin, gentity_t *attacker, float damage,
                                   float radius, gentity_t *ignore, int mod, int ignoreTeam )
 {
 	float     points, dist;
@@ -932,7 +932,7 @@ bool G_SelectiveRadiusDamage( vec3_t origin, gentity_t *attacker, float damage,
 	return hitClient;
 }
 
-bool G_RadiusDamage( vec3_t origin, gentity_t *attacker, float damage,
+bool G_RadiusDamage( const vec3_t origin, gentity_t *attacker, float damage,
                          float radius, gentity_t *ignore, int dflags, int mod, team_t testHit )
 {
 	float     points, dist;

--- a/src/sgame/sg_missile.cpp
+++ b/src/sgame/sg_missile.cpp
@@ -658,7 +658,7 @@ gentity_t *G_SpawnMissile( missile_t missile, gentity_t *parent, const vec3_t st
 G_SpawnFire
 ===============
 */
-gentity_t *G_SpawnFire( vec3_t origin, vec3_t normal, gentity_t *fireStarter )
+gentity_t *G_SpawnFire( const vec3_t origin, const vec3_t normal, gentity_t *fireStarter )
 {
 	gentity_t *fire;
 	vec3_t    snapHelper, floorNormal;
@@ -696,7 +696,7 @@ gentity_t *G_SpawnFire( vec3_t origin, vec3_t normal, gentity_t *fireStarter )
 	fire->r.ownerNum = fireStarter->num();
 
 	// normal
-	VectorNormalize( normal ); // make sure normal is a direction
+	//ASSERT( VectorLength( normal ) > 0.999f && VectorLength( normal ) < 1.001f );
 	VectorCopy( normal, fire->s.origin2 );
 
 	// origin

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -178,10 +178,10 @@ void              G_MapLog_Result( char result );
 void              Cmd_MapLog_f( gentity_t *ent );
 
 // sg_combat.c
-bool          G_CanDamage( gentity_t *targ, vec3_t origin );
-void              G_SelectiveDamage( gentity_t *targ, gentity_t *inflictor, gentity_t *attacker, vec3_t dir, vec3_t point, int damage, int dflags, int mod, int team );
-bool          G_RadiusDamage( vec3_t origin, gentity_t *attacker, float damage, float radius, gentity_t *ignore, int dflags, int mod, team_t testHit = TEAM_NONE );
-bool          G_SelectiveRadiusDamage( vec3_t origin, gentity_t *attacker, float damage, float radius, gentity_t *ignore, int mod, int ignoreTeam );
+bool          G_CanDamage( gentity_t *targ, const vec3_t origin );
+void              G_SelectiveDamage( gentity_t *targ, gentity_t *inflictor, gentity_t *attacker, const vec3_t dir, const vec3_t point, int damage, int dflags, int mod, int team );
+bool          G_RadiusDamage( const vec3_t origin, gentity_t *attacker, float damage, float radius, gentity_t *ignore, int dflags, int mod, team_t testHit = TEAM_NONE );
+bool          G_SelectiveRadiusDamage( const vec3_t origin, gentity_t *attacker, float damage, float radius, gentity_t *ignore, int mod, int ignoreTeam );
 void              G_RewardAttackers( gentity_t *self );
 void              G_AddCreditsToScore( gentity_t *self, int credits );
 void              G_AddMomentumToScore( gentity_t *self, float momentum );
@@ -247,7 +247,7 @@ bool          G_MapExists( const char *name );
 void              G_ExplodeMissile( gentity_t *ent );
 void              G_RunMissile( gentity_t *ent );
 gentity_t         *G_SpawnMissile( missile_t missile, gentity_t *parent, const vec3_t start, const vec3_t dir, gentity_t *target, void ( *think )( gentity_t *self ), int nextthink );
-gentity_t         *G_SpawnFire(vec3_t origin, vec3_t normal, gentity_t *fireStarter );
+gentity_t         *G_SpawnFire( const vec3_t origin, const vec3_t normal, gentity_t *fireStarter );
 
 // sg_namelog.c
 void              G_namelog_connect( gclient_t *client );


### PR DESCRIPTION
Add a new trace API G_Trace2 which always collides when there is something overlapping the start point, unlike standard tracing. Use this to fix a bug that some missiles don't explode when overlapping a player.