### PR TITLE
Don't zero hive missile velocity before death

### DIFF
--- a/src/sgame/sg_missile.cpp
+++ b/src/sgame/sg_missile.cpp
@@ -299,36 +299,14 @@ static int ImpactSlowblob( gentity_t *ent, trace_t *trace, gentity_t *hitEnt )
 
 static int ImpactHive( gentity_t *ent, trace_t*, gentity_t *hitEnt )
 {
-	if ( hitEnt->s.eType == entityType_t::ET_BUILDABLE && hitEnt->s.modelindex == BA_A_HIVE )
+	// Damage only humans and do so quietly.
+	if ( hitEnt->client && hitEnt->client->pers.team == TEAM_HUMANS )
 	{
-		if ( !ent->parent )
-		{
-			Log::Warn("Hive missile returned to hive that is not its parent." );
-		}
-		else
-		{
-			ent->parent->hiveInsectsActive = false;
-		}
-
-		return MIB_FREE;
+		return MIF_NO_EFFECT;
 	}
 	else
 	{
-		// Prevent a collision with the client when returning.
-		ent->r.ownerNum = hitEnt->num();
-
-		ent->think = G_ExplodeMissile;
-		ent->nextthink = level.time + FRAMETIME;
-
-		// Damage only humans and do so quietly.
-		if ( hitEnt->client && hitEnt->client->pers.team == TEAM_HUMANS )
-		{
-			return MIF_NO_EFFECT;
-		}
-		else
-		{
-			return MIB_FREE;
-		}
+		return MIB_FREE;
 	}
 }
 

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -209,7 +209,6 @@ struct gentity_t
 
 	// These formerly all used a field named "active" and are now split such that it gets easier
 	// to convert them to CBSE component members.
-	bool hiveInsectsActive;
 	bool medistationIsHealing;
 	bool bodyStartedSinking;
 	bool shaderActive;

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -648,7 +648,6 @@ void HiveMissileThink( gentity_t *self )
 
 		self->think = G_ExplodeMissile;
 		self->nextthink = level.time + 50;
-		self->parent->hiveInsectsActive = false; //allow the parent to start again
 		return;
 	}
 

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -642,12 +642,7 @@ void HiveMissileThink( gentity_t *self )
 
 	if ( level.time > self->timestamp ) // swarm lifetime exceeded
 	{
-		VectorCopy( self->r.currentOrigin, self->s.pos.trBase );
-		self->s.pos.trType = trType_t::TR_STATIONARY;
-		self->s.pos.trTime = level.time;
-
-		self->think = G_ExplodeMissile;
-		self->nextthink = level.time + 50;
+		G_FreeEntity( self );
 		return;
 	}
 


### PR DESCRIPTION
> The motivation for this was to simplify the code in preparation for
porting to CBSE. However it is also an aesthetic improvement. With the
old behavior, you typically get a cluster of bees spinning in a tight
circle. The spinning, alpha-fading circle of bees looks stupid. With the
new behavior they tend to disperse in various directions which seems
better.

Also remove nearby dead code.