### PR TITLE
Make overcharging lucifer cannon actually explode at the muzzle point

### DIFF
--- a/src/sgame/sg_missile.cpp
+++ b/src/sgame/sg_missile.cpp
@@ -460,12 +460,11 @@ static void MissileImpact( gentity_t *ent, trace_t *trace )
 void G_ExplodeMissile( gentity_t *ent )
 {
 	vec3_t dir;
-	vec3_t origin;
 	const missileAttributes_t *ma = BG_Missile( ent->s.modelindex );
 
-	BG_EvaluateTrajectory( &ent->s.pos, level.time, origin );
+	glm::vec3 origin = VEC2GLM( ent->r.currentOrigin );
 	SnapVector( origin );
-	G_SetOrigin( ent, VEC2GLM( origin ) );
+	G_SetOrigin( ent, origin );
 
 	// we don't have a valid direction, so just point straight up
 	dir[ 0 ] = dir[ 1 ] = 0;

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -824,17 +824,7 @@ static gentity_t *FireLcannonHelper( gentity_t *self,
 
 	if ( self->s.generic1 == WPM_PRIMARY )
 	{
-		int nextthink;
-
-		// explode in front of player when overcharged
-		if ( damage == LCANNON_DAMAGE )
-		{
-			nextthink = level.time;
-		}
-		else
-		{
-			nextthink = level.time + BG_Missile( MIS_LCANNON )->lifetime;
-		}
+		int nextthink = level.time + BG_Missile( MIS_LCANNON )->lifetime;
 
 		m = G_SpawnMissile( MIS_LCANNON, self, start, dir, nullptr, G_ExplodeMissile, nextthink );
 
@@ -853,6 +843,12 @@ static gentity_t *FireLcannonHelper( gentity_t *self,
 		if ( m->s.torsoAnim < 0 )
 		{
 			m->s.torsoAnim = 0;
+		}
+
+		// explode in front of player when overcharged
+		if ( damage == LCANNON_DAMAGE )
+		{
+			G_ExplodeMissile( m );
 		}
 	}
 	else


### PR DESCRIPTION
The old behavior was that the projectile actually travels a short distance before exploding. But it was actually possible for it to hit something before the programmed self-destruction, and score a direct hit for 265 damage. This seems like an illogical mechanic and a bug, so ensure that the missile explodes at its start point without being allowed to hit anything.