### PR TITLE
add quake and emoticons attributes to inlinecvar element

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/error.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/error.rml
@@ -6,7 +6,7 @@
 <body id="error" onhide='Events.pushevent("exec set com_errorMessage", event)' template="window" style="width: 32em; margin: 1em;">
 <h1><translate>Error!</translate></h1>
 <p class="inline">
-<inlinecvar cvar="ui_errorMessage"/>
+<inlinecvar quake cvar="ui_errorMessage"/>
 </p>
 <button onclick='Events.pushevent("hide error", event)'><translate>Ok</translate></button>
 </body>

--- a/src/cgame/rocket/rocketCvarInlineElement.h
+++ b/src/cgame/rocket/rocketCvarInlineElement.h
@@ -99,6 +99,26 @@ public:
 				}
 			}
 
+			if ( type != NUMBER )
+			{
+				int flags = 0;
+
+				if ( HasAttribute( "quake" ) )
+				{
+					flags |= RP_QUAKE;
+				}
+
+				if ( HasAttribute( "emoticons" ) )
+				{
+					flags |= RP_EMOTICONS;
+				}
+
+				if ( flags )
+				{
+					value = Rocket_QuakeToRML( value.c_str(), flags );
+				}
+			}
+
 			SetInnerRML( value );
 			dirty_value = false;
 		}


### PR DESCRIPTION
Made to please @cu-kai for:

- https://github.com/DaemonEngine/Daemon/pull/937

This is totally untested.

- rocket: add `quake` and `emoticons` attributes to `inlinecvar` element
- dpkdir/ui: enable `quake coloring` for `ui_errorMessage` printing