### PR TITLE
improve formatting of the ban disconnection message

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -1694,7 +1694,7 @@ static void G_admin_ban_message(
 		                  sizeof( duration ) );
 		// part of this might get cut off on the connect screen
 		Com_sprintf( creason, clen,
-					"You have been banned by %s^* duration: %s%s reason: %s",
+					"^7You have been banned by %s\n^7Duration: ^3%s%s\n^7Reason: ^3%s",
 					ban->banner,
 					time, duration,
 					ban->reason );


### PR DESCRIPTION
This improves the formatting of the ban message presented to banned users. Companion to https://github.com/DaemonEngine/Daemon/pull/937 and https://github.com/Unvanquished/Unvanquished/pull/2814.