### PR TITLE
dpkdir/ui: center the error message window

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/error.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/error.rml
@@ -3,7 +3,7 @@
 <link type="text/rcss" href="/ui/shared/basics.rcss" />
 <link type="text/template" href="/ui/shared/window.rml" />
 </head>
-<body id="error" onhide='Events.pushevent("exec set com_errorMessage", event)' template="window" style="width: 32em; margin: 1em;">
+<body id="error" onhide='Events.pushevent("exec set com_errorMessage", event)' template="window" style="width: 32em; margin: 30%;">
 <h1><translate>Error!</translate></h1>
 <p class="inline">
 <inlinecvar quake cvar="ui_errorMessage"/>


### PR DESCRIPTION
Center the error message window.

I don't know what I am doing, I copy-pasted the cargo-cult way what was already done in `options_welcome.rml`.

It works for me.

❤️ @cu-kai