### PR TITLE
Fix double-send of info queries on server refresh

### DIFF
--- a/src/cgame/cg_rocket_events.cpp
+++ b/src/cgame/cg_rocket_events.cpp
@@ -87,7 +87,9 @@ static void CG_Rocket_InitServers()
 		trap_SendConsoleCommand( "localservers\n" );
 	}
 
-	trap_LAN_UpdateVisiblePings( CG_StringToNetSource( src ) );
+	// Hack to avoid calling UpdateVisiblePings in the same frame that /globalservers
+	// is sent, which would ping the old server list (see CG_Rocket_BuildServerList)
+	rocketInfo.serversLastRefresh = rocketInfo.realtime;
 }
 
 static void CG_Rocket_BuildDS()


### PR DESCRIPTION
When refreshing the serverlist, the "globalservers" or "localservers" console command is used to make the engine query the master server again and rebuild the list of potential servers. The command is buffered and not executed until after the cgame frame finishes. Meanwhile the cgame immediately sends trap_LAN_ResetPings and trap_LAN_UpdateVisiblePings which causes pings to be sent for all the servers in the *old* list. As soon as the new list arrives from the master, everything on the new list is pinged as well.