### PR TITLE
allow bots to evolve when the cost is zero

### DIFF
--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -613,7 +613,7 @@ AINodeStatus_t BotActionEvolve( gentity_t *self, AIGenericNode_t* )
 	{
 		if ( cl.item == currentClass )
 		{
-			break;  // no smaller classes left to try
+			break;  // no bigger classes left to try
 		}
 
 		evolveInfo_t info = BG_ClassEvolveInfoFromTo( currentClass, cl.item );

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -613,8 +613,11 @@ AINodeStatus_t BotActionEvolve( gentity_t *self, AIGenericNode_t* )
 	{
 		evolveInfo_t info = BG_ClassEvolveInfoFromTo( currentClass, cl.item );
 
-		if ( info.evolveCost > 0 // no devolving or evolving to the same
-				&& BotEvolveToClass( self, cl.item ) )
+		bool isBuilder = currentClass == PCL_ALIEN_BUILDER0 || currentClass == PCL_ALIEN_BUILDER0_UPG;
+		if ( ( info.evolveCost > 0     // no devolving or evolving to the same
+			   || ( isBuilder && cl.item == PCL_ALIEN_LEVEL0 )
+			   || ( currentClass == PCL_ALIEN_BUILDER0 && cl.item == PCL_ALIEN_BUILDER0_UPG ) )
+			 && BotEvolveToClass( self, cl.item ) )
 		{
 			return STATUS_SUCCESS;
 		}

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -611,13 +611,14 @@ AINodeStatus_t BotActionEvolve( gentity_t *self, AIGenericNode_t* )
 
 	for ( auto const& cl : classes )
 	{
+		if ( cl.item == currentClass )
+		{
+			break;  // no smaller classes left to try
+		}
+
 		evolveInfo_t info = BG_ClassEvolveInfoFromTo( currentClass, cl.item );
 
-		bool isBuilder = currentClass == PCL_ALIEN_BUILDER0 || currentClass == PCL_ALIEN_BUILDER0_UPG;
-		if ( ( info.evolveCost > 0     // no devolving or evolving to the same
-			   || ( isBuilder && cl.item == PCL_ALIEN_LEVEL0 )
-			   || ( currentClass == PCL_ALIEN_BUILDER0 && cl.item == PCL_ALIEN_BUILDER0_UPG ) )
-			 && BotEvolveToClass( self, cl.item ) )
+		if ( !info.isDevolving && BotEvolveToClass( self, cl.item ) )
 		{
 			return STATUS_SUCCESS;
 		}

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -611,14 +611,9 @@ AINodeStatus_t BotActionEvolve( gentity_t *self, AIGenericNode_t* )
 
 	for ( auto const& cl : classes )
 	{
-		if ( cl.item == currentClass )
-		{
-			break;  // no bigger classes left to try
-		}
-
 		evolveInfo_t info = BG_ClassEvolveInfoFromTo( currentClass, cl.item );
 
-		if ( !info.isDevolving && BotEvolveToClass( self, cl.item ) )
+		if ( !info.isDevolving && cl.item != currentClass && BotEvolveToClass( self, cl.item ) )
 		{
 			return STATUS_SUCCESS;
 		}


### PR DESCRIPTION
Bots cannot evolve from grangers to dretch or from granger to advanced granger. Since we merged a bot build action, this is a bug now. Fix it.

To see the current problem, set an alien bot to use `build.bt`, and then set it to use `default.bt`. If it has less than 2 morph points, it will be a battle granger.