### PR TITLE
human bots walk when low on stamina

### DIFF
--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1054,7 +1054,10 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 		BotStandStill( self );
 	}
 
-	BotSprint( self, true );
+	if ( !BotWalkIfStaminaLow( self ) )
+	{
+		BotSprint( self, true );
+	}
 
 	return STATUS_RUNNING;
 }

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -1083,7 +1083,7 @@ bool BotMoveToGoal( gentity_t *self )
 
 	// if target is friendly, let's go there quickly (heal, poison) by using trick moves
 	// when available (still need to implement wall walking, but that will be more complex)
-	if ( G_Team( self ) != targetTeam )
+	if ( G_Team( self ) == TEAM_ALIENS && G_Team( self ) != targetTeam )
 	{
 		BotTryMoveUpward( self );
 		return true;
@@ -1099,6 +1099,10 @@ bool BotMoveToGoal( gentity_t *self )
 	if ( ( G_Team( self ) == TEAM_HUMANS && !self->botMind->skillSet[BOT_H_FAST_FLEE] )
 			|| ( G_Team( self ) == TEAM_ALIENS && !self->botMind->skillSet[BOT_A_FAST_FLEE] ) )
 	{
+		if ( G_Team( self ) == TEAM_HUMANS )
+		{
+			BotWalkIfStaminaLow( self );
+		}
 		return true;
 	}
 	switch ( ps.stats [ STAT_CLASS ] )
@@ -1108,6 +1112,7 @@ bool BotMoveToGoal( gentity_t *self )
 		case PCL_HUMAN_MEDIUM:
 		case PCL_HUMAN_BSUIT:
 			BotSprint( self, true );
+			BotWalkIfStaminaLow( self );
 			break;
 		//those classes do not really have capabilities allowing them to be
 		//significantly faster while fleeing (except jumps, but that also

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -2545,12 +2545,10 @@ void BotCalculateStuckTime( gentity_t *self )
 	self->botMind->lastThink = level.time;
 }
 
-static Cvar::Cvar<int> g_bot_walkAfterCombat( "g_bot_walkAfterCombat", "how many milliseconds must pass after combat until human bots are allowed to walk when low on stamina", Cvar::NONE, 3000 );
-
 bool BotWalkIfStaminaLow( gentity_t *self )
 {
 	if ( self->client->ps.stats[ STAT_STAMINA ] < BG_Class( self->client->ps.stats[ STAT_CLASS ] )->staminaJumpCost
-		 && level.time - self->client->lastCombatTime > g_bot_walkAfterCombat.Get() )
+		 && level.time - self->client->lastCombatTime > 3000 )  // do not walk for 3s after combat
 	{
 		BotWalk( self, true );
 		return true;

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -2545,6 +2545,19 @@ void BotCalculateStuckTime( gentity_t *self )
 	self->botMind->lastThink = level.time;
 }
 
+static Cvar::Cvar<int> g_bot_walkAfterCombat( "g_bot_walkAfterCombat", "how many milliseconds must pass after combat until human bots are allowed to walk when low on stamina", Cvar::NONE, 3000 );
+
+bool BotWalkIfStaminaLow( gentity_t *self )
+{
+	if ( self->client->ps.stats[ STAT_STAMINA ] < BG_Class( self->client->ps.stats[ STAT_CLASS ] )->staminaJumpCost
+		 && level.time - self->client->lastCombatTime > g_bot_walkAfterCombat.Get() )
+	{
+		BotWalk( self, true );
+		return true;
+	}
+	return false;
+}
+
 /*
 ========================
 botTarget_t methods implementations

--- a/src/sgame/sg_bot_util.h
+++ b/src/sgame/sg_bot_util.h
@@ -129,6 +129,7 @@ void     BotStrafeDodge( gentity_t *self );
 void     BotAlternateStrafe( gentity_t *self );
 void     BotMoveInDir( gentity_t *self, uint32_t moveDir );
 void     BotStandStill( gentity_t *self );
+bool BotWalkIfStaminaLow( gentity_t *self );
 
 // navigation queries
 bool  GoalInRange( const gentity_t *self, float r );


### PR DESCRIPTION
Because otherwise, they often get stuck in their own base, running against a building until they regain enough stamina to jump. This is especially bad for battlesuits. Do not make them walk while in combat, though.