### PR TITLE
Fix bug (#2839) with setting trap_Trace's entityNum

### DIFF
--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -189,6 +189,8 @@ static void CG_ClipMoveToEntities( const vec3_t start, const vec3_t mins,
 		else if ( trace.startsolid )
 		{
 			tr->startsolid = true;
+			// FIXME: the trace didn't hit anything so the entityNum shouldn't get set.
+			// The behavior here is different from sgame's trap_Trace.
 			tr->entityNum = ent->number;
 		}
 

--- a/src/sgame/components/SpikerComponent.cpp
+++ b/src/sgame/components/SpikerComponent.cpp
@@ -161,7 +161,7 @@ bool SpikerComponent::SafeToShoot(glm::vec3 direction) {
 	glm::vec3 end = VEC2GLM( entity.oldEnt->s.origin ) + (SPIKE_RANGE * direction);
 
 	// Test once with normal and once with inflated missile bounding box.
-	// FIXME: relies on wonky entityNum behavior (see trap_Trace comment)
+	// TODO: Consider using G_Trace2 - entities overlapping the trace at the start are sometimes ignored
 	for (float traceSize : {missileSize, missileSize * SAFETY_TRACE_INFLATION}) {
 		mins[0] = mins[1] = mins[2] = -traceSize;
 		maxs[0] = maxs[1] = maxs[2] =  traceSize;

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -1636,7 +1636,7 @@ static void G_UnlaggedDetectCollisions( gentity_t *ent )
 
 	G_UnlaggedOn( ent, ent->client->oldOrigin, range );
 
-	// FIXME: uses wonky entityNum behavior (see trap_Trace comment)
+	// TODO: consider using G_Trace2 as this misses players overlapping at the start of the trace
 	trap_Trace( &tr, ent->client->oldOrigin, ent->r.mins, ent->r.maxs,
 	            ent->client->ps.origin, ent->s.number, MASK_PLAYERSOLID, 0 );
 

--- a/src/sgame/sg_api.cpp
+++ b/src/sgame/sg_api.cpp
@@ -183,14 +183,8 @@ bool trap_EntityContact(const vec3_t mins, const vec3_t maxs, const gentity_t *e
 //     passEntityNum: if not ENTITYNUM_NONE, ignore the entity of this number and any entities owned by it
 //
 // `results` is populated according to the trace_t documentation, except there is one additional
-// field, entityNum. entityNum can be either one of two things:
-//   * an entity hit by the trace
-//   * an entity other than ENTITYNUM_WORLD that caused the startsolid flag to be set
-// If a trace both starts overlapping a non-world entity, and hits a different entity,
-// then entityNum may correspond to either one at random (higher entity numbers would overwrite
-// lower ones). TODO: fix wonky entityNum behavior by making it always correspond to the hit entity
-// (thus ignoring collisions that set startsolid but not allsolid). Some callers must be fixed that
-// rely on this behavior; create a new API if necessary.
+// field, entityNum. If fraction < 1.0, entityNum is the number of the hit entity (ENTITYNUM_WORLD
+// if it hits the level geometry). If fraction == 1.0f, entityNum is ENTITYNUM_NONE.
 void trap_Trace( trace_t *results, const vec3_t start, const vec3_t mins, const vec3_t maxs,
                  const vec3_t end, int passEntityNum, int contentmask, int skipmask )
 {

--- a/src/sgame/sg_cm_world.cpp
+++ b/src/sgame/sg_cm_world.cpp
@@ -763,7 +763,7 @@ static void G_CM_ClipMoveToEntities( moveclip_t *clip )
 		if ( trace.allsolid )
 		{
 			clip->trace = trace;
-			trace.entityNum = touch->num();
+			clip->trace.entityNum = touch->num();
 		}
 		else if ( trace.fraction < clip->trace.fraction )
 		{
@@ -776,10 +776,9 @@ static void G_CM_ClipMoveToEntities( moveclip_t *clip )
 			clip->trace = trace;
 			clip->trace.startsolid |= oldStart;
 		}
-		else if ( trace.startsolid )
+		else
 		{
-			clip->trace.startsolid = true;
-			trace.entityNum = touch->num();
+			clip->trace.startsolid |= trace.startsolid;
 		}
 	}
 }


### PR DESCRIPTION
Recently I documented something I called the "wonky entityNum behavior" of trap_Trace, which refers to traces with startsolid=true and fraction=1.0f setting the entitynum, which they really shouldn't since the trace "missed". It turns out this behavior never existed. Due to typos assigning to the wrong variable (which already existed in the initial commit), the entityNum is not actually changed in this startsolid-but-not-allsolid case. If this behavior had worked as intended, G_WideTrace would not have the bug where a tyrant can't hit an enemy standing on its head.

Meanwhile, 317cfb198e3033aaae6bcf7ac5225dd63a273418 retained the typos while making their consequences worse. After this, traces sometimes return 0 in the entityNum instead of ENTITYNUM_NONE. Besides being wrong, this causes crashes in dedicated servers since entity number 0 might not exist.

Since the wonky entityNum behavior never even worked as intended, we can NUKE it without affecting compatibility with existing trap_Trace callers.

Fixes #2839.