### PR TITLE
fix bots sometimes building two armouries, medistations, etc instead of only one

### DIFF
--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1294,18 +1294,12 @@ static bool build( gentity_t *self, buildable_t toBuild )
 		return false;
 	}
 
-	if ( level.team[ G_Team( self ) ].botBuildingInThisFrame )
-	{
-		return false;
-	}
-
 	self->client->ps.stats[ STAT_BUILDABLE ] &= ~SB_BUILDABLE_MASK;
 	self->client->ps.stats[ STAT_BUILDABLE ] |= toBuild;
 	if ( self->client->ps.stats[ STAT_MISC ] == 0 )
 	{
 		BotFireWeapon( WPM_PRIMARY, &self->botMind->cmdBuffer );
 	}
-	level.team[ G_Team( self ) ].botBuildingInThisFrame = true;
 	return true;
 }
 

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1289,13 +1289,7 @@ static bool build( gentity_t *self, buildable_t toBuild )
 		G_ForceWeaponChange( self, WP_HBUILD );
 	}
 
-	if ( SB_BUILDABLE_TO_IBE( self->client->ps.stats[ STAT_BUILDABLE ] ) != IBE_NONE )
-	{
-		return false;
-	}
-
-	self->client->ps.stats[ STAT_BUILDABLE ] &= ~SB_BUILDABLE_MASK;
-	self->client->ps.stats[ STAT_BUILDABLE ] |= toBuild;
+	self->client->ps.stats[ STAT_BUILDABLE ] = toBuild;
 	if ( self->client->ps.stats[ STAT_MISC ] == 0 )
 	{
 		BotFireWeapon( WPM_PRIMARY, &self->botMind->cmdBuffer );

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1289,7 +1289,13 @@ static bool build( gentity_t *self, buildable_t toBuild )
 		G_ForceWeaponChange( self, WP_HBUILD );
 	}
 
-	self->client->ps.stats[ STAT_BUILDABLE ] = toBuild;
+	if ( SB_BUILDABLE_TO_IBE( self->client->ps.stats[ STAT_BUILDABLE ] ) != IBE_NONE )
+	{
+		return false;
+	}
+
+	self->client->ps.stats[ STAT_BUILDABLE ] &= ~SB_BUILDABLE_MASK;
+	self->client->ps.stats[ STAT_BUILDABLE ] |= toBuild;
 	if ( self->client->ps.stats[ STAT_MISC ] == 0 )
 	{
 		BotFireWeapon( WPM_PRIMARY, &self->botMind->cmdBuffer );

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1294,12 +1294,18 @@ static bool build( gentity_t *self, buildable_t toBuild )
 		return false;
 	}
 
+	if ( level.team[ G_Team( self ) ].botBuildingInThisFrame )
+	{
+		return false;
+	}
+
 	self->client->ps.stats[ STAT_BUILDABLE ] &= ~SB_BUILDABLE_MASK;
 	self->client->ps.stats[ STAT_BUILDABLE ] |= toBuild;
 	if ( self->client->ps.stats[ STAT_MISC ] == 0 )
 	{
 		BotFireWeapon( WPM_PRIMARY, &self->botMind->cmdBuffer );
 	}
+	level.team[ G_Team( self ) ].botBuildingInThisFrame = true;
 	return true;
 }
 

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1210,11 +1210,11 @@ buildable_t BotChooseBuildableToBuild( gentity_t *self )
 	buildable_t toBuild = BA_NONE;
 	if ( G_Team( self ) == TEAM_HUMANS )
 	{
-		if ( !self->botMind->closestBuildings[ BA_H_REACTOR ].ent )
+		if ( level.numBuildablesEstimate[ BA_H_REACTOR ] == 0 )
 		{
 			toBuild = BA_H_REACTOR;
 		}
-		else if ( !self->botMind->closestBuildings[ BA_H_DRILL ].ent )
+		else if ( level.numBuildablesEstimate[ BA_H_DRILL ] == 0 )
 		{
 			toBuild = BA_H_DRILL;
 		}
@@ -1222,11 +1222,11 @@ buildable_t BotChooseBuildableToBuild( gentity_t *self )
 		{
 			toBuild = BA_H_SPAWN;
 		}
-		else if ( !self->botMind->closestBuildings[ BA_H_ARMOURY ].ent )
+		else if ( level.numBuildablesEstimate[ BA_H_ARMOURY ] == 0 )
 		{
 			toBuild = BA_H_ARMOURY;
 		}
-		else if ( !self->botMind->closestBuildings[ BA_H_MEDISTAT ].ent )
+		else if ( level.numBuildablesEstimate[ BA_H_MEDISTAT ] == 0 )
 		{
 			toBuild = BA_H_MEDISTAT;
 		}
@@ -1242,11 +1242,11 @@ buildable_t BotChooseBuildableToBuild( gentity_t *self )
 	}
 	else if ( G_Team( self ) == TEAM_ALIENS )
 	{
-		if ( !self->botMind->closestBuildings[ BA_A_OVERMIND ].ent )
+		if ( level.numBuildablesEstimate[ BA_A_OVERMIND ] == 0 )
 		{
 			toBuild = BA_A_OVERMIND;
 		}
-		else if ( !self->botMind->closestBuildings[ BA_A_LEECH ].ent )
+		else if ( level.numBuildablesEstimate[ BA_A_LEECH ] == 0 )
 		{
 			toBuild = BA_A_LEECH;
 		}
@@ -1254,7 +1254,7 @@ buildable_t BotChooseBuildableToBuild( gentity_t *self )
 		{
 			toBuild = BA_A_SPAWN;
 		}
-		else if ( BG_BuildableUnlocked( BA_A_BOOSTER ) && !self->botMind->closestBuildings[ BA_A_BOOSTER ].ent )
+		else if ( BG_BuildableUnlocked( BA_A_BOOSTER ) && level.numBuildablesEstimate[ BA_A_BOOSTER ] == 0 )
 		{
 			toBuild = BA_A_BOOSTER;
 		}

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -2212,8 +2212,6 @@ void G_RunFrame( int levelTime )
 	G_CheckPmoveParamChanges();
 
 	int numBuildables[ BA_NUM_BUILDABLES ] = {};
-	level.team[ TEAM_ALIENS ].botBuildingInThisFrame = false;
-	level.team[ TEAM_HUMANS ].botBuildingInThisFrame = false;
 
 	// go through all allocated objects
 	ent = &g_entities[ 0 ];

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -2212,6 +2212,8 @@ void G_RunFrame( int levelTime )
 	G_CheckPmoveParamChanges();
 
 	int numBuildables[ BA_NUM_BUILDABLES ] = {};
+	level.team[ TEAM_ALIENS ].botBuildingInThisFrame = false;
+	level.team[ TEAM_HUMANS ].botBuildingInThisFrame = false;
 
 	// go through all allocated objects
 	ent = &g_entities[ 0 ];

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -2211,7 +2211,7 @@ void G_RunFrame( int levelTime )
 
 	G_CheckPmoveParamChanges();
 
-	int numBuildables[ BA_NUM_BUILDABLES ] = { 0 };
+	int numBuildables[ BA_NUM_BUILDABLES ] = {};
 
 	// go through all allocated objects
 	ent = &g_entities[ 0 ];

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -2211,6 +2211,8 @@ void G_RunFrame( int levelTime )
 
 	G_CheckPmoveParamChanges();
 
+	int numBuildables[ BA_NUM_BUILDABLES ] = { 0 };
+
 	// go through all allocated objects
 	ent = &g_entities[ 0 ];
 	for ( i = 0; i < level.num_entities; i++, ent++ )
@@ -2257,6 +2259,7 @@ void G_RunFrame( int levelTime )
 				// TODO: Do buildables make any use of G_Physics' functionality apart from the call
 				//       to G_RunThink?
 				G_Physics( ent );
+				numBuildables[ ent->s.modelindex ]++;
 				continue;
 
 			case entityType_t::ET_CORPSE:
@@ -2354,6 +2357,8 @@ void G_RunFrame( int levelTime )
 
 	BotDebugDrawMesh();
 	G_BotUpdateObstacles();
+
+	memcpy( level.numBuildablesEstimate, numBuildables, sizeof( level.numBuildablesEstimate ) );
 }
 
 void G_PrepareEntityNetCode() {

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -629,6 +629,12 @@ struct level_locals_t
 	int              buildId;
 	int              numBuildLogs;
 
+	// this is an estimate of the number of each buildable type
+	// the buildables are counted efficiently in the server's main entity loop,
+	// these numbers might be slightly outdated
+	// however, the numbers will not be more than two frames behind
+	int numBuildablesEstimate[ BA_NUM_BUILDABLES ];
+
 	struct
 	{
 		// voting state

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -673,6 +673,7 @@ struct level_locals_t
 		int              lastTeamStatus;
 		int              lastTacticId;
 		int              lastTacticTime;
+		bool             botBuildingInThisFrame;
 	} team[ NUM_TEAMS ];
 
 	struct {

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -673,7 +673,6 @@ struct level_locals_t
 		int              lastTeamStatus;
 		int              lastTacticId;
 		int              lastTacticTime;
-		bool             botBuildingInThisFrame;
 	} team[ NUM_TEAMS ];
 
 	struct {


### PR DESCRIPTION
Currently, building bots rely on `self->botMind->closestBuildings` to find out if there is an existing armoury. This excludes a currently building armoury, which takes longer to complete than the build timer to expire. The result is that bots regularly build two drills, two armouries, two medistations, etc.

Additionally, current bot build code cannot specify to build, say, 3 armouries; whatever this would be good for.

A straightforward way to fix this would be to count each buildable type for each bot. But this would be rather expensive. The current implementation of bot building scales well only when avoiding loops over entities.

This PR counts the buildables in the existing main loop over all entities the server does at each frame. These numbers can be used in the next frame as a sufficiently accurate estimate for the building bots. This is as fast as it gets.