### PR TITLE
buildlog: it is not possible for a building to be "unpowered"

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -5519,8 +5519,7 @@ static const char *const fates[] =
 	N_("^7replaced^*"),
 	N_("^5destroyed^*"),
 	N_("^1TEAMKILLED^*"),
-	N_("^7unpowered^*"),
-	N_("removed")
+	N_("^aremoved^*")
 };
 bool G_admin_buildlog( gentity_t *ent )
 {


### PR DESCRIPTION
There are only 6 fates, this commit removes the irrelevant one from the buildlog code and fixes a bug where buildings that are "removed" are incorrectly shown as "unpowered" in the buildlog.