### PR TITLE
Beacons: allow tagging buildables under construction + perf improvements

### DIFF
--- a/src/sgame/Beacon.cpp
+++ b/src/sgame/Beacon.cpp
@@ -52,6 +52,10 @@ along with Daemon.  If not, see <http://www.gnu.org/licenses/>.
 static Cvar::Cvar<bool> g_mainBuildableStartingBeacons(
 	"g_mainBuildableStartingBeacons", "get beacon for enemy's main structure at match start",
 	Cvar::NONE, true);
+static Cvar::Cvar<int> g_tagDelay(
+	"g_tagDelay", "duration in ms one has to stare at an enemy to place a beacon",
+	Cvar::NONE, 500);
+
 
 namespace Beacon //this should eventually become a class
 {
@@ -777,5 +781,17 @@ namespace Beacon //this should eventually become a class
 		if ( ent->s.eType == entityType_t::ET_BUILDABLE ) BaseClustering::Update( beacon );
 
 		Propagate( beacon );
+	}
+
+	// Increases the tag score and tags it if the threshold is hit
+	void Tag( gentity_t *ent, team_t team, bool permanent, int scoreDelta )
+	{
+		ent->tagScore += scoreDelta;
+		ent->tagScoreTime = level.time;
+
+		if ( ent->tagScore > g_tagDelay.Get() )
+		{
+			Tag( ent, team, permanent );
+		}
 	}
 }

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -34,7 +34,6 @@ bool ClientInactivityTimer( gentity_t *ent, bool active );
 static Cvar::Cvar<float> g_devolveReturnRate(
 	"g_devolveReturnRate", "Evolution points per second returned after devolving", Cvar::NONE, 0.4);
 static Cvar::Cvar<bool> g_remotePoison( "g_remotePoison", "booster gives poison when in heal range", Cvar::NONE, false );
-static Cvar::Cvar<int> g_tagDelay( "g_tagDelay", "duration in ms one has to stare at an enemy to place a beacon", Cvar::NONE, 500 );
 
 static Cvar::Cvar<bool> g_poisonIgnoreArmor(
 	"g_poisonIgnoreArmor",
@@ -881,10 +880,8 @@ static void BeaconAutoTag( gentity_t *self, int timePassed )
 		      ( target->s.eType != entityType_t::ET_BUILDABLE ||
 		        G_LineOfSight( self, target, MASK_SOLID, false ) ) ) )
 		{
-			target->tagScore     += timePassed;
-			target->tagScoreTime  = level.time;
-			if( target->tagScore > g_tagDelay.Get() )
-				Beacon::Tag( target, team, ( target->s.eType == entityType_t::ET_BUILDABLE ) );
+			Beacon::Tag(
+				target, team, ( target->s.eType == entityType_t::ET_BUILDABLE ), timePassed );
 		}
 	}
 }

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -64,6 +64,7 @@ namespace Beacon
 	bool EntityTaggable( int num, team_t team, bool trace );
 	gentity_t *TagTrace( const vec3_t begin, const vec3_t end, int skip, int mask, team_t team, bool refreshTagged );
 	void Tag( gentity_t *ent, team_t team, bool permanent );
+	void Tag( gentity_t *ent, team_t team, bool permanent, int scoreDelta );
 	void UpdateTags( gentity_t *ent );
 	void DetachTags( gentity_t *ent );
 	void DeleteTags( gentity_t *ent );


### PR DESCRIPTION
#2788 was pretty well-hidden: the culprit was a function named G_IterateEntities that skips buildables under construction because they are "disabled".