### PR TITLE
cgame/cg_marks: process all impact marks at once

### DIFF
--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -317,8 +317,9 @@ static void CG_Creep( centity_t *cent )
 
 	if ( size > 0.0f && tr.fraction < 1.0f )
 	{
-		CG_ImpactMark( cgs.media.creepShader, tr.endpos, cent->currentState.origin2,
-		               0.0f, 1.0f, 1.0f, 1.0f, 1.0f, false, size, true );
+		CG_RegisterImpactMark( cgs.media.creepShader, tr.endpos, cent->currentState.origin2,
+			0.0f, 1.0f, 1.0f, 1.0f, 1.0f,
+			false, size, true );
 	}
 }
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2150,12 +2150,15 @@ void CG_DrawMinimap( const rectDef_t *rect, const Color::Color& color );
 //
 void CG_InitMarkPolys();
 void CG_AddMarks();
-void CG_ImpactMark( qhandle_t markShader,
+void CG_RegisterImpactMark( qhandle_t markShader,
                     const vec3_t origin, const vec3_t dir,
                     float orientation,
                     float r, float g, float b, float a,
                     bool alphaFade,
                     float radius, bool temporary );
+
+void CG_ResetImpactMarks();
+void CG_ProcessImpactMarks();
 
 //
 // cg_snapshot.c

--- a/src/cgame/cg_particles.cpp
+++ b/src/cgame/cg_particles.cpp
@@ -2338,8 +2338,9 @@ static void CG_EvaluateParticlePhysics( particle_t *p )
 
 	if ( bp->bounceMarkName[ 0 ] && p->bounceMarkCount > 0 )
 	{
-		CG_ImpactMark( bp->bounceMark, trace.endpos, trace.plane.normal,
-		               random() * 360, 1, 1, 1, 1, true, bp->bounceMarkRadius, false );
+		CG_RegisterImpactMark( bp->bounceMark, trace.endpos, trace.plane.normal,
+			random() * 360, 1, 1, 1, 1,
+			true, bp->bounceMarkRadius, false );
 		p->bounceMarkCount--;
 	}
 

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -2516,8 +2516,9 @@ static void CG_PlayerUpgrades( centity_t *cent, refEntity_t *torso )
 
 		if ( size > 0.0f )
 		{
-			CG_ImpactMark( cgs.media.creepShader, origin, up,
-			               0.0f, 1.0f, 1.0f, 1.0f, 1.0f, false, size, true );
+			CG_RegisterImpactMark( cgs.media.creepShader, origin, up,
+				0.0f, 1.0f, 1.0f, 1.0f, 1.0f,
+				false, size, true );
 		}
 	}
 }
@@ -2641,9 +2642,9 @@ static bool CG_PlayerShadow( centity_t *cent, class_t class_ )
 
 	// add the mark as a temporary, so it goes directly to the renderer
 	// without taking a spot in the cg_marks array
-	CG_ImpactMark( cgs.media.shadowMarkShader, trace.endpos, trace.plane.normal,
-	               cent->pe.legs.yawAngle, 0.0f, 0.0f, 0.0f, alpha, false,
-	               24.0f * BG_ClassModelConfig( class_ )->shadowScale, true );
+	CG_RegisterImpactMark( cgs.media.shadowMarkShader, trace.endpos, trace.plane.normal,
+		cent->pe.legs.yawAngle, 0.0f, 0.0f, 0.0f, alpha,
+		false, 24.0f * BG_ClassModelConfig( class_ )->shadowScale, true );
 
 	return true;
 }
@@ -2713,9 +2714,9 @@ static void CG_PlayerSplash( centity_t *cent, class_t class_ )
 		return;
 	}
 
-	CG_ImpactMark( cgs.media.wakeMarkShader, trace.endpos, trace.plane.normal,
-	               cent->pe.legs.yawAngle, 1.0f, 1.0f, 1.0f, 1.0f, false,
-	               32.0f * BG_ClassModelConfig( class_ )->shadowScale, true );
+	CG_RegisterImpactMark( cgs.media.wakeMarkShader, trace.endpos, trace.plane.normal,
+		cent->pe.legs.yawAngle, 1.0f, 1.0f, 1.0f, 1.0f,
+		false, 32.0f * BG_ClassModelConfig( class_ )->shadowScale, true );
 }
 
 #define TRACE_DEPTH    32.0f

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -1861,6 +1861,8 @@ void CG_DrawActiveFrame( int serverTime, bool demoPlayback )
 	cg.demoPlayback = demoPlayback;
 	cg.currentCmdNumber = trap_GetCurrentCmdNumber();
 
+	CG_ResetImpactMarks();
+
 	CG_NotifyHooks();
 
 	// any looped sounds will be respecified as entities
@@ -1947,6 +1949,8 @@ void CG_DrawActiveFrame( int serverTime, bool demoPlayback )
 
 	// update audio positions
 	trap_S_Respatialize( cg.snap->ps.clientNum, cg.refdef.vieworg, cg.refdef.viewaxis, inwater );
+
+	CG_ProcessImpactMarks();
 
 	cg.frametime = cg.time - cg.oldTime;
 

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -2597,7 +2597,9 @@ void CG_HandleWeaponHitWall( entityState_t *es, vec3_t origin )
 	// mark
 	if ( wim->impactMark && wim->impactMarkSize > 0.0f )
 	{
-		CG_ImpactMark( wim->impactMark, origin, normal, random() * 360, 1, 1, 1, 1, false, wim->impactMarkSize, false );
+		CG_RegisterImpactMark( wim->impactMark, origin, normal,
+			random() * 360, 1, 1, 1, 1,
+			false, wim->impactMarkSize, false );
 	}
 
 	// tracer
@@ -2671,8 +2673,9 @@ void CG_HandleMissileHitWall( entityState_t *es, vec3_t origin )
 	// mark
 	if ( ma->impactMark && ma->impactMarkSize > 0.0f )
 	{
-		CG_ImpactMark( ma->impactMark, origin, normal, random() * 360, 1, 1, 1, 1, false,
-		               ma->impactMarkSize, false );
+		CG_RegisterImpactMark( ma->impactMark, origin, normal,
+			random() * 360, 1, 1, 1, 1,
+			false, ma->impactMarkSize, false );
 	}
 }
 


### PR DESCRIPTION
For now, it doesn't bring performance improvement, but the loop calling `trap_CM_MarkFragments` for every impact mark can be rewritten to only process data that would be fetched in a single call by a future `trap_CM_MarkFragmentsArray` before entering the loop.

This patch is what I talked about in #846:

- https://github.com/DaemonEngine/Daemon/issues/846#issuecomment-1537131791

> The next performance glutton is `trap_CM_MarkFragments`, and then after that, `trap_R_AddPolyToScene`. They're both called by `CG_ImpactMark`. The cgame calls `CG_ImpactMark`  each time it want's to add a mark. I have a patch that turns `CG_ImpactMark` into `CG_RegisterImpactMark` (it just stores the data to be processed later), then at the end of `CG_DrawActiveFrame` I call a new `CG_ProcessImpactMarks` function that processes all those registered impact marks. For now this can't bring any performance improvement since it just iterates the registered impact marks and calls `trap_CM_MarkFragments` the same way as before, but this will allow us to rewrite `trap_CM_MarkFragments` to send a whole array of impact marks at once. This last part (sending and receiving arrays of such data) isn't an easy task unfortunately, so I make a pause in my development for now.

This is a preparatory work, as the `trap_CM_MarkFragmentsArray` function is not implemented yet, but this code is required to be able to use `trap_CM_MarkFragmentsArray` once implemented.

Unlike any implementation of `trap_CM_MarkFragmentsArray`, this code doesn't break engine compatibility.

The purpose of this code is to defer the calling of `CG_ProcessImpactMarks` to a place where all impact marks are processed at once (this is implemented), allowing us to also fetch all mark fragments at once (this is not implemented yet).

I'm not available to implement `trap_CM_MarkFragmentsArray` and I have not been since May, but if we merge this it becomes possible to others to implement it instead of waiting on me.