### PR TITLE
make bots always use adv granger when they should

### DIFF
--- a/pkg/unvanquished_src.dpkdir/bots/default.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/default.bt
@@ -15,7 +15,11 @@ selectClass
 					&& !teamateHasWeapon( WP_ABUILD )
 					&& !teamateHasWeapon( WP_ABUILD2 )
 				{
-					spawnAs PCL_ALIEN_BUILDER0
+					selector
+					{
+						spawnAs PCL_ALIEN_BUILDER0_UPG
+						spawnAs PCL_ALIEN_BUILDER0
+					}
 				}
 				spawnAs PCL_ALIEN_LEVEL0
 			}

--- a/pkg/unvanquished_src.dpkdir/bots/default_aliens.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/default_aliens.bt
@@ -44,6 +44,14 @@ selector
 
 			decorator return( STATUS_FAILURE )
 			{
+				condition class == PCL_ALIEN_BUILDER0
+				{
+					action evolveTo( PCL_ALIEN_BUILDER0_UPG )
+				}
+			}
+
+			decorator return( STATUS_FAILURE )
+			{
 				action buildNowChosenBuildable
 			}
 			action roamInRadius( E_A_OVERMIND, 700 )


### PR DESCRIPTION
Handle the two missing cases:

- spawn as adv granger when unlocked
- evolve from granger to adv granger when unlocked