### PR TITLE
ui: fix server label in server list

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/server_browser.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/server_browser.rml
@@ -39,7 +39,7 @@
 			<tab><translate>Internet</translate></tab>
 			<panel>
 				<datagrid id="iServers" source="server_browser.internet">
-					<col fields="label" width="3%" class="label" formatter="ServerLabel"></col>
+					<col fields="label" width="3%" class="label"></col>
 					<col fields="name" width="50%" class="name"><ilink style="text-align:left;" onclick='Events.pushevent("sortDS server_browser internet name", event)'><translate>Name:</translate></ilink></col>
 					<col fields="map" width="18%" class="map"><ilink onclick='Events.pushevent("sortDS server_browser internet map", event)'><translate>Map:</translate></ilink></col>
 					<col fields="players,bots,maxClients" width="18%" formatter="ServerPlayers" class="players"><ilink onclick='Events.pushevent("sortDS server_browser internet players", event)'><translate>Players (Bots)</translate></ilink></col>

--- a/src/cgame/cg_rocket_dataformatter.cpp
+++ b/src/cgame/cg_rocket_dataformatter.cpp
@@ -136,12 +136,6 @@ static void CG_Rocket_DFClassName( int handle, const char *data )
 	Rocket_DataFormatterFormattedData( handle, BG_Class( atoi( Info_ValueForKey( data, "1" ) ) )->name, true );
 }
 
-static void CG_Rocket_DFServerLabel( int handle, const char *data )
-{
-	const char *str = Info_ValueForKey( data, "1" );
-	Rocket_DataFormatterFormattedData( handle, *data ? ++str : "&nbsp;", false );
-}
-
 static void CG_Rocket_DFGWeaponDamage( int handle, const char *data )
 {
 	weapon_t weapon = (weapon_t) atoi( Info_ValueForKey( data, "1" ) );
@@ -280,7 +274,6 @@ static const dataFormatterCmd_t dataFormatterCmdList[] =
 	{ "LevelShot", &CG_Rocket_DFLevelShot },
 	{ "PlayerName", &CG_Rocket_DFPlayerName },
 	{ "Resolution", &CG_Rocket_DFResolution },
-	{ "ServerLabel", &CG_Rocket_DFServerLabel },
 	{ "ServerPing", &CG_Rocket_DFServerPing },
 	{ "ServerPlayers", &CG_Rocket_DFServerPlayers },
 	{ "UpgradeName", &CG_Rocket_DFUpgradeName },


### PR DESCRIPTION
Fix the display of the server label in server list.

I don't know what the original code was for, but deleting it fixes all the bugs:

- it doesn't seem to eat or hide the first character
- emoticons work

If I use this `featured.txt` file with unvanquished master server:

```
[official]
	206.189.56.213:27960
	82.165.236.249:27960
```

I get this in game:

![unvanquished_2023-11-29_193755_000](https://github.com/Unvanquished/Unvanquished/assets/2311649/e92f0b2d-8396-415c-87b4-7196ac9e9671)
