### PR TITLE
Fix attack warning bugs

### DIFF
--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -1286,22 +1286,13 @@ void CG_EntityEvent( centity_t *cent, vec3_t position )
 			// if eventParm is non-zero, there is a nearby main structure (OM/RC). Humans are only notified
 			// of base attacks if RC is in range. Aliens are notified of any base attacks, but base attacks
 			// without the OM in range do not give you the location of the attack.
-			if ( es->eventParm >= MAX_CLIENTS && es->eventParm < MAX_GENTITIES )
+			if ( es->eventParm >= 0 && es->eventParm < MAX_LOCATIONS )
 			{
-				const char *location;
 				const char *emoticon = CG_MyTeam() == TEAM_ALIENS ? "[overmind]" : "[reactor]";
-				centity_t  *locent = CG_GetLocation( cg_entities[ es->eventParm ].currentState.origin );
 
 				CG_CenterPrint( _( "Our base is under attack!" ), 1.25f );
 
-				if ( locent )
-				{
-					location = CG_ConfigString( CS_LOCATIONS + locent->currentState.generic1 );
-				}
-				else
-				{
-					location = CG_ConfigString( CS_LOCATIONS );
-				}
+				const char *location = CG_ConfigString( CS_LOCATIONS + es->eventParm );
 
 				if ( location && *location )
 				{
@@ -1314,6 +1305,7 @@ void CG_EntityEvent( centity_t *cent, vec3_t position )
 			}
 			else // this is for aliens, and the overmind is in range
 			{
+				ASSERT_EQ( es->eventParm, MAX_LOCATIONS );
 				CG_CenterPrint( _( "Our base is under attack!" ), 1.25f );
 			}
 

--- a/src/sgame/components/BuildableComponent.cpp
+++ b/src/sgame/components/BuildableComponent.cpp
@@ -74,12 +74,12 @@ void BuildableComponent::HandleDie(gentity_t* killer, meansOfDeath_t meansOfDeat
 		if (!location) location = level.fakeLocation;
 
 		// Warn if there was no warning for this location recently.
-		if (level.time > location->warnTimer) {
+		if (level.time > location->mapEntity.warnTimer[team]) {
 			bool inBase = G_InsideBase(entity.oldEnt);
 
 			G_BroadcastEvent(EV_WARN_ATTACK, inBase ? 0 : location->num(), team);
 			Beacon::NewArea(BCT_DEFEND, entity.oldEnt->s.origin, team);
-			location->warnTimer = level.time + ATTACKWARN_NEARBY_PERIOD;
+			location->mapEntity.warnTimer[team] = level.time + ATTACKWARN_NEARBY_PERIOD;
 		}
 	}
 

--- a/src/sgame/components/BuildableComponent.cpp
+++ b/src/sgame/components/BuildableComponent.cpp
@@ -77,7 +77,7 @@ void BuildableComponent::HandleDie(gentity_t* killer, meansOfDeath_t meansOfDeat
 		if (level.time > location->mapEntity.warnTimer[team]) {
 			bool inBase = G_InsideBase(entity.oldEnt);
 
-			G_BroadcastEvent(EV_WARN_ATTACK, inBase ? 0 : location->num(), team);
+			G_BroadcastEvent(EV_WARN_ATTACK, inBase ? MAX_LOCATIONS : location->s.generic1, team);
 			Beacon::NewArea(BCT_DEFEND, entity.oldEnt->s.origin, team);
 			location->mapEntity.warnTimer[team] = level.time + ATTACKWARN_NEARBY_PERIOD;
 		}

--- a/src/sgame/sg_map_entity.h
+++ b/src/sgame/sg_map_entity.h
@@ -281,6 +281,9 @@ struct mapEntity_t
 	int         last_move_time;
 	bool         locked;
 
+	// for a location entity, timer set when nearby buildings attacked (EV_WARN_ATTACK)
+	int warnTimer[ NUM_TEAMS ];
+
 // functions
 	inline bool triggerTeam( team_t other ) const
 	{

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -264,7 +264,6 @@ struct gentity_t
 	float       barbRegeneration; // goon barb regeneration is complete if this value is >= 1
 
 	bool        deconMarkHack; // TODO: Remove.
-	int         warnTimer; // nearby building(s) being attacked
 	int         nextPhysicsTime; // buildables don't need to check what they're sitting on
 	// every single frame.. so only do it periodically
 	int         clientSpawnTime; // the time until this spawn can spawn a client


### PR DESCRIPTION
The commit `Simplify EV_WARN_ATTACK location lookup` might not fix #2472 (I haven't really tried to reproduce it), but at least it makes things simpler so there is less chance to go wrong.