### PR TITLE
show *DEAD* instead of location name for dead players in team chat

### DIFF
--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -844,6 +844,11 @@ static void CG_Say( const char *name, int clientNum, saymode_t mode, const char 
 					location = va( " (%s^*)", s );
 				}
 			}
+
+			if ( CG_MyTeam() != TEAM_NONE && !CG_IsAlive( &cg_entities[ clientNum ] ) )
+			{
+				location = va( " %s", _( "^1*DEAD*^*" ) );
+			}
 		}
 	}
 	else if ( name )


### PR DESCRIPTION
Simple change, as per the title. Here is the result:

![image](https://github.com/Unvanquished/Unvanquished/assets/13281185/0aa745b3-70a3-4c2b-95e2-6cffb6fdfb21)

Previously, dead players would show their location as the nearest one to the intermission they are currently spectating from.