### PR TITLE
tools: add git-version to print a package version from git references

### DIFF
--- a/tools/git-version/git-version
+++ b/tools/git-version/git-version
@@ -1,0 +1,35 @@
+#! /usr/bin/env python3
+
+# Daemon BSD Source Code
+# Copyright (c) 2024, Daemon Developers
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of the <organization> nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+
+script_dir_name = os.path.dirname(os.path.realpath(__file__))
+
+module_path = os.path.join(script_dir_name, "..", "..", "daemon", "tools", "git-version", "git-version")
+
+exec(open(module_path).read())


### PR DESCRIPTION
This is a simple wrapper around `daemon/tools/git-version/git-version`, but reporting Unvanquished version.

This way, when doing that:

```
daemon/tools/git-version/git-version
tools/git-version/git-version
```

The first command prints the engine version string, and the second one the Unvanquished version string.

The Unvanquished versions string is expected to be the same of the unvanquished dpk version string, and then usable to be used as unizip version string and symbols archive version string.

See also:

- https://github.com/DaemonEngine/Daemon/pull/1009