### PR TITLE
ui, presets: adjust for new cvars and cvar types

### DIFF
--- a/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
@@ -1,8 +1,8 @@
+seta r_lightMode 3
 seta r_lightStyles 1
 seta r_dynamicLight 2
 seta r_halfLambertLighting 1
 seta r_rimLighting 1
-seta r_vertexLighting 0
 seta r_normalMapping 1
 seta r_deluxeMapping 1
 seta r_specularMapping 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
@@ -12,6 +12,7 @@ seta r_heatHaze 1
 seta r_bloom 1
 seta r_subdivisions 4
 seta r_imageMaxDimension 2048
+seta r_highPrecisionRendering on
 seta r_ext_texture_filter_anisotropic 8
 seta r_textureMode "GL_LINEAR_MIPMAP_LINEAR"
 seta r_clear 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
@@ -11,6 +11,7 @@ seta r_reliefMapping 0
 seta r_heatHaze 1
 seta r_bloom 1
 seta r_subdivisions 4
+seta r_imageFitScreen 1
 seta r_imageMaxDimension 2048
 seta r_highPrecisionRendering on
 seta r_ext_texture_filter_anisotropic 8

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
@@ -15,7 +15,7 @@ seta r_imageMaxDimension 2048
 seta r_ext_texture_filter_anisotropic 8
 seta r_textureMode "GL_LINEAR_MIPMAP_LINEAR"
 seta r_clear 1
-seta r_fastsky 0
+seta r_fastsky off
 seta cg_shadows 1
 seta cg_playerShadows 1
 seta cg_buildableShadows 0

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
@@ -1,4 +1,5 @@
 reset r_clear
+reset r_picmip
 seta r_lightMode 3
 seta r_lightStyles 1
 seta r_realtimeLighting on

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
@@ -1,5 +1,6 @@
 reset r_clear
 reset r_picmip
+seta r_colorGrading on
 seta r_lightMode 3
 seta r_lightStyles 1
 seta r_realtimeLighting on

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
@@ -1,6 +1,6 @@
 seta r_lightMode 3
 seta r_lightStyles 1
-seta r_dynamicLight 2
+seta r_realtimeLighting on
 seta r_halfLambertLighting 1
 seta r_rimLighting 1
 seta r_normalMapping 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
@@ -1,3 +1,4 @@
+reset r_clear
 seta r_lightMode 3
 seta r_lightStyles 1
 seta r_realtimeLighting on
@@ -14,7 +15,6 @@ seta r_imageMaxDimension 2048
 seta r_highPrecisionRendering on
 seta r_ext_texture_filter_anisotropic 8
 seta r_textureMode "GL_LINEAR_MIPMAP_LINEAR"
-seta r_clear 1
 seta r_fastsky off
 seta cg_shadows 1
 seta cg_playerShadows 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
@@ -1,7 +1,6 @@
 seta r_lightMode 3
 seta r_lightStyles 1
 seta r_realtimeLighting on
-seta r_halfLambertLighting 1
 seta r_rimLighting 1
 seta r_normalMapping 1
 seta r_deluxeMapping 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
@@ -1,8 +1,8 @@
+seta r_lightMode 3
 seta r_lightStyles 1
 seta r_dynamicLight 0
 seta r_halfLambertLighting 1
 seta r_rimLighting 1
-seta r_vertexLighting 0
 seta r_normalMapping 0
 seta r_deluxeMapping 0
 seta r_specularMapping 0

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
@@ -1,3 +1,4 @@
+reset r_clear
 seta r_lightMode 3
 seta r_lightStyles 1
 seta r_realtimeLighting off
@@ -14,7 +15,6 @@ seta r_imageMaxDimension 256
 seta r_highPrecisionRendering off
 seta r_ext_texture_filter_anisotropic 2
 seta r_textureMode "GL_LINEAR_MIPMAP_NEAREST"
-seta r_clear 1
 seta r_fastsky off
 seta cg_shadows 1
 seta cg_playerShadows 0

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
@@ -15,7 +15,7 @@ seta r_imageMaxDimension 256
 seta r_ext_texture_filter_anisotropic 2
 seta r_textureMode "GL_LINEAR_MIPMAP_NEAREST"
 seta r_clear 1
-seta r_fastsky 0
+seta r_fastsky off
 seta cg_shadows 1
 seta cg_playerShadows 0
 seta cg_buildableShadows 0

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
@@ -1,4 +1,5 @@
 reset r_clear
+reset r_picmip
 seta r_lightMode 3
 seta r_lightStyles 1
 seta r_realtimeLighting off

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
@@ -12,6 +12,7 @@ seta r_heatHaze 0
 seta r_bloom 0
 seta r_subdivisions 12
 seta r_imageMaxDimension 256
+seta r_highPrecisionRendering off
 seta r_ext_texture_filter_anisotropic 2
 seta r_textureMode "GL_LINEAR_MIPMAP_NEAREST"
 seta r_clear 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
@@ -1,7 +1,6 @@
 seta r_lightMode 3
 seta r_lightStyles 1
 seta r_realtimeLighting off
-seta r_halfLambertLighting 1
 seta r_rimLighting 1
 seta r_normalMapping 0
 seta r_deluxeMapping 0

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
@@ -1,5 +1,6 @@
 reset r_clear
 reset r_picmip
+seta r_colorGrading off
 seta r_lightMode 3
 seta r_lightStyles 1
 seta r_realtimeLighting off

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
@@ -11,6 +11,7 @@ seta r_reliefMapping 0
 seta r_heatHaze 0
 seta r_bloom 0
 seta r_subdivisions 12
+seta r_imageFitScreen 2
 seta r_imageMaxDimension 256
 seta r_highPrecisionRendering off
 seta r_ext_texture_filter_anisotropic 2

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
@@ -1,6 +1,6 @@
 seta r_lightMode 3
 seta r_lightStyles 1
-seta r_dynamicLight 0
+seta r_realtimeLighting off
 seta r_halfLambertLighting 1
 seta r_rimLighting 1
 seta r_normalMapping 0

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
@@ -1,8 +1,8 @@
+seta r_lightMode 1
 seta r_lightStyles 0
 seta r_dynamicLight 0
 seta r_halfLambertLighting 1
 seta r_rimLighting 0
-seta r_vertexLighting 0
 seta r_normalMapping 0
 seta r_deluxeMapping 0
 seta r_specularMapping 0

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
@@ -11,6 +11,7 @@ seta r_reliefMapping 0
 seta r_heatHaze 0
 seta r_bloom 0
 seta r_subdivisions 20
+seta r_imageFitScreen 2
 seta r_imageMaxDimension 64
 seta r_highPrecisionRendering off
 seta r_ext_texture_filter_anisotropic 0

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
@@ -1,3 +1,4 @@
+reset r_clear
 seta r_lightMode 1
 seta r_lightStyles 0
 seta r_realtimeLighting off
@@ -14,7 +15,6 @@ seta r_imageMaxDimension 64
 seta r_highPrecisionRendering off
 seta r_ext_texture_filter_anisotropic 0
 seta r_textureMode "GL_LINEAR_MIPMAP_NEAREST"
-seta r_clear 1
 seta r_fastsky on
 seta cg_shadows 0
 seta cg_playerShadows 0

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
@@ -1,6 +1,6 @@
 seta r_lightMode 1
 seta r_lightStyles 0
-seta r_dynamicLight 0
+seta r_realtimeLighting off
 seta r_halfLambertLighting 1
 seta r_rimLighting 0
 seta r_normalMapping 0

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
@@ -1,7 +1,6 @@
 seta r_lightMode 1
 seta r_lightStyles 0
 seta r_realtimeLighting off
-seta r_halfLambertLighting 1
 seta r_rimLighting 0
 seta r_normalMapping 0
 seta r_deluxeMapping 0

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
@@ -12,6 +12,7 @@ seta r_heatHaze 0
 seta r_bloom 0
 seta r_subdivisions 20
 seta r_imageMaxDimension 64
+seta r_highPrecisionRendering off
 seta r_ext_texture_filter_anisotropic 0
 seta r_textureMode "GL_LINEAR_MIPMAP_NEAREST"
 seta r_clear 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
@@ -1,4 +1,5 @@
 reset r_clear
+reset r_picmip
 seta r_lightMode 1
 seta r_lightStyles 0
 seta r_realtimeLighting off
@@ -12,7 +13,7 @@ seta r_heatHaze 0
 seta r_bloom 0
 seta r_subdivisions 20
 seta r_imageFitScreen 2
-seta r_imageMaxDimension 64
+seta r_imageMaxDimension 16
 seta r_highPrecisionRendering off
 seta r_ext_texture_filter_anisotropic 0
 seta r_textureMode "GL_LINEAR_MIPMAP_NEAREST"

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
@@ -15,7 +15,7 @@ seta r_imageMaxDimension 64
 seta r_ext_texture_filter_anisotropic 0
 seta r_textureMode "GL_LINEAR_MIPMAP_NEAREST"
 seta r_clear 1
-seta r_fastsky 1
+seta r_fastsky on
 seta cg_shadows 0
 seta cg_playerShadows 0
 seta cg_buildableShadows 0

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
@@ -1,5 +1,6 @@
 reset r_clear
 reset r_picmip
+seta r_colorGrading off
 seta r_lightMode 1
 seta r_lightStyles 0
 seta r_realtimeLighting off

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
@@ -1,8 +1,8 @@
+seta r_lightMode 3
 seta r_lightStyles 1
 seta r_dynamicLight 0
 seta r_halfLambertLighting 1
 seta r_rimLighting 1
-seta r_vertexLighting 0
 seta r_normalMapping 1
 seta r_deluxeMapping 1
 seta r_specularMapping 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
@@ -1,5 +1,6 @@
 reset r_clear
 reset r_picmip
+seta r_colorGrading on
 seta r_lightMode 3
 seta r_lightStyles 1
 seta r_realtimeLighting off

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
@@ -1,3 +1,4 @@
+reset r_clear
 seta r_lightMode 3
 seta r_lightStyles 1
 seta r_realtimeLighting off
@@ -14,7 +15,6 @@ seta r_imageMaxDimension 512
 seta r_highPrecisionRendering on
 seta r_ext_texture_filter_anisotropic 4
 seta r_textureMode "GL_LINEAR_MIPMAP_LINEAR"
-seta r_clear 1
 seta r_fastsky off
 seta cg_shadows 1
 seta cg_playerShadows 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
@@ -1,4 +1,5 @@
 reset r_clear
+reset r_picmip
 seta r_lightMode 3
 seta r_lightStyles 1
 seta r_realtimeLighting off

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
@@ -15,7 +15,7 @@ seta r_imageMaxDimension 512
 seta r_ext_texture_filter_anisotropic 4
 seta r_textureMode "GL_LINEAR_MIPMAP_LINEAR"
 seta r_clear 1
-seta r_fastsky 0
+seta r_fastsky off
 seta cg_shadows 1
 seta cg_playerShadows 1
 seta cg_buildableShadows 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
@@ -11,6 +11,7 @@ seta r_reliefMapping 0
 seta r_heatHaze 0
 seta r_bloom 1
 seta r_subdivisions 8
+seta r_imageFitScreen 1
 seta r_imageMaxDimension 512
 seta r_highPrecisionRendering on
 seta r_ext_texture_filter_anisotropic 4

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
@@ -1,7 +1,6 @@
 seta r_lightMode 3
 seta r_lightStyles 1
 seta r_realtimeLighting off
-seta r_halfLambertLighting 1
 seta r_rimLighting 1
 seta r_normalMapping 1
 seta r_deluxeMapping 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
@@ -12,6 +12,7 @@ seta r_heatHaze 0
 seta r_bloom 1
 seta r_subdivisions 8
 seta r_imageMaxDimension 512
+seta r_highPrecisionRendering on
 seta r_ext_texture_filter_anisotropic 4
 seta r_textureMode "GL_LINEAR_MIPMAP_LINEAR"
 seta r_clear 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
@@ -1,6 +1,6 @@
 seta r_lightMode 3
 seta r_lightStyles 1
-seta r_dynamicLight 0
+seta r_realtimeLighting off
 seta r_halfLambertLighting 1
 seta r_rimLighting 1
 seta r_normalMapping 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
@@ -1,8 +1,8 @@
+seta r_lightMode 3
 seta r_lightStyles 1
 seta r_dynamicLight 2
 seta r_halfLambertLighting 1
 seta r_rimLighting 1
-seta r_vertexLighting 0
 seta r_normalMapping 1
 seta r_deluxeMapping 1
 seta r_specularMapping 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
@@ -1,3 +1,4 @@
+reset r_clear
 seta r_lightMode 3
 seta r_lightStyles 1
 seta r_realtimeLighting on
@@ -14,7 +15,6 @@ seta r_imageMaxDimension 4096
 seta r_highPrecisionRendering on
 seta r_ext_texture_filter_anisotropic 16
 seta r_textureMode "GL_LINEAR_MIPMAP_LINEAR"
-seta r_clear 1
 seta r_fastsky off
 seta cg_shadows 1
 seta cg_playerShadows 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
@@ -15,7 +15,7 @@ seta r_imageMaxDimension 4096
 seta r_ext_texture_filter_anisotropic 16
 seta r_textureMode "GL_LINEAR_MIPMAP_LINEAR"
 seta r_clear 1
-seta r_fastsky 0
+seta r_fastsky off
 seta cg_shadows 1
 seta cg_playerShadows 1
 seta cg_buildableShadows 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
@@ -11,6 +11,7 @@ seta r_reliefMapping 1
 seta r_heatHaze 1
 seta r_bloom 1
 seta r_subdivisions 1
+seta r_imageFitScreen 1
 seta r_imageMaxDimension 4096
 seta r_highPrecisionRendering on
 seta r_ext_texture_filter_anisotropic 16

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
@@ -1,4 +1,5 @@
 reset r_clear
+reset r_picmip
 seta r_lightMode 3
 seta r_lightStyles 1
 seta r_realtimeLighting on

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
@@ -1,5 +1,6 @@
 reset r_clear
 reset r_picmip
+seta r_colorGrading on
 seta r_lightMode 3
 seta r_lightStyles 1
 seta r_realtimeLighting on

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
@@ -1,6 +1,6 @@
 seta r_lightMode 3
 seta r_lightStyles 1
-seta r_dynamicLight 2
+seta r_realtimeLighting on
 seta r_halfLambertLighting 1
 seta r_rimLighting 1
 seta r_normalMapping 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
@@ -12,6 +12,7 @@ seta r_heatHaze 1
 seta r_bloom 1
 seta r_subdivisions 1
 seta r_imageMaxDimension 4096
+seta r_highPrecisionRendering on
 seta r_ext_texture_filter_anisotropic 16
 seta r_textureMode "GL_LINEAR_MIPMAP_LINEAR"
 seta r_clear 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
@@ -1,7 +1,6 @@
 seta r_lightMode 3
 seta r_lightStyles 1
 seta r_realtimeLighting on
-seta r_halfLambertLighting 1
 seta r_rimLighting 1
 seta r_normalMapping 1
 seta r_deluxeMapping 1

--- a/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
@@ -93,9 +93,9 @@
 			<panel>
 				<h2><translate>Lights</translate></h2>
 				<row>
-					<select cvar="r_vertexLighting">
-						<option value="0"><translate>Light mapping</translate>&nbsp;(<translate>normal</translate>)</option>
-						<option value="1"><translate>Grid lighting</translate>&nbsp;(<translate>low, ugly</translate>)</option>
+					<select cvar="r_lightMode">
+						<option value="3"><translate>Light mapping</translate>&nbsp;(<translate>normal</translate>)</option>
+						<option value="1"><translate>Vertex lighting</translate>&nbsp;(<translate>low, ugly</translate>)</option>
 					</select>
 					<h3><translate>Lighting system</translate></h3>
 				</row>

--- a/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
@@ -123,11 +123,6 @@
 					<select cvar="cg_shadows" style="width:20em;">
 						<option value="0"><translate>None</translate></option>
 						<option value="1"><translate>Blobs</translate>&nbsp;(<translate>low</translate>)</option>
-						<!-- Implementations for those options are broken and can make the game unusable
-						<option value="3"><translate>Exponential mapping</translate></option>
-						<option value="5"><translate>Variance mapping</translate></option>
-						<option value="6"><translate>Exponential + variance</translate>&nbsp;(<translate>high</translate>)</option>
-						-->
 					</select>
 					<h3><translate>Shadows</translate></h3>
 				</row>

--- a/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
@@ -25,7 +25,7 @@
 				<h2><translate>Presets</translate></h2>
 				<row>
 					<button onclick='Cmd.exec("preset presets/graphics/lowest.cfg")'><translate>Lowest</translate></button>
-					<span><translate>Low subdivisions, no sky, no shadow, no bouncing particles, 64-pixel textures…</translate></span>
+					<span><translate>Low subdivisions, no sky, no shadow, no bouncing particles, 16-pixel textures…</translate></span>
 				</row>
 				<row>
 					<button onclick='Cmd.exec("preset presets/graphics/low.cfg")'><translate>Low</translate></button>
@@ -135,13 +135,16 @@
 			<panel>
 				<h2><translate>General</translate></h2>
 				<row>
-					<select cvar="r_picmip" style="width: 20em;">
-						<option value="2"><translate>Low</translate>&nbsp;(1:4)</option>
-						<option value="1"><translate>Medium</translate>&nbsp;(1:2)</option>
-						<option value="0"><translate>Full</translate>&nbsp;(1:1)</option>
+					<select cvar="r_imageMaxDimension">
+						<option value="0"><translate>No limit</translate></option>
+						<option value="4096">4096&nbsp;<translate>(ultra)</translate></option>
+						<option value="2048">2048&nbsp;<translate>(high)</translate></option>
+						<option value="512">512&nbsp;<translate>(medium)</translate></option>
+						<option value="256">256&nbsp;<translate>(low)</translate></option>
+						<option value="16">64&nbsp;<translate>(lowest)</translate></option>
 					</select>
-					<h3><translate>Texture size</translate></h3>
-					<p><translate>Lower texture size is useful for cards with limited video memory (VRAM).</translate></p>
+					<h3><translate>Image size limit</translate></h3>
+					<p><translate>Limit image size to save on memory.</translate></p>
 				</row>
 
 				<row>

--- a/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
@@ -231,6 +231,11 @@
 					<p><translate>Makes bright areas on your screen glow.</translate></p>
 				</row>
 				<row>
+					<h3><translate>Color grading</translate></h3>
+					<input cvar="r_colorGrading" type="checkbox" />
+					<p><translate>Alter colors to create specific ambiences.</translate></p>
+				</row>
+				<row>
 					<h3><translate>Heat-haze</translate></h3>
 					<input cvar="r_heatHaze" type="checkbox" />
 					<p><translate>Simulate air refraction in severe heat.</translate></p>

--- a/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
@@ -144,6 +144,16 @@
 					<p><translate>Lower texture size is useful for cards with limited video memory (VRAM).</translate></p>
 				</row>
 
+				<row>
+					<select cvar="r_imageFitScreen">
+						<option value="2"><translate>No larger than screen</translate></option>
+						<option value="1"><translate>No smaller than screen</translate></option>
+						<option value="0"><translate>No limit</translate></option>
+					</select>
+					<h3><translate>Menu image size limit</translate></h3>
+					<p><translate>Limit menu image size to save on memory.</translate></p>
+				</row>
+
 				<h2><translate>High-precision rendering</translate></h2>
 				<row>
 					<input cvar="r_highPrecisionRendering" type="checkbox" />

--- a/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
@@ -106,7 +106,7 @@
 				</row>
 				<row>
 					<h3><translate>Dynamic lights</translate></h3>
-					<input cvar="r_dynamicLight" type="checkbox" checked-value="2" />
+					<input cvar="r_realtimeLighting" type="checkbox" />
 					<p><translate>Realtime dynamic lights emitted by moving objects like weapons and buildings.</translate></p>
 				</row>
 				<row>

--- a/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
@@ -101,7 +101,7 @@
 				</row>
 				<row>
 					<h3><translate>Light styles</translate></h3>
-					<input cvar="r_lightStyles" type="checkbox" checked-value="1" />
+					<input cvar="r_lightStyles" type="checkbox" />
 					<p><translate>Precomputed dynamic lights emitted by static map objects.</translate></p>
 				</row>
 				<row>

--- a/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
@@ -144,6 +144,11 @@
 					<p><translate>Lower texture size is useful for cards with limited video memory (VRAM).</translate></p>
 				</row>
 
+				<h2><translate>High-precision rendering</translate></h2>
+				<row>
+					<input cvar="r_highPrecisionRendering" type="checkbox" />
+					<p><translate>Use high-precision pixel buffers, which reduce color banding.</translate></p>
+				</row>
 				<h2><translate>Mip-mapping</translate></h2>
 				<p><translate>Mip-mapping makes distant surfaces look better by using lower-resolution textures on them. This generally does not affect performance.</translate></p>
 				<row>


### PR DESCRIPTION
The graphics menu now list light mapping and vertex lighting and makes use of the r_lightMode cvar.

The lowest graphics preset now uses vertex lighting.

See:

- https://github.com/DaemonEngine/Daemon/pull/992