### PR TITLE
sgame: fix a crash (regression) with missing string in entity list

### DIFF
--- a/src/sgame/sg_map_entity.h
+++ b/src/sgame/sg_map_entity.h
@@ -305,6 +305,11 @@ struct mapEntity_t
 
 	char const* nameList() const
 	{
+		if ( names[0] == nullptr )
+		{
+			return "";
+		}
+
 		static std::string buffer;
 		buffer = names[0];
 		for ( size_t i = 1; i < MAX_ENTITY_ALIASES; ++i )


### PR DESCRIPTION
Fixes #2897:

- https://github.com/Unvanquished/Unvanquished/issues/2897