### PR TITLE
Allow using binds in some circle menus

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/alien_build.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/alien_build.rml
@@ -121,7 +121,7 @@
 	end
 </script>
 </head>
-<body id="alien_build" class="circlemenu alien" onkeydown="CirclemenuHandleKey(event, document, AlienBuildableClick)" onshow="BuildAlienBuildMenu(document)">
+<body id="alien_build" class="circlemenu alien" onkeydown="CirclemenuHandleKey(event, document, AlienBuildableClick)" onshow="CloseOtherCirclemenus(event) BuildAlienBuildMenu(document)">
 <tabset class="circlemenu">
 <tab><translate>Build</translate></tab>
 <panel>

--- a/pkg/unvanquished_src.dpkdir/ui/alien_evo.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/alien_evo.rml
@@ -136,7 +136,7 @@
 	end
 </script>
 </head>
-<body id="alien_evo" class="circlemenu alien" onkeydown="CirclemenuHandleKey(event, document, EvolutionClick)" onshow="BuildEvolveMenu(document)">
+<body id="alien_evo" class="circlemenu alien" onkeydown="CirclemenuHandleKey(event, document, EvolutionClick)" onshow="CloseOtherCirclemenus(event) BuildEvolveMenu(document)">
 <tabset class="circlemenu">
 <tab><translate>Evolve</translate></tab>
 <panel>

--- a/pkg/unvanquished_src.dpkdir/ui/human_build.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/human_build.rml
@@ -122,7 +122,7 @@
 	end
 </script>
 </head>
-<body id="human_build" class="circlemenu human" onkeydown="CirclemenuHandleKey(event, document, HumanBuildableClick)" onshow="BuildHumanBuildMenu(document)">
+<body id="human_build" class="circlemenu human" onkeydown="CirclemenuHandleKey(event, document, HumanBuildableClick)" onshow="CloseOtherCirclemenus(event) BuildHumanBuildMenu(document)">
 <tabset class="circlemenu">
 <tab><translate>Build</translate></tab>
 <panel>

--- a/pkg/unvanquished_src.dpkdir/ui/human_buy.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/human_buy.rml
@@ -193,6 +193,7 @@
 				local tabset = Element.As.ElementTabSet(document:GetElementById("tabset"))
 				if event.parameters.key_identifier == rmlui.key_identifier.TAB then
 					tabset.active_tab = tabset.active_tab + 1 <= tabset.num_tabs and tabset.active_tab + 1 or 1
+					event:StopPropagation()
 				else
 					local handler = ({[1]=WeaponClick, [2]=UpgradeClick})[tabset.active_tab]
 					CirclemenuHandleKey(event, document, handler)

--- a/pkg/unvanquished_src.dpkdir/ui/human_buy.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/human_buy.rml
@@ -202,7 +202,7 @@
 		</script>
 	</head>
 	<body id="human_buy" class="circlemenu human" onkeydown="HumanBuyHandleKey(event, document)"
-	 onshow="WeaponClear(document) UpgradeClear(document) BuildWeaponMenu(document) BuildUpgradeMenu(document)"
+	 onshow="CloseOtherCirclemenus(event) WeaponClear(document) UpgradeClear(document) BuildWeaponMenu(document) BuildUpgradeMenu(document)"
 	 onrefreshdata="BuildWeaponMenu(document) BuildUpgradeMenu(document)">
 	<tabset class="circlemenu" id="tabset">
 		<tab onclick="WeaponClear(document) BuildWeaponMenu(document)">

--- a/pkg/unvanquished_src.dpkdir/ui/ingame_beaconmenu.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/ingame_beaconmenu.rml
@@ -73,7 +73,7 @@
 			end
 		</script>
 	</head>
-	<body id="ingame_beaconmenu" class="circlemenu" onkeydown="CirclemenuHandleKey(event, document, BeaconClick)" onshow="BuildBeaconMenu(document)">
+	<body id="ingame_beaconmenu" class="circlemenu" onkeydown="CirclemenuHandleKey(event, document, BeaconClick)" onshow="CloseOtherCirclemenus(event) BuildBeaconMenu(document)">
 		<tabset class="circlemenu">
 			<tab><translate>Beacons</translate></tab>
 			<panel>

--- a/pkg/unvanquished_src.dpkdir/ui/lua/util.lua
+++ b/pkg/unvanquished_src.dpkdir/ui/lua/util.lua
@@ -41,6 +41,7 @@ function detectEscape(event, document)
 				v:Hide()
 			end
 		end
+		event:StopPropagation()
 	end
 end
 
@@ -101,6 +102,7 @@ function CirclemenuHandleKey(event, document, num_handler)
 		return
 	end
 	num_handler(index, event)
+	event:StopPropagation()
 end
 
 function welcome(event, document)

--- a/pkg/unvanquished_src.dpkdir/ui/lua/util.lua
+++ b/pkg/unvanquished_src.dpkdir/ui/lua/util.lua
@@ -105,6 +105,23 @@ function CirclemenuHandleKey(event, document, num_handler)
 	event:StopPropagation()
 end
 
+circlemenu_documents = {
+	"alien_build",
+	"alien_evo",
+	"human_build",
+	"human_buy",
+	"ingame_beaconmenu",
+}
+function CloseOtherCirclemenus(event)
+	-- The event is assumed to be on the <body> element
+	my_id = event.target_element.id
+	for _, doc_id in ipairs(circlemenu_documents) do
+		if doc_id ~= my_id then
+			Events.pushcmd("hide " .. doc_id)
+		end
+	end
+end
+
 function welcome(event, document)
 	if Cvar.get("cg_welcome") ~= "1" and Cvar.get("name") == "UnnamedPlayer" then
 		Cvar.set("name", "Player#" .. math.ceil(math.random()*10000000))

--- a/pkg/unvanquished_src.dpkdir/ui/options_mouse.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_mouse.rml
@@ -31,5 +31,10 @@
 			<input cvar="cl_freelook" type="checkbox" />
 			<p><translate>Turn off only if you are a Quake junkie.</translate></p>
 		</row>
+		<row>
+			<h3><translate>Circle menu mouse capture</translate></h3>
+			<input cvar="cg_circleMenusCaptureMouse" type="checkbox" />
+			<p><translate>Circle menus (excluding Armoury menu) take mouse inputs</translate></p>
+		</row>
 	</body>
 </rml>

--- a/pkg/unvanquished_src.dpkdir/ui/rocket.txt
+++ b/pkg/unvanquished_src.dpkdir/ui/rocket.txt
@@ -23,12 +23,12 @@
 		ui/ingame_teamselect.rml ingame_teamselect             // ROCKETMENU_TEAMSELECT
 		ui/human_spawn.rml human_spawn                         // ROCKETMENU_HUMANSPAWN
 		ui/alien_spawn.rml alien_spawn                         // ROCKETMENU_ALIENSPAWN
-		ui/alien_build.rml alien_build                         // ROCKETMENU_ALIENBUILD
-		ui/human_build.rml human_build                         // ROCKETMENU_HUMANBUILD
+		ui/alien_build.rml alien_build passthrough             // ROCKETMENU_ALIENBUILD
+		ui/human_build.rml human_build passthrough             // ROCKETMENU_HUMANBUILD
 		ui/human_buy.rml human_buy                             // ROCKETMENU_ARMOURYBUY
-		ui/alien_evo.rml alien_evo                             // ROCKETMENU_ALIENEVOLVE
+		ui/alien_evo.rml alien_evo passthrough                 // ROCKETMENU_ALIENEVOLVE
 		ui/ingame_chat.rml ingame_chat                         // ROCKETMENU_CHAT
-		ui/ingame_beaconmenu.rml ingame_beaconmenu             // ROCKETMENU_BEACONS
+		ui/ingame_beaconmenu.rml ingame_beaconmenu passthrough // ROCKETMENU_BEACONS
 		ui/error.rml error                                     // ROCKETMENU_ERROR
 		ui/welcome.rml welcome                                 // ROCKETMENU_WELCOME
 	}

--- a/src/cgame/cg_api.cpp
+++ b/src/cgame/cg_api.cpp
@@ -89,9 +89,16 @@ void VM::VMHandleSyscall(uint32_t id, Util::Reader reader) {
                 });
                 break;
 
-            case CG_KEY_EVENT:
-                IPC::HandleMsg<CGameKeyEventMsg>(VM::rootChannel, std::move(reader), [] (Keyboard::Key key, bool down) {
-                    CG_KeyEvent(key, down);
+            case CG_KEY_DOWN_EVENT:
+                IPC::HandleMsg<CGameKeyDownEventMsg>(VM::rootChannel, std::move(reader), [] (Keyboard::Key key, bool /*repeat*/, bool& consumed) {
+                    consumed = CG_KeyEvent(key, true);
+                    cmdBuffer.TryFlush();
+                });
+                break;
+
+            case CG_KEY_UP_EVENT:
+                IPC::HandleMsg<CGameKeyUpEventMsg>(VM::rootChannel, std::move(reader), [] (Keyboard::Key key) {
+                    CG_KeyEvent(key, false);
                     cmdBuffer.TryFlush();
                 });
                 break;

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -120,12 +120,6 @@ void CG_MousePosEvent( int x, int y )
 	{
 		Rocket_MouseMove( x, y );
 	}
-	else if ( ( cg.predictedPlayerState.pm_type == PM_NORMAL ||
-	       cg.predictedPlayerState.pm_type == PM_SPECTATOR ) &&
-	     !cg.showScores )
-	{
-		CG_SetKeyCatcher( 0 );
-	}
 }
 
 void CG_KeyEvent( Keyboard::Key key, bool down )
@@ -133,12 +127,6 @@ void CG_KeyEvent( Keyboard::Key key, bool down )
 	if ( rocketInfo.keyCatcher & KEYCATCH_UI )
 	{
 		Rocket_ProcessKeyInput( key, down );
-	}
-	else if ( cg.predictedPlayerState.pm_type == PM_NORMAL ||
-	     ( cg.predictedPlayerState.pm_type == PM_SPECTATOR &&
-	       !cg.showScores ) )
-	{
-		CG_SetKeyCatcher( 0 );
 	}
 }
 

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // active (after loading) gameplay
 
 #include "cg_local.h"
+#include "rocket/rocket.h"
 
 /*
 ==============
@@ -124,8 +125,7 @@ void CG_MousePosEvent( int x, int y )
 
 bool CG_KeyEvent( Keyboard::Key key, bool down )
 {
-	if ( down && key == Keyboard::Key(K_ESCAPE) &&
-		!( rocketInfo.keyCatcher & ( KEYCATCH_UI_KEY | KEYCATCH_UI_MOUSE ) ) )
+	if ( down && key == Keyboard::Key(K_ESCAPE) && !CG_AnyMenuOpen() )
 	{
 		// Open the main menu if no menus are open
 		trap_SendConsoleCommand( "toggleMenu" );

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -116,18 +116,24 @@ void CG_MousePosEvent( int x, int y )
 {
 	rocketInfo.cursor_pos.x = x;
 	rocketInfo.cursor_pos.y = y;
-	if ( rocketInfo.keyCatcher & KEYCATCH_UI)
+	if ( rocketInfo.keyCatcher & KEYCATCH_UI_MOUSE )
 	{
 		Rocket_MouseMove( x, y );
 	}
 }
 
-void CG_KeyEvent( Keyboard::Key key, bool down )
+bool CG_KeyEvent( Keyboard::Key key, bool down )
 {
-	if ( rocketInfo.keyCatcher & KEYCATCH_UI )
+	if ( down && key == Keyboard::Key(K_ESCAPE) &&
+		!( rocketInfo.keyCatcher & ( KEYCATCH_UI_KEY | KEYCATCH_UI_MOUSE ) ) )
 	{
-		Rocket_ProcessKeyInput( key, down );
+		// Open the main menu if no menus are open
+		trap_SendConsoleCommand( "toggleMenu" );
+
+		return true;
 	}
+
+	return Rocket_ProcessKeyInput( key, down );
 }
 
 void CG_RunMenuScript( char **args )

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -652,7 +652,7 @@ Called on upgrade change
 void CG_Rocket_UpdateArmouryMenu()
 {
 	// Rebuild weapon lists if UI is in focus.
-	if ( rocketInfo.keyCatcher & KEYCATCH_UI && CG_MyTeam() == TEAM_HUMANS )
+	if ( menuContext && rocketInfo.menu[ ROCKETMENU_ARMOURYBUY ].id )
 	{
 		Rml::ElementDocument* document = menuContext->GetDocument( rocketInfo.menu[ ROCKETMENU_ARMOURYBUY ].id );
 		if ( document->IsVisible() )

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1342,6 +1342,7 @@ struct rocketMenu_t
 {
 	const char *path;
 	const char *id;
+	bool passthrough; // whether binds can be used while the menu is open
 };
 
 #define MAX_SERVERS 2048
@@ -1920,7 +1921,7 @@ void       CG_NotifyHooks();
 void       CG_UpdateCvars();
 
 int        CG_CrosshairPlayer();
-void       CG_KeyEvent( Keyboard::Key key, bool down );
+bool       CG_KeyEvent( Keyboard::Key key, bool down );
 void       CG_MouseEvent( int dx, int dy );
 void       CG_MousePosEvent( int x, int y );
 void       CG_FocusEvent( bool focus );
@@ -2399,7 +2400,7 @@ void Rocket_AddUnitToHud( int weapon, const char *id );
 void Rocket_ShowHud( int weapon );
 void Rocket_ClearHud( unsigned weapon );
 void Rocket_InitKeys();
-void Rocket_ProcessKeyInput( Keyboard::Key key, bool down );
+bool Rocket_ProcessKeyInput( Keyboard::Key key, bool down );
 void Rocket_ProcessTextInput( int c );
 void Rocket_MouseMove( int x, int y );
 void Rocket_RegisterProperty( const char *name, const char *defaultValue, bool inherited, bool force_layout, const char *parseAs );

--- a/src/cgame/cg_rocket.cpp
+++ b/src/cgame/cg_rocket.cpp
@@ -135,6 +135,22 @@ void CG_Rocket_Init( glconfig_t gl )
 				}
 
 				rocketInfo.menu[ i ].id = BG_strdup( token );
+
+				token = COM_ParseExt2( &text_p, false );
+
+				if ( !*token )
+				{
+					rocketInfo.menu[ i ].passthrough = false;
+				}
+				else if ( Str::IsIEqual( token, "passthrough" ) )
+				{
+					rocketInfo.menu[ i ].passthrough = true;
+				}
+				else
+				{
+					Sys::Drop( "Error parsing %s. Unexpected token '%s', expected 'passthrough' or end of line",
+						rocket_menuFile.Get(), token );
+				}
 			}
 
 			token = COM_Parse2( &text_p );
@@ -237,7 +253,7 @@ void CG_Rocket_Init( glconfig_t gl )
 		Rocket_DocumentAction( rocketInfo.menu[ ROCKETMENU_ERROR ].id, "open" );
 	}
 
-	CG_SetKeyCatcher( rocketInfo.keyCatcher | KEYCATCH_UI );
+	CG_SetKeyCatcher( rocketInfo.keyCatcher | KEYCATCH_UI_KEY | KEYCATCH_UI_MOUSE );
 }
 
 void CG_Rocket_LoadHuds()

--- a/src/cgame/rocket/rocket.cpp
+++ b/src/cgame/rocket/rocket.cpp
@@ -321,6 +321,10 @@ static RocketFocusManager fm;
 Rml::Context *menuContext = nullptr;
 Rml::Context *hudContext = nullptr;
 
+Cvar::Cvar<bool> cg_circleMenusCaptureMouse(
+	"cg_circleMenusCaptureMouse", "circlemenus (except armoury) take mouse inputs",
+	Cvar::NONE, true);
+
 Rml::PropertyId UnvPropertyId::Orientation;
 
 // TODO
@@ -453,9 +457,9 @@ void Rocket_Shutdown()
 	trap_RemoveCommand( "rocketDebug" );
 }
 
-static bool ShouldDrawMenu()
+bool CG_AnyMenuOpen()
 {
-	return trap_Key_GetCatcher() & KEYCATCH_UI_MOUSE;
+	return fm.GetState() != VisibleMenusState::NONE;
 }
 
 void Rocket_Render()
@@ -467,7 +471,7 @@ void Rocket_Render()
 	}
 
 	// Render menus on top of the HUD
-	if ( ShouldDrawMenu() && menuContext )
+	if ( CG_AnyMenuOpen() && menuContext )
 	{
 		menuContext->Render();
 	}
@@ -476,7 +480,7 @@ void Rocket_Render()
 
 void Rocket_Update()
 {
-	if ( ShouldDrawMenu() )
+	if ( CG_AnyMenuOpen() )
 	{
 		menuContext->Update();
 	}

--- a/src/cgame/rocket/rocket.cpp
+++ b/src/cgame/rocket/rocket.cpp
@@ -453,7 +453,10 @@ void Rocket_Shutdown()
 	trap_RemoveCommand( "rocketDebug" );
 }
 
-static bool drawMenu;
+static bool ShouldDrawMenu()
+{
+	return trap_Key_GetCatcher() & KEYCATCH_UI_MOUSE;
+}
 
 void Rocket_Render()
 {
@@ -464,7 +467,7 @@ void Rocket_Render()
 	}
 
 	// Render menus on top of the HUD
-	if ( drawMenu && menuContext )
+	if ( ShouldDrawMenu() && menuContext )
 	{
 		menuContext->Render();
 	}
@@ -473,7 +476,7 @@ void Rocket_Render()
 
 void Rocket_Update()
 {
-	if ( drawMenu && menuContext )
+	if ( ShouldDrawMenu() )
 	{
 		menuContext->Update();
 	}
@@ -679,8 +682,7 @@ static EngineCursor engineCursor;
 
 void Rocket_SetActiveContext( int catcher )
 {
-	drawMenu = catcher & KEYCATCH_UI;
-	engineCursor.Show( catcher & ( KEYCATCH_UI | KEYCATCH_CONSOLE ) );
+	engineCursor.Show( catcher );
 }
 
 void CG_FocusEvent( bool has_focus )

--- a/src/cgame/rocket/rocket.h
+++ b/src/cgame/rocket/rocket.h
@@ -49,6 +49,8 @@ Maryland 20850 USA.
 extern Rml::Context *menuContext;
 extern Rml::Context *hudContext;
 
+extern Cvar::Cvar<bool> cg_circleMenusCaptureMouse;
+
 class RocketEvent_t
 {
 public:
@@ -78,6 +80,8 @@ std::string CG_KeyBinding( const char *bind, int team );
 
 void Rocket_AddEvent( RocketEvent_t *event );
 void Rocket_SetDocumentScale( Rml::ElementDocument& document );
+
+bool CG_AnyMenuOpen();
 
 struct UnvPropertyId {
 	static Rml::PropertyId Orientation;

--- a/src/cgame/rocket/rocket_keys.cpp
+++ b/src/cgame/rocket/rocket_keys.cpp
@@ -187,7 +187,7 @@ static KeyModifier Rocket_GetKeyModifiers()
 static void Rocket_ProcessMouseClick( int button, bool down )
 {
 	static bool wasDownBefore = false;
-	if ( !menuContext || rocketInfo.keyCatcher & KEYCATCH_CONSOLE || !rocketInfo.keyCatcher )
+	if ( !menuContext || rocketInfo.keyCatcher & KEYCATCH_CONSOLE || !( rocketInfo.keyCatcher & KEYCATCH_UI_MOUSE ) )
 	{
 		return;
 	}
@@ -228,11 +228,11 @@ static void Rocket_ProcessMouseClick( int button, bool down )
 }
 
 #define MOUSEWHEEL_DELTA 5
-void Rocket_ProcessKeyInput( Keyboard::Key key, bool down )
+bool Rocket_ProcessKeyInput( Keyboard::Key key, bool down )
 {
-	if ( !menuContext || rocketInfo.keyCatcher & KEYCATCH_CONSOLE || !rocketInfo.keyCatcher )
+	if ( !menuContext || rocketInfo.keyCatcher & KEYCATCH_CONSOLE || !( rocketInfo.keyCatcher & KEYCATCH_UI_MOUSE ) )
 	{
-		return;
+		return false;
 	}
 
 	keyNum_t keynum = key.AsKeynum();
@@ -240,7 +240,10 @@ void Rocket_ProcessKeyInput( Keyboard::Key key, bool down )
 	if ( ( keynum >= K_MOUSE1 && keynum <= K_MOUSE5 ) || ( keynum >= K_AUX1 && keynum <= K_AUX16 ) )
 	{
 		Rocket_ProcessMouseClick( keynum, down );
-		return;
+		// TODO detect whether mouse click is consumed?
+		// Well it would probably be weird and bad if MOUSE1 were not consumed by the menu,
+		// but like MOUSE3 could be useful
+		return true;
 	}
 
 	if ( ( keynum == K_MWHEELDOWN || keynum == K_MWHEELUP ) )
@@ -249,17 +252,17 @@ void Rocket_ProcessKeyInput( Keyboard::Key key, bool down )
 		// We only want to catch one of these.
 		if ( !down )
 		{
-			return;
+			return false;
 		}
 
-		menuContext->ProcessMouseWheel( keynum == K_MWHEELDOWN ? MOUSEWHEEL_DELTA : -MOUSEWHEEL_DELTA, Rocket_GetKeyModifiers() );
-		return;
+		return !menuContext->ProcessMouseWheel( keynum == K_MWHEELDOWN ? MOUSEWHEEL_DELTA : -MOUSEWHEEL_DELTA, Rocket_GetKeyModifiers() );
 	}
 	KeyIdentifier rocketKey = Rocket_FromQuake( key.AsLegacyInt() );
 	if ( down )
 	{
+		bool consumed = false;
 		if (rocketKey != KI_UNKNOWN) {
-			menuContext->ProcessKeyDown( rocketKey, Rocket_GetKeyModifiers() );
+			consumed = !menuContext->ProcessKeyDown( rocketKey, Rocket_GetKeyModifiers() );
 		}
 		Rml::Element* focus = menuContext->GetFocusElement();
 		if ( focus != nullptr ) {
@@ -269,19 +272,23 @@ void Rocket_ProcessKeyInput( Keyboard::Key key, bool down )
 			// it will cancel the binding and not bind Escape.
 			focus->DispatchEvent( BINDABLE_KEY_EVENT, dict );
 		}
+		// This will be incorrect if it was consumed by the bind menu, but the bind
+		// menu should have KEYCATCH_UI_KEY on so it doesn't matter
+		return consumed;
 	}
 	else
 	{
 		if (rocketKey != KI_UNKNOWN) {
-			menuContext->ProcessKeyUp( rocketKey, Rocket_GetKeyModifiers() );
+			return !menuContext->ProcessKeyUp( rocketKey, Rocket_GetKeyModifiers() );
 		}
+		return false;
 	}
 }
 
 
 void Rocket_ProcessTextInput( int c )
 {
-	if ( !menuContext || rocketInfo.keyCatcher & KEYCATCH_CONSOLE || !rocketInfo.keyCatcher )
+	if ( !menuContext || rocketInfo.keyCatcher & KEYCATCH_CONSOLE || !( rocketInfo.keyCatcher & KEYCATCH_UI_KEY ) )
 	{
 		return;
 	}
@@ -299,7 +306,7 @@ void Rocket_ProcessTextInput( int c )
 
 void Rocket_MouseMove( int x, int y )
 {
-	if ( !menuContext || ! ( rocketInfo.keyCatcher & KEYCATCH_UI ) || rocketInfo.cursorFreezeTime == rocketInfo.realtime )
+	if ( !menuContext || ! ( rocketInfo.keyCatcher & KEYCATCH_UI_MOUSE ) || rocketInfo.cursorFreezeTime == rocketInfo.realtime )
 	{
 		return;
 	}

--- a/src/cgame/rocket/rocket_keys.cpp
+++ b/src/cgame/rocket/rocket_keys.cpp
@@ -230,7 +230,7 @@ static void Rocket_ProcessMouseClick( int button, bool down )
 #define MOUSEWHEEL_DELTA 5
 bool Rocket_ProcessKeyInput( Keyboard::Key key, bool down )
 {
-	if ( !menuContext || rocketInfo.keyCatcher & KEYCATCH_CONSOLE || !( rocketInfo.keyCatcher & KEYCATCH_UI_MOUSE ) )
+	if ( !menuContext || rocketInfo.keyCatcher & KEYCATCH_CONSOLE || !CG_AnyMenuOpen() )
 	{
 		return false;
 	}
@@ -239,6 +239,11 @@ bool Rocket_ProcessKeyInput( Keyboard::Key key, bool down )
 	// Our input system sends mouse events as key presses.
 	if ( ( keynum >= K_MOUSE1 && keynum <= K_MOUSE5 ) || ( keynum >= K_AUX1 && keynum <= K_AUX16 ) )
 	{
+		if ( !( rocketInfo.keyCatcher & KEYCATCH_UI_MOUSE ) )
+		{
+			return false;
+		}
+
 		Rocket_ProcessMouseClick( keynum, down );
 		// TODO detect whether mouse click is consumed?
 		// Well it would probably be weird and bad if MOUSE1 were not consumed by the menu,
@@ -248,6 +253,11 @@ bool Rocket_ProcessKeyInput( Keyboard::Key key, bool down )
 
 	if ( ( keynum == K_MWHEELDOWN || keynum == K_MWHEELUP ) )
 	{
+		if ( !( rocketInfo.keyCatcher & KEYCATCH_UI_MOUSE ) )
+		{
+			return false;
+		}
+
 		// Our input system sends an up event right after a down event
 		// We only want to catch one of these.
 		if ( !down )


### PR DESCRIPTION
Stacked on #2899. It's not really entwined with that, but first I had to fix the bind menu, to ensure that I am not breaking it.

Engine companion: https://github.com/DaemonEngine/Daemon/pull/1030

> It is now possible to use binds while the evolve menu, build menu, or
beacon menu is open. So, for example, you can walk forward while
choosing an alien class, or use wallwalk in non-toggling mode while
choosing a structure as Advanced Granger.

> A menu may be configured to allow binds at the same time by adding the
"passthrough" keyword in rocket.txt. This means that the menu will only
capture keystrokes that do something in the menu (e.g. numbers in circle
menus), while unconsumed keystrokes will be processed as binds. Note
that mouse clicks and mouse movements are still always captured by any
open menu.

> I excluded the armory menu because it might be frustrating for purchases
to fail due to having moved too far from the armory.

Fixes #1195.