### PR TITLE
voting improvements - add colours and formatting

### DIFF
--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -3530,15 +3530,18 @@ static void CG_Rocket_DrawVote_internal( team_t team )
 	std::string yeskey = CG_EscapeHTMLText( CG_KeyBinding( va( "%svote yes", team == TEAM_NONE ? "" : "team" ), bindTeam ) );
 	std::string nokey = CG_EscapeHTMLText( CG_KeyBinding( va( "%svote no", team == TEAM_NONE ? "" : "team" ), bindTeam ) );
 	std::string voteString = CG_EscapeHTMLText( cgs.voteString[ team ] );
-	Rml::String caller = Rocket_QuakeToRML( cgs.voteCaller[ team ], RP_EMOTICONS ); // colors are stripped by the server
-	// The byte sequences are U+E8DC/U+E8DB - thumbs up/down in our icon font
-	std::string s = Str::Format( "%sVOTE(%i): %s\n"
-			"    Called by: \"%s\"\n"
-			"    [%s][<span class='material-icon'>\xee\xa3\x9c</span>]:%i [%s][<span class='material-icon'>\xee\xa3\x9b</span>]:%i\n",
-			team == TEAM_NONE ? "" : "TEAM", sec, voteString,
-			caller.c_str(), yeskey, cgs.voteYes[ team ], nokey, cgs.voteNo[ team ] );
+	int timerColor = ( sec > 10 ? 7 : 1 );
+	int timerColor2 = ( sec > 10 ? 3 : 7 );
 
-	Rocket_SetInnerRMLRaw( s.c_str() );
+	std::string s = Str::Format( "^3%sVOTE: ^7%s\n"
+			"^7Called by: %s\n"
+			"^7[^2%s^7] [check]: %i [^1%s^7] [cross]: %i\n"
+			"^%iEnds in ^%i%i ^%iseconds\n",
+			team == TEAM_NONE ? "" : "TEAM", voteString,
+			cgs.voteCaller[ team ], yeskey, cgs.voteYes[ team ], nokey, cgs.voteNo[ team ], 
+			timerColor, timerColor2, sec, timerColor );
+
+	Rocket_SetInnerRML( s.c_str(), RP_EMOTICONS );
 }
 
 static void CG_Rocket_DrawVersion()

--- a/src/sgame/sg_votes.cpp
+++ b/src/sgame/sg_votes.cpp
@@ -721,6 +721,10 @@ void G_HandleVote( gentity_t* ent )
 		trap_SendServerCommand( -1, va( "print_tr %s %s %s", QQ( N_( "$1$^* called a vote: $2$" ) ),
 		                                Quote( ent->client->pers.netname ),
 		                                Quote( level.team[ team ].voteDisplayString ) ) );
+
+		trap_SendServerCommand( -1, va( "cp_tr %s %s %s", QQ( N_( "$1$^7 called a vote:\n^7$2$" ) ),
+		                                Quote( ent->client->pers.netname ),
+		                                Quote( level.team[ team ].voteDisplayString ) ) );
 	}
 	else
 	{
@@ -735,14 +739,19 @@ void G_HandleVote( gentity_t* ent )
 				       G_admin_permission( &g_entities[ i ], ADMF_SPEC_ALLCHAT ) ) )
 				{
 					trap_SendServerCommand(
-						i, va( "print_tr %s %s %s", QQ( N_( "$1$^* called a team vote: $2t$" ) ),
+					    i, va( "print_tr %s %s %s", QQ( N_( "$1$^* called a team vote: $2t$" ) ),
+					           Quote( ent->client->pers.netname ),
+					           Quote( level.team[ team ].voteDisplayString ) ) );
+				
+					trap_SendServerCommand(
+					    i, va( "cp_tr %s %s %s", QQ( N_( "$1$^7 called a team vote:\n^7$2t$" ) ),
 					           Quote( ent->client->pers.netname ),
 					           Quote( level.team[ team ].voteDisplayString ) ) );
 				}
 				else if ( G_admin_permission( &g_entities[ i ], ADMF_ADMINCHAT ) )
 				{
 					trap_SendServerCommand(
-						i, va( "chat -1 %d ^3%s\"^3 called a team vote (%ss): \"%s", SAY_ADMINS,
+					    i, va( "chat -1 %d ^3%s\"^3 called a team vote (%ss): \"%s", SAY_ADMINS,
 					           Quote( ent->client->pers.netname ), BG_TeamName( team ),
 					           Quote( level.team[ team ].voteDisplayString ) ) );
 				}
@@ -750,13 +759,10 @@ void G_HandleVote( gentity_t* ent )
 		}
 	}
 
-	std::string caller = ent->client->pers.netname;
-	caller = Color::StripColors( caller );
-
 	level.team[ team ].voteTime = level.time;
 	trap_SetConfigstring( CS_VOTE_TIME + team, va( "%d", level.team[ team ].voteTime ) );
 	trap_SetConfigstring( CS_VOTE_STRING + team, level.team[ team ].voteDisplayString );
-	trap_SetConfigstring( CS_VOTE_CALLER + team, caller.c_str() );
+	trap_SetConfigstring( CS_VOTE_CALLER + team, ent->client->pers.netname );
 
 	if ( vi.special != VOTE_NO_AUTO )
 	{


### PR DESCRIPTION
This PR changes the vote style to be less ugly. Now it will no longer to sometimes wrap text in an ugly way if the string is too long. It will also now use Quake colour codes and display name colours correctly.

A CenterPrint message is also sent to the relevant clients when the vote is started.

![image](https://github.com/Unvanquished/Unvanquished/assets/13281185/2c53d9cf-e017-4122-8167-7fdde8f6e0a6)

The countdown timer will become red after 10 seconds in the hope that it draws more attention to itself.

![image](https://github.com/Unvanquished/Unvanquished/assets/13281185/1f194e0b-8645-4090-abca-e5f02c204d78)

In future perhaps we could replace the check / cross emoticons to be nicer than these ones but for now I think this is acceptable.
