### PR TITLE
Put navgen use-other-class setting in code + optionally generate less

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1065,7 +1065,13 @@ static void GenerateNavmeshes()
 	std::string mapName = Cvar::GetValue( "mapname" );
 	std::vector<class_t> missing;
 	NavgenConfig config = ReadNavgenConfig( mapName );
-	for ( class_t species : RequiredNavmeshes() )
+	bool reduceTypes;
+	if ( !Cvar::ParseCvarValue( Cvar::GetValue( "g_bot_navmeshReduceTypes" ), reduceTypes ) )
+	{
+		ASSERT_UNREACHABLE(); // sgame should have been loaded and this cvar initialized
+	}
+
+	for ( class_t species : RequiredNavmeshes( reduceTypes ) )
 	{
 		fileHandle_t f;
 		std::string filename = NavmeshFilename( mapName, species );

--- a/src/sgame/botlib/bot_nav.cpp
+++ b/src/sgame/botlib/bot_nav.cpp
@@ -114,16 +114,7 @@ void G_BotEnableArea( const glm::vec3 &origin, const glm::vec3 &mins, const glm:
 
 void G_BotSetNavMesh( int botClientNum, class_t newClass )
 {
-	const classModelConfig_t *model = BG_ClassModelConfig( newClass );
-	if ( model->navMeshClass )
-	{
-		newClass = model->navMeshClass;
-		if ( BG_ClassModelConfig( model->navMeshClass )->navMeshClass != PCL_NONE )
-		{
-			Log::Warn( "useNavMesh must not chain (%s -> %s -> ...)",
-			           model->humanName, BG_ClassModelConfig( model->navMeshClass )->humanName );
-		}
-	}
+	newClass = NavmeshForClass( newClass );
 
 	NavData_t *nav = nullptr;
 

--- a/src/sgame/botlib/bot_nav.cpp
+++ b/src/sgame/botlib/bot_nav.cpp
@@ -114,7 +114,7 @@ void G_BotEnableArea( const glm::vec3 &origin, const glm::vec3 &mins, const glm:
 
 void G_BotSetNavMesh( int botClientNum, class_t newClass )
 {
-	newClass = NavmeshForClass( newClass );
+	newClass = NavmeshForClass( newClass, g_bot_navmeshReduceTypes.Get() );
 
 	NavData_t *nav = nullptr;
 

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -6222,7 +6222,7 @@ bool G_admin_navgen( gentity_t* ent )
 	{
 		if ( Str::IsIEqual( args.Argv( i ), "all" ) )
 		{
-			for ( class_t species : RequiredNavmeshes() )
+			for ( class_t species : RequiredNavmeshes( g_bot_navmeshReduceTypes.Get() ) )
 			{
 				targets[ species ] = true;
 			}
@@ -6230,7 +6230,7 @@ bool G_admin_navgen( gentity_t* ent )
 		else if ( Str::IsIEqual ( args.Argv( i ), "missing" ) )
 		{
 			NavgenConfig config = ReadNavgenConfig( mapName );
-			for (class_t species : RequiredNavmeshes())
+			for (class_t species : RequiredNavmeshes( g_bot_navmeshReduceTypes.Get() ))
 			{
 				fileHandle_t f;
 				std::string filename = Str::Format(

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -190,13 +190,6 @@ void G_BotNavInit( int generateNeeded )
 
 	for ( class_t i : RequiredNavmeshes() )
 	{
-		const classModelConfig_t *model = BG_ClassModelConfig( i );
-		if ( model->navMeshClass != PCL_NONE )
-		{
-			Log::Warn( "%s shouldn't be in the required navmesh list as it uses another class's navmesh",
-			           model->humanName );
-		}
-
 		switch ( G_BotSetupNav( config, i ) )
 		{
 		case navMeshStatus_t::UNINITIALIZED:

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -219,5 +219,6 @@ extern Cvar::Cvar<bool> g_bot_infiniteFunds;
 extern Cvar::Cvar<bool> g_bot_infiniteMomentum;
 extern Cvar::Cvar<int> g_bot_aliensenseRange;
 extern Cvar::Modified<Cvar::Cvar<int>> g_bot_defaultFill;
+extern Cvar::Cvar<bool> g_bot_navmeshReduceTypes;
 
 #endif // SG_EXTERN_H_

--- a/src/shared/bg_parse.cpp
+++ b/src/shared/bg_parse.cpp
@@ -1532,22 +1532,9 @@ void BG_ParseClassModelFile( const char *filename, classModelConfig_t *cc )
 
 			defined |= SHOULDEROFFSETS;
 		}
-		else if ( !Q_stricmp( token, "useNavMesh" ) )
+		else if ( !Q_stricmp( token, "useNavMesh" ) ) // TODO(0.55): remove
 		{
-			const classModelConfig_t *model;
-
 			PARSE(text, token);
-
-			model = BG_ClassModelConfigByName( token );
-
-			if ( model && *model->modelName )
-			{
-				cc->navMeshClass = (class_t) ( model - BG_ClassModelConfig( PCL_NONE ) );
-			}
-			else
-			{
-				Log::Warn( "%s: unknown or yet-unloaded player model '%s'", filename, token );
-			}
 		}
 		else
 		{

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -1309,8 +1309,6 @@ struct classModelConfig_t
 	float  zOffset;
 	vec3_t shoulderOffsets;
 	bool segmented;
-
-	class_t navMeshClass; // if not PCL_NONE, which model's navmesh to use
 };
 
 #define MAX_BUILDABLE_MODELS 3

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -267,20 +267,41 @@ struct LinearAllocator : public dtTileCacheAlloc
 	size_t getHighSize() { return high; }
 };
 
+// Maybe use another alien form's navmesh instead of generating one for this class
+inline class_t NavmeshForClass( class_t species )
+{
+	switch ( species )
+	{
+	case PCL_HUMAN_LIGHT:
+	case PCL_HUMAN_MEDIUM:
+		return PCL_HUMAN_NAKED;
+
+	case PCL_ALIEN_BUILDER0_UPG:
+		return PCL_ALIEN_BUILDER0;
+
+	default:
+		return species;
+	}
+}
+
 inline std::vector<class_t> RequiredNavmeshes()
 {
-	return {
-		PCL_ALIEN_BUILDER0,
-		PCL_ALIEN_LEVEL0,
-		PCL_ALIEN_LEVEL1,
-		PCL_ALIEN_LEVEL2,
-		PCL_ALIEN_LEVEL2_UPG,
-		PCL_ALIEN_LEVEL3,
-		PCL_ALIEN_LEVEL3_UPG,
-		PCL_ALIEN_LEVEL4,
-		PCL_HUMAN_NAKED,
-		PCL_HUMAN_BSUIT,
-	};
+	std::vector<class_t> required;
+	for ( int c = PCL_NONE; ++c < PCL_NUM_CLASSES; )
+	{
+		auto useMesh = NavmeshForClass( static_cast<class_t>( c ) );
+
+		if ( useMesh == c )
+		{
+			required.push_back( useMesh );
+		}
+		else
+		{
+			ASSERT_EQ( NavmeshForClass( useMesh ), useMesh ); // chaining not allowed
+		}
+	}
+
+	return required;
 }
 
 inline std::string NavmeshFilename(Str::StringRef mapName, class_t species)

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -268,28 +268,41 @@ struct LinearAllocator : public dtTileCacheAlloc
 };
 
 // Maybe use another alien form's navmesh instead of generating one for this class
-inline class_t NavmeshForClass( class_t species )
+inline class_t NavmeshForClass( class_t species, bool reduceTypes )
 {
 	switch ( species )
 	{
+	// Naked, Light, and Medium human forms are truly identical.
+	// Battlesuit is taller, but otherwise the same.
+	case PCL_HUMAN_NAKED:
 	case PCL_HUMAN_LIGHT:
 	case PCL_HUMAN_MEDIUM:
-		return PCL_HUMAN_NAKED;
+		return reduceTypes ? PCL_HUMAN_BSUIT : PCL_HUMAN_NAKED;
 
+	// Grangers are the same size, but the advanced one can jump higher and if you provide
+	// navcons its wallwalk may be exploited
 	case PCL_ALIEN_BUILDER0_UPG:
-		return PCL_ALIEN_BUILDER0;
+		return reduceTypes ? PCL_ALIEN_BUILDER0 : PCL_ALIEN_BUILDER0_UPG;
+
+	// Mantis is the same size as dretch but can jump higher
+	case PCL_ALIEN_LEVEL1:
+		return reduceTypes ? PCL_ALIEN_LEVEL0 : PCL_ALIEN_LEVEL1;
+
+	// Marauder is slightly smaller than Advanced Marauder, otherwise the same
+	case PCL_ALIEN_LEVEL2:
+		return reduceTypes ? PCL_ALIEN_LEVEL2_UPG : PCL_ALIEN_LEVEL2;
 
 	default:
 		return species;
 	}
 }
 
-inline std::vector<class_t> RequiredNavmeshes()
+inline std::vector<class_t> RequiredNavmeshes( bool reduceTypes )
 {
 	std::vector<class_t> required;
 	for ( int c = PCL_NONE; ++c < PCL_NUM_CLASSES; )
 	{
-		auto useMesh = NavmeshForClass( static_cast<class_t>( c ) );
+		auto useMesh = NavmeshForClass( static_cast<class_t>( c ), reduceTypes );
 
 		if ( useMesh == c )
 		{
@@ -297,7 +310,7 @@ inline std::vector<class_t> RequiredNavmeshes()
 		}
 		else
 		{
-			ASSERT_EQ( NavmeshForClass( useMesh ), useMesh ); // chaining not allowed
+			ASSERT_EQ( NavmeshForClass( useMesh, reduceTypes ), useMesh ); // chaining not allowed
 		}
 	}
 


### PR DESCRIPTION
Some ideas discussed in #2901 comments. The settings for which player classes should use another class's navmesh instead of generating its own are moved into the code so that res-players does not have to be updated. Introduce a cvar to generate less classes so that generation takes less time.

Thoughts on whether the cvar should be on or off by default?

If people like this I will make a PR to res-players to remove the setting, and also add a UI checkbox for the cvar.