### PR TITLE
add navcfg option cellSizeFactor

### DIFF
--- a/src/shared/bot_nav_shared.cpp
+++ b/src/shared/bot_nav_shared.cpp
@@ -146,6 +146,18 @@ static void ParseOption( Str::StringRef name, Str::StringRef value, Str::StringR
 			return;
 		}
 	}
+	else if ( Str::IsIEqual( name, "cellSizeFactor" ) )
+	{
+		if ( floatValue < 0.1f || 10.f < floatValue )
+		{
+			Log::Warn( "%s: incorrect value for cellSizeFactor '%f': must be between 0.1 and 10", file, floatValue );
+		}
+		else if ( floatValue > 0.0f )
+		{
+			config.cellSizeFactor = floatValue;
+			return;
+		}
+	}
 	else if ( Str::IsIEqual( name, "crouch" ) )
 	{
 		if ( !( boolValue & ~1 ) )

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -84,8 +84,9 @@ struct NavgenConfig {
 	int generatePatchTris; // boolean - generate triangles from the BSP's patches
 	float autojumpSecurity; // percentage - allow to use part of jump magnitude (with default gravity of 800) as stepsize. The result can not excess the agent's height, except if STEPSIZE is already doing it (then STEPSIZE will be used)
 	int crouchSupport; // boolean - use crouchMaxs.z value instead of maxs.z to compute paths
+	float cellSizeFactor;
 
-	static NavgenConfig Default() { return { 2.0f, STEPSIZE, 1, 1, 1, 1, 0.5f, false }; }
+	static NavgenConfig Default() { return { 2.0f, STEPSIZE, 1, 1, 1, 1, 0.5f, false, 0.25f }; }
 };
 
 struct NavgenMapIdentification

--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -1031,7 +1031,7 @@ void NavmeshGenerator::StartGeneration( class_t species )
 	//height of agent (BBox maxs[2] - BBox mins[2])
 	float height = ( config_.crouchSupport ? dimensions->crouchMaxs[2] : dimensions->maxs[2] ) - dimensions->mins[2];
 
-	const float cellSize = radius / 4.0f;
+	const float cellSize = radius * config_.cellSizeFactor;
 
 	rcCalcGridSize( bmin, bmax, cellSize, &gw, &gh );
 


### PR DESCRIPTION
There is a hardcoded magic number controlling a crucial parameter of the navmesh generation: its "cell size". The cell size determines how big a navmesh's tiles will be.

As it turns out, https://github.com/Unvanquished/Unvanquished/issues/2357 can (at least almost) always be resolved by tweaking this number. This PR adds a field `cellSizeFactor` to the .navcfg files to allow for that. A mapper or server operator may choose any number they see fit.

The magic number is in `src/shared/navgen/nav.cpp`, it is the divisor 4 in:

```
const float cellSize = radius / 4.0f;
```

The `radius` is the radius of the class. 

This PR allows to specify any number (in a sensible range) instead of this number 4. We all hate divisions, so let's make this a multiplication by 0.25 by default.

For example, look at the map `void2` (you can find it here: https://github.com/Masmblr/map-Void2_src). With the default value of 0.25, you see this when doing `/navedit enable level0`:

![unvanquished_2024-01-24_164056_000](https://github.com/Unvanquished/Unvanquished/assets/110394607/25ded7d3-2ca8-49ad-aae5-814cd6f703a1)

Now, using this PR, create a file `maps/void2.navcfg`:

```
cellSizeFactor 0.5
```

Load the map again, and you will see this:

![unvanquished_2024-01-24_164344_000](https://github.com/Unvanquished/Unvanquished/assets/110394607/28b479c7-3f4a-47fb-91bf-89be8b4a89f9)

Notice how the size of the tiles has doubled (in each dimension). The choice of this number has influence on the path search at runtime, I assume fewer tiles mean more robotic behavior, but faster search. Notice also that anything making the bots use the whole map is better than restricting them to one half.