### PR TITLE
Fix portal rotation

### DIFF
--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -627,18 +627,11 @@ static void CG_Portal( centity_t *cent )
 	refEntity_t ent{};
 	VectorCopy( cent->lerpOrigin, ent.origin );
 	VectorCopy( s1->origin2, ent.oldorigin );
-	ByteToDir( s1->eventParm, ent.axis[ 0 ] );
-	PerpendicularVector( ent.axis[ 1 ], ent.axis[ 0 ] );
 
-	// negating this tends to get the directions like they want
-	// we really should have a camera roll value
-	VectorSubtract( vec3_origin, ent.axis[ 1 ], ent.axis[ 1 ] );
-
-	CrossProduct( ent.axis[ 0 ], ent.axis[ 1 ], ent.axis[ 2 ] );
+	AnglesToAxis( s1->angles2, ent.axis );
 	ent.reType = refEntityType_t::RT_PORTALSURFACE;
 	ent.oldframe = s1->misc;
 	ent.frame = s1->frame; // rotation speed
-	ent.skinNum = s1->clientNum / 256.0 * 360; // roll offset
 
 	// add to refresh list
 	trap_R_AddRefEntityToScene( &ent );


### PR DESCRIPTION
Complementary pr to: https://github.com/DaemonEngine/Daemon/pull/1037

New behaviour uses spawnflags bit 3 (8). Since maps without it only used roll to compensate for incorrect code, roll will now be set to 0 without that flag (unless no spawnflags are set i. e. bobbing rotate, where roll will be used as normally).

Portal rotation will now be set by sgame only by using self->s.angles2. For portal cameras that use "target" keyword roll of 0 is assumed, unless specified otherwise with the "roll" keyword. Removed clientNum usage, angles will now always have the correct angle.

Removed the usage of DirToByte() and ByteToDir() functions for portals because they were resulting in incorrect angles.