### PR TITLE
Fix undefined behavior in BSP entity parser

### DIFF
--- a/src/sgame/sg_spawn.cpp
+++ b/src/sgame/sg_spawn.cpp
@@ -690,7 +690,7 @@ static void G_ParseField( const char *key, const char *rawString, gentity_t *ent
 {
 	fieldDescriptor_t *fieldDescriptor;
 	byte    *entityDataField;
-	vec4_t  tmpFloatData;
+	vec4_t tmpFloatData = {};
 	variatingTime_t varTime = {0, 0};
 
 	fieldDescriptor = (fieldDescriptor_t*) bsearch( key, fields, ARRAY_LEN( fields ), sizeof( fieldDescriptor_t ), cmdcmp );


### PR DESCRIPTION
When parsing an F_3D_VECTOR or F_4D_VECTOR field of a BSP entity, if not all elements of the vector parse successfully, set the remaining elements to 0 rather than from an uninitialized variable.