### PR TITLE
Add a translucent option for weapons

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/options_movements_cosmetic.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_movements_cosmetic.rml
@@ -38,6 +38,8 @@
 				<option value="0"><translate>Disable</translate></option>
 				<option value="1"><translate>Humans only</translate></option>
 				<option value="2"><translate>Humans and aliens</translate></option>
+				<option value="3"><translate>Humans (translucent)</translate></option>
+				<option value="4"><translate>Humans and aliens (translucent)</translate></option>
 			</select>
 			<h3><translate>First-person weapons</translate></h3>
 			<p><translate>Show gun, pincer, hand and mandible models in first-person.</translate></p>

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -69,7 +69,7 @@ Cvar::Cvar<bool> cg_noPlayerAnims("cg_noplayeranims", "disable player animations
 Cvar::Cvar<bool> cg_footsteps("cg_footsteps", "make footstep sounds", Cvar::CHEAT, true);
 Cvar::Cvar<bool> cg_addMarks("cg_marks", "enable marks (e.g. bullet holes)", Cvar::NONE, true);
 Cvar::Cvar<int> cg_viewsize("cg_viewsize", "size of rectangle the world is drawn in", Cvar::NONE, 100);
-Cvar::Range<Cvar::Cvar<int>> cg_drawGun("cg_drawGun", "draw 1st-person weapon (1 = guns, 2 = guns & claws)", Cvar::NONE, 1, 0, 2);
+Cvar::Range<Cvar::Cvar<int>> cg_drawGun("cg_drawGun", "draw 1st-person weapon (1 = guns, 2 = guns & claws, 3 = translucent guns, 4 = translucent guns and claws)", Cvar::NONE, 1, 0, 4);
 Cvar::Cvar<float> cg_gun_x("cg_gunX", "model debugging: gun x offset", Cvar::CHEAT, 0);
 Cvar::Cvar<float> cg_gun_y("cg_gunY", "model debugging: gun y offset", Cvar::CHEAT, 0);
 Cvar::Cvar<float> cg_gun_z("cg_gunZ", "model debugging: gun z offset", Cvar::CHEAT, 0);

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -1414,6 +1414,12 @@ void CG_AddPlayerWeapon( refEntity_t *parent, playerState_t *ps, centity_t *cent
 			CG_TransformSkeleton( &gun.skeleton, weapon->scale );
 		}
 
+		if ( cg_drawGun.Get() >= 3 && ps ) {
+			gun.shaderRGBA = Color::White;
+			gun.shaderRGBA.SetAlpha( 32 );
+			gun.customShader = cgs.media.plainColorShader;
+		}
+
 		trap_R_AddRefEntityToScene( &gun );
 
 		if ( !ps )
@@ -1428,6 +1434,12 @@ void CG_AddPlayerWeapon( refEntity_t *parent, playerState_t *ps, centity_t *cent
 		else
 		{
 			barrel.hModel = weapon->barrelModel;
+
+			if ( cg_drawGun.Get() >= 3 ) {
+				barrel.shaderRGBA = Color::White;
+				barrel.shaderRGBA.SetAlpha( 32 );
+				barrel.customShader = cgs.media.plainColorShader;
+			}
 		}
 
 		// add the spinning barrel
@@ -1585,10 +1597,12 @@ void CG_AddViewWeapon( playerState_t *ps )
 
 	wi = &cg_weapons[ weapon ];
 
-	/* cg_drawGun has 3 values:
+	/* cg_drawGun has 5 values:
 	- 0 : draw no gun at all
 	- 1 : draw gun for humans
-	- 2 : draw gun for humans and aliens */
+	- 2 : draw gun for humans and aliens
+	- 3 : draw translucent gun for humans
+	- 4 : draw translucent gun for humans and aliens */
 	switch ( cg_drawGun.Get() )
 	{
 		case 0: // none
@@ -1608,6 +1622,12 @@ void CG_AddViewWeapon( playerState_t *ps )
 			drawGun = true;
 			break;
 		*/
+
+		case 3: // humans only
+			if ( BG_Weapon( weapon )->team == TEAM_ALIENS ) {
+				drawGun = false;
+			}
+			break;
 	}
 
 	if ( !wi->registered )


### PR DESCRIPTION
Adds a cg_drawGun 3 parameter that makes the first-person gun model translucent. Also adds a cg_drawGun 4 that renders both translucent guns and claws. This is a middle ground between not drawing the weapon at all so it doesn't obstruct the screen and still being able to see it.

![unvanquished_2024-02-07_151142_000](https://github.com/Unvanquished/Unvanquished/assets/10687142/aeaea7b6-62f3-4c13-bda3-406cf112529a)
![unvanquished_2024-02-07_151200_000](https://github.com/Unvanquished/Unvanquished/assets/10687142/972a7e97-90b9-4085-b903-3fd29798dacb)
3rd-person models keep using the non-translucent shaders:
![unvanquished_2024-02-07_151354_000](https://github.com/Unvanquished/Unvanquished/assets/10687142/e91b7efa-b0ad-4af6-968d-f84f76598e67)
