### PR TITLE
Use proper scaling for crosshair outlines

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/options_ui.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_ui.rml
@@ -183,6 +183,10 @@
 							<input type="range" min="-5" max="5" step="0.05" cvar="cg_crosshairOutlineScale"/>
 							<translate>Scale:</translate>&nbsp;<inlinecvar cvar="cg_crosshairOutlineScale" type="number" format="%0.2f"/>
 						</row>
+						<row>
+							<input type="range" min="-5" max="5" step="0.05" cvar="cg_crosshairOutlineOffset"/>
+							<translate>Offset:</translate>&nbsp;<inlinecvar cvar="cg_crosshairOutlineOffset" type="number" format="%0.2f"/>
+						</row>
 					</p>
 				</row>
 				<row>

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -972,6 +972,7 @@ struct weaponInfo_t
 	qhandle_t        crossHair;
 	qhandle_t        crossHairIndicator;
 	int              crossHairSize;
+	float            crossHairSizeNoBorder; // For crosshair outlines
 
 	sfxHandle_t      readySound;
 
@@ -1804,6 +1805,7 @@ extern Cvar::Cvar<float> cg_crosshairColorBlue;
 extern Cvar::Cvar<float> cg_crosshairColorAlpha;
 extern Cvar::Range<Cvar::Cvar<int>> cg_crosshairOutlineStyle;
 extern Cvar::Cvar<float> cg_crosshairOutlineScale;
+extern Cvar::Cvar<float> cg_crosshairOutlineOffset;
 extern Cvar::Cvar<float> cg_crosshairOutlineColorRed;
 extern Cvar::Cvar<float> cg_crosshairOutlineColorGreen;
 extern Cvar::Cvar<float> cg_crosshairOutlineColorBlue;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -59,7 +59,8 @@ Cvar::Cvar<float> cg_crosshairColorGreen( "cg_crosshairColorGreen", "crosshair c
 Cvar::Cvar<float> cg_crosshairColorBlue( "cg_crosshairColorBlue", "crosshair colour blue", Cvar::NONE, 1.0 );
 Cvar::Cvar<float> cg_crosshairColorAlpha( "cg_crosshairColorAlpha", "crosshair colour alpha", Cvar::NONE, 1.0 );
 Cvar::Range<Cvar::Cvar<int>> cg_crosshairOutlineStyle( "cg_crosshairOutlineStyle", "crosshair outline style (0 = none, 1 = auto colour, 2 = custom colour)", Cvar::NONE, 0, 0, 2 );
-Cvar::Cvar<float> cg_crosshairOutlineScale( "cg_crosshairOutlineScale", "crosshair outline scale", Cvar::NONE, 2.0 );
+Cvar::Cvar<float> cg_crosshairOutlineScale( "cg_crosshairOutlineScale", "crosshair outline scale", Cvar::NONE, 1.05 );
+Cvar::Cvar<float> cg_crosshairOutlineOffset( "cg_crosshairOutlineOffset", "crosshair outline offset", Cvar::NONE, 2.0 );
 Cvar::Cvar<float> cg_crosshairOutlineColorRed( "cg_crosshairOutlineColorRed", "crosshair colour green", Cvar::NONE, 0.5 );
 Cvar::Cvar<float> cg_crosshairOutlineColorGreen( "cg_crosshairOutlineColorGreen", "crosshair colour green", Cvar::NONE, 0.5 );
 Cvar::Cvar<float> cg_crosshairOutlineColorBlue( "cg_crosshairOutlineColorBlue", "crosshair colour blue", Cvar::NONE, 0.5 );

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -797,8 +797,9 @@ public:
 				}
 
 				const float scale = cg_crosshairOutlineScale.Get();
-				const float outlineWidth = w + scale * cgs.aspectScale;
-				const float outlineHeight = h + scale;
+				const float outlineHeight = ( wi->crossHairSizeNoBorder * scale + cg_crosshairOutlineOffset.Get() )
+										    * ( wi->crossHairSize / wi->crossHairSizeNoBorder ) * cg_crosshairSize.Get();
+				const float outlineWidth = outlineHeight * cgs.aspectScale;
 				const float outlineX = rect.x + ( rect.w / 2 ) - ( outlineWidth / 2 );
 				const float outlineY = rect.y + ( rect.h / 2 ) - ( outlineHeight / 2 );
 

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -879,6 +879,24 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 			wi->crossHairSize = size;
 
 			continue;
+		} else if ( !Q_stricmp( token, "crosshairSizeNoBorder" ) ) {
+			float size;
+
+			token = COM_Parse( &text_p );
+
+			if ( !token ) {
+				break;
+			}
+
+			size = atof( token );
+
+			if ( size < 0.0f ) {
+				size = 0.0f;
+			}
+
+			wi->crossHairSizeNoBorder = size;
+
+			continue;
 		}
 		else if ( !Q_stricmp( token, "disableIn3rdPerson" ) )
 		{
@@ -939,6 +957,11 @@ static bool CG_ParseWeaponFile( const char *filename, int weapon, weaponInfo_t *
 
 		Log::Warn( "unknown token '%s'", token );
 		return false;
+	}
+
+	if ( wi->crossHairSizeNoBorder == 0.0f && wi->crossHair ) {
+		Log::Warn( "weapon %s crossHairSizeNoBorder not set or is 0, setting to crossHairSize", filename );
+		wi->crossHairSizeNoBorder = wi->crossHairSize;
 	}
 
 	return true;


### PR DESCRIPTION
Adds a crossHairSizeNoBorder to the weapon info. This is the size of the visible part of the crosshair, either width or height (whichever is larger). This is required because crossHairSize is the size of the image, not the actual visible part of the crosshair. All crosshair images we have are 256x256, which corresponds to size 64.

Both sizes are in virtual coordinates: the game maps the screen to 640x480 coordinates for UI, regardless of screen resolution.
The crosshairSizeNoBorder can be found as `(pixelCoord2 - pixelCoord1 + 1) / imageSize * crossHairSize`
pixelCoord2 and pixelCoord1 - coordinates in pixels of the closest and furthest visible pixels (either x or y, wherever the larger part ofthe crosshair is).
imageSize - size of the crosshair image dimension in pixels

If no crosshairSizeNoBorder is specified, it defaults to crossHairSize.
You can find the updated weapon config files at https://github.com/UnvanquishedAssets/res-weapons_src.dpkdir/pull/16.