### PR TITLE
HUD: use exponential moving average FPS counter

### DIFF
--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -517,71 +517,39 @@ private:
 	int clips_;
 };
 
-
-static const int FPS_FRAMES = 20;
-
 class FpsHudElement : public TextHudElement
 {
 public:
 	FpsHudElement( const Rml::String& tag )
 			: TextHudElement( tag, ELEMENT_ALL ),
-			  shouldShowFps_( true ),
-			  index_(0),
-			  previous_(0) {}
+			  showingFps_( false ),
+			  lastFrame_( 0 ),
+			  fps_( 0 ) {}
 
 	void DoOnUpdate() override
 	{
-		int        i, total;
-		int        fps;
-		int        t, frameTime;
-
-		if ( !cg_drawFPS.Get() && shouldShowFps_ )
-		{
-			shouldShowFps_ = false;
-			SetText( "" );
-			return;
-		} else if ( !shouldShowFps_ )
-		{
-			shouldShowFps_ = true;
-		}
-
 		// don't use serverTime, because that will be drifting to
 		// correct for Internet lag changes, timescales, timedemos, etc.
-		t = trap_Milliseconds();
-		frameTime = t - previous_;
-		previous_ = t;
+		int t = trap_Milliseconds();
+		Util::UpdateFPSCounter( 1.0f, t - lastFrame_, fps_ );
+		lastFrame_ = t;
 
-		previousTimes_[ index_ % FPS_FRAMES ] = frameTime;
-		index_++;
-
-		if ( index_ > FPS_FRAMES )
+		if ( cg_drawFPS.Get() )
 		{
-			// average multiple frames together to smooth changes out a bit
-			total = 0;
-
-			for ( i = 0; i < FPS_FRAMES; i++ )
-			{
-				total += previousTimes_[ i ];
-			}
-
-			if ( !total )
-			{
-				total = 1;
-			}
-
-			fps = 1000 * FPS_FRAMES / total;
+			SetText( Str::Format("%.0f", fps_) );
+			showingFps_ = true;
 		}
-
-		else
-			fps = 0;
-
-		SetText( va( "%d", fps ) );
+		else if ( showingFps_ )
+		{
+			SetText( "" );
+			showingFps_ = false;
+		}
 	}
+
 private:
-	bool shouldShowFps_;
-	int previousTimes_[ FPS_FRAMES ];
-	int index_;
-	int previous_;
+	bool showingFps_;
+	int lastFrame_;
+	float fps_;
 };
 
 #define CROSSHAIR_INDICATOR_HITFADE 500


### PR DESCRIPTION
This makes the FPS counter be constant instead of flickering when the frame rate is steady.