### PR TITLE
add code for see if the server is hosted by user, for show/hide menus

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/menu_ingame.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/menu_ingame.rml
@@ -31,18 +31,19 @@
 						<button-menu style="width:87%"  onclick='Events.pushevent("exec team human; hide ingame_menu", event)'><translate>Join Humans</translate></button-menu>
 						<br/>
 						<button-menu style="width:87%"  onclick='Events.pushevent("exec team spec; hide ingame_menu", event)'><translate>Spectate</translate></button-menu>
-						<if cvar="sv_running" condition="==" value="1">
-							<button-menu style="width:87%" onclick='Events.pushevent("show options_bots", event)'><translate>Bots</translate></button-menu>
-						</if>
 						<button-menu style="width:87%" onclick='Events.pushevent("show options_democracy", event)'><translate>Democracy</translate></button-menu>
 					</indent>
 
 					<if cvar="sv_running" condition="==" value="1">
 						<h1><translate>Host menu</translate></h1>
 						<indent>
+                                                        <button-menu style="width:87%" onclick='Events.pushevent("show server_setup", event)'><translate>Server setup</translate></button-menu>
+                                                        <br/>
 							<button-menu style="width:87%"  class="rightfloat" onclick='Events.pushevent("exec disconnect", event)'><translate>Stop server</translate></button-menu>
 							<br/>
 							<button-menu style="width:87%"  class="leftalign" onclick='Events.pushevent("exec pause", event)'><translate>Pause server</translate></button-menu>
+                                                        <br/>
+					                <button-menu style="width:87%" onclick='Events.pushevent("show options_bots", event)'><translate>Bots</translate></button-menu>
 						</indent>
 					</if>
 
@@ -51,9 +52,6 @@
 						<button-menu style="width:87%" onclick='Events.pushevent("show serverbrowser", event)'><translate>Server listings</translate></button-menu>
 						<button-menu style="width:87%" onclick='Events.pushevent("show createserver", event)'><translate>Start local/LAN game</translate></button-menu>
 						<button-menu style="width:87%" onclick='Events.pushevent("show options", event)'><translate>Options</translate></button-menu>
-						<if cvar="sv_running" condition="==" value="1">
-							<button-menu style="width:87%" onclick='Events.pushevent("show server_setup", event)'><translate>Server setup</translate></button-menu>
-						</if>
 						<button-menu style="width:87%" onclick='Events.pushevent("show help_gameplay", event)'><translate>Gameplay guide</translate></button-menu>
 					</indent>
 					<br/>

--- a/pkg/unvanquished_src.dpkdir/ui/menu_ingame.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/menu_ingame.rml
@@ -31,7 +31,9 @@
 						<button-menu style="width:87%"  onclick='Events.pushevent("exec team human; hide ingame_menu", event)'><translate>Join Humans</translate></button-menu>
 						<br/>
 						<button-menu style="width:87%"  onclick='Events.pushevent("exec team spec; hide ingame_menu", event)'><translate>Spectate</translate></button-menu>
-						<button-menu style="width:87%" onclick='Events.pushevent("show options_bots", event)'><translate>Bots</translate></button-menu>
+						<if cvar="sv_running" condition="==" value="1">
+							<button-menu style="width:87%" onclick='Events.pushevent("show options_bots", event)'><translate>Bots</translate></button-menu>
+						</if>
 						<button-menu style="width:87%" onclick='Events.pushevent("show options_democracy", event)'><translate>Democracy</translate></button-menu>
 					</indent>
 
@@ -49,7 +51,9 @@
 						<button-menu style="width:87%" onclick='Events.pushevent("show serverbrowser", event)'><translate>Server listings</translate></button-menu>
 						<button-menu style="width:87%" onclick='Events.pushevent("show createserver", event)'><translate>Start local/LAN game</translate></button-menu>
 						<button-menu style="width:87%" onclick='Events.pushevent("show options", event)'><translate>Options</translate></button-menu>
-						<button-menu style="width:87%" onclick='Events.pushevent("show server_setup", event)'><translate>Server setup</translate></button-menu>
+						<if cvar="sv_running" condition="==" value="1">
+							<button-menu style="width:87%" onclick='Events.pushevent("show server_setup", event)'><translate>Server setup</translate></button-menu>
+						</if>
 						<button-menu style="width:87%" onclick='Events.pushevent("show help_gameplay", event)'><translate>Gameplay guide</translate></button-menu>
 					</indent>
 					<br/>


### PR DESCRIPTION
with these modifications, these menus will be not accessible for the users that don't host : 
* Bots 
* Server setup

Note that the bot menu work with /bot.

for can enable it for all the users, we have to make votes for remove/add only *ONE* bot per team, like in the current bot menu.

![Screenshot_20240218_125942](https://github.com/Unvanquished/Unvanquished/assets/148749571/2b3806c7-02b2-4754-a88b-b9e43d897ab8)
