### PR TITLE
crosshair: Fix bugs with crosshair preview

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/options_ui.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_ui.rml
@@ -2,10 +2,21 @@
 	<head>
 		<link type="text/rcss" href="/ui/shared/basics.rcss" />
 		<link type="text/template" href="/ui/shared/window.rml" />
+		<script>
+			function setWeapon(document, weapon)
+				if document == nil then
+					return
+				end
+				if (weapon == "" or weapon == nil) then
+					return
+				end
+				document:GetElementById("crosshair"):SetAttribute("weapon", weapon)
+			end
+		</script>
 	</head>
 	<body id="options_ui" template="window" class="window-options" style="margin-top: 10%; width: 32em;">
 		<h1><translate>User interface</translate></h1>
-		<tabset>
+		<tabset ontabchange='setWeapon(document, "rifle")'>
 			<tab><translate>Main</translate></tab>
 			<panel class="main">
 				<row>
@@ -79,9 +90,14 @@
 			</panel>
 			<tab><translate>Crosshair</translate></tab>
 			<panel class="crosshair">
+				<if cvar="p_classname" condition="==" value="">
+				<row>
+					<div style="color: red;"><translate>WARN: Preview only works in game.</translate></div>
+				</row>
+				</if>
 				<row>
 					<h3><translate>Weapon</translate></h3>
-					<select name="crosshair_weapon" value="rifle" onchange='document:GetElementById("crosshair"):SetAttribute("weapon", event.current_element.attributes["value"])'>
+					<select name="crosshair_weapon" value="rifle" onchange='setWeapon(document, event.current_element.attributes["value"])'>
 						<option value="level0"><translate>Aliens</translate></option>
 						<option value="blaster"><translate>Blaster</translate></option>
 						<option value="rifle"><translate>Rifle</translate></option>

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -590,7 +590,7 @@ class CrosshairIndicatorHudElement : public HudElement
 {
 public:
 	CrosshairIndicatorHudElement( const Rml::String& tag ) :
-			HudElement( tag, ELEMENT_BOTH, true ),
+			HudElement( tag, ELEMENT_GAME, true ),
 			color_( Color::White ) {}
 
 	void OnPropertyChange( const Rml::PropertyIdSet& changed_properties ) override
@@ -698,7 +698,7 @@ private:
 class CrosshairHudElement : public HudElement {
 public:
 	CrosshairHudElement( const Rml::String& tag ) :
-			HudElement( tag, ELEMENT_ALL, true ),
+			HudElement( tag, ELEMENT_GAME, true ),
 			// Use as a sentinel value to denote that no weapon is
 			// explicitly set.
 			weapon_( WP_NUM_WEAPONS ) {
@@ -707,6 +707,11 @@ public:
 	void OnAttributeChange( const Rml::ElementAttributes& changed_attributes ) override
 	{
 		HudElement::OnAttributeChange( changed_attributes );
+		// If we are not in game, then don't bother looking up weapon info, since it's not loaded.
+		if ( rocketInfo.cstate.connState != connstate_t::CA_ACTIVE )
+		{
+			return;
+		}
 		// If we have a weapon attribute, then *always* display the crosshair for that weapon, regardless
 		// of team or spectator state.
 		auto it = changed_attributes.find( "weapon" );
@@ -714,7 +719,7 @@ public:
 		{
 			auto weaponName = it->second.Get<std::string>();
 			auto wa = BG_WeaponByName( weaponName.c_str() );
-			if ( wa == nullptr )
+			if ( wa == nullptr || wa->number == WP_NONE )
 			{
 				Log::Warn( "Invalid forced crosshair weapon: %s", weaponName );
 			}

--- a/src/cgame/rocket/rocketConditionalElement.h
+++ b/src/cgame/rocket/rocketConditionalElement.h
@@ -64,15 +64,11 @@ public:
 		it = changed_attributes.find( "value" );
 		if ( it != changed_attributes.end() )
 		{
-			char *end = nullptr;
-			const char *val = it->second.Get<std::string>().c_str();
-			// Check if float
-			float floatVal = strtof( val, &end );
-
-			// Is either an integer or float
-			if ( end && end != val )
+			std::string val = it->second.Get<std::string>();
+			try
 			{
-				// is integer
+				float floatVal = std::stof( val );
+				// Is either an integer or float
 				if ( static_cast< int >( floatVal ) == floatVal )
 				{
 					value = static_cast< int >( floatVal );
@@ -82,9 +78,8 @@ public:
 					value = floatVal;
 				}
 			}
-
-			// Is a string
-			else
+			// Failed conversion means it's a string.
+			catch ( const std::invalid_argument& )
 			{
 				value = it->second.Get<std::string>();
 			}

--- a/src/cgame/rocket/rocketConditionalElement.h
+++ b/src/cgame/rocket/rocketConditionalElement.h
@@ -41,7 +41,7 @@ Maryland 20850 USA.
 class RocketConditionalElement : public Rml::Element
 {
 public:
-	RocketConditionalElement( const Rml::String &tag ) : Rml::Element( tag ), condition( NOT_EQUAL ), dirty_value( false ) {}
+	RocketConditionalElement( const std::string &tag ) : Rml::Element( tag ), condition( NOT_EQUAL ), dirty_value( false ) {}
 
 	virtual void OnAttributeChange( const Rml::ElementAttributes &changed_attributes )
 	{
@@ -50,25 +50,27 @@ public:
 		it = changed_attributes.find( "cvar" );
 		if ( it != changed_attributes.end() )
 		{
-			cvar = it->second.Get<Rml::String>();
+			cvar = it->second.Get<std::string>();
 			cvar_value = Cvar::GetValue( cvar.c_str() ).c_str();
+			dirty_value = true;
 		}
 
 		it = changed_attributes.find( "condition" );
 		if ( it != changed_attributes.end() )
 		{
-			ParseCondition( it->second.Get<Rml::String>() );
+			ParseCondition( it->second.Get<std::string>() );
 		}
 
 		it = changed_attributes.find( "value" );
-		if ( it !=  changed_attributes.end() )
+		if ( it != changed_attributes.end() )
 		{
 			char *end = nullptr;
+			const char *val = it->second.Get<std::string>().c_str();
 			// Check if float
-			float floatVal = strtof( it->second.Get<Rml::String>().c_str(), &end );
+			float floatVal = strtof( val, &end );
 
 			// Is either an integer or float
-			if ( end )
+			if ( end && end != val )
 			{
 				// is integer
 				if ( static_cast< int >( floatVal ) == floatVal )
@@ -84,7 +86,7 @@ public:
 			// Is a string
 			else
 			{
-				value = it->second;
+				value = it->second.Get<std::string>();
 			}
 
 			dirty_value = true;
@@ -130,7 +132,7 @@ private:
 		NOT_EQUAL
 	};
 
-	void ParseCondition( const Rml::String& str )
+	void ParseCondition( const std::string& str )
 	{
 		if ( str == "==" )
 		{
@@ -181,7 +183,7 @@ private:
 				Compare( flt, value.Get<float>() );
 			}
 			default:
-				Compare( str, value.Get< Rml::String >().c_str() );
+				Compare( str, value.Get< std::string >().c_str() );
 		}
 	}
 
@@ -201,8 +203,8 @@ private:
 		return 0;
 	}
 
-	Rml::String cvar;
-	Rml::String cvar_value;
+	std::string cvar;
+	std::string cvar_value;
 	Condition condition;
 	Rml::Variant value;
 	bool dirty_value;


### PR DESCRIPTION
 - The `<if>` element doesn't correctly handle string. When we set the variant, we need to properly initialize it as a string. Otherwise it defaults to an int.

 - If we are not in game, then the BG_LoadAllConfigs() function won't have run yet, meaning we haven't initialized any of the BG_* functions. Calling it earlier doesn't help because then necessary paks haven't have been loaded so things like crosshairs won't work anyways. Instead, just show a warning that the crosshair preview will only work in game.

 - Similarly, make sure that we ignore calls that reference BG_* variables unless we are in a game to avoid spurious logs.

 - Lastly, make sure we initialize the default value of the select menu when the menu is shown. Technically, it also sets it when we switch away from the tab, but I'm guessing that this isn't a significant penalty.