### PR TITLE
tyrant bots cancels charge when in attack range

### DIFF
--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -2100,6 +2100,10 @@ void BotFireWeaponAI( gentity_t *self )
 			}
 			else
 			{
+				if ( self->client->ps.stats[ STAT_STATE ] & SS_CHARGING )
+				{
+					self->client->ps.weaponCharge = 0;
+				}
 				BotFireWeapon( WPM_PRIMARY, botCmdBuffer );    //rant swipe
 			}
 			break;


### PR DESCRIPTION
(insert an essay about why players cancel the trample when in swipe range)

You might say that a player will not move for 2 or 5 frames when releasing the forward key for a short time. I say it is better for the bot to cancel it in one frame than not to cancel it at all.