### PR TITLE
bots: reduce target prioritiy for enemy spawns

### DIFF
--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -522,7 +522,7 @@ float BotGetEnemyPriority( gentity_t *self, gentity_t *ent )
 				enemyScore = 0.7;
 				break;
 			case BA_H_SPAWN:
-				enemyScore = 0.9;
+				enemyScore = 0.4;
 				break;
 			case BA_H_ARMOURY:
 				enemyScore = 0.8;
@@ -534,7 +534,7 @@ float BotGetEnemyPriority( gentity_t *self, gentity_t *ent )
 				enemyScore = 0.7;
 				break;
 			case BA_A_SPAWN:
-				enemyScore = 0.9;
+				enemyScore = 0.4;
 				break;
 			case BA_A_OVERMIND:
 				enemyScore = 0.5;


### PR DESCRIPTION
A well built base requires attacking the non-spawn buildables first.