### PR TITLE
Fix truncated loading screen message

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -67,8 +67,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define CGAME_CHAR_WIDTH               32
 #define CGAME_CHAR_HEIGHT              48
 
-#define MAX_LOADING_TEXT_LENGTH        64
-
 #define MAX_MINIMAP_ZONES              32
 
 enum footstep_t
@@ -1246,7 +1244,7 @@ struct cg_t
 	/* loading */
 	std::string mapLongName;
 	std::string mapAuthors;
-	char                    loadingText[ MAX_LOADING_TEXT_LENGTH ];
+	std::string loadingText;
 	float                   loadingFraction; // loading percentages
 	float                   mediaLoadingFraction;
 	float                   buildableLoadingFraction;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -442,7 +442,7 @@ static void CG_UpdateLoadingProgress( int step, const char *label, const char* l
 {
 	cg.loadingFraction = ( 1.0f * step ) / LOAD_DONE;
 
-	Q_strncpyz( cg.loadingText, loadingText, sizeof( cg.loadingText ) );
+	cg.loadingText = loadingText;
 
 	Log::Debug( "CG_Init: %d%% %s.", static_cast<int>( 100 * cg.loadingFraction ), label );
 
@@ -1108,7 +1108,7 @@ static void GenerateNavmeshes()
 	const std::string message = _("Generating bot navigation meshes");
 	cg.navmeshLoadingFraction = 0;
 	cg.loadingNavmesh = true;
-	Q_strncpyz( cg.loadingText, message.c_str(), sizeof(cg.loadingText) );
+	cg.loadingText = message;
 	trap_UpdateScreen();
 
 	NavmeshGenerator navgen;
@@ -1119,8 +1119,8 @@ static void GenerateNavmeshes()
 	float classesTotal = classesCompleted + missing.size();
 	for ( class_t species : missing )
 	{
-		std::string message2 = Str::Format( "%s — %s", message, BG_ClassModelConfig( species )->humanName );
-		Q_strncpyz( cg.loadingText, message2.c_str(), sizeof(cg.loadingText) );
+		cg.loadingText =
+			Str::Format( "%s — %s", message, BG_ClassModelConfig( species )->humanName );
 		cg.loadingFraction = classesCompleted / classesTotal;
 		trap_UpdateScreen();
 

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -3660,7 +3660,7 @@ static void CG_Rocket_DrawProgressValue()
 
 static void CG_Rocket_DrawLoadingText()
 {
-	Rocket_SetInnerRML( cg.loadingText, 0 );
+	Rocket_SetInnerRML( cg.loadingText.c_str(), 0 );
 }
 
 static void CG_Rocket_DrawLevelAuthors()


### PR DESCRIPTION
The 64-byte cg.loadingText buffer not big enough to contain the translated messages for all languages.