### PR TITLE
[tinygettext] Fix language matching, compare to lowercase-d specs

### DIFF
--- a/libs/tinygettext/src/dictionary_manager.cpp
+++ b/libs/tinygettext/src/dictionary_manager.cpp
@@ -125,7 +125,7 @@ DictionaryManager::get_dictionary(const Language& language)
         if (has_suffix(*filename, ".po"))
         { // ignore anything that isn't a .po file
 
-          Language po_language = Language::from_env(convertFilename2Language(*filename));
+          Language po_language = Language::from_env(*filename);
 
           if (!po_language)
           {
@@ -258,41 +258,6 @@ DictionaryManager::set_filesystem(std::unique_ptr<FileSystem> filesystem_)
 {
   filesystem = std::move(filesystem_);
 }
-// ----------------------------------------------------------------------------
-/** This function converts a .po filename (e.g. zh_TW.po) into a language
- *  specification (zh_TW). On case insensitive file systems (think windows)
- *  the filename and therefore the country specification is lower case
- *  (zh_tw). It Converts the lower case characters of the country back to
- *  upper case, otherwise tinygettext does not identify the country
- *  correctly.
- */
-std::string DictionaryManager::convertFilename2Language(const std::string &s_in) const
-{
-    std::string s;
-    if(s_in.substr(s_in.size()-3, 3)==".po")
-        s = s_in.substr(0, s_in.size()-3);
-    else
-        s = s_in;
-
-    bool underscore_found = false;
-    for(unsigned int i=0; i<s.size(); i++)
-    {
-        if(underscore_found)
-        {
-            // If we get a non-alphanumerical character/
-            // we are done (en_GB.UTF-8) - only convert
-            // the 'gb' part ... if we ever get this kind
-            // of filename.
-            if(!::isalpha(s[i]))
-                break;
-            s[i] = static_cast<char>(::toupper(s[i]));
-        }
-        else
-            underscore_found = s[i]=='_';
-    }
-    return s;
-}   // convertFilename2Language
-
 
 } // namespace tinygettext
 

--- a/libs/tinygettext/src/language.cpp
+++ b/libs/tinygettext/src/language.cpp
@@ -281,6 +281,9 @@ static const LanguageSpec languages[] = {
   { "zh", "CN", nullptr, "Chinese (simplified)"        },
   { "zh", "HK", nullptr, "Chinese (Hong Kong)"         },
   { "zh", "TW", nullptr, "Chinese (traditional)"       },
+  { "zh", "Hans",     nullptr, "Chinese (simplified)"        },
+  { "zh", "Hant_HK",  nullptr, "Chinese (Hong Kong)"         },
+  { "zh", "Hant",     nullptr, "Chinese (traditional)"       },
   { "zu", nullptr,    nullptr, "Zulu"                        },
   { nullptr, nullptr,    nullptr, nullptr                          }
 };
@@ -463,10 +466,19 @@ Language::Language()
 {
 }
 
+static std::string asciitolower(const std::string& str) {
+  std::string s = str;
+  for (char& c : s)
+  {
+    c = tolower(c);
+  }
+  return s;
+}
+
 int
 Language::match(const Language& lhs, const Language& rhs)
 {
-  if (lhs.get_language() != rhs.get_language())
+  if (asciitolower(lhs.get_language()) != asciitolower(rhs.get_language()))
   {
     return 0;
   }
@@ -480,7 +492,7 @@ Language::match(const Language& lhs, const Language& rhs)
     };
 
     int c;
-    if (lhs.get_country() == rhs.get_country())
+    if (asciitolower(lhs.get_country()) == asciitolower(rhs.get_country()))
       c = 0;
     else if (lhs.get_country().empty() || rhs.get_country().empty())
       c = 1;
@@ -488,7 +500,7 @@ Language::match(const Language& lhs, const Language& rhs)
       c = 2;
 
     int m;
-    if (lhs.get_modifier() == rhs.get_modifier())
+    if (asciitolower(lhs.get_modifier()) == asciitolower(rhs.get_modifier()))
       m = 0;
     else if (lhs.get_modifier().empty() || rhs.get_modifier().empty())
       m = 1;

--- a/libs/tinygettext/src/language.cpp
+++ b/libs/tinygettext/src/language.cpp
@@ -278,12 +278,12 @@ static const LanguageSpec languages[] = {
   { "yi", nullptr,    nullptr, "Yiddish"                     },
   { "yo", nullptr,    nullptr, "Yoruba"                      },
   { "zh", nullptr,    nullptr, "Chinese"                     },
-  { "zh", "CN", nullptr, "Chinese (simplified)"        },
-  { "zh", "HK", nullptr, "Chinese (Hong Kong)"         },
-  { "zh", "TW", nullptr, "Chinese (traditional)"       },
-  { "zh", "Hans",     nullptr, "Chinese (simplified)"        },
-  { "zh", "Hant_HK",  nullptr, "Chinese (Hong Kong)"         },
-  { "zh", "Hant",     nullptr, "Chinese (traditional)"       },
+  { "zh", "CN", nullptr, "Chinese (China)"     },
+  { "zh", "HK", nullptr, "Chinese (Hong Kong)" },
+  { "zh", "TW", nullptr, "Chinese (Taiwan)"    },
+  { "zh", "Hans",     nullptr, "Chinese (simplified)"             },
+  { "zh", "Hant_HK",  nullptr, "Chinese (traditional, Hong Kong)" },
+  { "zh", "Hant",     nullptr, "Chinese (traditional)"            },
   { "zu", nullptr,    nullptr, "Zulu"                        },
   { nullptr, nullptr,    nullptr, nullptr                          }
 };

--- a/src/cgame/translation.cpp
+++ b/src/cgame/translation.cpp
@@ -250,7 +250,7 @@ static void Trans_SetLanguage( const char* lang )
 
 	trans_manager.set_language( bestLang );
 
-	LOG.Notice( "Set language to %s" , bestLang.get_name().c_str() );
+	LOG.Notice( "Set language to %s_%s (%s)" , bestLang.get_language().c_str() , bestLang.get_country().c_str() , bestLang.get_name().c_str() );
 }
 
 // TODO: update automatically on modification instead of having this stupid command


### PR DESCRIPTION
[tinygettext] Fix language matching, compare to lowercase-d specs, instead of forcibly making "country" spec uppercase (which could go wrong when that field isn’t really a country)

Fixes #2938 the hard way.

Note that this fix assumes that results from `Language::from_env` are only used for comparison to preset languages, rather than being used directly.