### PR TITLE
navgen: Use parallel threads to generate navmeshes

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1091,6 +1091,7 @@ static void GenerateNavmeshes()
 			missing.push_back( species );
 			continue;
 		}
+
 		NavMeshSetHeader header = {};
 		std::string error = GetNavmeshHeader( f, config, header, mapName );
 		if ( !error.empty() )
@@ -1112,30 +1113,32 @@ static void GenerateNavmeshes()
 	trap_UpdateScreen();
 
 	auto now = trap_Milliseconds();
-	NavmeshGenerator navgen;
-	NavgenStatus status = navgen.Init( mapName );
-	if ( !status.ok() )
 	{
-		Log::Warn( "Failed to load map data while generating navmesh: %s", status.String() );
-		return;
-	}
+		NavmeshGenerator navgen;
+		NavgenStatus status = navgen.Init( mapName );
+		if ( !status.ok() )
+		{
+			Log::Warn( "Failed to load map data while generating navmesh: %s", status.String() );
+			return;
+		}
 
-	for ( class_t species : missing )
-	{
-		navgen.StartGeneration( species );
-	}
+		for ( class_t species : missing )
+		{
+			navgen.StartGeneration( species );
+		}
 
-	float progress = 0.0f;
-	do
-	{
-		std::this_thread::sleep_for( std::chrono::seconds( 1 ) );
-		progress = navgen.Progress();
-		cg.loadingFraction = progress;
-		navgen.RunTasks();
-		trap_UpdateScreen();
-		Log::Notice( "Navmesh generation progress: %.0f%%", progress * 100 );
-	} while ( progress < 0.9f );
-	Log::Notice( "TOOK %d ms to gen navmeshes", (trap_Milliseconds() - now));
+		float progress = 0.0f;
+		do
+		{
+			std::this_thread::sleep_for( std::chrono::seconds( 1 ) );
+			progress = navgen.Progress();
+			cg.loadingFraction = progress;
+			navgen.RunTasks();
+			trap_UpdateScreen();
+			Log::Notice( "Navmesh generation progress: %.0f%%", progress * 100 );
+		} while ( progress < 1.0f );
+	}
+	Log::Notice( "Took %d ms to generate navmeshes", (trap_Milliseconds() - now));
 	cg.loadingNavmesh = false;
 }
 

--- a/src/sgame/botlib/bot_load.cpp
+++ b/src/sgame/botlib/bot_load.cpp
@@ -399,7 +399,7 @@ static navMeshStatus_t BotLoadNavMesh( int f, const NavgenConfig &config, const 
 
 		if ( dtStatusFailed( status ) )
 		{
-			Log::Warn("Failed to add tile to navmesh" );
+			Log::Warn( "Failed to add tile to navmesh" );
 			dtFree( data );
 			dtFreeTileCache( nav.cache );
 			dtFreeNavMesh( nav.mesh );

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -77,7 +77,7 @@ void G_BlockingGenerateNavmesh( std::bitset<PCL_NUM_CLASSES> classes )
 		progress = navgen.Progress();
 		navgen.RunTasks();
 		Log::Notice( "Navmesh generation progress: %.2f%%", progress * 100 );
-	} while ( navgen.Progress() < 0.9f );
+	} while ( navgen.Progress() < 1.0f );
 }
 
 // TODO: Latch(), when supported in gamelogic

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -116,6 +116,8 @@ struct NavMeshSetHeader
 	NavgenConfig config;
 	dtNavMeshParams params;
 	dtTileCacheParams cacheParams;
+
+	std::string ToString() const;
 };
 
 NavgenMapIdentification GetNavgenMapId( Str::StringRef mapName );

--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -1237,6 +1237,12 @@ float NavmeshGenerator::Progress()
 	return p / tasks_.size();
 }
 
+int NavmeshGenerator::ActiveTasks()
+{
+	const std::lock_guard<std::mutex> lock(mu_);
+	return tasks_.size() - statuses_.size();
+}
+
 void NavmeshGenerator::UpdateStatus( class_t species, NavgenStatus status )
 {
 	const std::lock_guard<std::mutex> lock(mu_);

--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -1279,7 +1279,7 @@ void NavmeshGenerator::StartGeneration( class_t species )
 		LOG.Warn( "Already started generation for %s.", BG_Class( species )->name );
 		return;
 	}
-	auto it = tasks_.insert({species, PerClassData()});
+	auto it = tasks_.emplace(std::pair<class_t, PerClassData>({species, PerClassData()}));
 	it.first->second.thread.reset(new std::thread(&NavmeshGenerator::Generate, this, species));
 }
 

--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -91,7 +91,7 @@ NavgenStatus NavmeshGenerator::WriteError(const PerClassData& data, const Navgen
 	trap_FS_FOpenFile( filename.c_str(), &file, fsMode_t::FS_WRITE );
 
 	if ( !file ) {
-		log( RC_LOG_ERROR, "failed to open file %s", filename );
+		log( RC_LOG_ERROR, "failed to open file %s", filename.c_str() );
 		return { NavgenStatus::PERMANENT_FAILURE, Str::Format( "failed to open file %s", filename ) };
 	}
 
@@ -150,7 +150,7 @@ NavgenStatus NavmeshGenerator::WriteFile( const PerClassData& data ) {
 	trap_FS_FOpenFile( filename.c_str(), &file, fsMode_t::FS_WRITE );
 
 	if ( !file ) {
-		log( RC_LOG_ERROR, "failed to open file %s", filename );
+		log( RC_LOG_ERROR, "failed to open file %s", filename.c_str() );
 		return { NavgenStatus::PERMANENT_FAILURE, Str::Format( "failed to open file %s", filename ) };
 	}
 

--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -1125,7 +1125,10 @@ NavgenStatus NavmeshGenerator::InitPerClassData( class_t species, PerClassData *
 			{
 				LOG.Warn( "Error writing error for %s: %s", BG_Class( species )->name, error.String() );
 			}
+
 		});
+		// Mark this as complete.
+		data->y = data->th;
 		return ret;
 	}
 
@@ -1161,6 +1164,8 @@ NavgenStatus NavmeshGenerator::Step(PerClassData *data)
 				LOG.Warn( "Error writing error for %s: %s", BG_Class( data->species )->name, error.String() );
 			}
 		});
+		// Mark this as complete.
+		data->y = data->th;
 		return status;
 	}
 

--- a/src/shared/navgen/navgen.h
+++ b/src/shared/navgen/navgen.h
@@ -213,4 +213,7 @@ public:
 
 	// Return progress of all tasks from 0 to 1.0.
 	float Progress();
+
+	// Return the number of active generation tasks.
+	int ActiveTasks();
 };


### PR DESCRIPTION
This greatly speeds up navmesh generation since now we can generate all the classes at once.

For comparison: generating plat23 takes ~30s serially but takes ~3s in parallel. Anthil takes 7 min serially but takes 30s in parallel.

We use C++'s regular thread interface which is supported by NaCL as well. One interesting thing about using multiple threads in the gamelogic is that we cannot make trap calls on threads since our trap call interface is single threaded (ie, we send a message and immediately wait for a reply on the same socket. If we send two messages, we will mess up replies for one or the other). Therefore, to work around this problem, there is a new `AsyncRunOnMainThread` interface which will asynchronously run trap calls on the main thread when you call `RunTasks()`. This works well enough.

To control parallelism, we added two cvars (for cgame and sgame): `cg_navgen_maxThreads` and `g_navgen_maxThreads`. Setting these to zero or below will result in all navmeshes being generated at once. By default, we generate them all at once as this is the fastest. It might be required to limit parallelism for some more unique maps like epic5 where it might eat up all your RAM and cause daemon to OOM.

Lastly, you can create navmeshes without starting the game using daemonded:

```
./daemonded -pakpath ../pkg -pakpath ~/.local/share/unvanquished/base/pkg -set vm.sgame.type 3 -set vm.cgame.type 3 +devmap <MAP_NAME> +navgen all +quit
```
