### PR TITLE
increase recast option EXPECTED_LAYERS_PER_TILE

### DIFF
--- a/src/shared/navgen/navgen.h
+++ b/src/shared/navgen/navgen.h
@@ -34,7 +34,7 @@
 #include "shared/bg_public.h"
 
 static const int MAX_LAYERS = 32;
-static const int EXPECTED_LAYERS_PER_TILE = 4;
+static const int EXPECTED_LAYERS_PER_TILE = 12;
 
 struct ladder_t
 {


### PR DESCRIPTION
Fix https://github.com/Unvanquished/Unvanquished/issues/2926.

It seems we set an upper bound of tiles for recast. It depends on `EXPECTED_LAYERS_PER_TILE`, in `nav.cpp`, we use this number to set something called `tcparams.maxTiles`.

I had to increase the number to as much as 12, in order to create complete navmeshes for map-cube.

