### PR TITLE
add navgen option walkableRadiusFactor

### DIFF
--- a/src/shared/bot_nav_shared.cpp
+++ b/src/shared/bot_nav_shared.cpp
@@ -167,6 +167,18 @@ static void ParseOption( Str::StringRef name, Str::StringRef value, Str::StringR
 			return;
 		}
 	}
+	else if ( Str::IsIEqual( name, "walkableRadiusFactor" ) )
+	{
+		if ( floatValue < 0.1f || 10.f < floatValue )
+		{
+			Log::Warn( "%s: incorrect value for walkableRadiusFactor '%f': must be between 0.1 and 10", file, floatValue );
+		}
+		else
+		{
+			config.walkableRadiusFactor = floatValue;
+			return;
+		}
+	}
 	else
 	{
 		Log::Warn( "%s: unknown navgen setting '%s'", file, name );

--- a/src/shared/bot_nav_shared.cpp
+++ b/src/shared/bot_nav_shared.cpp
@@ -169,9 +169,9 @@ static void ParseOption( Str::StringRef name, Str::StringRef value, Str::StringR
 	}
 	else if ( Str::IsIEqual( name, "walkableRadiusFactor" ) )
 	{
-		if ( floatValue < 0.1f || 10.f < floatValue )
+		if ( floatValue < 0.6f || 2.f < floatValue )
 		{
-			Log::Warn( "%s: incorrect value for walkableRadiusFactor '%f': must be between 0.1 and 10", file, floatValue );
+			Log::Warn( "%s: incorrect value for walkableRadiusFactor '%f': must be between 0.6 and 2", file, floatValue );
 		}
 		else
 		{

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -85,8 +85,9 @@ struct NavgenConfig {
 	float autojumpSecurity; // percentage - allow to use part of jump magnitude (with default gravity of 800) as stepsize. The result can not excess the agent's height, except if STEPSIZE is already doing it (then STEPSIZE will be used)
 	int crouchSupport; // boolean - use crouchMaxs.z value instead of maxs.z to compute paths
 	float cellSizeFactor;
+	float walkableRadiusFactor;
 
-	static NavgenConfig Default() { return { 2.0f, STEPSIZE, 1, 1, 1, 1, 0.5f, false, 0.25f }; }
+	static NavgenConfig Default() { return { 2.0f, STEPSIZE, 1, 1, 1, 1, 0.5f, false, 0.25f, 1.0f }; }
 };
 
 struct NavgenMapIdentification

--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -1071,7 +1071,7 @@ std::unique_ptr<NavgenTask> NavmeshGenerator::StartGeneration( class_t species )
 	t->cfg.walkableSlopeAngle = RAD2DEG( acosf( MIN_WALK_NORMAL ) );
 	t->cfg.walkableHeight = ( int ) ceilf( height / t->cfg.ch );
 	t->cfg.walkableClimb = ( int ) floorf( climb / t->cfg.ch );
-	t->cfg.walkableRadius = ( int ) ceilf( radius / t->cfg.cs );
+	t->cfg.walkableRadius = ( int ) ceilf( radius * config_.walkableRadiusFactor / t->cfg.cs );
 	t->cfg.maxEdgeLen = 0;
 	t->cfg.maxSimplificationError = 1.3f;
 	t->cfg.minRegionArea = rcSqr( 25 );
@@ -1093,7 +1093,7 @@ std::unique_ptr<NavgenTask> NavmeshGenerator::StartGeneration( class_t species )
 	t->tcparams.width = ts;
 	t->tcparams.height = ts;
 	t->tcparams.walkableHeight = height;
-	t->tcparams.walkableRadius = radius;
+	t->tcparams.walkableRadius = radius * config_.walkableRadiusFactor;
 	t->tcparams.walkableClimb = climb;
 	t->tcparams.maxSimplificationError = 1.3;
 	t->tcparams.maxTiles = t->tw * t->th * EXPECTED_LAYERS_PER_TILE;


### PR DESCRIPTION
There is a margin between the edge of a navmesh, and the actual geometry causing this edge. Look at the level4 navmesh on map antares for example:

![unvanquished_2024-03-06_103603_000](https://github.com/Unvanquished/Unvanquished/assets/110394607/d4cdc731-839e-4f85-9cf7-1f11d0d196da)

Notice how these margins cause a gap in the navmesh, where the white circle is. The tyrant bots will not leave their base on this path, despite the fact that a tyrant fits in there. 

This is very unfortunate, as there is a similar gap at the other exit as well. So tyrant bots cannot leave their base.

The margin is controlled by a value `walkableRadius` we tell recast to use. Add a navgen option `walkableRadiusFactor`, to tweak this value. For example, create a file `game/maps/antares.navcfg`:

```
walkableRadiusFactor 0.75
```

Restart, and look at the same navmesh:

![unvanquished_2024-03-06_103634_000](https://github.com/Unvanquished/Unvanquished/assets/110394607/b91a40fb-2c61-4a14-a141-1389d9218ba7)

There is one other important reason to keep the margins as small as we can: bots will only pick enemy buildings as targets if their origin is over the navmesh (with minor exceptions).

This is a very dangerous value to tweak. Make the margin too small, and bots might get stuck at little edges on the walls.
