### PR TITLE
add Chinese language to the UI menu for selection

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/options_ui.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_ui.rml
@@ -33,6 +33,9 @@
 						<option value="it">Italiano</option>
 						<option value="es">Español</option>
 						<option value="fi">Suomi</option>
+						<option value="zh_Hans">中文（简体）</option>
+						<option value="zh_Hant_HK">中文（香港）</option>
+						<option value="zh_Hant">中文（正體）</option>
 					</select>
 					<button style="width:50%; margin:auto; margin-top:1.5em;" onclick='Events.pushevent("exec language", event);Events.pushevent("exec updatelanguage", event)'><translate>Change language</translate></button>
 				</row>


### PR DESCRIPTION
After #2941, both client and server can handle locale code with “country specification” correctly. They will, say, distinguish `zh_Hans` vs `zh_Hant` or `en_US` vs `en_GB`, not mixing them up.

This adds 3 variants of Chinese language (`zh_Hans`, `zh_Hant_HK` and `zh_Hant`) to the UI menu for selection, as they are completed (>50% progress), and will just work.
(“completed” as “100% progress”, proof reading & quality fixes going on 😄)

Note that language detection isn’t fixed at the moment, so a clean startup on a machine with `LANG=zh_*` would always select a specific variant, whichever the code encounters first.
