### PR TITLE
Use multiple threads to generate navmeshes

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/server_setup.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/server_setup.rml
@@ -235,6 +235,18 @@
 				<input cvar="g_bot_infiniteMomentum" type="checkbox" />
 				<h3> Ignore momentum </h3>
 			</row>
+			<h2>Navmesh generation</h2>
+			<row>
+				<input cvar="cg_navgenOnLoad" type="checkbox" />
+				<h3>Generate navmeshes at load time</h3>
+			</row>
+			<row>
+				<input type="range" min="1" max="16" step="1" cvar="cg_navgenMaxThreads"/>
+				<h3>Number of worker threads</h3>
+				<p class="inline">
+					Current: <inlinecvar cvar="cg_navgenMaxThreads" type="number" format="%.0f"/>
+				</p>
+			</row>
 		</panel>
 
 		<!-- HUMANS BOT CONFIG -->

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1125,16 +1125,16 @@ static void GenerateNavmeshes()
 		cg.navmeshLoadingFraction = classesCompleted / classesTotal;
 		trap_UpdateScreen();
 
-		navgen.StartGeneration( species );
+		std::unique_ptr<NavgenTask> task = navgen.StartGeneration( species );
 		do
 		{
-			float fraction = ( classesCompleted + navgen.SpeciesFractionCompleted() ) / classesTotal;
+			float fraction = ( classesCompleted + task->FractionCompleted() ) / classesTotal;
 			if ( fraction - cg.navmeshLoadingFraction > 0.01 )
 			{
 				cg.navmeshLoadingFraction = fraction;
 				trap_UpdateScreen();
 			}
-		} while ( !navgen.Step() );
+		} while ( !navgen.Step( *task ) );
 		++classesCompleted;
 	}
 	cg.loadingNavmesh = false;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1117,7 +1117,7 @@ static void GenerateNavmeshes()
 	trap_UpdateScreen();
 
 	NavmeshGenerator navgen;
-	navgen.EnqueueTasks( mapName, missing );
+	navgen.LoadMapAndEnqueueTasks( mapName, missing );
 	navgen.StartBackgroundThreads( cg_navgenMaxThreads.Get() );
 	navgen.WaitInMainThread( []( float progress ) {
 		if ( progress >= cg.navmeshLoadingFraction + 0.01f )

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1122,7 +1122,7 @@ static void GenerateNavmeshes()
 	{
 		cg.loadingText =
 			Str::Format( "%s — %s", message, BG_ClassModelConfig( species )->humanName );
-		cg.loadingFraction = classesCompleted / classesTotal;
+		cg.navmeshLoadingFraction = classesCompleted / classesTotal;
 		trap_UpdateScreen();
 
 		navgen.StartGeneration( species );
@@ -1349,7 +1349,6 @@ void CG_Init( int serverMessageNum, int clientNum, const glconfig_t& gl, const G
 	CG_Rocket_LoadHuds();
 	CG_LoadBeaconsConfig();
 
-	CG_UpdateLoadingStep( LOAD_GLSL );
 	trap_S_EndRegistration();
 
 	if ( cg_navgenOnLoad.Get() && Cvar::GetValue( "sv_running" ) == "1" )

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -158,9 +158,10 @@ Cvar::Cvar<float> cg_motionblurMinSpeed("cg_motionblurMinSpeed", "minimum speed 
 Cvar::Cvar<bool> cg_spawnEffects("cg_spawnEffects", "desaturate world view when dead or spawning", Cvar::NONE, true);
 
 static Cvar::Cvar<bool> cg_navgenOnLoad("cg_navgenOnLoad", "generate navmeshes when starting a local game", Cvar::NONE, true);
+// hardware_concurrency() miraculously works in NaCl.
 static Cvar::Cvar<int> cg_navgenMaxThreads(
 	"cg_navgenMaxThreads", "Maximum number of threads to use when generating navmeshes",
-	Cvar::NONE, 2);
+	Cvar::NONE, std::max(1, int(std::thread::hardware_concurrency()) - 1));
 
 // search 'fovCvar' to find usage of these (names come from config files)
 // 0 means use global FOV setting

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -6215,6 +6215,12 @@ bool G_admin_navgen( gentity_t* ent )
 		return false;
 	}
 
+	if ( navMeshLoaded == navMeshStatus_t::GENERATING )
+	{
+		ADMP( QQ( "^3navgen:^* navmesh generation is already running" ) );
+		return false;
+	}
+
 	std::string mapName = Cvar::GetValue( "mapname" );
 	std::bitset<PCL_NUM_CLASSES> targets;
 

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -69,7 +69,7 @@ Cvar::Cvar<bool> g_bot_navmeshReduceTypes(
 	Cvar::NONE, false);
 
 static Cvar::Range<Cvar::Cvar<int>> msecPerFrame(
-	"g_bot_navgen_msecPerFrame", "time budget per frame for navmesh generation",
+	"g_bot_navgen_msecPerFrame", "time budget per frame for single-threaded navmesh generation",
 	Cvar::NONE, 20, 1, 1500 );
 
 static Cvar::Cvar<int> frameToggle("g_bot_navgen_frame", "FOR INTERNAL USE", Cvar::NONE, 0);

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -58,7 +58,7 @@ void G_BlockingGenerateNavmesh( std::bitset<PCL_NUM_CLASSES> classes )
 {
 	std::string mapName = Cvar::GetValue( "mapname" );
 	NavmeshGenerator navgen;
-	navgen.EnqueueTasks( mapName, classes );
+	navgen.LoadMapAndEnqueueTasks( mapName, classes );
 	navgen.StartBackgroundThreads( g_bot_navgen_maxThreads.Get() );
 	navgen.WaitInMainThread( []( float ) {} );
 }
@@ -236,7 +236,7 @@ void G_BotNavInit( int generateNeeded )
 		else
 		{
 			ASSERT( !generatingNow );
-			navgen.EnqueueTasks( mapName, missing );
+			navgen.LoadMapAndEnqueueTasks( mapName, missing );
 			usingBackgroundThreads = g_bot_navgen_maxThreads.Get() > 0;
 
 			if ( usingBackgroundThreads )

--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -70,6 +70,8 @@ void UnvContext::DoMainThreadTasks()
 	{
 		f();
 	}
+
+	mainThreadTasks_.clear();
 }
 
 static NavgenStatus::Code CodeForFailedDtStatus(dtStatus status)
@@ -1164,6 +1166,7 @@ std::unique_ptr<NavgenTask> NavmeshGenerator::StartGeneration( class_t species )
 	return t;
 }
 
+// May be called from a worker thread, thus must not use trap calls.
 std::unique_ptr<NavgenTask> NavmeshGenerator::PopTask()
 {
 	if ( taskQueue_.empty() )
@@ -1181,6 +1184,7 @@ float NavmeshGenerator::FractionComplete() const
 	return float(fractionCompleteNumerator_) / float(fractionCompleteDenominator_);
 }
 
+// May be called from a worker thread, thus must not use trap calls.
 bool NavmeshGenerator::Step( NavgenTask &t )
 {
 	if ( t.status.code != NavgenStatus::OK || t.y >= t.th || t.tw == 0 )

--- a/src/shared/navgen/navgen.h
+++ b/src/shared/navgen/navgen.h
@@ -112,7 +112,7 @@ const rcChunkyTriMesh *getChunkyMesh() { return &mesh; }
 
 class UnvContext : public rcContext
 {
-	void doLog(const rcLogCategory /*category*/, const char* msg, const int /*len*/) override;
+	void doLog(rcLogCategory category, const char* msg, int len) override;
 };
 
 struct NavgenStatus

--- a/src/shared/navgen/navgen.h
+++ b/src/shared/navgen/navgen.h
@@ -174,25 +174,23 @@ private:
 	std::vector<std::unique_ptr<NavgenTask>> taskQueue_;
 
 	std::atomic<int> fractionCompleteNumerator_{0};
-	int fractionCompleteDenominator_ = 0;
+	int fractionCompleteDenominator_;
 
 	// Map geometry loading
 	void LoadBSP();
 	void LoadGeometry();
 	void LoadTris(std::vector<float>& verts, std::vector<int>& tris);
+	// in principle mapName could be different from the current map, if the necessary pak is loaded
+	void LoadMap(Str::StringRef mapName);
 
 	void WriteFile(const NavgenTask& t);
-
-	// load the BSP if it has not been loaded already
-	// in principle mapName could be different from the current map, if the necessary pak is loaded
-	void Init(Str::StringRef mapName);
 
 public:
 	~NavmeshGenerator();
 
 	std::unique_ptr<NavgenTask> StartGeneration(class_t species);
 
-	void EnqueueTasks(Str::StringRef mapName, std::bitset<PCL_NUM_CLASSES> classes);
+	void LoadMapAndEnqueueTasks(Str::StringRef mapName, std::bitset<PCL_NUM_CLASSES> classes);
 
 	// Only intended to be meaningful if no tasks have failed
 	float FractionComplete() const;


### PR DESCRIPTION
Some improvements compared to #2944, in particular:
- keeps code for generating on main thread only for sgame background navgen
- can cancel navgen if the sgame shuts down so as not to hang the server
- fixes regression that map-level errors are no longer cached

Also I added menu options.