### PR TITLE
add attack.bt

### DIFF
--- a/pkg/unvanquished_src.dpkdir/bots/attack.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/attack.bt
@@ -1,0 +1,110 @@
+selectClass
+{
+	selector
+	{
+		condition team == TEAM_ALIENS
+		{
+			spawnAs PCL_ALIEN_LEVEL0
+		}
+		condition team == TEAM_HUMANS
+		{
+			spawnAs WP_MACHINEGUN
+		}
+	}
+}
+
+selector
+{
+	// reset the suicide timer
+	decorator return( STATUS_FAILURE )
+	{
+		action resetMyTimer
+	}
+
+	behavior unstick
+
+	condition team == TEAM_HUMANS
+	{
+		selector
+		{
+			behavior use_medkit
+
+			sequence
+			{
+				condition alertedToEnemy
+				condition percentAmmoClip > 0 || percentClips > 0
+				{
+					selector
+					{
+						sequence
+						{
+							//if goal is a close enough enemy building or if we're gonna die
+							condition ( percentHealth( E_SELF ) < 0.3 || ( distanceTo( E_GOAL ) < 400 && goalType == ET_BUILDABLE ) )
+							condition ( distanceTo( E_FRIENDLYBUILDING ) > 400 )
+							selector
+							{
+								// no need to check the upgrade is in inventory, since action would fail
+								action activateUpgrade( UP_FIREBOMB )
+								action activateUpgrade( UP_GRENADE )
+							}
+						}
+						action fight
+					}
+				}
+			}
+
+			sequence
+			{
+				// the bot is required to attack, only visit an armoury
+				// if one is near
+				condition ( distanceTo( E_H_ARMOURY ) < 500 )
+				action equip
+			}
+
+			selector
+			{
+				condition percentAmmoClip == 0 && percentClips == 0
+				{
+					// refill at a suitable building
+					// TODO: reload energy weapons at reactor etc
+					action moveTo( E_H_ARMOURY )
+				}
+			}
+
+			sequence
+			{
+				// the bot cannot refill or equip, it must fight with the blaster
+				condition alertedToEnemy
+				action fight
+			}
+
+			action rush
+			action roamInRadius( E_A_OVERMIND, 500 )
+			action roamInRadius( E_A_SPAWN, 500 )
+			action roam
+		}
+
+	}
+
+	condition team == TEAM_ALIENS
+	{
+		selector
+		{
+			condition ( aliveTime > 1500 && healScore < 0.5 )
+			{
+				action evolve
+			}
+
+			sequence
+			{
+				condition alertedToEnemy
+				action fight
+			}
+
+			action rush
+			action roamInRadius( E_H_REACTOR, 500 )
+			action roamInRadius( E_H_SPAWN, 500 )
+			action roam
+		}
+	}
+}

--- a/pkg/unvanquished_src.dpkdir/bots/reckless.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/reckless.bt
@@ -1,3 +1,7 @@
+// this is a minimal example behavior
+// it makes a bot attack constantly
+// see attack.bt for a more elaborate variant of this to use in serious games
+
 selector
 {
 	behavior unstick


### PR DESCRIPTION
This is the fifth bot behavior players can use on my server. It makes a bot attack the enemy base.

For reference, I use this on my server:
```
set g_tacticBehaviors "default, defend, attack, follow, stay-here"
```

This is similar to `reckless.bt`, but more elaborate. I do not dare to change `reckless.bt`. It is the simplest interesting example behavior, and was the first behavior I studied while learning the behavior tree language.