### PR TITLE
add bt function timeSinceLastCombat

### DIFF
--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -404,6 +404,11 @@ static AIValue_t stuckTime( gentity_t *self, const AIValue_t* )
 	return AIBoxInt( level.time - self->botMind->stuckTime );
 }
 
+static AIValue_t timeSinceLastCombat( gentity_t *self, const AIValue_t* )
+{
+	return AIBoxInt( level.time - self->client->lastCombatTime );
+}
+
 static AIValue_t usableBuildPoints( gentity_t *self, const AIValue_t* )
 {
 	team_t team = G_Team( self );
@@ -505,6 +510,7 @@ static const struct AIConditionMap_s
 	{ "stuckTime",         stuckTime,         0 },
 	{ "team",              botTeam,           0 },
 	{ "teamateHasWeapon",  teamateHasWeapon,  1 },
+	{ "timeSinceLastCombat", timeSinceLastCombat, 0 },
 	{ "usableBuildPoints", usableBuildPoints, 0 },
 	{ "weapon",            currentWeapon,     0 }
 };


### PR DESCRIPTION
There is an old, reliable integer in each client state on the server: the last combat time. It is the last time when a player has been hurt by the opponent team. The original purpose for this number was probably to restrict players from joining the specator team to avoid being killed.

There have been discussions about this number. Should it account for other damage times as well? I think the conclusion was to keep its ancient behavior.

Add a bot behavior function to query this number. This will be useful for future PRs. A bot frequently needs to find out if it is currently in combat.

Edit:
We have a rule: do not merge anything that is not used. This rule does not apply here. This an extension to the bot configuration language.