### PR TITLE
reduce g_bot_chasetime to two seconds

### DIFF
--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -289,7 +289,7 @@ Cvar::Cvar<bool> g_bot_level4("g_bot_level4", "whether bots use Tyrant", Cvar::N
 // misc bot cvars
 Cvar::Cvar<bool> g_bot_attackStruct("g_bot_attackStruct", "whether bots target buildables", Cvar::NONE, true);
 Cvar::Cvar<float> g_bot_fov("g_bot_fov", "bots' \"field of view\"", Cvar::NONE, 125);
-Cvar::Cvar<int> g_bot_chasetime("g_bot_chasetime", "bots stop chasing after x ms out of sight", Cvar::NONE, 5000);
+Cvar::Cvar<int> g_bot_chasetime("g_bot_chasetime", "bots stop chasing after x ms out of sight", Cvar::NONE, 2000);
 Cvar::Cvar<int> g_bot_reactiontime("g_bot_reactiontime", "bots' reaction time to enemies (milliseconds)", Cvar::NONE, 500);
 Cvar::Cvar<bool> g_bot_infiniteFunds("g_bot_infiniteFunds", "give bots unlimited funds", Cvar::NONE, false);
 Cvar::Cvar<bool> g_bot_infiniteMomentum("g_bot_infiniteMomentum", "allow bots to ignore momentum, but not other restrictions", Cvar::NONE, false);


### PR DESCRIPTION
The bot chase time controls a rather cheaty bot feature. If a bot targets an enemy, and loses the line of sight, it will magically know the enemy's position and chase it. This is a crucial feature, as the line of sight might be blocked only for a few frames, and we have to avoid retargeting during this short time.

Like all cheaty bot features, this should be as short a time as possible. The main reason is: it is easy to exploit. If a player is low on funds, they can try to pull enemy bots away from their team one by one, and kill them for funds once isolated. This is far too easy with the old chase time of five seconds.

This mainly affects human bots without radar.