### PR TITLE
cg_trails: do not send message with an allocated array of size 0, fix #2682

### DIFF
--- a/src/cgame/cg_trails.cpp
+++ b/src/cgame/cg_trails.cpp
@@ -302,7 +302,12 @@ static void CG_RenderBeam( trailBeam_t *tb )
 	}
 	while ( i );
 
-	trap_R_AddPolysToScene( tb->class_->shader, 4, &verts[ 0 ], numVerts / 4 );
+	numVerts /= 4;
+
+	if ( numVerts )
+	{
+		trap_R_AddPolysToScene( tb->class_->shader, 4, &verts[ 0 ], numVerts );
+	}
 }
 
 /*


### PR DESCRIPTION
Do not send message with an allocated array of size 0, fix #2682:

- https://github.com/Unvanquished/Unvanquished/issues/2682