### PR TITLE
cgame: Fix ckit taunt not working

### DIFF
--- a/src/shared/bg_pmove.cpp
+++ b/src/shared/bg_pmove.cpp
@@ -4236,7 +4236,7 @@ static void PM_Animate()
 		{
 			int wpAnim = TORSO_GESTURE_BLASTER + ( pm->ps->weapon - WP_BLASTER );
 			//and now I know why build stuff must be last in the weapon list...
-			PM_StartTorsoAnim( wpAnim > WP_LUCIFER_CANNON ?  TORSO_GESTURE_CKIT : wpAnim );
+			PM_StartTorsoAnim( wpAnim > TORSO_GESTURE_LUCI ?  TORSO_GESTURE_CKIT : wpAnim );
 			doit = true;
 		}
 		// This code could likely be purged, really (but double

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -846,6 +846,8 @@ enum playerAnimNumber_t
   BOTH_DEATH2,
   BOTH_DEATH3,
 
+  // IMPORTANT: Must be first in gesture list, and these should generally follow the
+  // the order of the WP_ enum because we do enum math that assumes this.
   TORSO_GESTURE_BLASTER,
   TORSO_GESTURE,
   TORSO_GESTURE_PSAW,
@@ -856,6 +858,8 @@ enum playerAnimNumber_t
   TORSO_GESTURE_PRIFLE,
   TORSO_GESTURE_FLAMER,
   TORSO_GESTURE_LUCI,
+  // IMPORTANT: Must be last in gesture list.
+  // We do enum math and special cases that assume that this is the last entry.
   TORSO_GESTURE_CKIT,
 
   TORSO_RALLY,


### PR DESCRIPTION
We were comparing the wrong enum type. We were comparing a WP_ enum to an animation enum. This causes ckit taunt to not work. Add some comments in bg_public.h indicating that the animation enum order is important and load bearing.