### PR TITLE
cg_marks: implement `trap_CM_BatchMarkFragments` to process all impact marks in one call

### DIFF
--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -317,8 +317,9 @@ static void CG_Creep( centity_t *cent )
 
 	if ( size > 0.0f && tr.fraction < 1.0f )
 	{
-		CG_ImpactMark( cgs.media.creepShader, tr.endpos, cent->currentState.origin2,
-		               0.0f, 1.0f, 1.0f, 1.0f, 1.0f, false, size, true );
+		CG_RegisterMark( cgs.media.creepShader, tr.endpos, cent->currentState.origin2,
+			0.0f, 1.0f, 1.0f, 1.0f, 1.0f,
+			false, size, true );
 	}
 }
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -834,7 +834,7 @@ struct markPoly_t
 	markPoly_t *prevMark, *nextMark;
 
 	int               time;
-	qhandle_t         markShader;
+	qhandle_t shader;
 	bool          alphaFade; // fade alpha instead of rgb
 	float             color[ 4 ];
 	poly_t            poly;
@@ -2146,13 +2146,16 @@ void CG_DrawMinimap( const rectDef_t *rect, const Color::Color& color );
 // cg_marks.c
 //
 void CG_InitMarkPolys();
-void CG_AddMarks();
-void CG_ImpactMark( qhandle_t markShader,
+void CG_AddMarkPolys();
+void CG_RegisterMark( qhandle_t shader,
                     const vec3_t origin, const vec3_t dir,
                     float orientation,
                     float r, float g, float b, float a,
                     bool alphaFade,
                     float radius, bool temporary );
+
+void CG_ResetMarks();
+void CG_ProcessMarks();
 
 //
 // cg_snapshot.c

--- a/src/cgame/cg_marks.cpp
+++ b/src/cgame/cg_marks.cpp
@@ -39,7 +39,6 @@ MARK POLYS
 markPoly_t cg_activeMarkPolys; // double linked list
 markPoly_t *cg_freeMarkPolys; // single linked list
 markPoly_t cg_markPolys[ MAX_MARK_POLYS ];
-static int markTotal;
 
 /*
 ===================
@@ -92,7 +91,7 @@ CG_AllocMark
 Will always succeed, even if it requires freeing an old active mark
 ===================
 */
-static markPoly_t *CG_AllocMark()
+static markPoly_t *CG_AllocMarkPoly()
 {
 	markPoly_t *le;
 	int        time;
@@ -122,34 +121,136 @@ static markPoly_t *CG_AllocMark()
 	return le;
 }
 
-/*
-=================
-CG_ImpactMark
+struct mark_t
+{
+	// Set at register time.
 
-origin should be a point within a unit of the plane
-dir should be the plane normal
+	qhandle_t shader;
+	// origin should be a point within a unit of the plane.
+	vec3_t origin;
+	// dir should be the plane normal
+	vec3_t dir;
+	float orientation;
+	float red;
+	float green;
+	float blue;
+	float alpha;
+	bool alphaFade;
+	float radius;
+	/* temporary marks will not be stored or randomly oriented,
+	but immediately passed to the renderer. */
+	bool temporary;
 
-temporary marks will not be stored or randomly oriented, but immediately
-passed to the renderer.
-=================
-*/
-#define MAX_MARK_FRAGMENTS 128
-#define MAX_MARK_POINTS    384
+	// Set at processing time.
 
-void CG_ImpactMark( qhandle_t markShader, const vec3_t origin, const vec3_t dir,
+	vec3_t axis[ 3 ];
+	float texCoordScale;
+};
+
+BoundedVector<mark_t, MAX_MARK_POLYS> newMarks;
+
+void CG_ProcessMarks()
+{
+	std::vector<markMsgInput_t> markMsgInput;
+	std::vector<markMsgOutput_t> markMsgOutput;
+	markMsgInput.reserve( newMarks.size() );
+
+	for ( mark_t &m : newMarks )
+	{
+		markMsgInput_t input;
+		auto& originalPoints = input.first;
+		auto& projection = input.second;
+
+		// create the texture axis
+		VectorNormalize2( m.dir, m.axis[ 0 ] );
+		PerpendicularVector( m.axis[ 1 ], m.axis[ 0 ] );
+		RotatePointAroundVector( m.axis[ 2 ], m.axis[ 0 ], m.axis[ 1 ], m.orientation );
+		CrossProduct( m.axis[ 0 ], m.axis[ 2 ], m.axis[ 1 ] );
+
+		m.texCoordScale = 0.5 * 1.0 / m.radius;
+
+		// create the full polygon
+		originalPoints.resize( 4 );
+		for ( size_t i = 0; i < 3; i++ )
+		{
+			originalPoints[ 0 ][ i ] = m.origin[ i ] - m.radius * m.axis[ 1 ][ i ] - m.radius * m.axis[ 2 ][ i ];
+			originalPoints[ 1 ][ i ] = m.origin[ i ] + m.radius * m.axis[ 1 ][ i ] - m.radius * m.axis[ 2 ][ i ];
+			originalPoints[ 2 ][ i ] = m.origin[ i ] + m.radius * m.axis[ 1 ][ i ] + m.radius * m.axis[ 2 ][ i ];
+			originalPoints[ 3 ][ i ] = m.origin[ i ] - m.radius * m.axis[ 1 ][ i ] + m.radius * m.axis[ 2 ][ i ];
+		}
+
+		VectorScale( m.dir, -20, projection );
+		markMsgInput.push_back( input );
+	}
+
+	trap_CM_BatchMarkFragments( 384, 128, markMsgInput, markMsgOutput );
+
+	size_t numMarks = markMsgInput.size();
+	for ( size_t k = 0; k < numMarks; k++ )
+	{
+		const markMsgOutput_t& output = markMsgOutput[ k ];
+		const std::vector<markFragment_t> &markFragments = output.second;
+		const auto &markPoints = output.first;
+
+		const mark_t& m = newMarks[ k ];
+
+		byte colors[ 4 ];
+		colors[ 0 ] = m.red * 255;
+		colors[ 1 ] = m.green * 255;
+		colors[ 2 ] = m.blue * 255;
+		colors[ 3 ] = m.alpha * 255;
+
+		for ( const markFragment_t &markFragment : markFragments )
+		{
+			// we have an upper limit on the complexity of polygons
+			// that we store persistently
+			const int numPoints = std::min( markFragment.numPoints, MAX_VERTS_ON_POLY );
+
+			polyVert_t verts[ MAX_VERTS_ON_POLY ];
+
+			for ( int j = 0; j < numPoints; j++ )
+			{
+				polyVert_t& vert = verts[ j ];
+				const std::array<float, 3> &markPoint = markPoints[ markFragment.firstPoint + j ];
+
+				VectorCopy( markPoint, vert.xyz );
+
+				vec3_t delta;
+				VectorSubtract( vert.xyz, m.origin, delta );
+
+				vert.st[ 0 ] = 0.5 + DotProduct( delta, m.axis[ 1 ] ) * m.texCoordScale;
+				vert.st[ 1 ] = 0.5 + DotProduct( delta, m.axis[ 2 ] ) * m.texCoordScale;
+				*(int*) vert.modulate = *(int*) colors;
+			}
+
+			// if it is a temporary (shadow) mark, add it immediately and forget about it
+			if ( m.temporary )
+			{
+				trap_R_AddPolyToScene( m.shader, numPoints, verts );
+				continue;
+			}
+
+			// otherwise save it persistently
+			markPoly_t *mp = CG_AllocMarkPoly();
+
+			mp->time = cg.time;
+			mp->alphaFade = m.alphaFade;
+			mp->shader = m.shader;
+			mp->poly.numVerts = numPoints;
+			mp->color[ 0 ] = m.red;
+			mp->color[ 1 ] = m.green;
+			mp->color[ 2 ] = m.blue;
+			mp->color[ 3 ] = m.alpha;
+
+			memcpy( mp->verts, verts, numPoints * sizeof( polyVert_t ) );
+		}
+	}
+}
+
+void CG_RegisterMark( qhandle_t shader, const vec3_t origin, const vec3_t dir,
                     float orientation, float red, float green, float blue, float alpha,
                     bool alphaFade, float radius, bool temporary )
 {
-	vec3_t         axis[ 3 ];
-	float          texCoordScale;
-	vec3_t         originalPoints[ 4 ];
-	byte           colors[ 4 ];
-	int            i, j;
-	int            numFragments;
-	markFragment_t markFragments[ MAX_MARK_FRAGMENTS ], *mf;
-	vec3_t         markPoints[ MAX_MARK_POINTS ];
-	vec3_t         projection;
-
 	if ( !cg_addMarks.Get() )
 	{
 		return;
@@ -165,86 +266,29 @@ void CG_ImpactMark( qhandle_t markShader, const vec3_t origin, const vec3_t dir,
 
 	if ( radius <= 0 )
 	{
-		Sys::Drop( "CG_ImpactMark called with <= 0 radius" );
+		Sys::Drop( "CG_ProcessMark called with <= 0 radius" );
 	}
 
-	//if ( markTotal >= MAX_MARK_POLYS ) {
-	//  return;
-	//}
+	mark_t m;
 
-	// create the texture axis
-	VectorNormalize2( dir, axis[ 0 ] );
-	PerpendicularVector( axis[ 1 ], axis[ 0 ] );
-	RotatePointAroundVector( axis[ 2 ], axis[ 0 ], axis[ 1 ], orientation );
-	CrossProduct( axis[ 0 ], axis[ 2 ], axis[ 1 ] );
+	m.shader = shader;
+	VectorCopy( origin, m.origin );
+	VectorCopy( dir, m.dir );
+	m.orientation = orientation;
+	m.red = red;
+	m.green = green;
+	m.blue = blue;
+	m.alpha = alpha;
+	m.alphaFade = alphaFade;
+	m.radius = radius;
+	m.temporary = temporary;
 
-	texCoordScale = 0.5 * 1.0 / radius;
+	newMarks.append( m );
+}
 
-	// create the full polygon
-	for ( i = 0; i < 3; i++ )
-	{
-		originalPoints[ 0 ][ i ] = origin[ i ] - radius * axis[ 1 ][ i ] - radius * axis[ 2 ][ i ];
-		originalPoints[ 1 ][ i ] = origin[ i ] + radius * axis[ 1 ][ i ] - radius * axis[ 2 ][ i ];
-		originalPoints[ 2 ][ i ] = origin[ i ] + radius * axis[ 1 ][ i ] + radius * axis[ 2 ][ i ];
-		originalPoints[ 3 ][ i ] = origin[ i ] - radius * axis[ 1 ][ i ] + radius * axis[ 2 ][ i ];
-	}
-
-	// get the fragments
-	VectorScale( dir, -20, projection );
-	numFragments = trap_CM_MarkFragments( 4, ( const vec3_t * ) originalPoints,
-	                                      projection, MAX_MARK_POINTS, markPoints[ 0 ],
-	                                      MAX_MARK_FRAGMENTS, markFragments );
-
-	colors[ 0 ] = red * 255;
-	colors[ 1 ] = green * 255;
-	colors[ 2 ] = blue * 255;
-	colors[ 3 ] = alpha * 255;
-
-	for ( i = 0, mf = markFragments; i < numFragments; i++, mf++ )
-	{
-		polyVert_t *v;
-		polyVert_t verts[ MAX_VERTS_ON_POLY ];
-		markPoly_t *mark;
-
-		// we have an upper limit on the complexity of polygons
-		// that we store persistently
-		if ( mf->numPoints > MAX_VERTS_ON_POLY )
-		{
-			mf->numPoints = MAX_VERTS_ON_POLY;
-		}
-
-		for ( j = 0, v = verts; j < mf->numPoints; j++, v++ )
-		{
-			vec3_t delta;
-
-			VectorCopy( markPoints[ mf->firstPoint + j ], v->xyz );
-
-			VectorSubtract( v->xyz, origin, delta );
-			v->st[ 0 ] = 0.5 + DotProduct( delta, axis[ 1 ] ) * texCoordScale;
-			v->st[ 1 ] = 0.5 + DotProduct( delta, axis[ 2 ] ) * texCoordScale;
-			* ( int * ) v->modulate = * ( int * ) colors;
-		}
-
-		// if it is a temporary (shadow) mark, add it immediately and forget about it
-		if ( temporary )
-		{
-			trap_R_AddPolyToScene( markShader, mf->numPoints, verts );
-			continue;
-		}
-
-		// otherwise save it persistently
-		mark = CG_AllocMark();
-		mark->time = cg.time;
-		mark->alphaFade = alphaFade;
-		mark->markShader = markShader;
-		mark->poly.numVerts = mf->numPoints;
-		mark->color[ 0 ] = red;
-		mark->color[ 1 ] = green;
-		mark->color[ 2 ] = blue;
-		mark->color[ 3 ] = alpha;
-		memcpy( mark->verts, verts, mf->numPoints * sizeof( verts[ 0 ] ) );
-		markTotal++;
-	}
+void CG_ResetMarks()
+{
+	newMarks.clear();
 }
 
 /*
@@ -255,7 +299,7 @@ CG_AddMarks
 #define MARK_TOTAL_TIME 10000
 #define MARK_FADE_TIME  1000
 
-void CG_AddMarks()
+void CG_AddMarkPolys()
 {
 	int        j;
 	markPoly_t *mp, *next;
@@ -306,6 +350,6 @@ void CG_AddMarks()
 				}
 			}
 		}
-		trap_R_AddPolyToScene( mp->markShader, mp->poly.numVerts, mp->verts );
+		trap_R_AddPolyToScene( mp->shader, mp->poly.numVerts, mp->verts );
 	}
 }

--- a/src/cgame/cg_particles.cpp
+++ b/src/cgame/cg_particles.cpp
@@ -2338,8 +2338,9 @@ static void CG_EvaluateParticlePhysics( particle_t *p )
 
 	if ( bp->bounceMarkName[ 0 ] && p->bounceMarkCount > 0 )
 	{
-		CG_ImpactMark( bp->bounceMark, trace.endpos, trace.plane.normal,
-		               random() * 360, 1, 1, 1, 1, true, bp->bounceMarkRadius, false );
+		CG_RegisterMark( bp->bounceMark, trace.endpos, trace.plane.normal,
+			random() * 360, 1, 1, 1, 1,
+			true, bp->bounceMarkRadius, false );
 		p->bounceMarkCount--;
 	}
 

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -2516,8 +2516,9 @@ static void CG_PlayerUpgrades( centity_t *cent, refEntity_t *torso )
 
 		if ( size > 0.0f )
 		{
-			CG_ImpactMark( cgs.media.creepShader, origin, up,
-			               0.0f, 1.0f, 1.0f, 1.0f, 1.0f, false, size, true );
+			CG_RegisterMark( cgs.media.creepShader, origin, up,
+				0.0f, 1.0f, 1.0f, 1.0f, 1.0f,
+				false, size, true );
 		}
 	}
 }
@@ -2641,9 +2642,9 @@ static bool CG_PlayerShadow( centity_t *cent, class_t class_ )
 
 	// add the mark as a temporary, so it goes directly to the renderer
 	// without taking a spot in the cg_marks array
-	CG_ImpactMark( cgs.media.shadowMarkShader, trace.endpos, trace.plane.normal,
-	               cent->pe.legs.yawAngle, 0.0f, 0.0f, 0.0f, alpha, false,
-	               24.0f * BG_ClassModelConfig( class_ )->shadowScale, true );
+	CG_RegisterMark( cgs.media.shadowMarkShader, trace.endpos, trace.plane.normal,
+		cent->pe.legs.yawAngle, 0.0f, 0.0f, 0.0f, alpha,
+		false, 24.0f * BG_ClassModelConfig( class_ )->shadowScale, true );
 
 	return true;
 }
@@ -2713,9 +2714,9 @@ static void CG_PlayerSplash( centity_t *cent, class_t class_ )
 		return;
 	}
 
-	CG_ImpactMark( cgs.media.wakeMarkShader, trace.endpos, trace.plane.normal,
-	               cent->pe.legs.yawAngle, 1.0f, 1.0f, 1.0f, 1.0f, false,
-	               32.0f * BG_ClassModelConfig( class_ )->shadowScale, true );
+	CG_RegisterMark( cgs.media.wakeMarkShader, trace.endpos, trace.plane.normal,
+		cent->pe.legs.yawAngle, 1.0f, 1.0f, 1.0f, 1.0f,
+		false, 32.0f * BG_ClassModelConfig( class_ )->shadowScale, true );
 }
 
 #define TRACE_DEPTH    32.0f

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -1861,6 +1861,8 @@ void CG_DrawActiveFrame( int serverTime, bool demoPlayback )
 	cg.demoPlayback = demoPlayback;
 	cg.currentCmdNumber = trap_GetCurrentCmdNumber();
 
+	CG_ResetMarks();
+
 	CG_NotifyHooks();
 
 	// any looped sounds will be respecified as entities
@@ -1924,7 +1926,8 @@ void CG_DrawActiveFrame( int serverTime, bool demoPlayback )
 	if ( !cg.hyperspace )
 	{
 		CG_AddPacketEntities(); // after calcViewValues, so predicted player state is correct
-		CG_AddMarks();
+		CG_ProcessMarks();
+		CG_AddMarkPolys();
 	}
 
 	CG_AddViewWeapon( &cg.predictedPlayerState );

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -2597,7 +2597,9 @@ void CG_HandleWeaponHitWall( entityState_t *es, vec3_t origin )
 	// mark
 	if ( wim->impactMark && wim->impactMarkSize > 0.0f )
 	{
-		CG_ImpactMark( wim->impactMark, origin, normal, random() * 360, 1, 1, 1, 1, false, wim->impactMarkSize, false );
+		CG_RegisterMark( wim->impactMark, origin, normal,
+			random() * 360, 1, 1, 1, 1,
+			false, wim->impactMarkSize, false );
 	}
 
 	// tracer
@@ -2671,8 +2673,9 @@ void CG_HandleMissileHitWall( entityState_t *es, vec3_t origin )
 	// mark
 	if ( ma->impactMark && ma->impactMarkSize > 0.0f )
 	{
-		CG_ImpactMark( ma->impactMark, origin, normal, random() * 360, 1, 1, 1, 1, false,
-		               ma->impactMarkSize, false );
+		CG_RegisterMark( ma->impactMark, origin, normal,
+			random() * 360, 1, 1, 1, 1,
+			false, ma->impactMarkSize, false );
 	}
 }
 


### PR DESCRIPTION
It requires:

- https://github.com/DaemonEngine/Daemon/pull/1114

It expands:

- https://github.com/Unvanquished/Unvanquished/pull/2847