### PR TITLE
HACK: rocket: use direct Cvar access for HUD cvars

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2298,6 +2298,7 @@ void CG_SetKeyCatcher( int catcher );
 //
 
 void CG_Rocket_Init( glconfig_t gl );
+std::string CG_Rocket_GetCvarValue( std::string );
 void CG_Rocket_LoadHuds();
 void CG_Rocket_Frame( cgClientState_t state );
 const char *CG_Rocket_GetTag();

--- a/src/cgame/cg_rocket.cpp
+++ b/src/cgame/cg_rocket.cpp
@@ -240,6 +240,194 @@ void CG_Rocket_Init( glconfig_t gl )
 	CG_SetKeyCatcher( rocketInfo.keyCatcher | KEYCATCH_UI );
 }
 
+// Cvars set in cgame and made public
+#define CGAME_CVAR( cvar ) if ( name == #cvar ) { return std::to_string( cvar.Get() ); }
+#define CGAME_CVAR2( cvar, obj ) if ( name == #cvar ) { return std::to_string( obj.Get() ); }
+// Cvars set in cgame but not made public
+#define PRIVATE_CVAR( cvar ) if ( name == #cvar ) { return Cvar::GetValue( #cvar ); }
+// Cvars set in cgame using trap_Cvar_Set()
+#define DIRECT_CVAR PRIVATE_CVAR
+// Cvars set in RML
+#define RML_CVAR PRIVATE_CVAR
+// Cvars set in sgame
+#define SGAME_CVAR PRIVATE_CVAR
+// Cvars set in engine
+#define ENGINE_CVAR PRIVATE_CVAR
+
+// Set to 1 to catch cvars that are used by the UI but unknown yet.
+#define REPORT_UNKNOWN_CVARS 0
+
+// HACK: Use local cvar access for known ones when possible.
+std::string CG_Rocket_GetCvarValue( std::string name )
+{
+	/* HUD cvars used on every frame,
+	using direct access is critical for performance. */
+	CGAME_CVAR( cg_drawClock );
+	CGAME_CVAR( cg_drawFPS );
+	CGAME_CVAR( cg_drawMinimap );
+	CGAME_CVAR( cg_drawSpeed );
+	CGAME_CVAR( cg_drawTimer );
+	CGAME_CVAR( cg_lagometer );
+	CGAME_CVAR( cg_minimapActive );
+
+	// Menus
+	CGAME_CVAR( cg_bounceParticles );
+	CGAME_CVAR( cg_crosshairColorAlpha );
+	CGAME_CVAR( cg_crosshairColorBlue );
+	CGAME_CVAR( cg_crosshairColorGreen );
+	CGAME_CVAR( cg_crosshairColorRed );
+	CGAME_CVAR( cg_crosshairOutlineColorAlpha );
+	CGAME_CVAR( cg_crosshairOutlineColorBlue );
+	CGAME_CVAR( cg_crosshairOutlineColorGreen );
+	CGAME_CVAR( cg_crosshairOutlineColorRed );
+	CGAME_CVAR( cg_crosshairOutlineOffset );
+	CGAME_CVAR( cg_crosshairOutlineScale );
+	CGAME_CVAR( cg_crosshairOutlineStyle );
+	CGAME_CVAR( cg_crosshairSize );
+	CGAME_CVAR( cg_crosshairStyle );
+	CGAME_CVAR( cg_drawCrosshair );
+	CGAME_CVAR( cg_mirrorgun );
+	CGAME_CVAR( cg_motionblur );
+	CGAME_CVAR( cg_motionblurMinSpeed );
+	CGAME_CVAR( cg_sprintToggle );
+	CGAME_CVAR( cg_teamChatsOnly );
+	CGAME_CVAR( cg_tutorial );
+	CGAME_CVAR( cg_wwSmoothTime );
+
+	CGAME_CVAR2( cg_drawgun, cg_drawGun );
+	CGAME_CVAR2( cg_marks, cg_addMarks );
+
+#if REPORT_UNKNOWN_CVARS
+	// Not private but there is no to_string() for this one:
+	PRIVATE_CVAR( cg_rangeMarkerBuildableTypes );
+
+	// Silence the Debug log for every remaining known ones.
+	PRIVATE_CVAR( cg_fov_builder );
+	PRIVATE_CVAR( cg_fov_human );
+	PRIVATE_CVAR( cg_fov_level0 );
+	PRIVATE_CVAR( cg_fov_level1 );
+	PRIVATE_CVAR( cg_fov_level2 );
+	PRIVATE_CVAR( cg_fov_level3 );
+	PRIVATE_CVAR( cg_fov_level4 );
+	PRIVATE_CVAR( cg_navgenMaxThreads );
+	PRIVATE_CVAR( cg_navgenOnLoad );
+	PRIVATE_CVAR( cg_welcome );
+	PRIVATE_CVAR( cg_wwFollow );
+	PRIVATE_CVAR( cg_wwToggle );
+
+	DIRECT_CVAR( p_classname );
+	DIRECT_CVAR( ui_errorMessage );
+	DIRECT_CVAR( ui_winner );
+
+	RML_CVAR( ui_dialogCvar1 );
+	RML_CVAR( ui_dialogCvar2 );
+	RML_CVAR( m_pitch );
+	RML_CVAR( m_filter );
+
+	SGAME_CVAR( g_bot_alienAimDelay );
+	SGAME_CVAR( g_bot_defaultFill );
+	SGAME_CVAR( g_bot_defaultSkill );
+	SGAME_CVAR( g_bot_fov );
+	SGAME_CVAR( g_bot_humanAimDelay );
+	SGAME_CVAR( g_bot_reactiontime );
+	SGAME_CVAR( g_BPBudgetPerMiner );
+	SGAME_CVAR( g_BPInitialBudget );
+	SGAME_CVAR( g_BPRecoveryInitialRate );
+	SGAME_CVAR( g_BPRecoveryRateHalfLife );
+	SGAME_CVAR( g_doWarmup );
+	SGAME_CVAR( g_freeFundPeriod );
+	SGAME_CVAR( g_friendlyFireAlienMultiplier );
+	SGAME_CVAR( g_friendlyFireHumanMultiplier );
+	SGAME_CVAR( g_gravity );
+	SGAME_CVAR( g_momentumBaseMod );
+	SGAME_CVAR( g_momentumBuildMod );
+	SGAME_CVAR( g_momentumDeconMod );
+	SGAME_CVAR( g_momentumDestroyMod );
+	SGAME_CVAR( g_momentumHalfLife );
+	SGAME_CVAR( g_momentumKillMod );
+	SGAME_CVAR( g_momentumRewardDoubleTime );
+	SGAME_CVAR( g_warmup );
+	SGAME_CVAR( sv_running );
+	SGAME_CVAR( g_friendlyBuildableFire );
+	SGAME_CVAR( g_allowVote );
+	SGAME_CVAR( g_alienAllowBuilding );
+	SGAME_CVAR( g_humanAllowBuilding );
+	SGAME_CVAR( g_dretchpunt );
+	SGAME_CVAR( g_antiSpawnBlock );
+	SGAME_CVAR( g_bot_attackStruct );
+	SGAME_CVAR( g_bot_infiniteFunds );
+	SGAME_CVAR( g_bot_infiniteMomentum );
+	SGAME_CVAR( g_bot_buy );
+	SGAME_CVAR( g_bot_ckit );
+	SGAME_CVAR( g_bot_rifle );
+	SGAME_CVAR( g_bot_painsaw );
+	SGAME_CVAR( g_bot_shotgun );
+	SGAME_CVAR( g_bot_lasgun );
+	SGAME_CVAR( g_bot_mdriver );
+	SGAME_CVAR( g_bot_chain );
+	SGAME_CVAR( g_bot_flamer );
+	SGAME_CVAR( g_bot_prifle );
+	SGAME_CVAR( g_bot_lcannon );
+	SGAME_CVAR( g_bot_lightarmour );
+	SGAME_CVAR( g_bot_mediumarmour );
+	SGAME_CVAR( g_bot_battlesuit );
+	SGAME_CVAR( g_bot_firebomb );
+	SGAME_CVAR( g_bot_grenade );
+	SGAME_CVAR( g_bot_radar );
+	SGAME_CVAR( g_bot_evolve );
+	SGAME_CVAR( g_bot_level1 );
+	SGAME_CVAR( g_bot_level2 );
+	SGAME_CVAR( g_bot_level2upg );
+	SGAME_CVAR( g_bot_level3 );
+	SGAME_CVAR( g_bot_level3upg );
+	SGAME_CVAR( g_bot_level4 );
+	SGAME_CVAR( sv_hostname );
+	SGAME_CVAR( g_password );
+
+	ENGINE_CVAR( audio.dopplerExaggeration );
+	ENGINE_CVAR( audio.reverbIntensity );
+	ENGINE_CVAR( audio.volume.effects );
+	ENGINE_CVAR( audio.volume.master );
+	ENGINE_CVAR( audio.volume.music );
+	ENGINE_CVAR( cg_shadows );
+	ENGINE_CVAR( cl_freelook );
+	ENGINE_CVAR( con_colorAlpha );
+	ENGINE_CVAR( con_colorBlue );
+	ENGINE_CVAR( con_colorGreen );
+	ENGINE_CVAR( con_colorRed );
+	ENGINE_CVAR( fs_extrapaks );
+	ENGINE_CVAR( in_joystick );
+	ENGINE_CVAR( language );
+	ENGINE_CVAR( name );
+	ENGINE_CVAR( r_bloom );
+	ENGINE_CVAR( r_deluxeMapping );
+	ENGINE_CVAR( r_dynamicLight );
+	ENGINE_CVAR( r_ext_texture_filter_anisotropic );
+	ENGINE_CVAR( r_fullscreen );
+	ENGINE_CVAR( r_FXAA );
+	ENGINE_CVAR( r_gamma );
+	ENGINE_CVAR( r_halfLambertLighting );
+	ENGINE_CVAR( r_heatHaze );
+	ENGINE_CVAR( r_lightStyles );
+	ENGINE_CVAR( r_noBorder );
+	ENGINE_CVAR( r_normalMapping );
+	ENGINE_CVAR( r_physicalMapping );
+	ENGINE_CVAR( r_picmip );
+	ENGINE_CVAR( r_reliefMapping );
+	ENGINE_CVAR( r_rimLighting );
+	ENGINE_CVAR( r_specularMapping );
+	ENGINE_CVAR( r_ssao );
+	ENGINE_CVAR( r_swapinterval );
+	ENGINE_CVAR( r_textureMode );
+	ENGINE_CVAR( r_vertexLighting );
+	ENGINE_CVAR( sensitivity );
+
+	Log::Warn( "Cvar used in UI without optimized call: %s", name );
+#endif
+
+	return Cvar::GetValue( name.c_str() );
+}
+
 void CG_Rocket_LoadHuds()
 {
 	int i;

--- a/src/cgame/rocket/lua/Cvar.cpp
+++ b/src/cgame/rocket/lua/Cvar.cpp
@@ -33,12 +33,13 @@ Maryland 20850 USA.
 */
 
 #include "common/Common.h"
+#include "cgame/cg_local.h"
 #include "register_lua_extensions.h"
 
 static int Cvar_get(lua_State* L)
 {
 	const char *cvar = luaL_checkstring(L, 1);
-	lua_pushstring(L, Cvar::GetValue(cvar).c_str());
+	lua_pushstring(L, CG_Rocket_GetCvarValue( cvar ).c_str());
 	return 1;
 }
 

--- a/src/cgame/rocket/rocketConditionalElement.h
+++ b/src/cgame/rocket/rocketConditionalElement.h
@@ -51,7 +51,7 @@ public:
 		if ( it != changed_attributes.end() )
 		{
 			cvar = it->second.Get<std::string>();
-			cvar_value = Cvar::GetValue( cvar.c_str() ).c_str();
+			cvar_value = CG_Rocket_GetCvarValue( cvar );
 			dirty_value = true;
 		}
 
@@ -90,7 +90,7 @@ public:
 
 	virtual void OnUpdate()
 	{
-		if ( dirty_value || ( !cvar.empty() && cvar_value != Cvar::GetValue( cvar.c_str() ).c_str() ) )
+		if ( dirty_value || ( !cvar.empty() && cvar_value != CG_Rocket_GetCvarValue( cvar ) ) )
 		{
 			if ( IsConditionValid() )
 			{
@@ -107,7 +107,7 @@ public:
 				}
 			}
 
-			cvar_value = Cvar::GetValue( cvar.c_str() ).c_str();
+			cvar_value = CG_Rocket_GetCvarValue( cvar );
 
 			if ( dirty_value )
 			{
@@ -166,7 +166,7 @@ private:
 
 	bool IsConditionValid()
 	{
-		std::string str = Cvar::GetValue( cvar.c_str() );
+		std::string str = CG_Rocket_GetCvarValue( cvar );
 		switch ( value.GetType() )
 		{
 			case Rml::Variant::INT:

--- a/src/cgame/rocket/rocketCvarInlineElement.h
+++ b/src/cgame/rocket/rocketCvarInlineElement.h
@@ -83,19 +83,19 @@ public:
 
 	virtual void OnUpdate()
 	{
-		if ( dirty_value || ( !cvar.empty() && cvar_value.c_str() != Cvar::GetValue( cvar.c_str() ) ) )
+		if ( dirty_value || ( !cvar.empty() && cvar_value != CG_Rocket_GetCvarValue( cvar ) ) )
 		{
-			Rml::String value = cvar_value = Cvar::GetValue( cvar.c_str() ).c_str();
+			Rml::String value = cvar_value = CG_Rocket_GetCvarValue( cvar ).c_str();
 
 			if (!format.empty())
 			{
 				if (type == NUMBER)
 				{
-					value = va( format.c_str(), atof( Cvar::GetValue( cvar.c_str() ).c_str() ) );
+					value = va( format.c_str(), atof( CG_Rocket_GetCvarValue( cvar ).c_str() ) );
 				}
 				else
 				{
-					value = va( format.c_str(), Cvar::GetValue(cvar.c_str()).c_str() );
+					value = va( format.c_str(), CG_Rocket_GetCvarValue( cvar ) );
 				}
 			}
 

--- a/src/cgame/rocket/rocketFormControlInput.h
+++ b/src/cgame/rocket/rocketFormControlInput.h
@@ -147,7 +147,7 @@ private:
 			if ( type == "checkbox" )
 			{
 				bool result;
-				std::string stringValue = Cvar::GetValue( cvar.c_str() );
+				std::string stringValue = CG_Rocket_GetCvarValue( cvar );
 				if ( !Cvar::ParseCvarValue( stringValue, result ) )
 				{
 					// ParseCvarValue<bool> will only work correctly for a Cvar<bool>
@@ -167,7 +167,7 @@ private:
 
 			else if ( type == "radio" )
 			{
-				if ( GetValue() == Cvar::GetValue( cvar.c_str() ).c_str() )
+				if ( GetValue() == CG_Rocket_GetCvarValue( cvar ) )
 				{
 					SetAttribute( "checked", "" );
 				}
@@ -175,7 +175,7 @@ private:
 
 			else
 			{
-				SetValue( Cvar::GetValue( cvar.c_str() ).c_str() );
+				SetValue( CG_Rocket_GetCvarValue( cvar ) );
 			}
 
 			ignoreChangeEvent = false;

--- a/src/cgame/rocket/rocketFormControlSelect.h
+++ b/src/cgame/rocket/rocketFormControlSelect.h
@@ -118,7 +118,7 @@ public:
 
 	void UpdateValue()
 	{
-		Rml::String cvarValue = Cvar::GetValue( cvar.c_str() );
+		Rml::String cvarValue = CG_Rocket_GetCvarValue( cvar );
 		for ( int i = 0; i < GetNumOptions(); ++i )
 		{
 			Rml::Element* e = GetOption(i);


### PR DESCRIPTION
This is a HACK.

Those cvar checks in the HUD are doing one trap call per frame:

```
pkg/unvanquished_src.dpkdir/ui/hud_basics.rml
184:		<if cvar="cg_minimapActive" condition="==" value="1">
191:			<if cvar="cg_drawTimer" condition="==" value="1">
194:			<if cvar="cg_drawClock" condition="!=" value="0">
197:			<if cvar="cg_drawFPS" condition="==" value="1">
203:			<if cvar="cg_lagometer" condition="==" value="1">
224:	<if cvar="cg_drawSpeed" condition="!=" value="0">
```

Those cvars are defined in game client side, so we don't need a trap call at all.

This implementation is an ugly HACK.

What I would like to see instead, is that when a Cvar is defined from the client source code, it is added to a local Cvar Map, either automatically for all of them, either by an explicit call to some function similar to `Cvar::Latch`, something like:

```c
Cvar::Local(g_drawSpeed);
```