### PR TITLE
rocket: do not write cg_activeMinimap on every frame and fix toggling minimap display

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/hud_basics.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/hud_basics.rml
@@ -84,19 +84,19 @@
 			display: block;
 			width: 12em;
 			height: 12em;
-
-			float: right;
-
 			background-color: black;
 		}
 
-		statsbox {
+		div#minimapbox {
+			float: right;
+		}
+
+		div#statsbox {
 			display: block;
 			width: 25em;
 			height: 12em;
-			padding: 0.5em;
-
 			float: right;
+			padding: 0.5em;
 		}
 
 		stat {
@@ -181,11 +181,15 @@
 </head>
 <body id="hud_basics">
 	<region class="topright">
-		<if cvar="cg_minimapActive" condition="==" value="1">
-			<minimap />
-		</if>
+		<div id="minimapbox">
+			<if cvar="cg_minimapActive" condition="==" value="1">
+				<if cvar="cg_drawMinimap" condition="==" value="1">
+					<minimap />
+				</if>
+			</if>
+		</div>
 
-		<statsbox>
+		<div id="statsbox">
 			<location />
 
 			<if cvar="cg_drawTimer" condition="==" value="1">
@@ -203,7 +207,7 @@
 			<if cvar="cg_lagometer" condition="==" value="1">
 				<stat><lagometer /></stat>
 			</if>
-		</statsbox>
+		</div>
 	</region>
 
 	<region class="votes">

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1031,7 +1031,6 @@ struct minimapZone_t
 
 struct minimap_t
 {
-    bool     active;
     bool     defined;
     int          lastZone;
     int          nZones;

--- a/src/cgame/cg_minimap.cpp
+++ b/src/cgame/cg_minimap.cpp
@@ -373,20 +373,6 @@ static void CG_DrawMinimapObject( const qhandle_t image, const vec3_t pos3d, con
     trap_R_DrawRotatedPic( x, y, wh, wh, 0.0, 0.0, 1.0, 1.0, image, realAngle );
 }
 
-/*
-================
-CG_UpdateMinimapActive
-================
-*/
-static void CG_UpdateMinimapActive(minimap_t* m)
-{
-    bool active = m->defined && cg_drawMinimap.Get();
-
-    m->active = active;
-
-    cg_minimapActive.Set(+active);
-}
-
 //Other logical minimap functions
 
 /*
@@ -651,7 +637,7 @@ void CG_InitMinimap()
     m->gfx.playerArrow = trap_R_RegisterShader( "gfx/feedback/minimap/player-arrow", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
     m->gfx.teamArrow = trap_R_RegisterShader( "gfx/feedback/minimap/team-arrow", (RegisterShaderFlags_t) ( RSF_NOMIP ) );
 
-    CG_UpdateMinimapActive( m );
+    cg_minimapActive.Set( m->defined );
 }
 
 /*
@@ -664,13 +650,6 @@ void CG_DrawMinimap( const rectDef_t* rect640, const Color::Color& teamColor )
     minimap_t* m = &cg.minimap;
     minimapZone_t *z = nullptr;
     rectDef_t rect = *rect640;
-
-    CG_UpdateMinimapActive( m );
-
-    if( !m->active )
-    {
-        return;
-    }
 
     z = CG_ChooseMinimapZone( m );
 

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -3061,7 +3061,7 @@ static void CG_DrawPlayerClipsStack()
 
 static void CG_Rocket_DrawMinimap()
 {
-	if ( cg.minimap.defined )
+	if ( cg.minimap.defined && cg_drawMinimap.Get() )
 	{
 		Color::Color foreColor;
 		rectDef_t    rect;


### PR DESCRIPTION
This code was inefficient in multiple ways:

- It wrote every frame (and doing a synchronous trap call) a special cvar to tell RmlUi the minimap was both available and enabled.
- The code to toggle the “available and enabled“ state was only run when the state was “available and enabled”, meaning disabling minimap and re-enabling it would not bring it back.
- The Rml was poorly written and displayed the things differently given the `<if>` markup was `true` or `false` at map load, meaning disabling minimap and re-enabling it would not display the HUD the same way as before disabling it.

Alongside the toggling fixes, it trades:

- 1 cvar read
- 1 cvar write

against:

- 2 cvar reads

Right now the code still does two synchronous trap calls per frame just to tell RmlUi to render the minimap, which is super inefficient, as inefficient as before. But the good news is that there are ways to make RmlUi reading cgame Cvars without trap calls, see #2984 for a HACKY proof of concept:

- https://github.com/Unvanquished/Unvanquished/pull/2984

Combining the two PRs means Unvanquished can do no trap calls at all to render the HUD, instead of doing 6 synchronous IPC trap calls per frame just to know if HUD elements should be displayed or not…