### PR TITLE
fonts: Delete placeholder roboto.ttf

### DIFF
--- a/pkg/unvanquished_src.dpkdir/fonts/roboto.ttf
+++ b/pkg/unvanquished_src.dpkdir/fonts/roboto.ttf
@@ -1,7 +1,0 @@
-I AM A DUMMY FILE
-
-I'm working around a font/filesystem bug where an old Roboto Thin  (found in the alpha 0.25 package) overrides the normal Roboto font.  I do this by camping on it's filename (roboto.ttf) so it cannot load.
-
-Veyrdite, 2014-07-31
-
-(This is a bad hack)


### PR DESCRIPTION
We tend to regenerate unvanquished_*.dpk and ship less partial diffs, so this is safe to remove now.

Addresses part of #1883