### PR TITLE
cgame: parse modelRotation for player models, fix modelScale

### DIFF
--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -2733,7 +2733,7 @@ void CG_Player( centity_t *cent )
 	int           renderfx;
 	entityState_t *es = &cent->currentState;
 	class_t       class_ = (class_t) ( ( es->misc >> 8 ) & 0xFF );
-	float         scale;
+	const classModelConfig_t *cmc = BG_ClassModelConfig( class_ );
 	vec3_t        tempAxis[ 3 ], tempAxis2[ 3 ];
 	vec3_t        angles;
 	int           held = es->modelindex;
@@ -2939,7 +2939,35 @@ void CG_Player( centity_t *cent )
 			legs.origin[ 0 ] -= ci->headOffset[ 0 ];
 			legs.origin[ 1 ] -= ci->headOffset[ 1 ];
 			legs.origin[ 2 ] -= 22 + ci->headOffset[ 2 ];
-			VectorMA( legs.origin, BG_ClassModelConfig( class_ )->zOffset, surfNormal, legs.origin );
+
+			// Apply rotation from config.
+			{
+				matrix_t axisMat;
+				quat_t axisQuat, rotQuat;
+
+				QuatFromAngles( rotQuat,
+					cmc->modelRotation[ PITCH ],
+					cmc->modelRotation[ YAW ],
+					cmc->modelRotation[ ROLL ] );
+
+				MatrixFromVectorsFLU( axisMat, legs.axis[ 0 ], legs.axis[ 1 ], legs.axis[ 2 ] );
+				QuatFromMatrix( axisQuat, axisMat );
+				QuatMultiply2( axisQuat, rotQuat );
+				MatrixFromQuat( axisMat, axisQuat );
+				MatrixToVectorsFLU( axisMat, legs.axis[ 0 ], legs.axis[ 1 ], legs.axis[ 2 ] );
+			}
+
+			// Apply scale from config.
+			if ( cmc->modelScale != 1.0f )
+			{
+				VectorScale( legs.axis[ 0 ], cmc->modelScale, legs.axis[ 0 ] );
+				VectorScale( legs.axis[ 1 ], cmc->modelScale, legs.axis[ 1 ] );
+				VectorScale( legs.axis[ 2 ], cmc->modelScale, legs.axis[ 2 ] );
+
+				legs.nonNormalizedAxes = true;
+			}
+
+			VectorMA( legs.origin, cmc->zOffset, surfNormal, legs.origin );
 		}
 
 		VectorCopy( legs.origin, legs.lightingOrigin );
@@ -3102,20 +3130,35 @@ void CG_Player( centity_t *cent )
 		VectorCopy( legs.origin, legs.oldorigin );  // don't positionally lerp at all
 	}
 
-	//rescale the model
-	scale = BG_ClassModelConfig( class_ )->modelScale;
-
-	if ( scale != 1.0f )
+	// Apply rotation from config.
 	{
-		VectorScale( legs.axis[ 0 ], scale, legs.axis[ 0 ] );
-		VectorScale( legs.axis[ 1 ], scale, legs.axis[ 1 ] );
-		VectorScale( legs.axis[ 2 ], scale, legs.axis[ 2 ] );
+		matrix_t axisMat;
+		quat_t axisQuat, rotQuat;
+
+		QuatFromAngles( rotQuat,
+			cmc->modelRotation[ PITCH ],
+			cmc->modelRotation[ YAW ],
+			cmc->modelRotation[ ROLL ] );
+
+		MatrixFromVectorsFLU( axisMat, legs.axis[ 0 ], legs.axis[ 1 ], legs.axis[ 2 ] );
+		QuatFromMatrix( axisQuat, axisMat );
+		QuatMultiply2( axisQuat, rotQuat );
+		MatrixFromQuat( axisMat, axisQuat );
+		MatrixToVectorsFLU( axisMat, legs.axis[ 0 ], legs.axis[ 1 ], legs.axis[ 2 ] );
+	}
+
+	// Apply scale from config.
+	if ( cmc->modelScale != 1.0f )
+	{
+		VectorScale( legs.axis[ 0 ], cmc->modelScale, legs.axis[ 0 ] );
+		VectorScale( legs.axis[ 1 ], cmc->modelScale, legs.axis[ 1 ] );
+		VectorScale( legs.axis[ 2 ], cmc->modelScale, legs.axis[ 2 ] );
 
 		legs.nonNormalizedAxes = true;
 	}
 
 	//offset on the Z axis if required
-	VectorMA( legs.origin, BG_ClassModelConfig( class_ )->zOffset, surfNormal, legs.origin );
+	VectorMA( legs.origin, cmc->zOffset, surfNormal, legs.origin );
 	VectorCopy( legs.origin, legs.lightingOrigin );
 	VectorCopy( legs.origin, legs.oldorigin );  // don't positionally lerp at all
 
@@ -3234,7 +3277,7 @@ void CG_Corpse( centity_t *cent )
 	entityState_t *es = &cent->currentState;
 	int           renderfx;
 	vec3_t        origin, liveZ, deadZ, deadMax;
-	float         scale;
+	const classModelConfig_t *cmc = BG_ClassModelConfig( es->clientNum );
 
 	ci = GetCorpseInfo( (class_t) es->clientNum );
 
@@ -3349,14 +3392,30 @@ void CG_Corpse( centity_t *cent )
 	legs.origin[ 2 ] += BG_ClassModelConfig( es->clientNum )->zOffset;
 	VectorCopy( legs.origin, legs.oldorigin );  // don't positionally lerp at all
 
-	//rescale the model
-	scale = BG_ClassModelConfig( es->clientNum )->modelScale;
-
-	if ( scale != 1.0f && !ci->skeletal )
+	// Apply rotation from config.
+	if ( !ci->skeletal )
 	{
-		VectorScale( legs.axis[ 0 ], scale, legs.axis[ 0 ] );
-		VectorScale( legs.axis[ 1 ], scale, legs.axis[ 1 ] );
-		VectorScale( legs.axis[ 2 ], scale, legs.axis[ 2 ] );
+		matrix_t axisMat;
+		quat_t axisQuat, rotQuat;
+
+		QuatFromAngles( rotQuat,
+			cmc->modelRotation[ PITCH ],
+			cmc->modelRotation[ YAW ],
+			cmc->modelRotation[ ROLL ] );
+
+		MatrixFromVectorsFLU( axisMat, legs.axis[ 0 ], legs.axis[ 1 ], legs.axis[ 2 ] );
+		QuatFromMatrix( axisQuat, axisMat );
+		QuatMultiply2( axisQuat, rotQuat );
+		MatrixFromQuat( axisMat, axisQuat );
+		MatrixToVectorsFLU( axisMat, legs.axis[ 0 ], legs.axis[ 1 ], legs.axis[ 2 ] );
+	}
+
+	// Apply scale from config.
+	if ( !ci->skeletal && cmc->modelScale != 1.0f )
+	{
+		VectorScale( legs.axis[ 0 ], cmc->modelScale, legs.axis[ 0 ] );
+		VectorScale( legs.axis[ 1 ], cmc->modelScale, legs.axis[ 1 ] );
+		VectorScale( legs.axis[ 2 ], cmc->modelScale, legs.axis[ 2 ] );
 
 		legs.nonNormalizedAxes = true;
 	}

--- a/src/shared/bg_parse.cpp
+++ b/src/shared/bg_parse.cpp
@@ -787,7 +787,6 @@ void BG_ParseBuildableModelFile( const char *filename, buildableModelConfig_t *b
 		ZOFFSET = 1 << 4,
 		OLDSCALE = 1 << 5,
 		OLDOFFSET = 1 << 6,
-		MODEL_ROTATION = 1 << 7
 	};
 
 	if( !BG_ReadWholeFile( filename, text_buffer, sizeof(text_buffer) ) )
@@ -850,8 +849,6 @@ void BG_ParseBuildableModelFile( const char *filename, buildableModelConfig_t *b
 			bc->modelRotation[ 1 ] = atof( token );
 			PARSE( text, token );
 			bc->modelRotation[ 2 ] = atof( token );
-
-			defined |= MODEL_ROTATION;
 		}
 		else if ( !Q_stricmp( token, "mins" ) )
 		{
@@ -1394,6 +1391,15 @@ void BG_ParseClassModelFile( const char *filename, classModelConfig_t *cc )
 			cc->modelScale = scale;
 
 			defined |= MODELSCALE;
+		}
+		else if ( !Q_stricmp( token, "modelRotation" ) )
+		{
+			PARSE( text, token );
+			cc->modelRotation[ 0 ] = atof( token );
+			PARSE( text, token );
+			cc->modelRotation[ 1 ] = atof( token );
+			PARSE( text, token );
+			cc->modelRotation[ 2 ] = atof( token );
 		}
 		else if ( !Q_stricmp( token, "shadowScale" ) )
 		{
@@ -2100,7 +2106,6 @@ void BG_ParseMissileDisplayFile( const char *filename, missileAttributes_t *ma )
 		IMPACT_SOUND     = 1 << 20,
 		IMPACT_FLESH_SND = 1 << 21,
 		MODEL_SCALE      = 1 << 22,
-		MODEL_ROTATION   = 1 << 23,
 	};
 
 	if( !BG_ReadWholeFile( filename, text_buffer, sizeof( text_buffer ) ) )
@@ -2138,8 +2143,6 @@ void BG_ParseMissileDisplayFile( const char *filename, missileAttributes_t *ma )
 			ma->modelRotation[ 1 ] = atof( token );
 			PARSE( text, token );
 			ma->modelRotation[ 2 ] = atof( token );
-
-			defined |= MODEL_ROTATION;
 		}
 		else if ( !Q_stricmp( token, "sound" ) )
 		{

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -1287,6 +1287,7 @@ struct classModelConfig_t
 {
 	char   modelName[ MAX_QPATH ];
 	float  modelScale;
+	vec3_t modelRotation;
 	char   skinName[ MAX_QPATH ];
 	float  shadowScale;
 	char   hudName[ MAX_QPATH ];


### PR DESCRIPTION
Bug:

The `modelScale` field from `configs/classes/*.model.cfg` was unused with skeletals models, unlike `configs/buildables/*.model.cfg` and `configs/missiles/*.model.cfg`.

Feature request:

The `modelRotation` field was not implemented in `configs/classes/*.model.cfg`,  unlike `configs/buildables/*.model.cfg` and `configs/missiles/*.model.cfg`.

Clean-up:

A `MODEL_ROTATION` enum value was set but had no usage.