### PR TITLE
cgame: introduce cg_lowQualityModels to load low quality models

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1905,6 +1905,7 @@ extern Cvar::Cvar<bool> cg_spawnEffects;
 extern Cvar::Cvar<std::string> cg_sayCommand;
 
 extern Cvar::Cvar<bool> cg_lazyLoadModels;
+extern Cvar::Cvar<bool> cg_lowQualityModels;
 
 //
 // cg_main.c

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -185,6 +185,8 @@ Cvar::Cvar<std::string> cg_sayCommand("cg_sayCommand", "instead of talking, chat
 // TODO: only works for player models. Buildings and weapons are also relevant
 Cvar::Cvar<bool> cg_lazyLoadModels("cg_lazyLoadModels", "load models only when needed", Cvar::CHEAT, false);
 
+Cvar::Cvar<bool> cg_lowQualityModels("cg_lowQualityModels", "load low quality models when available", Cvar::NONE, false);
+
 // USERINFO cvars - transmitted to the server
 static Cvar::Range<Cvar::Cvar<int>> cg_disableBlueprintErrors("cg_disableBlueprintErrors", "allow placement of some currently non-buildable structures", Cvar::USERINFO, 0, 0, 1);
 static Cvar::Cvar<int> cg_flySpeed("cg_flySpeed", "spectator movement speed", Cvar::USERINFO, 800);


### PR DESCRIPTION
Add `cg_lowModels` to load low quality models.

The purpose of this cvar is to be used in `low` and `lowest` presets.

If `cg_lowModels` is enabled, when looking for `buildables/eggpod/eggpod.iqm`, load `buildables/eggpod/eggpod_low.iqm` if it exists.

It is only implemented for buildables for now, I may implement it for player models later.

The purpose is to load a low quality variant of a model for performance purpose.

This may be a low poly model, but I doubt we have the resource to produce some.

What we can do though, is to edit existing IQM models with IQE Browser and delete some bones.

Some low-end old graphics card can only hardware accelerate the model animations if the models have no more than 41 bones.

Some of our models have many more than that, sometime more than an hundreds of that, forcing the game to fallback on a slow CPU implementation.

But many of our models have some bones we can remove, like legs of buildables. Those legs are animated for moving when being hurt or things like that, but removing the leg animation bones and a few others like the head bones do not break the whole animation most of the time.

It looks like `Cvar::Latch` is not implemented yet on CGame side, this would be appreciated as the `cg_lowModels` cvar should be latched (we need to reload the models to see a difference).

This commit should works on `master` but I make this PR target `for-0.55.0/sync` because since it requires models that are not released, no one can use the cvar yet anyway, and targetting the `for-0.55.0/sync` makes things easier to me when dealing with the various repositories.

_Edit:_ It now also changes the md5anim prefix path to be like IQM, so we better target the future branch.