### PR TITLE
calculate navcon distance using the navcon end point

### DIFF
--- a/src/sgame/botlib/bot_nav.cpp
+++ b/src/sgame/botlib/bot_nav.cpp
@@ -284,8 +284,6 @@ void G_BotUpdatePath( int botClientNum, const botRouteTarget_t *target, botNavCm
 
 		cmd->havePath = !bot->needReplan;
 
-		bool usingNavcon = false;
-
 		if ( overOffMeshConnectionStart( bot, spos ) )
 		{
 			dtPolyRef refs[ 2 ];
@@ -301,7 +299,20 @@ void G_BotUpdatePath( int botClientNum, const botRouteTarget_t *target, botNavCm
 				bot->offMeshEnd = end;
 				bot->offMeshStart = start;
 
-				usingNavcon = true;
+				// save some characteristics about the connection in the bot's mind, for later use
+				// this happens quite rarely, so we can afford a square root for the
+				// distance here
+				gentity_t *self = &g_entities[ botClientNum ];
+				self->botMind->lastNavconTime = level.time;
+				glm::vec3 nextCorner = glm::vec3( end[ 0 ], end[ 2 ], end[ 1 ] );
+				glm::vec3 ownPos = VEC2GLM( self->s.origin );
+				// HACK: if the bot wants to move upward, make the distance
+				// positive, make it negative otherwise
+				self->botMind->lastNavconDistance = glm::distance( ownPos , nextCorner );
+				if ( nextCorner.z - ownPos.z < 0 )
+				{
+					self->botMind->lastNavconDistance = -self->botMind->lastNavconDistance;
+				}
 			}
 		}
 
@@ -343,33 +354,6 @@ void G_BotUpdatePath( int botClientNum, const botRouteTarget_t *target, botNavCm
 				cmd->tpos[ 1 ] = height;
 			}
 			recast2quake( cmd->tpos );
-		}
-
-		// when the bot is using an offmesh connection:
-		// save some characteristics about the connection in its mind, for later use
-		// this happens quite rarely, so we can afford a square root for the
-		// distance here
-		if ( usingNavcon )
-		{
-			gentity_t *self = &g_entities[ botClientNum ];
-			self->botMind->lastNavconTime = level.time;
-			glm::vec3 nextCorner;
-			glm::vec3 ownPos = VEC2GLM( self->s.origin );
-			if ( G_BotPathNextCorner( self->client->num(), nextCorner ) )
-			{
-				// HACK: if the bot wants to move upward, make the distance
-				// positive, make it negative otherwise
-				self->botMind->lastNavconDistance = glm::distance( ownPos , nextCorner );
-				if ( nextCorner.z - ownPos.z < 0 )
-				{
-					self->botMind->lastNavconDistance = -self->botMind->lastNavconDistance;
-				}
-			}
-			else
-			{
-				// should not happen, but let's play it safe here
-				self->botMind->lastNavconDistance = 0;
-			}
 		}
 	}
 


### PR DESCRIPTION
The original author did not realize that the coordinates of the navcon endpoint are right there. This fixes a rare bug where bots fail to activate the wall walk.

Edit: I am the original author.