### PR TITLE
rocket: avoid doing 2 or 3 Cvar::Get() trap calls per OnUpdate() call per cvar element

### DIFF
--- a/src/cgame/rocket/rocketConditionalElement.h
+++ b/src/cgame/rocket/rocketConditionalElement.h
@@ -90,7 +90,22 @@ public:
 
 	virtual void OnUpdate()
 	{
-		if ( dirty_value || ( !cvar.empty() && cvar_value != Cvar::GetValue( cvar.c_str() ).c_str() ) )
+		Rml::String value;
+		bool modified = false;
+
+		if ( dirty_value )
+		{
+			value = Cvar::GetValue( cvar );
+			modified = true;
+		}
+		else if ( !cvar.empty() )
+		{
+			value = Cvar::GetValue( cvar );
+
+			modified = cvar_value != value;
+		}
+
+		if ( modified )
 		{
 			if ( IsConditionValid() )
 			{
@@ -107,7 +122,7 @@ public:
 				}
 			}
 
-			cvar_value = Cvar::GetValue( cvar.c_str() ).c_str();
+			cvar_value = value;
 
 			if ( dirty_value )
 			{

--- a/src/cgame/rocket/rocketCvarInlineElement.h
+++ b/src/cgame/rocket/rocketCvarInlineElement.h
@@ -83,19 +83,34 @@ public:
 
 	virtual void OnUpdate()
 	{
-		if ( dirty_value || ( !cvar.empty() && cvar_value.c_str() != Cvar::GetValue( cvar.c_str() ) ) )
-		{
-			Rml::String value = cvar_value = Cvar::GetValue( cvar.c_str() ).c_str();
+		Rml::String value;
+		bool modified = false;
 
-			if (!format.empty())
+		if ( dirty_value )
+		{
+			value = Cvar::GetValue( cvar );
+			modified = true;
+		}
+		else if ( !cvar.empty() )
+		{
+			value = Cvar::GetValue( cvar );
+
+			modified = cvar_value != value;
+		}
+
+		if ( modified )
+		{
+			cvar_value = value;
+
+			if ( !format.empty() )
 			{
 				if (type == NUMBER)
 				{
-					value = va( format.c_str(), atof( Cvar::GetValue( cvar.c_str() ).c_str() ) );
+					value = va( format.c_str(), atof( cvar_value.c_str() ) );
 				}
 				else
 				{
-					value = va( format.c_str(), Cvar::GetValue(cvar.c_str()).c_str() );
+					value = va( format.c_str(), cvar_value.c_str() );
 				}
 			}
 


### PR DESCRIPTION
Avoid doing 2 or 3 `Cvar::Get()` trap calls per `OnUpdate()` call per `cvar` element per frame.

🤦‍♀️️🤦‍♀️️🤦‍♀️️