### PR TITLE
tools: update translation-related scripts

### DIFF
--- a/tools/translation/README.md
+++ b/tools/translation/README.md
@@ -1,5 +1,25 @@
 # Unvanquished translation string generator
 
-`generate_pot.sh` is the entry point. It generates the .po files containing the strings from the
-source code that need to be translated from English to other languages. These are uploaded somehow
-to the translation tool hosted at https://hosted.weblate.org/projects/unvanquished/unvanquished/
+Once committed and pushed, the translation files are automatically pulled by
+the Weblate translation tool hosted at:
+
+- https://hosted.weblate.org/projects/unvanquished/unvanquished/
+
+The `generate.sh` script is the entry point. It is recommended to run it after
+merging translation changes from Weblate.
+
+It runs the `generate_pot.sh` script that generate the `.pot` files containing
+the strings from the source code that need to be translated from English to
+other languages.
+
+It then runs the `update_po.sh` script to merge them in `.po` files containing
+the translated strings. The `update_po.sh` only updates existing `.po` file,
+adding a new `.po` file for a new language must be done separately, the Weblate
+tool does it automatically when adding a language in Weblate.
+
+The `generate.sh` script always run the `update_po.sh` script after running
+the `generate_pot.sh` script as there have been doubt Weblate only merged
+the updated strings from `.pot` files even if such updated strings existed
+in `.po` files. In case it's not needed anymore it can't do harm anyway, and
+it makes the `.po` files ready to use outside of Weblate.
+

--- a/tools/translation/generate.sh
+++ b/tools/translation/generate.sh
@@ -1,0 +1,32 @@
+#! /usr/bin/env bash
+
+# ===========================================================================
+#
+# Copyright (c) 2024 Unvanquished Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# ===========================================================================
+
+set -u -e -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+"${script_dir}/generate_pot.sh"
+"${script_dir}/update_po.sh"

--- a/tools/translation/translation.conf
+++ b/tools/translation/translation.conf
@@ -1,0 +1,2 @@
+game=true
+commands=false

--- a/tools/translation/update_po.sh
+++ b/tools/translation/update_po.sh
@@ -1,0 +1,51 @@
+#! /usr/bin/env bash
+
+# ===========================================================================
+#
+# Copyright (c) 2024 Unvanquished Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# ===========================================================================
+
+set -u -e -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+repo_dir="$(realpath "${script_dir}/../..")"
+dpk_dir="${repo_dir}/pkg/unvanquished_src.dpkdir"
+pot_dir="${dpk_dir}/translation"
+
+. "${script_dir}/translation.conf"
+
+cd "${dpk_dir}"
+
+for name in 'game' 'commands'
+do
+	if eval "\${${name}}"
+	then
+		pot_file="${pot_dir}/${name}.pot"
+
+		if [ -f "${pot_file}" -a -d "${name}" ]
+		then
+			find "${name}" -type f -name '*.po' -print0 \
+			| xargs -0 -r -I'{}' -P"$(nproc)" \
+				msgmerge --no-fuzzy-matching -o {} {} "${pot_file}"
+		fi
+	fi
+done


### PR DESCRIPTION
- disable the generation of `commands.pot`,
  we dont translate this for now and having to delete the file by hand on every rule of the script is annoying.
- add `update_po.sh` script,
  this automatically updates the existing `.po` files using the `.pot` files.

It looks like I never found the time to push `update_po.sh` before.