### PR TITLE
fix quake/recast coord mismatch in G_BotPathNextCorner

### DIFF
--- a/src/sgame/botlib/bot_nav.cpp
+++ b/src/sgame/botlib/bot_nav.cpp
@@ -250,7 +250,10 @@ bool G_BotPathNextCorner( int botClientNum, glm::vec3 &result )
 	}
 	dtPolyRef firstPoly = bot->corridor.getFirstPoly();
 	float corner[ 3 ] = { 0 };
-	bot->nav->query->closestPointOnPolyBoundary( firstPoly, ent->s.origin, corner );
+	vec3_t ownPos;
+	VectorCopy( ent->s.origin, ownPos );
+	std::swap( ownPos[ 1 ], ownPos[ 2 ] );
+	bot->nav->query->closestPointOnPolyBoundary( firstPoly, ownPos, corner );
 	std::swap( corner[ 1 ], corner[ 2 ] );  // recast and daemon have these swapped
 	result = VEC2GLM( corner );
 	return true;


### PR DESCRIPTION
I forgot the conversion of the bot's position. Do not ask me how this could work reasonably well. Fix it.

A map to test this on is `map-test-navcons` in UnvanquishedTestAssets.