### PR TITLE
Remove unused bot session data

### DIFF
--- a/src/sgame/sg_api.cpp
+++ b/src/sgame/sg_api.cpp
@@ -88,7 +88,7 @@ void VM::VMHandleSyscall(uint32_t id, Util::Reader reader) {
 
 		case GAME_CLIENT_CONNECT:
 			IPC::HandleMsg<GameClientConnectMsg>(VM::rootChannel, std::move(reader), [](int clientNum, bool firstTime, int isBot, bool& denied, std::string& reason) {
-				const char* deniedStr = isBot ? ClientBotConnect(clientNum, firstTime, TEAM_NONE) : ClientConnect(clientNum, firstTime);
+				const char* deniedStr = isBot ? ClientBotConnect(clientNum, firstTime) : ClientConnect(clientNum, firstTime);
 				denied = deniedStr != nullptr;
 				if (denied)
 					reason = deniedStr;

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -244,7 +244,7 @@ bool G_BotSetBehavior( botMemory_t *botMind, Str::StringRef behavior )
 	return true;
 }
 
-bool G_BotSetDefaults( int clientNum, team_t team, int skill, Str::StringRef behavior )
+bool G_BotSetDefaults( int clientNum, team_t team, Str::StringRef behavior )
 {
 	botMemory_t *botMind;
 	gentity_t *self = &g_entities[ clientNum ];
@@ -297,7 +297,7 @@ bool G_BotAdd( const char *name, team_t team, int skill, const char *behavior, b
 	}
 
 	//default bot data
-	bool okay = G_BotSetDefaults( clientNum, team, skill, behavior );
+	bool okay = G_BotSetDefaults( clientNum, team, behavior );
 
 	// register user information
 	userinfo[0] = '\0';
@@ -319,7 +319,7 @@ bool G_BotAdd( const char *name, team_t team, int skill, const char *behavior, b
 	trap_SetUserinfo( clientNum, userinfo );
 
 	// have it connect to the game as a normal client
-	if ( ( s = ClientBotConnect( clientNum, true, team ) ) )
+	if ( ( s = ClientBotConnect( clientNum, true ) ) )
 	{
 		// won't let us join
 		Log::Warn( s );

--- a/src/sgame/sg_bot_public.h
+++ b/src/sgame/sg_bot_public.h
@@ -47,7 +47,7 @@ void G_BotSetSkill( int clientNum, int skill );
 const char *G_BotGetBehavior( int clientNum );
 void G_BotChangeBehavior( int clientNum, Str::StringRef behavior );
 bool G_BotSetBehavior( botMemory_t *botMind, Str::StringRef behavior );
-bool G_BotSetDefaults( int clientNum, team_t team, int skill, Str::StringRef behavior );
+bool G_BotSetDefaults( int clientNum, team_t team, Str::StringRef behavior );
 void G_BotDel( int clientNum );
 void G_BotDelAllBots();
 void G_BotThink( gentity_t *self );

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -720,11 +720,12 @@ void G_ShutdownGame( int /* restart */ )
 		level.logGameplayFile = 0;
 	}
 
-	// write all the client session data so we can get it back
+	G_BotCleanup();
+
+	// write all the non-bot client session data so we can get it back
 	G_WriteSessionData();
 
 	G_admin_cleanup();
-	G_BotCleanup();
 	G_namelog_cleanup();
 
 	G_UnregisterCommands();

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -135,7 +135,7 @@ bool          SpotWouldTelefrag( gentity_t *spot );
 bool          G_IsUnnamed( const char *name );
 void              G_ClientCleanName( const char *in, char *out, size_t outSize, gclient_t *client );
 const char        *ClientConnect( int clientNum, bool firstTime );
-const char        *ClientBotConnect( int clientNum, bool firstTime, team_t team );
+const char        *ClientBotConnect( int clientNum, bool firstTime );
 const char        *ClientUserinfoChanged( int clientNum, bool forceName );
 void              ClientDisconnect( int clientNum );
 void              ClientBegin( int clientNum );

--- a/src/sgame/sg_session.cpp
+++ b/src/sgame/sg_session.cpp
@@ -48,19 +48,12 @@ static void G_WriteClientSessionData( int clientNum )
 	const char *s;
 	const char *var;
 	gclient_t  *client = &level.clients[ clientNum ];
-	const char *behavior = G_BotGetBehavior( clientNum );
-	if ( behavior == nullptr )
-	{
-		behavior = "default";
-	}
 
-	s = va( "%i %i %i %i %i %s %s",
+	s = va( "%i %i %i %i %s",
 		client->sess.spectatorState,
 		client->sess.spectatorClient,
 		client->sess.restartTeam,
 		client->sess.seenWelcome,
-		G_BotGetSkill( clientNum ),
-		behavior,
 		Com_ClientListString( &client->sess.ignoreList )
 	);
 
@@ -82,27 +75,21 @@ void G_ReadSessionData( gclient_t *client )
 	const char *var;
 	int        spectatorState;
 	int        restartTeam;
-	int        botSkill;
-	char       botTree[ MAX_QPATH ];
 	char       ignorelist[ 17 ];
 
 	var = va( "session%i", client->num() );
 	trap_Cvar_VariableStringBuffer( var, s, sizeof( s ) );
 
-	sscanf( s, "%i %i %i %i %i %63s %16s",
+	sscanf( s, "%i %i %i %i %16s",
 	        &spectatorState,
 	        &client->sess.spectatorClient,
 	        &restartTeam,
 	        &client->sess.seenWelcome,
-	        &botSkill,
-	        botTree,
 	        ignorelist
 	      );
 
 	client->sess.spectatorState = ( spectatorState_t ) spectatorState;
 	client->sess.restartTeam = ( team_t ) restartTeam;
-	client->sess.botSkill = botSkill;
-	Q_strncpyz( client->sess.botTree, botTree, sizeof( client->sess.botTree ) );
 	Com_ClientListParse( &client->sess.ignoreList, ignorelist );
 }
 
@@ -120,8 +107,6 @@ void G_InitSessionData( gclient_t *client, const char *userinfo )
 	sess->restartTeam = TEAM_NONE;
 	sess->spectatorState = SPECTATOR_FREE;
 	sess->spectatorClient = -1;
-	sess->botSkill = 0;
-	sess->botTree[ 0 ] = '\0';
 
 	memset( &sess->ignoreList, 0, sizeof( sess->ignoreList ) );
 	sess->seenWelcome = 0;
@@ -146,6 +131,7 @@ void G_WriteSessionData()
 	{
 		if ( level.clients[ i ].pers.connected == CON_CONNECTED )
 		{
+			ASSERT( !( g_entities[ i ].r.svFlags & SVF_BOT ) );
 			G_WriteClientSessionData( i );
 		}
 	}

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -320,8 +320,6 @@ struct clientSession_t
 	spectatorState_t spectatorState;
 	int              spectatorClient; // for chasecam and follow mode
 	team_t           restartTeam; //for !restart keepteams and !restart switchteams
-	int              botSkill;
-	char             botTree[ MAX_QPATH ];
 	clientList_t     ignoreList;
 	int              seenWelcome; // determines if the client has seen server's welcome message
 };


### PR DESCRIPTION
Since 2017, bots are never allowed to rejoin after a map restart (71b2b4042496f5f8a1dba0833a21ae770f849f99).