### PR TITLE
fix the "wallwalk-on-back" bug 

### DIFF
--- a/src/shared/bg_pmove.cpp
+++ b/src/shared/bg_pmove.cpp
@@ -2612,6 +2612,7 @@ static void PM_GroundClimbTrace()
 
 			// calculate angle between trace and ref
 			traceDOTref = DotProduct( trace.plane.normal, refNormal );
+			traceDOTref = Math::Clamp( traceDOTref, -1.f, +1.f );
 			traceANGref = RAD2DEG( acosf( traceDOTref ) );
 
 			if ( traceANGref > 180.0f )
@@ -2621,6 +2622,7 @@ static void PM_GroundClimbTrace()
 
 			// calculate angle between surf and ref
 			surfDOTref = DotProduct( surfNormal, refNormal );
+			surfDOTref = Math::Clamp( surfDOTref, -1.f, +1.f );
 			surfANGref = RAD2DEG( acosf( surfDOTref ) );
 
 			if ( surfANGref > 180.0f )
@@ -2649,6 +2651,7 @@ static void PM_GroundClimbTrace()
 
 					//calculate angle between refTOtrace and refTOsurfTOtrace
 					rTtDOTrTsTt = DotProduct( refTOtrace, refTOsurfTOtrace );
+					rTtDOTrTsTt = Math::Clamp( rTtDOTrTsTt, -1.f, +1.f );
 					rTtANGrTsTt = ANGLE2SHORT( RAD2DEG( acosf( rTtDOTrTsTt ) ) );
 
 					if ( rTtANGrTsTt > 32768 )

--- a/src/shared/bg_pmove.cpp
+++ b/src/shared/bg_pmove.cpp
@@ -2602,6 +2602,7 @@ static void PM_GroundClimbTrace()
 
 			// calculate angle between surf and trace
 			traceDOTsurf = DotProduct( trace.plane.normal, surfNormal );
+			traceDOTsurf = Math::Clamp( traceDOTsurf, -1.f, +1.f );
 			traceANGsurf = RAD2DEG( acosf( traceDOTsurf ) );
 
 			if ( traceANGsurf > 180.0f )


### PR DESCRIPTION
> `2024-05-26 20:48:17 +0200 <freem>` Hi. illwieckz, perturbed, Ishq, I have a fix for the problem which makes player "wallwalk on the back".

The first patch is the said fix.

freem also said there is not only  1 but 4 `acosf()` in the same function that receives invalid values. I guess my extra patch is what is needed.