### PR TITLE
Include common/Common.h (PCH) first in every .cpp

### DIFF
--- a/src/cgame/CombatFeedback.cpp
+++ b/src/cgame/CombatFeedback.cpp
@@ -21,6 +21,7 @@ along with Daemon.  If not, see <http://www.gnu.org/licenses/>.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "cg_local.h"
 
 #include <glm/geometric.hpp>

--- a/src/cgame/cg_animation.cpp
+++ b/src/cgame/cg_animation.cpp
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "cg_local.h"
 
 /*

--- a/src/cgame/cg_animdelta.cpp
+++ b/src/cgame/cg_animdelta.cpp
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "cg_animdelta.h"
 
 namespace

--- a/src/cgame/cg_animmapobj.cpp
+++ b/src/cgame/cg_animmapobj.cpp
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "cg_local.h"
 
 /*

--- a/src/cgame/cg_api.cpp
+++ b/src/cgame/cg_api.cpp
@@ -32,6 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "cg_local.h"
 #include "engine/client/cg_msgdef.h"
 

--- a/src/cgame/cg_attachment.cpp
+++ b/src/cgame/cg_attachment.cpp
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // cg_attachment.c -- an abstract attachment system
 
+#include "common/Common.h"
 #include "cg_local.h"
 
 /*

--- a/src/cgame/cg_beacon.cpp
+++ b/src/cgame/cg_beacon.cpp
@@ -25,6 +25,7 @@ along with Unvanquished.  If not, see <http://www.gnu.org/licenses/>.
 // cg_beacon.c
 // beacon code shared by HUD and minimap
 
+#include "common/Common.h"
 #include "shared/parse.h"
 #include "cg_local.h"
 

--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // cg_consolecmds.c -- text commands typed in at the local console, or
 // executed by a key binding
 
+#include "common/Common.h"
 #include "cg_local.h"
 
 /*

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // cg_draw.c -- draw all of the graphical elements during
 // active (after loading) gameplay
 
+#include "common/Common.h"
 #include "cg_local.h"
 
 /*

--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // cg_drawtools.c -- helper functions called by cg_draw, cg_scoreboard, cg_info, etc
 
+#include "common/Common.h"
 #include "cg_local.h"
 
 /*

--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // cg_ents.c -- present snapshot entities, happens every single frame
 
+#include "common/Common.h"
 #include "cg_local.h"
 
 /* It is dynamically adjusted in CG_AddPacketEntities() to avoid looping

--- a/src/cgame/cg_event.cpp
+++ b/src/cgame/cg_event.cpp
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // cg_event.c -- handle entity events at snapshot or playerstate transitions
 
+#include "common/Common.h"
 #include "cg_local.h"
 #include "rocket/rocket.h"
 

--- a/src/cgame/cg_gameinfo.cpp
+++ b/src/cgame/cg_gameinfo.cpp
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // gameinfo.c
 //
 
+#include "common/Common.h"
 #include "common/FileSystem.h"
 #include "cg_local.h"
 

--- a/src/cgame/cg_key_name.cpp
+++ b/src/cgame/cg_key_name.cpp
@@ -21,10 +21,8 @@ along with Unvanquished. If not, see <http://www.gnu.org/licenses/>.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "cg_key_name.h"
-
-#include "common/Log.h"
-#include "common/String.h"
 #include "engine/client/cg_api.h"
 
 using Keyboard::Key;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // cg_main.c -- initialization for cgame
 
+#include "common/Common.h"
 #include "cg_local.h"
 #include "cg_key_name.h"
 #include "shared/parse.h"

--- a/src/cgame/cg_marks.cpp
+++ b/src/cgame/cg_marks.cpp
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // cg_marks.c -- wall marks
 
+#include "common/Common.h"
 #include "cg_local.h"
 
 /*

--- a/src/cgame/cg_minimap.cpp
+++ b/src/cgame/cg_minimap.cpp
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "cg_local.h"
 
 #define MINIMAP_MAP_DISPLAY_SIZE 1024.0f

--- a/src/cgame/cg_parseutils.cpp
+++ b/src/cgame/cg_parseutils.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "cg_local.h"
 #include "shared/parse.h"
 

--- a/src/cgame/cg_particles.cpp
+++ b/src/cgame/cg_particles.cpp
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // cg_particles.c -- the particle system
 
+#include "common/Common.h"
 #include "common/FileSystem.h"
 #include "cg_local.h"
 

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // cg_players.c -- handle the media and animation for player entities
 
+#include "common/Common.h"
 #include "common/FileSystem.h"
 #include "cg_local.h"
 #include "cg_animdelta.h"

--- a/src/cgame/cg_playerstate.cpp
+++ b/src/cgame/cg_playerstate.cpp
@@ -29,6 +29,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // when following another player or playing back a demo,
 // changes will be checked when the snapshot transitions
 
+#include "common/Common.h"
 #include "cg_local.h"
 
 /*

--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -29,6 +29,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // ahead the client's movement.
 // It also handles local physics interaction, like fragments bouncing off walls
 
+#include "common/Common.h"
 #include "cg_local.h"
 
 Log::Logger predictionLog("cgame.prediction", "[client-side prediction]", Log::Level::WARNING);

--- a/src/cgame/cg_rocket.cpp
+++ b/src/cgame/cg_rocket.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "common/FileSystem.h"
 #include "cg_local.h"
 

--- a/src/cgame/cg_rocket_dataformatter.cpp
+++ b/src/cgame/cg_rocket_dataformatter.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "cg_local.h"
 
 static int GCD( int a, int b )

--- a/src/cgame/cg_rocket_datasource.cpp
+++ b/src/cgame/cg_rocket_datasource.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "cg_local.h"
 
 static bool AddToServerList( const char *name, const char *label, int clients, int bots, int ping, int maxClients, char *mapName, char *addr, int netSrc )

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "common/FileSystem.h"
 #include "cg_local.h"
 #include "cg_key_name.h"

--- a/src/cgame/cg_rocket_events.cpp
+++ b/src/cgame/cg_rocket_events.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "cg_local.h"
 #include "shared/CommonProxies.h"
 

--- a/src/cgame/cg_rocket_progressbar.cpp
+++ b/src/cgame/cg_rocket_progressbar.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "cg_local.h"
 
 static float CG_Rocket_GetLoadProgress()

--- a/src/cgame/cg_segmented_skeleton.cpp
+++ b/src/cgame/cg_segmented_skeleton.cpp
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "cg_segmented_skeleton.h"
 
 static int BoneLookup(const clientInfo_t* ci, const char* name)

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // these are processed at snapshot transition time, so there will definitely
 // be a valid snapshot this frame
 
+#include "common/Common.h"
 #include "cg_local.h"
 #include "shared/CommonProxies.h"
 

--- a/src/cgame/cg_snapshot.cpp
+++ b/src/cgame/cg_snapshot.cpp
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // cg_snapshot.c -- things that happen on snapshot transition,
 // not necessarily every single rendered frame
 
+#include "common/Common.h"
 #include "cg_local.h"
 
 /*

--- a/src/cgame/cg_trails.cpp
+++ b/src/cgame/cg_trails.cpp
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // cg_trails.c -- the trail system
 
+#include "common/Common.h"
 #include "common/FileSystem.h"
 #include "cg_local.h"
 

--- a/src/cgame/cg_tutorial.cpp
+++ b/src/cgame/cg_tutorial.cpp
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // cg_tutorial.c -- the tutorial system
 
+#include "common/Common.h"
 #include "cg_key_name.h"
 #include "cg_local.h"
 

--- a/src/cgame/cg_utils.cpp
+++ b/src/cgame/cg_utils.cpp
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // cg_utils.c -- utility functions
 
+#include "common/Common.h"
 #include "cg_local.h"
 
 /*

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // cg_view.c -- setup all the parameters (position, angle, etc)
 // for a 3D rendering
 
+#include "common/Common.h"
 #include "cg_local.h"
 
 /*

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // cg_weapons.c -- events and effects dealing with weapons
 
+#include "common/Common.h"
 #include "common/FileSystem.h"
 #include "cg_local.h"
 

--- a/src/cgame/rocket/lua/CDataSource.cpp
+++ b/src/cgame/rocket/lua/CDataSource.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "cgame/rocket/rocket.h"
 #include <RmlUi/Core.h>
 #include <RmlUi/Core/Elements/DataSource.h>

--- a/src/cgame/rocket/lua/Cmd.cpp
+++ b/src/cgame/rocket/lua/Cmd.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "../../cg_local.h"
 #include "register_lua_extensions.h"
 

--- a/src/cgame/rocket/lua/Events.cpp
+++ b/src/cgame/rocket/lua/Events.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "cgame/rocket/rocket.h"
 #include <RmlUi/Lua/LuaType.h>
 #include "register_lua_extensions.h"

--- a/src/cgame/rocket/lua/Timer.cpp
+++ b/src/cgame/rocket/lua/Timer.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "../../cg_local.h"
 #include "register_lua_extensions.h"
 

--- a/src/cgame/rocket/rocket_dataformatter.cpp
+++ b/src/cgame/rocket/rocket_dataformatter.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "rocket.h"
 #include <RmlUi/Core.h>
 #include "../cg_local.h"

--- a/src/cgame/rocket/rocket_datagrid.cpp
+++ b/src/cgame/rocket/rocket_datagrid.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "rocket.h"
 #include <RmlUi/Core.h>
 #include "rocketDataGrid.h"

--- a/src/cgame/rocket/rocket_documents.cpp
+++ b/src/cgame/rocket/rocket_documents.cpp
@@ -34,6 +34,7 @@ Maryland 20850 USA.
 
 // Code to deal with libRocket's loading and handling of documents and elements
 
+#include "common/Common.h"
 #include "rocket.h"
 #include "../cg_local.h"
 

--- a/src/cgame/rocket/rocket_element.cpp
+++ b/src/cgame/rocket/rocket_element.cpp
@@ -31,8 +31,8 @@ Maryland 20850 USA.
 
 ===========================================================================
 */
-#include <unordered_map>
 
+#include "common/Common.h"
 #include "rocket.h"
 #include "rocketElement.h"
 #include <RmlUi/Core.h>

--- a/src/cgame/rocket/rocket_events.cpp
+++ b/src/cgame/rocket/rocket_events.cpp
@@ -34,7 +34,7 @@ Maryland 20850 USA.
 
 // Code for generating custom events for libRocket
 
-#include <queue>
+#include "common/Common.h"
 #include "rocket.h"
 #include <RmlUi/Core.h>
 #include "../cg_local.h"

--- a/src/cgame/rocket/rocket_hud.cpp
+++ b/src/cgame/rocket/rocket_hud.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "rocket.h"
 #include "../cg_local.h"
 

--- a/src/cgame/rocket/rocket_keys.cpp
+++ b/src/cgame/rocket/rocket_keys.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "rocket.h"
 #include "rocketKeyBinder.h"
 #include "../cg_key_name.h"

--- a/src/cgame/translation.cpp
+++ b/src/cgame/translation.cpp
@@ -32,7 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
-#include "engine/qcommon/q_shared.h"
+#include "common/Common.h"
 #include "engine/qcommon/qcommon.h"
 #include "engine/client/cg_api.h"
 

--- a/src/sgame/BaseClustering.cpp
+++ b/src/sgame/BaseClustering.cpp
@@ -21,6 +21,7 @@ along with Unvanquished. If not, see <http://www.gnu.org/licenses/>.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 
 #define MININUM_BASE_RADIUS 128.0f

--- a/src/sgame/Beacon.cpp
+++ b/src/sgame/Beacon.cpp
@@ -25,6 +25,7 @@ along with Daemon.  If not, see <http://www.gnu.org/licenses/>.
 // Beacon.cpp
 // handle the server-side beacon-related stuff
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "Entities.h"
 

--- a/src/sgame/CombatFeedback.cpp
+++ b/src/sgame/CombatFeedback.cpp
@@ -21,6 +21,7 @@ along with Daemon.  If not, see <http://www.gnu.org/licenses/>.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 
 namespace CombatFeedback {

--- a/src/sgame/Entities.cpp
+++ b/src/sgame/Entities.cpp
@@ -22,6 +22,7 @@ along with Unvanquished.  If not, see <http://www.gnu.org/licenses/>.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "Entities.h"
 #include "CBSE.h"
 

--- a/src/sgame/botlib/bot_convert.cpp
+++ b/src/sgame/botlib/bot_convert.cpp
@@ -31,6 +31,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "bot_convert.h"
 
 rVec::rVec( float x, float y, float z )

--- a/src/sgame/botlib/bot_debug.cpp
+++ b/src/sgame/botlib/bot_debug.cpp
@@ -31,6 +31,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "engine/server/sg_msgdef.h"
 #include "shared/VMMain.h"
 #include "DetourDebugDraw.h"

--- a/src/sgame/botlib/bot_local.cpp
+++ b/src/sgame/botlib/bot_local.cpp
@@ -31,6 +31,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "bot_local.h"
 #include "sgame/sg_local.h"
 

--- a/src/sgame/botlib/bot_nav.cpp
+++ b/src/sgame/botlib/bot_nav.cpp
@@ -31,6 +31,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "bot_local.h"
 #include "bot_api.h"
 #include "sgame/sg_local.h"

--- a/src/sgame/botlib/bot_nav_edit.cpp
+++ b/src/sgame/botlib/bot_nav_edit.cpp
@@ -31,6 +31,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "common/cm/cm_public.h"
 #include "sgame/sg_local.h"
 #include "sgame/sg_bot_util.h"

--- a/src/sgame/components/AcidTubeComponent.cpp
+++ b/src/sgame/components/AcidTubeComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "AcidTubeComponent.h"
 #include "../Entities.h"
 

--- a/src/sgame/components/AlienBuildableComponent.cpp
+++ b/src/sgame/components/AlienBuildableComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "AlienBuildableComponent.h"
 #include "../Entities.h"
 #include <random>

--- a/src/sgame/components/AlienClassComponent.cpp
+++ b/src/sgame/components/AlienClassComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "AlienClassComponent.h"
 
 AlienClassComponent::AlienClassComponent(Entity& entity, ClientComponent& r_ClientComponent, TeamComponent& r_TeamComponent, ArmorComponent& r_ArmorComponent, KnockbackComponent& r_KnockbackComponent, HealthComponent& r_HealthComponent)

--- a/src/sgame/components/ArmorComponent.cpp
+++ b/src/sgame/components/ArmorComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "ArmorComponent.h"
 
 static Log::Logger armorLogger("sgame.armor");

--- a/src/sgame/components/ArmouryComponent.cpp
+++ b/src/sgame/components/ArmouryComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "ArmouryComponent.h"
 
 ArmouryComponent::ArmouryComponent(Entity& entity, HumanBuildableComponent& r_HumanBuildableComponent)

--- a/src/sgame/components/BarricadeComponent.cpp
+++ b/src/sgame/components/BarricadeComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "BarricadeComponent.h"
 
 BarricadeComponent::BarricadeComponent(Entity& entity, AlienBuildableComponent& r_AlienBuildableComponent)

--- a/src/sgame/components/BoosterComponent.cpp
+++ b/src/sgame/components/BoosterComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "BoosterComponent.h"
 
 BoosterComponent::BoosterComponent(Entity& entity, AlienBuildableComponent& r_AlienBuildableComponent)

--- a/src/sgame/components/BuildableComponent.cpp
+++ b/src/sgame/components/BuildableComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "BuildableComponent.h"
 
 BuildableComponent::BuildableComponent(Entity& entity, HealthComponent& r_HealthComponent,

--- a/src/sgame/components/ClientComponent.cpp
+++ b/src/sgame/components/ClientComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "ClientComponent.h"
 
 ClientComponent::ClientComponent(Entity& entity, gclient_t* clientData, TeamComponent& r_TeamComponent)

--- a/src/sgame/components/DeferredFreeingComponent.cpp
+++ b/src/sgame/components/DeferredFreeingComponent.cpp
@@ -22,6 +22,7 @@ along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "DeferredFreeingComponent.h"
 
 DeferredFreeingComponent::DeferredFreeingComponent(Entity &entity)

--- a/src/sgame/components/DrillComponent.cpp
+++ b/src/sgame/components/DrillComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "DrillComponent.h"
 
 DrillComponent::DrillComponent(Entity& entity, HumanBuildableComponent& r_HumanBuildableComponent, MiningComponent& r_MiningComponent)

--- a/src/sgame/components/EggComponent.cpp
+++ b/src/sgame/components/EggComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "EggComponent.h"
 
 EggComponent::EggComponent(Entity& entity, AlienBuildableComponent& r_AlienBuildableComponent, SpawnerComponent& r_SpawnerComponent)

--- a/src/sgame/components/HealthComponent.cpp
+++ b/src/sgame/components/HealthComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "HealthComponent.h"
 #include "math.h"
 

--- a/src/sgame/components/HiveComponent.cpp
+++ b/src/sgame/components/HiveComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "HiveComponent.h"
 #include "../Entities.h"
 

--- a/src/sgame/components/HumanBuildableComponent.cpp
+++ b/src/sgame/components/HumanBuildableComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "HumanBuildableComponent.h"
 #include "../Entities.h"
 

--- a/src/sgame/components/HumanClassComponent.cpp
+++ b/src/sgame/components/HumanClassComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "HumanClassComponent.h"
 
 HumanClassComponent::HumanClassComponent(Entity& entity, ClientComponent& r_ClientComponent, TeamComponent& r_TeamComponent, ArmorComponent& r_ArmorComponent, KnockbackComponent& r_KnockbackComponent, HealthComponent& r_HealthComponent)

--- a/src/sgame/components/IgnitableComponent.cpp
+++ b/src/sgame/components/IgnitableComponent.cpp
@@ -22,6 +22,7 @@ along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "IgnitableComponent.h"
 
 static Log::Logger fireLogger("sgame.fire");

--- a/src/sgame/components/KnockbackComponent.cpp
+++ b/src/sgame/components/KnockbackComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "KnockbackComponent.h"
 
 #include <glm/geometric.hpp>

--- a/src/sgame/components/LeechComponent.cpp
+++ b/src/sgame/components/LeechComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "LeechComponent.h"
 
 LeechComponent::LeechComponent(Entity& entity, AlienBuildableComponent& r_AlienBuildableComponent, MiningComponent& r_MiningComponent)

--- a/src/sgame/components/MGTurretComponent.cpp
+++ b/src/sgame/components/MGTurretComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "MGTurretComponent.h"
 
 #include <glm/geometric.hpp>

--- a/src/sgame/components/MainBuildableComponent.cpp
+++ b/src/sgame/components/MainBuildableComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "MainBuildableComponent.h"
 
 MainBuildableComponent::MainBuildableComponent(Entity& entity, BuildableComponent& r_BuildableComponent)

--- a/src/sgame/components/MedipadComponent.cpp
+++ b/src/sgame/components/MedipadComponent.cpp
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 ===========================================================================
 */
+#include "common/Common.h"
 #include "MedipadComponent.h"
 #include "sgame/Entities.h"
 

--- a/src/sgame/components/MiningComponent.cpp
+++ b/src/sgame/components/MiningComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "MiningComponent.h"
 #include "../Entities.h"
 

--- a/src/sgame/components/OvermindComponent.cpp
+++ b/src/sgame/components/OvermindComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "OvermindComponent.h"
 #include "../Entities.h"
 

--- a/src/sgame/components/ReactorComponent.cpp
+++ b/src/sgame/components/ReactorComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "ReactorComponent.h"
 
 const float ReactorComponent::ATTACK_RANGE  = 200.0f;

--- a/src/sgame/components/RocketpodComponent.cpp
+++ b/src/sgame/components/RocketpodComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "RocketpodComponent.h"
 #include "../Entities.h"
 

--- a/src/sgame/components/SpawnerComponent.cpp
+++ b/src/sgame/components/SpawnerComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "SpawnerComponent.h"
 #include "../Entities.h"
 #include "common/Util.h"

--- a/src/sgame/components/SpectatorComponent.cpp
+++ b/src/sgame/components/SpectatorComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "SpectatorComponent.h"
 
 SpectatorComponent::SpectatorComponent(Entity& entity, ClientComponent& r_ClientComponent)

--- a/src/sgame/components/SpikerComponent.cpp
+++ b/src/sgame/components/SpikerComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "SpikerComponent.h"
 
 #include <glm/geometric.hpp>

--- a/src/sgame/components/TeamComponent.cpp
+++ b/src/sgame/components/TeamComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "TeamComponent.h"
 
 TeamComponent::TeamComponent(Entity& entity, team_t team)

--- a/src/sgame/components/TelenodeComponent.cpp
+++ b/src/sgame/components/TelenodeComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "TelenodeComponent.h"
 
 TelenodeComponent::TelenodeComponent(Entity& entity, HumanBuildableComponent& r_HumanBuildableComponent, SpawnerComponent& r_SpawnerComponent)

--- a/src/sgame/components/ThinkingComponent.cpp
+++ b/src/sgame/components/ThinkingComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "ThinkingComponent.h"
 
 static Log::Logger thinkLogger("sgame.thinking");

--- a/src/sgame/components/TrapperComponent.cpp
+++ b/src/sgame/components/TrapperComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "TrapperComponent.h"
 
 TrapperComponent::TrapperComponent(Entity& entity, AlienBuildableComponent& r_AlienBuildableComponent)

--- a/src/sgame/components/TurretComponent.cpp
+++ b/src/sgame/components/TurretComponent.cpp
@@ -1,3 +1,4 @@
+#include "common/Common.h"
 #include "TurretComponent.h"
 #include <glm/gtx/norm.hpp>
 #include <glm/gtx/io.hpp>

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "Entities.h"
 #include "CBSE.h"

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -38,6 +38,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // For commands that can only be used by the server console, see sg_svcmds.cpp.
 // For gameplay commands/commands that can be done by any network client, see sg_cmds.cpp.
 
+#include "common/Common.h"
 #include "sg_local.h"
 
 #include <glm/gtx/norm.hpp>

--- a/src/sgame/sg_api.cpp
+++ b/src/sgame/sg_api.cpp
@@ -32,6 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "sg_cm_world.h"
 #include "botlib/bot_api.h"

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_bot_parse.h"
 #include "sg_bot_util.h"
 #include "Entities.h"

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_bot_ai.h"
 #include "sg_bot_util.h"
 #include "botlib/bot_api.h"

--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_bot_util.h"
 #include "botlib/bot_types.h"
 #include "botlib/bot_api.h"

--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "shared/parse.h"
 #include "sg_bot_parse.h"
 #include "sg_bot_util.h"

--- a/src/sgame/sg_bot_skilltree.cpp
+++ b/src/sgame/sg_bot_skilltree.cpp
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_bot_util.h"
 #include "../shared/parse.h"
 

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_bot_ai.h"
 #include "sg_bot_util.h"
 #include "botlib/bot_api.h"

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "common/FileSystem.h"
 #include "shared/bg_gameplay.h"
 #include "shared/parse.h"

--- a/src/sgame/sg_buildpoints.cpp
+++ b/src/sgame/sg_buildpoints.cpp
@@ -22,6 +22,7 @@ along with Unvanquished. If not, see <http://www.gnu.org/licenses/>.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "CBSE.h"
 

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "engine/qcommon/q_unicode.h"
 #include "Entities.h"

--- a/src/sgame/sg_cm_world.cpp
+++ b/src/sgame/sg_cm_world.cpp
@@ -34,6 +34,7 @@ Maryland 20850 USA.
 
 // sg_cm_world.c -- world query functions
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "sg_cm_world.h"
 

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -29,6 +29,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // For commands which can only be performed by the server console, see sg_svcmds.cpp.
 // For administrator commands (requiring authentication), see sg_admin.cpp.
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "engine/qcommon/q_unicode.h"
 #include "botlib/bot_api.h"

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "Entities.h"
 #include "CBSE.h"

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "sg_entities.h"
 #include "CBSE.h"

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "shared/parse.h"
 #include "Entities.h"

--- a/src/sgame/sg_maprotation.cpp
+++ b/src/sgame/sg_maprotation.cpp
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // See https://wiki.unvanquished.net/wiki/Server/Map_rotation for user documentation
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "common/FileSystem.h"
 

--- a/src/sgame/sg_missile.cpp
+++ b/src/sgame/sg_missile.cpp
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "sg_cm_world.h"
 #include "Entities.h"

--- a/src/sgame/sg_momentum.cpp
+++ b/src/sgame/sg_momentum.cpp
@@ -22,6 +22,7 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "Entities.h"
 

--- a/src/sgame/sg_namelog.cpp
+++ b/src/sgame/sg_namelog.cpp
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 
 void G_namelog_cleanup()

--- a/src/sgame/sg_physics.cpp
+++ b/src/sgame/sg_physics.cpp
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "sg_cm_world.h"
 

--- a/src/sgame/sg_session.cpp
+++ b/src/sgame/sg_session.cpp
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 
 /*

--- a/src/sgame/sg_spawn.cpp
+++ b/src/sgame/sg_spawn.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "sg_spawn.h"
 

--- a/src/sgame/sg_spawn_afx.cpp
+++ b/src/sgame/sg_spawn_afx.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "sg_spawn.h"
 #include "CBSE.h"

--- a/src/sgame/sg_spawn_ctrl.cpp
+++ b/src/sgame/sg_spawn_ctrl.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "sg_spawn.h"
 

--- a/src/sgame/sg_spawn_fx.cpp
+++ b/src/sgame/sg_spawn_fx.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "sg_spawn.h"
 

--- a/src/sgame/sg_spawn_game.cpp
+++ b/src/sgame/sg_spawn_game.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "sg_spawn.h"
 #include "Entities.h"

--- a/src/sgame/sg_spawn_generic.cpp
+++ b/src/sgame/sg_spawn_generic.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "sg_spawn.h"
 #include "CBSE.h"

--- a/src/sgame/sg_spawn_gfx.cpp
+++ b/src/sgame/sg_spawn_gfx.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "sg_spawn.h"
 

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "sg_spawn.h"
 #include "Entities.h"

--- a/src/sgame/sg_spawn_position.cpp
+++ b/src/sgame/sg_spawn_position.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "sg_spawn.h"
 

--- a/src/sgame/sg_spawn_sensor.cpp
+++ b/src/sgame/sg_spawn_sensor.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "sg_spawn.h"
 

--- a/src/sgame/sg_spawn_shared.cpp
+++ b/src/sgame/sg_spawn_shared.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "sg_spawn.h"
 

--- a/src/sgame/sg_svcmds.cpp
+++ b/src/sgame/sg_svcmds.cpp
@@ -37,6 +37,7 @@ Maryland 20850 USA.
 // For administrator commands (performed by console *or* remote clients), see sg_admin.cpp.
 // TODO: Convert all these commands to Cmd::StaticCmd (which works for these, but not networked commands)
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "botlib/bot_api.h"
 

--- a/src/sgame/sg_team.cpp
+++ b/src/sgame/sg_team.cpp
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "Entities.h"
 

--- a/src/sgame/sg_utils.cpp
+++ b/src/sgame/sg_utils.cpp
@@ -26,6 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // sg_utils.c -- misc utility functions for game module
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "Entities.h"
 #include "CBSE.h"

--- a/src/sgame/sg_votes.cpp
+++ b/src/sgame/sg_votes.cpp
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "sg_votes.h"
 
 #include "sg_local.h"

--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // sg_weapon.c
 // perform the server side effects of a weapon firing
 
+#include "common/Common.h"
 #include "sg_local.h"
 #include "Entities.h"
 #include "CBSE.h"

--- a/src/shared/bg_alloc.cpp
+++ b/src/shared/bg_alloc.cpp
@@ -24,7 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
-#include "engine/qcommon/q_shared.h"
+#include "common/Common.h"
 #include "bg_public.h"
 
 void *BG_Alloc( size_t size )

--- a/src/shared/bg_gameplay.cpp
+++ b/src/shared/bg_gameplay.cpp
@@ -23,8 +23,8 @@ along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>
 */
 
 
+#include "common/Common.h"
 #include "bg_gameplay.h"
-#include "engine/qcommon/q_shared.h"
 
 /*
  * This file contains gameplay constants.

--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -26,8 +26,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 // bg_misc.c -- both games misc functions, all completely stateless
 
-#include <stddef.h>
-#include "engine/qcommon/q_shared.h"
+#include "common/Common.h"
 #include "common/FileSystem.h"
 #include "shared/CommonProxies.h"
 #include "bg_public.h"

--- a/src/shared/bg_parse.cpp
+++ b/src/shared/bg_parse.cpp
@@ -26,8 +26,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA	02110-1301	USA
 
 // bg_parser.c -- parsers for configuration files
 
+#include "common/Common.h"
 #include "common/FileSystem.h"
-#include "engine/qcommon/q_shared.h"
 #include "bg_public.h"
 
 #ifdef BUILD_CGAME

--- a/src/shared/bg_pmove.cpp
+++ b/src/shared/bg_pmove.cpp
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // bg_pmove.c -- both games player movement code
 // takes a playerstate and a usercmd as input and returns a modified playerstate
 
-#include "engine/qcommon/q_shared.h"
+#include "common/Common.h"
 #include "bg_public.h"
 #include "bg_gameplay.h"
 

--- a/src/shared/bg_teamprogress.cpp
+++ b/src/shared/bg_teamprogress.cpp
@@ -22,7 +22,7 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 ===========================================================================
 */
 
-#include "engine/qcommon/q_shared.h"
+#include "common/Common.h"
 #include "bg_public.h"
 
 #ifdef BUILD_SGAME

--- a/src/shared/bg_utilities.cpp
+++ b/src/shared/bg_utilities.cpp
@@ -22,7 +22,7 @@ along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
 ===========================================================================
 */
 
-#include "engine/qcommon/q_shared.h"
+#include "common/Common.h"
 #include "bg_public.h"
 
 /**

--- a/src/shared/bg_voice.cpp
+++ b/src/shared/bg_voice.cpp
@@ -26,8 +26,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 // bg_voice.c -- both games voice functions
+#include "common/Common.h"
 #include "common/FileSystem.h"
-#include "engine/qcommon/q_shared.h"
 #include "shared/parse.h"
 #include "bg_public.h"
 

--- a/src/shared/bot_nav_shared.cpp
+++ b/src/shared/bot_nav_shared.cpp
@@ -31,6 +31,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "common/FileSystem.h"
 #include "shared/CommonProxies.h"
 #include "bot_nav_shared.h"

--- a/src/shared/navgen/brush.cpp
+++ b/src/shared/navgen/brush.cpp
@@ -29,7 +29,7 @@
 
 
 /* dependencies */
-#include <math.h>
+#include "common/Common.h"
 #include "engine/qcommon/qcommon.h"
 #include "common/cm/cm_polylib.h"
 

--- a/src/shared/parse.cpp
+++ b/src/shared/parse.cpp
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "shared/parse.h"
 #ifdef BUILD_CGAME
 #include "cgame/cg_local.h"


### PR DESCRIPTION
Always including the precompiled header first in every translation unit will help the build be consistent between PCH enabled and disabled.