### PR TITLE
rocket: silence unused parameter warning

### DIFF
--- a/src/cgame/rocket/rocketFocusManager.h
+++ b/src/cgame/rocket/rocketFocusManager.h
@@ -60,7 +60,7 @@ public:
 
 	VisibleMenusState GetState() { return state_; }
 
-	void ProcessEvent( Rml::Event &evt )
+	void ProcessEvent( Rml::Event& )
 	{
 		VisibleMenusState catchLevel;
 


### PR DESCRIPTION
Silence unused parameter warning. That warning turned into error breaks the CI:

```
FAILED: CMakeFiles/cgame-native-dll.dir/src/cgame/rocket/rocket.cpp.o 
In file included from src/cgame/rocket/rocket.cpp:51:
src/cgame/rocket/rocketFocusManager.h:63:33: error: unused parameter 'evt' [-Werror,-Wunused-parameter]
        void ProcessEvent( Rml::Event &evt )
                                       ^
1 error generated.
```
