### PR TITLE
malloc and memset cleanup

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -747,7 +747,7 @@ static void CG_RegisterGraphics()
 	};
 
 	// clear any references to old media
-	memset( &cg.refdef, 0, sizeof( cg.refdef ) );
+	cg.refdef = {};
 	trap_R_ClearScene();
 
 	CG_UpdateLoadingStep( LOAD_GEOMETRY );

--- a/src/cgame/cg_marks.cpp
+++ b/src/cgame/cg_marks.cpp
@@ -113,7 +113,7 @@ static markPoly_t *CG_AllocMark()
 	le = cg_freeMarkPolys;
 	cg_freeMarkPolys = cg_freeMarkPolys->nextMark;
 
-	memset( le, 0, sizeof( *le ) );
+	*le = {};
 
 	// link into the active list
 	le->nextMark = cg_activeMarkPolys.nextMark;

--- a/src/cgame/cg_particles.cpp
+++ b/src/cgame/cg_particles.cpp
@@ -156,7 +156,7 @@ static particle_t *CG_SpawnNewParticle( baseParticle_t *bp, particleEjector_t *p
 		//FIXME: the + 1 may be unnecessary
 		if ( !p->valid && cg.clientFrame > p->frameWhenInvalidated + 1 )
 		{
-			memset( p, 0, sizeof( particle_t ) );
+			*p = {};
 
 			//found a free slot
 			p->class_ = bp;
@@ -466,7 +466,7 @@ static particleEjector_t *CG_SpawnNewParticleEjector( baseParticleEjector_t *bpe
 
 		if ( !pe->valid )
 		{
-			memset( pe, 0, sizeof( particleEjector_t ) );
+			*pe = {};
 
 			//found a free slot
 			pe->class_ = bpe;
@@ -1487,7 +1487,7 @@ CG_InitialiseBaseParticle
 */
 static void CG_InitialiseBaseParticle( baseParticle_t *bp )
 {
-	memset( bp, 0, sizeof( baseParticle_t ) );
+	*bp = {};
 
 	memset( bp->initialColor, 0xFF, sizeof( bp->initialColor ) );
 	memset( bp->finalColor, 0xFF, sizeof( bp->finalColor ) );
@@ -1822,19 +1822,19 @@ void CG_LoadParticleSystems()
 	for ( int i = 0; i < MAX_BASEPARTICLE_SYSTEMS; i++ )
 	{
 		baseParticleSystem_t *bps = &baseParticleSystems[ i ];
-		memset( bps, 0, sizeof( baseParticleSystem_t ) );
+		*bps = {};
 	}
 
 	for ( int i = 0; i < MAX_BASEPARTICLE_EJECTORS; i++ )
 	{
 		baseParticleEjector_t *bpe = &baseParticleEjectors[ i ];
-		memset( bpe, 0, sizeof( baseParticleEjector_t ) );
+		*bpe = {};
 	}
 
 	for ( int i = 0; i < MAX_BASEPARTICLES; i++ )
 	{
 		baseParticle_t *bp = &baseParticles[ i ];
-		memset( bp, 0, sizeof( baseParticle_t ) );
+		*bp = {};
 	}
 
 	//and bring in the new
@@ -2368,8 +2368,7 @@ CG_Radix
 */
 static void CG_Radix( int bits, int size, particle_t **source, particle_t **dest )
 {
-	int count[ 256 ];
-	memset( count, 0, sizeof( count ) );
+	int count[ 256 ]{};
 
 	for ( int i = 0; i < size; i++ )
 	{

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -3278,7 +3278,7 @@ void CG_Corpse( centity_t *cent )
 	{
 		if ( ci->gender == GENDER_NEUTER )
 		{
-			memset( &cent->pe.nonseg, 0, sizeof( lerpFrame_t ) );
+			cent->pe.nonseg = {};
 			CG_RunCorpseLerpFrame( ci, &cent->pe.nonseg, es->legsAnim );
 			legs.oldframe = cent->pe.nonseg.oldFrame;
 			legs.frame = cent->pe.nonseg.frame;
@@ -3286,7 +3286,7 @@ void CG_Corpse( centity_t *cent )
 		}
 		else
 		{
-			memset( &cent->pe.legs, 0, sizeof( lerpFrame_t ) );
+			cent->pe.legs = {};
 			CG_RunCorpseLerpFrame( ci, &cent->pe.legs, es->legsAnim );
 			legs.oldframe = cent->pe.legs.oldFrame;
 			legs.frame = cent->pe.legs.frame;
@@ -3295,13 +3295,13 @@ void CG_Corpse( centity_t *cent )
 	}
 	else if ( !ci->nonsegmented )
 	{
-		memset( &cent->pe.legs, 0, sizeof( lerpFrame_t ) );
+		cent->pe.legs = {};
 		CG_RunPlayerLerpFrame( ci, &cent->pe.legs, es->legsAnim, nullptr );
 		legs.oldframe = cent->pe.legs.oldFrame;
 		legs.frame = cent->pe.legs.frame;
 		legs.backlerp = cent->pe.legs.backlerp;
 
-		memset( &cent->pe.torso, 0, sizeof( lerpFrame_t ) );
+		cent->pe.torso = {};
 		CG_RunPlayerLerpFrame( ci, &cent->pe.torso, es->torsoAnim, nullptr );
 		torso.oldframe = cent->pe.torso.oldFrame;
 		torso.frame = cent->pe.torso.frame;
@@ -3309,7 +3309,7 @@ void CG_Corpse( centity_t *cent )
 	}
 	else
 	{
-		memset( &cent->pe.nonseg, 0, sizeof( lerpFrame_t ) );
+		cent->pe.nonseg = {};
 		CG_RunPlayerLerpFrame( ci, &cent->pe.nonseg, es->legsAnim, nullptr );
 		legs.oldframe = cent->pe.nonseg.oldFrame;
 		legs.frame = cent->pe.nonseg.frame;
@@ -3446,19 +3446,19 @@ void CG_ResetPlayerEntity( centity_t *cent )
 	VectorCopy( cent->lerpOrigin, cent->rawOrigin );
 	VectorCopy( cent->lerpAngles, cent->rawAngles );
 
-	memset( &cent->pe.legs, 0, sizeof( cent->pe.legs ) );
+	cent->pe.legs = {};
 	cent->pe.legs.yawAngle = cent->rawAngles[ YAW ];
 	cent->pe.legs.yawing = false;
 	cent->pe.legs.pitchAngle = 0;
 	cent->pe.legs.pitching = false;
 
-	memset( &cent->pe.torso, 0, sizeof( cent->pe.torso ) );
+	cent->pe.torso = {};
 	cent->pe.torso.yawAngle = cent->rawAngles[ YAW ];
 	cent->pe.torso.yawing = false;
 	cent->pe.torso.pitchAngle = cent->rawAngles[ PITCH ];
 	cent->pe.torso.pitching = false;
 
-	memset( &cent->pe.nonseg, 0, sizeof( cent->pe.nonseg ) );
+	cent->pe.nonseg = {};
 	cent->pe.nonseg.yawAngle = cent->rawAngles[ YAW ];
 	cent->pe.nonseg.yawing = false;
 	cent->pe.nonseg.pitchAngle = cent->rawAngles[ PITCH ];

--- a/src/cgame/cg_rocket_datasource.cpp
+++ b/src/cgame/cg_rocket_datasource.cpp
@@ -242,7 +242,6 @@ static void CG_Rocket_BuildServerList( const char *args )
 
 void CG_Rocket_BuildServerList()
 {
-	char data[ MAX_INFO_STRING ] = { 0 };
 	int i;
 
 	rocketInfo.data.retrievingServers = true;
@@ -297,8 +296,6 @@ void CG_Rocket_BuildServerList()
 		char info[ MAX_STRING_CHARS ];
 		int ping, bots, clients, maxClients;
 
-		memset( &data, 0, sizeof( data ) );
-
 		if ( !trap_LAN_ServerIsVisible( netSrc, i ) )
 		{
 			continue;
@@ -328,6 +325,9 @@ void CG_Rocket_BuildServerList()
 		{
 			continue;
 		}
+
+		char data[ MAX_INFO_STRING ];
+		data[ 0 ] = '\0';
 
 		Info_SetValueForKey( data, "name", rocketInfo.data.servers[ netSrc ][ i ].name, false );
 		Info_SetValueForKey( data, "players", va( "%d", rocketInfo.data.servers[ netSrc ][ i ].clients ), false );

--- a/src/cgame/cg_trails.cpp
+++ b/src/cgame/cg_trails.cpp
@@ -1098,7 +1098,7 @@ CG_InitialiseBaseTrailBeam
 */
 static void CG_InitialiseBaseTrailBeam( baseTrailBeam_t *btb )
 {
-	memset( btb, 0, sizeof( baseTrailBeam_t ) );
+	*btb = {};
 
 	btb->numSegments = 1;
 	btb->frontWidth = btb->backWidth = 1.0f;
@@ -1314,13 +1314,13 @@ void CG_LoadTrailSystems()
 	for ( i = 0; i < MAX_BASETRAIL_SYSTEMS; i++ )
 	{
 		baseTrailSystem_t *bts = &baseTrailSystems[ i ];
-		memset( bts, 0, sizeof( baseTrailSystem_t ) );
+		*bts = {};
 	}
 
 	for ( i = 0; i < MAX_BASETRAIL_BEAMS; i++ )
 	{
 		baseTrailBeam_t *btb = &baseTrailBeams[ i ];
-		memset( btb, 0, sizeof( baseTrailBeam_t ) );
+		*btb = {};
 	}
 
 	//and bring in the new
@@ -1404,7 +1404,7 @@ static trailBeam_t *CG_SpawnNewTrailBeam( baseTrailBeam_t *btb,
 
 		if ( !tb->valid )
 		{
-			memset( tb, 0, sizeof( trailBeam_t ) );
+			*tb = {};
 
 			//found a free slot
 			tb->class_ = btb;

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -1630,7 +1630,7 @@ static int CG_CalcViewValues()
 {
 	playerState_t *ps;
 
-	memset( &cg.refdef, 0, sizeof( cg.refdef ) );
+	cg.refdef = {};
 
 	// calculate size of 3D view
 	CG_CalcVrect();

--- a/src/cgame/rocket/rocketDataFormatter.h
+++ b/src/cgame/rocket/rocketDataFormatter.h
@@ -53,7 +53,7 @@ public:
 
 	void FormatData( Rml::String &formatted_data, const Rml::StringList &raw_data )
 	{
-		memset( &data, 0, sizeof( data ) );
+		data[ 0 ] = '\0';
 
 		for ( size_t i = 0; i < raw_data.size(); ++i )
 		{

--- a/src/sgame/botlib/bot_nav.cpp
+++ b/src/sgame/botlib/bot_nav.cpp
@@ -437,7 +437,7 @@ bool G_BotNavTrace( int botClientNum, botTrace_t *trace, const glm::vec3& start_
 	rVec spos = qVec( start );
 	rVec epos = qVec( end );
 
-	memset( trace, 0, sizeof( *trace ) );
+	*trace = {};
 
 	Bot_t *bot = &agents[ botClientNum ];
 

--- a/src/sgame/botlib/bot_nav_edit.cpp
+++ b/src/sgame/botlib/bot_nav_edit.cpp
@@ -522,5 +522,5 @@ void NavEditShutdown()
 		Cvar::SetValue( "r_debugSurface", "0" );
 	}
 
-	memset( &cmd, 0, sizeof( cmd ) );
+	cmd = {};
 }

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -668,7 +668,7 @@ static void SpectatorThink( gentity_t *ent, usercmd_t *ucmd )
 		client->ps.weaponCharge = 0;
 
 		// Set up for pmove
-		memset( &pm, 0, sizeof( pm ) );
+		pm = {};
 		pm.ps = &client->ps;
 		pm.pmext = &client->pmext;
 		pm.cmd = *ucmd;
@@ -2055,7 +2055,7 @@ static void ClientThink_real( gentity_t *self )
 	// set up for pmove
 	oldEventSequence = client->ps.eventSequence;
 
-	memset( &pm, 0, sizeof( pm ) );
+	pm = {};
 
 	// clear fall impact velocity before every pmove
 	VectorSet( client->pmext.fallImpactVelocity, 0.0f, 0.0f, 0.0f );

--- a/src/sgame/sg_active.cpp
+++ b/src/sgame/sg_active.cpp
@@ -379,16 +379,12 @@ ClientImpacts
 static void ClientImpacts( gentity_t *ent, pmove_t *pm )
 {
 	int       i;
-	trace_t   trace;
 	gentity_t *other;
 
 	if( !ent || !ent->client )
 	{
 		return;
 	}
-
-	// clear a fake trace struct for touch function
-	memset( &trace, 0, sizeof( trace ) );
 
 	for ( i = 0; i < pm->numtouch; i++ )
 	{
@@ -435,7 +431,7 @@ static void ClientImpacts( gentity_t *ent, pmove_t *pm )
 		// touch triggers
 		if ( other->touch )
 		{
-			other->touch( other, ent, &trace );
+			other->touch( other, ent );
 		}
 	}
 }
@@ -453,7 +449,6 @@ void  G_TouchTriggers( gentity_t *ent )
 	int              i, num;
 	int              touch[ MAX_GENTITIES ];
 	gentity_t        *hit;
-	trace_t          trace;
 	vec3_t           mins, maxs;
 	vec3_t           pmins, pmaxs;
 	static const     vec3_t range = { 10, 10, 10 };
@@ -520,11 +515,9 @@ void  G_TouchTriggers( gentity_t *ent )
 			continue;
 		}
 
-		memset( &trace, 0, sizeof( trace ) );
-
 		if ( hit->touch )
 		{
-			hit->touch( hit, ent, &trace );
+			hit->touch( hit, ent );
 		}
 	}
 }

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -2108,14 +2108,13 @@ bool G_admin_readconfig( gentity_t *ent )
 		{
 			if ( l )
 			{
-				l = l->next = (g_admin_level_t*) BG_Alloc( sizeof( g_admin_level_t ) );
+				l = l->next = (g_admin_level_t*) BG_Calloc( sizeof( g_admin_level_t ) );
 			}
 			else
 			{
-				l = g_admin_levels = (g_admin_level_t*) BG_Alloc( sizeof( g_admin_level_t ) );
+				l = g_admin_levels = (g_admin_level_t*) BG_Calloc( sizeof( g_admin_level_t ) );
 			}
 
-			memset( l, 0, sizeof( *l ) );
 			level_open = true;
 			admin_open = ban_open = command_open = vote_open = false;
 			lc++;
@@ -2124,14 +2123,13 @@ bool G_admin_readconfig( gentity_t *ent )
 		{
 			if ( a )
 			{
-				a = a->next = (g_admin_admin_t*) BG_Alloc( sizeof( g_admin_admin_t ) );
+				a = a->next = (g_admin_admin_t*) BG_Calloc( sizeof( g_admin_admin_t ) );
 			}
 			else
 			{
-				a = g_admin_admins = (g_admin_admin_t*) BG_Alloc( sizeof( g_admin_admin_t ) );
+				a = g_admin_admins = (g_admin_admin_t*) BG_Calloc( sizeof( g_admin_admin_t ) );
 			}
 
-			memset( a, 0, sizeof( *a ) );
 			admin_open = true;
 			level_open = ban_open = command_open = vote_open = false;
 			ac++;

--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -167,7 +167,7 @@ private:
 	botNavCmd_t m_nav;
 public:
 	botNavCmd_t const& nav() const { return m_nav; };
-	void clearNav() { memset( &m_nav, 0, sizeof( m_nav ) ); }
+	void clearNav() { m_nav = {}; }
 	void setGoal( botTarget_t target, bool direct ) { goal = target; m_nav.directPathToGoal = direct; }
 	friend void G_BotThink( gentity_t * );
 	friend bool BotChangeGoal( gentity_t *, botTarget_t );

--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -733,12 +733,11 @@ static AIValue_t *parseFunctionParameters( pc_token_list **list, int *nparams, i
 static AIValueFunc_t *newValueFunc( pc_token_list **list )
 {
 	AIValueFunc_t *ret = nullptr;
-	AIValueFunc_t v;
 	pc_token_list *current = *list;
 	pc_token_list *parenBegin = nullptr;
 	struct AIConditionMap_s *f;
 
-	memset( &v, 0, sizeof( v ) );
+	AIValueFunc_t v{};
 
 	f = (struct AIConditionMap_s*) bsearch( current->token.string, conditionFuncs, ARRAY_LEN( conditionFuncs ), sizeof( *conditionFuncs ), cmdcmp );
 
@@ -996,7 +995,6 @@ static AIGenericNode_t *ReadDecoratorNode( pc_token_list **list )
 {
 	pc_token_list *current = *list;
 	struct AIDecoratorMap_s *dec;
-	AIDecoratorNode_t       node;
 	AIDecoratorNode_t       *ret;
 	pc_token_list           *parenBegin;
 
@@ -1023,7 +1021,7 @@ static AIGenericNode_t *ReadDecoratorNode( pc_token_list **list )
 
 	parenBegin = current->next;
 
-	memset( &node, 0, sizeof( node ) );
+	AIDecoratorNode_t node{};
 
 	BotInitNode( DECORATOR_NODE, dec->run, &node );
 

--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -634,7 +634,7 @@ static AIValue_t *newValueLiteral( pc_token_list **list )
 	pc_token_list *current = *list;
 	pc_token_stripped_t *token = &current->token;
 
-	ret = ( AIValue_t * ) BG_Alloc( sizeof( *ret ) );
+	ret = ( AIValue_t * ) BG_Malloc( sizeof( *ret ) );
 
 	*ret = AIBoxToken( token );
 

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -2500,9 +2500,7 @@ void BotSetSkillLevel( gentity_t *self, int skill )
 
 void BotResetEnemyQueue( enemyQueue_t *queue )
 {
-	queue->front = 0;
-	queue->back = 0;
-	memset( queue->enemys, 0, sizeof( queue->enemys ) );
+	*queue = {};
 }
 
 static void BotPushEnemy( enemyQueue_t *queue, gentity_t *enemy )

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -271,7 +271,7 @@ static void ABarricade_Think( gentity_t *self )
 	ABarricade_Shrink( self, !self->powered );
 }
 
-static void ABarricade_Touch( gentity_t *self, gentity_t *other, trace_t* )
+static void ABarricade_Touch( gentity_t *self, gentity_t *other )
 {
 	gclient_t *client = other->client;
 	int       client_z, min_z;
@@ -322,7 +322,7 @@ static void ABooster_Think( gentity_t *self )
 	}
 }
 
-static void ABooster_Touch( gentity_t *self, gentity_t *other, trace_t* )
+static void ABooster_Touch( gentity_t *self, gentity_t *other )
 {
 	gclient_t *client = other->client;
 
@@ -678,7 +678,6 @@ void G_BuildableTouchTriggers( gentity_t *ent )
 	int              i, num;
 	int              touch[ MAX_GENTITIES ];
 	gentity_t        *hit;
-	trace_t          trace;
 	vec3_t           mins, maxs;
 	vec3_t           bmins, bmaxs;
 	static    vec3_t range = { 10, 10, 10 };
@@ -732,11 +731,9 @@ void G_BuildableTouchTriggers( gentity_t *ent )
 			continue;
 		}
 
-		memset( &trace, 0, sizeof( trace ) );
-
 		if ( hit->touch )
 		{
-			hit->touch( hit, ent, &trace );
+			hit->touch( hit, ent );
 		}
 	}
 }

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -1087,7 +1087,7 @@ const char *ClientConnect( int clientNum, bool firstTime )
 	}
 
 	ent->client = client;
-	memset( client, 0, sizeof( *client ) );
+	ResetStruct( *client );
 
 	trap_GetUserinfo( clientNum, userinfo, sizeof( userinfo ) );
 
@@ -1235,7 +1235,7 @@ const char *ClientBotConnect( int clientNum, bool firstTime )
 	client = &level.clients[ clientNum ];
 
 	ent->client = client;
-	memset( client, 0, sizeof( *client ) );
+	ResetStruct( *client );
 
 	client->pers.localClient = true;
 	G_AddressParse( "localhost", &client->pers.ip );
@@ -1323,8 +1323,8 @@ void ClientBegin( int clientNum )
 	// so the viewpoint doesn't interpolate through the
 	// world to the new position
 	flags = client->ps.eFlags;
-	memset( &client->ps, 0, sizeof( client->ps ) );
-	memset( &client->pmext, 0, sizeof( client->pmext ) );
+	client->ps = {};
+	client->pmext = {};
 	client->ps.eFlags = flags;
 
 	// locate ent at a spawn point
@@ -1576,7 +1576,7 @@ void ClientSpawn( gentity_t *ent, gentity_t *spawn, const vec3_t origin, const v
 	}
 
 	eventSequence = client->ps.eventSequence;
-	memset( client, 0, sizeof( *client ) );
+	ResetStruct( *client );
 
 	client->pers = saved;
 	client->sess = savedSess;

--- a/src/sgame/sg_cm_world.cpp
+++ b/src/sgame/sg_cm_world.cpp
@@ -796,7 +796,6 @@ void G_CM_Trace( trace_t *results, const vec3_t start, const vec3_t mins2, const
                  const vec3_t end, int passEntityNum, int contentmask, int skipmask,
                  traceType_t type )
 {
-	moveclip_t clip;
 	int        i;
 
 	if ( !mins2 )
@@ -813,7 +812,7 @@ void G_CM_Trace( trace_t *results, const vec3_t start, const vec3_t mins2, const
 	VectorCopy(mins2, mins);
 	VectorCopy(maxs2, maxs);
 
-	memset( &clip, 0, sizeof( moveclip_t ) );
+	moveclip_t clip{};
 
 	// clip to world
 	// -------------

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -1819,7 +1819,6 @@ static void CheckIntermissionExit()
 	int          ready, notReady;
 	int          i;
 	gclient_t    *cl;
-	clientList_t readyMasks;
 	bool     voting = G_VotesRunning();
 
 	//if no clients are connected, just exit
@@ -1832,7 +1831,7 @@ static void CheckIntermissionExit()
 	// see which players are ready
 	ready = 0;
 	notReady = 0;
-	memset( &readyMasks, 0, sizeof( readyMasks ) );
+	clientList_t readyMasks{};
 
 	for ( i = 0; i < level.maxclients; i++ )
 	{

--- a/src/sgame/sg_maprotation.cpp
+++ b/src/sgame/sg_maprotation.cpp
@@ -1741,5 +1741,5 @@ void G_ShutdownMapRotations()
 		}
 	}
 
-	memset( &mapRotations, 0, sizeof( mapRotations ) );
+	mapRotations = {};
 }

--- a/src/sgame/sg_session.cpp
+++ b/src/sgame/sg_session.cpp
@@ -111,7 +111,7 @@ void G_InitSessionData( gclient_t *client )
 	sess->spectatorState = SPECTATOR_FREE;
 	sess->spectatorClient = -1;
 
-	memset( &sess->ignoreList, 0, sizeof( sess->ignoreList ) );
+	sess->ignoreList = {};
 	sess->seenWelcome = 0;
 
 	G_WriteClientSessionData( client->num() );

--- a/src/sgame/sg_spawn_afx.cpp
+++ b/src/sgame/sg_spawn_afx.cpp
@@ -78,7 +78,7 @@ trigger_push
 ==============================================================================
 */
 
-static void env_afx_push_touch( gentity_t *self, gentity_t *activator, trace_t* )
+static void env_afx_push_touch( gentity_t *self, gentity_t *activator )
 {
 	//only triggered by clients
 	if ( !activator || !activator->client )
@@ -124,7 +124,7 @@ trigger_teleport
 ==============================================================================
 */
 
-static void env_afx_teleporter_touch( gentity_t *self, gentity_t *other, trace_t* )
+static void env_afx_teleporter_touch( gentity_t *self, gentity_t *other )
 {
 	gentity_t *dest;
 
@@ -200,7 +200,7 @@ trigger_hurt
 ==============================================================================
 */
 
-static void env_afx_hurt_touch( gentity_t *self, gentity_t *other, trace_t* )
+static void env_afx_hurt_touch( gentity_t *self, gentity_t *other )
 {
 	int dflags;
 
@@ -263,7 +263,7 @@ static void env_afx_gravity_reset( gentity_t *self )
 	G_ResetIntField(&self->mapEntity.amount, false, self->mapEntity.config.amount, self->mapEntity.eclass->config.amount, g_gravity.Get());
 }
 
-static void env_afx_gravity_touch( gentity_t *ent, gentity_t *other, trace_t* )
+static void env_afx_gravity_touch( gentity_t *ent, gentity_t *other )
 {
 	//only triggered by clients
 	if ( !other->client )
@@ -312,7 +312,7 @@ trigger_heal
 =================================================================================
 */
 
-static void env_afx_heal_touch( gentity_t *self, gentity_t *other, trace_t* )
+static void env_afx_heal_touch( gentity_t *self, gentity_t *other )
 {
 	if ( !other->client )
 	{
@@ -364,7 +364,7 @@ trigger_ammo
 
 =================================================================================
 */
-static void env_afx_ammo_touch( gentity_t *self, gentity_t *other, trace_t* )
+static void env_afx_ammo_touch( gentity_t *self, gentity_t *other )
 {
 	int      maxClips, maxAmmo;
 	weapon_t weapon;

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -1547,7 +1547,7 @@ static void func_door_block( gentity_t *self, gentity_t *other )
 Touch_DoorTrigger
 ================
 */
-static void door_trigger_touch( gentity_t *self, gentity_t *other, trace_t* )
+static void door_trigger_touch( gentity_t *self, gentity_t *other )
 {
 	moverState_t groupState;
 
@@ -2043,7 +2043,7 @@ Touch_Plat
 Don't allow to descend if a live player is on it
 ===============
 */
-static void Touch_Plat( gentity_t *ent, gentity_t *other, trace_t* )
+static void Touch_Plat( gentity_t *ent, gentity_t *other )
 {
 	// DONT_WAIT
 	if ( ent->mapEntity.spawnflags & 1 )
@@ -2070,7 +2070,7 @@ Touch_PlatCenterTrigger
 If the plat is at the bottom position, start it going up
 ===============
 */
-static void Touch_PlatCenterTrigger( gentity_t *ent, gentity_t *other, trace_t* )
+static void Touch_PlatCenterTrigger( gentity_t *ent, gentity_t *other )
 {
 	if ( !other->client )
 	{
@@ -2202,7 +2202,7 @@ BUTTON
 ===============================================================================
 */
 
-static void Touch_Button( gentity_t *ent, gentity_t *other, trace_t* )
+static void Touch_Button( gentity_t *ent, gentity_t *other )
 {
 	if ( !other->client )
 	{

--- a/src/sgame/sg_spawn_sensor.cpp
+++ b/src/sgame/sg_spawn_sensor.cpp
@@ -127,7 +127,7 @@ static void trigger_multiple_act( gentity_t *self, gentity_t*,
 	trigger_checkWaitForReactivation( self );
 }
 
-static void trigger_multiple_touch( gentity_t *self, gentity_t *other, trace_t* )
+static void trigger_multiple_touch( gentity_t *self, gentity_t *other )
 {
 	trigger_multiple_act( self, other, other );
 }
@@ -345,7 +345,7 @@ static bool sensor_buildable_match( gentity_t *self, gentity_t *activator )
 	return false;
 }
 
-static void sensor_buildable_touch( gentity_t *self, gentity_t *activator, trace_t* )
+static void sensor_buildable_touch( gentity_t *self, gentity_t *activator )
 {
 	//sanity check
 	if ( !activator || activator->s.eType != entityType_t::ET_BUILDABLE )
@@ -459,7 +459,7 @@ static bool sensor_equipment_match( gentity_t *self, gentity_t *activator )
 	return false;
 }
 
-static void sensor_player_touch( gentity_t *self, gentity_t *activator, trace_t* )
+static void sensor_player_touch( gentity_t *self, gentity_t *activator )
 {
 	bool shouldFire;
 

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -217,7 +217,7 @@ struct gentity_t
 	int       nextthink;
 	void ( *think )( gentity_t *self );
 	void ( *reset )( gentity_t *self );
-	void ( *touch )( gentity_t *self, gentity_t *other, trace_t *trace );
+	void ( *touch )( gentity_t *self, gentity_t *other );
 	void ( *use )( gentity_t *self, gentity_t *other, gentity_t *activator );
 	void ( *pain )( gentity_t *self, gentity_t *attacker, int damage );
 	void ( *die )( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int mod );

--- a/src/sgame/sg_team.cpp
+++ b/src/sgame/sg_team.cpp
@@ -149,9 +149,7 @@ G_ClientListForTeam
 static clientList_t G_ClientListForTeam( team_t team )
 {
 	int          i;
-	clientList_t clientList;
-
-	memset( &clientList, 0, sizeof( clientList_t ) );
+	clientList_t clientList{};
 
 	for ( i = 0; i < level.maxclients; i++ )
 	{
@@ -184,8 +182,8 @@ void G_UpdateTeamConfigStrings()
 	if ( level.intermissiontime )
 	{
 		// No restrictions once the game has ended
-		memset( &alienTeam, 0, sizeof( clientList_t ) );
-		memset( &humanTeam, 0, sizeof( clientList_t ) );
+		alienTeam = {};
+		humanTeam = {};
 	}
 
 	trap_SetConfigstringRestrictions( CS_VOTE_TIME + TEAM_ALIENS,   &humanTeam );

--- a/src/sgame/sg_utils.cpp
+++ b/src/sgame/sg_utils.cpp
@@ -79,7 +79,7 @@ const char *BuildShaderStateConfig()
 	char        out[ MAX_QPATH * 2 + 5 ];
 	int         i;
 
-	memset( buff, 0, sizeof(buff) );
+	buff[ 0 ] = '\0';
 
 	for ( i = 0; i < remapCount; i++ )
 	{
@@ -558,7 +558,7 @@ static const char *addr4parse( const char *str, addr_t *addr )
 	int i;
 	int octet = 0;
 	int num = 0;
-	memset( addr, 0, sizeof( addr_t ) );
+	*addr = {};
 	addr->type = IPv4;
 
 	for ( i = 0; octet < 4; i++ )
@@ -683,7 +683,7 @@ static const char *addr6parse( const char *str, addr_t *addr )
 		return nullptr;
 	}
 
-	memset( addr, 0, sizeof( addr_t ) );
+	*addr = {};
 	addr->type = IPv6;
 
 	if ( before )

--- a/src/shared/bg_alloc.cpp
+++ b/src/shared/bg_alloc.cpp
@@ -27,12 +27,37 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "common/Common.h"
 #include "bg_public.h"
 
-void *BG_Alloc( size_t size )
-{
-	return calloc( size, 1 );
-}
-
 void BG_Free( void *ptr )
 {
 	free( ptr );
+}
+
+// Allocations uncategorized as to whether they really need zeroing
+void *BG_Alloc( size_t size )
+{
+  void* p = calloc( size, 1 );
+  if ( !p && size ) Sys::Error( "BG_Alloc: Out of memory" );
+  return p;
+}
+// Allocates unitialized memory like malloc
+void *BG_Malloc( size_t size )
+{
+    void* p = malloc( size );
+    if ( !p && size ) Sys::Error( "BG_Malloc: Out of memory" );
+    return p;
+}
+// Allocates zeroed memory like calloc
+void *BG_Calloc( size_t size )
+{
+    void* p = calloc( size, 1 );
+    if ( !p && size ) Sys::Error( "BG_Calloc: Out of memory" );
+    return p;
+}
+
+char *BG_strdup( const char *string )
+{
+	size_t length = strlen(string) + 1;
+	char *copy = static_cast<char*>( BG_Malloc(length) );
+	memcpy( copy, string, length );
+	return copy;
 }

--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -134,7 +134,7 @@ static void BG_InitBuildableAttributes()
 		ba = &bg_buildableList[i];
 
 		//Initialise default values for buildables
-		memset( ba, 0, sizeof( buildableAttributes_t ) );
+		*ba = {};
 
 		ba->number = bh->number;
 		ba->name = bh->name;
@@ -200,7 +200,7 @@ static void BG_InitBuildableModelConfigs()
 	for ( i = BA_NONE + 1; i < BA_NUM_BUILDABLES; i++ )
 	{
 		bc = BG_BuildableModelConfig( i );
-		memset( bc, 0, sizeof( buildableModelConfig_t ) );
+		*bc = {};
 
 		BG_ParseBuildableModelFile( va( "configs/buildables/%s.model.cfg",
 		                           BG_Buildable( i )->name ), bc );
@@ -620,7 +620,7 @@ static void BG_InitWeaponAttributes()
 		wd = &bg_weaponsData[i];
 		wa = &bg_weapons[i];
 
-		memset( wa, 0, sizeof( weaponAttributes_t ) );
+		*wa = {};
 
 		wa->number = wd->number;
 		wa->name   = wd->name;
@@ -709,7 +709,7 @@ static void BG_InitUpgradeAttributes()
 		ua = &bg_upgrades[i];
 
 		//Initialise default values for buildables
-		memset( ua, 0, sizeof( upgradeAttributes_t ) );
+		*ua = {};
 
 		ua->number = ud->number;
 		ua->name = ud->name;
@@ -798,7 +798,7 @@ static void BG_InitMissileAttributes()
 		md = &bg_missilesData[i];
 		ma = &bg_missiles[i];
 
-		memset( ma, 0, sizeof( missileAttributes_t ) );
+		*ma = {};
 
 		ma->name   = md->name;
 		ma->number = md->number;
@@ -960,7 +960,7 @@ static void BG_InitBeaconAttributes()
 		bd = bg_beaconsData + i;
 		ba = bg_beacons + i;
 
-		memset( ba, 0, sizeof( beaconAttributes_t ) );
+		*ba = {};
 
 		ba->number = bd->number;
 		ba->name = bd->name;

--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -2554,31 +2554,6 @@ char *Substring( const char *in, int start, int count )
 
 /*
 =================
-BG_strdup
-=================
-*/
-
-char *BG_strdup( const char *string )
-{
-	size_t length;
-	char *copy;
-
-	length = strlen(string) + 1;
-	copy = (char *)malloc(length);
-
-	if ( copy == nullptr )
-	{
-		return nullptr;
-	}
-
-	memcpy( copy, string, length );
-	return copy;
-}
-
-
-
-/*
-=================
 Trans_GenderContext
 =================
 */

--- a/src/shared/bg_pmove.cpp
+++ b/src/shared/bg_pmove.cpp
@@ -4573,7 +4573,7 @@ static void PmoveSingle( pmove_t *pmove )
 	}
 
 	// clear all pmove local vars
-	memset( &pml, 0, sizeof( pml ) );
+	pml = {};
 
 	// determine the time
 	pml.msec = pmove->cmd.serverTime - pm->ps->commandTime;

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -1680,6 +1680,8 @@ void     CG_UpdateUnlockables( playerState_t *ps );
 #define MASK_ENTITY      ( CONTENTS_MOVER )
 
 void     *BG_Alloc( size_t size );
+void     *BG_Malloc( size_t size );
+void     *BG_Calloc( size_t size );
 void     BG_Free( void *ptr );
 
 void     BG_EvaluateTrajectory( const trajectory_t *tr, int atTime, vec3_t result );

--- a/src/shared/bg_teamprogress.cpp
+++ b/src/shared/bg_teamprogress.cpp
@@ -242,10 +242,6 @@ void BG_ImportUnlockablesFromMask( int team, int mask )
 	int unlockableType = 0;
 	team_t           currentTeam;
 	bool         newStatus;
-#ifdef BUILD_CGAME
-	int              statusChanges[ NUM_UNLOCKABLES ];
-	int statusChangeCount = 0;
-#endif
 
 	// maintain a cache to prevent redundant imports
 	static int    lastMask = 0;
@@ -263,7 +259,8 @@ void BG_ImportUnlockablesFromMask( int team, int mask )
 
 #ifdef BUILD_CGAME
 	// no status change yet
-	memset( statusChanges, 0, sizeof( statusChanges ) );
+	int statusChanges[ NUM_UNLOCKABLES ]{};
+	int statusChangeCount = 0;
 #endif
 
 	for ( unlockableNum = 0; unlockableNum < NUM_UNLOCKABLES; unlockableNum++ )

--- a/src/shared/bg_voice.cpp
+++ b/src/shared/bg_voice.cpp
@@ -309,8 +309,7 @@ static bool BG_VoiceParseTrack( int handle, voiceTrack_t *voiceTrack )
 				                                token.string ) );
 			}
 
-			voiceTrack->text = ( char * ) BG_Alloc( tokenLen + 1 );
-			Q_strncpyz( voiceTrack->text, token.string, tokenLen + 1 );
+			voiceTrack->text = BG_strdup( token.string );
 			foundToken = Parse_ReadTokenHandle( handle, &token );
 			continue;
 		}

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -215,57 +215,38 @@ struct BasicMeshProcess : public dtTileCacheMeshProcess
 
 struct LinearAllocator : public dtTileCacheAlloc
 {
-	unsigned char* buffer = nullptr;
-	size_t capacity = 0;
-	size_t top = 0;
-	size_t high = 0;
+	char* buffer;
+	size_t capacity;
+	size_t top;
 
-	LinearAllocator( const size_t cap )
-	{
-		resize(cap);
-	}
+	LinearAllocator( const size_t cap ) :
+		buffer( static_cast<char *>( BG_Malloc( cap ) ) ),
+		capacity(cap), top(0)
+	{}
 
 	~LinearAllocator() override
 	{
-		free( buffer );
-	}
-
-	void resize( const size_t cap )
-	{
-		auto * tmp_buffer = static_cast<unsigned char*>( realloc( buffer, cap ) );
-		if ( !tmp_buffer )
-		{
-			Sys::Drop( "Failed to reallocate LinearAllocator" );
-		}
-		buffer = tmp_buffer;
-		capacity = cap;
+		BG_Free( buffer );
 	}
 
 	void reset() override
 	{
-		high = dtMax( high, top );
 		top = 0;
 	}
 
 	void* alloc( const size_t size ) override
 	{
-		if ( !buffer )
-		{
-			return nullptr;
-		}
-
 		if ( top + size > capacity )
 		{
 			return nullptr;
 		}
 
-		unsigned char* mem = &buffer[ top ];
+		char* mem = &buffer[ top ];
 		top += size;
 		return mem;
 	}
 
 	void free( void* /*ptr*/ ) override { }
-	size_t getHighSize() { return high; }
 };
 
 // Maybe use another alien form's navmesh instead of generating one for this class

--- a/src/shared/navgen/nav.cpp
+++ b/src/shared/navgen/nav.cpp
@@ -1138,8 +1138,7 @@ bool NavmeshGenerator::Step( NavgenTask &t )
 		return true;
 	}
 
-	TileCacheData tiles[ MAX_LAYERS ];
-	memset( tiles, 0, sizeof( tiles ) );
+	TileCacheData tiles[ MAX_LAYERS ]{};
 
 	int ntiles;
 	NavgenStatus status = rasterizeTileLayers(geo_, t.context, t.x, t.y, t.cfg, tiles, MAX_LAYERS, !!config_.filterGaps, &ntiles);

--- a/src/shared/navgen/navgen.h
+++ b/src/shared/navgen/navgen.h
@@ -63,9 +63,9 @@ struct RasterizationContext
 		triareas( 0 ),
 		lset( 0 ),
 		chf( 0 ),
-		ntiles( 0 ){
-		memset( tiles, 0, sizeof( TileCacheData ) * MAX_LAYERS );
-	}
+		tiles{},
+		ntiles( 0 )
+	{}
 
 	~RasterizationContext(){
 		rcFreeHeightField( solid );

--- a/src/shared/parse.cpp
+++ b/src/shared/parse.cpp
@@ -1060,7 +1060,7 @@ static int Parse_ReadScriptToken( script_t *script, token_t *token )
 	//save line counter
 	script->lastline = script->line;
 	//clear the token stuff
-	memset( token, 0, sizeof( token_t ) );
+	*token = {};
 	//start of the white space
 	script->whitespace_p = script->script_p;
 	token->whitespace_p = script->script_p;
@@ -1173,7 +1173,6 @@ static script_t *Parse_LoadScriptFile( const char *filename, int (*openFunc)(Str
 	memset( buffer, 0, sizeof( script_t ) + length + 1 );
 
 	script = ( script_t * ) buffer;
-	memset( script, 0, sizeof( script_t ) );
 	Q_strncpyz( script->filename, filename, sizeof( script->filename ) );
 	script->buffer = ( char * ) buffer + sizeof( script_t );
 	script->buffer[ length ] = 0;
@@ -1210,7 +1209,7 @@ static script_t *Parse_LoadScriptMemory( const char *ptr, int length, const char
 	buffer = BG_Malloc( sizeof( script_t ) + length + 1 );
 
 	script = ( script_t * ) buffer;
-	memset( script, 0, sizeof( script_t ) );
+	*script = {};
 	Q_strncpyz( script->filename, name, sizeof( script->filename ) );
 	script->buffer = ( char * ) buffer + sizeof( script_t );
 	script->length = length;
@@ -3882,14 +3881,13 @@ Parse_DefineFromString
 static define_t *Parse_DefineFromString( const char *string )
 {
 	script_t *script;
-	source_t src;
 	token_t  *t;
 	int      res, i;
 	define_t *def;
 
 	script = Parse_LoadScriptMemory( string, strlen( string ), "*extern" );
 	//create a new source
-	memset( &src, 0, sizeof( source_t ) );
+	source_t src{};
 	Q_strncpyz( src.filename, "*extern", MAX_QPATH );
 	//src.openFunc is null, as a define can't contain an include
 	src.scriptstack = script;

--- a/src/shared/parse.cpp
+++ b/src/shared/parse.cpp
@@ -329,7 +329,7 @@ static void Parse_CreatePunctuationTable( script_t *script, punctuation_t *punct
 	if ( !script->punctuationtable )
 	{
 		script->punctuationtable = ( punctuation_t ** )
-		                           BG_Alloc( 256 * sizeof( punctuation_t * ) );
+		                           BG_Malloc( 256 * sizeof( punctuation_t * ) );
 	}
 
 	memset( script->punctuationtable, 0, 256 * sizeof( punctuation_t * ) );
@@ -1207,14 +1207,12 @@ static script_t *Parse_LoadScriptMemory( const char *ptr, int length, const char
 	void     *buffer;
 	script_t *script;
 
-	buffer = BG_Alloc( sizeof( script_t ) + length + 1 );
-	memset( buffer, 0, sizeof( script_t ) + length + 1 );
+	buffer = BG_Malloc( sizeof( script_t ) + length + 1 );
 
 	script = ( script_t * ) buffer;
 	memset( script, 0, sizeof( script_t ) );
 	Q_strncpyz( script->filename, name, sizeof( script->filename ) );
 	script->buffer = ( char * ) buffer + sizeof( script_t );
-	script->buffer[ length ] = 0;
 	script->length = length;
 	//pointer in script buffer
 	script->script_p = script->buffer;
@@ -1229,6 +1227,7 @@ static script_t *Parse_LoadScriptMemory( const char *ptr, int length, const char
 	Parse_SetScriptPunctuations( script, nullptr );
 	//
 	memcpy( script->buffer, ptr, length );
+	script->buffer[ length ] = '\0';
 	//
 	return script;
 }
@@ -1353,14 +1352,9 @@ static token_t *Parse_CopyToken( const token_t *token )
 {
 	token_t *t;
 
-//  t = (token_t *) malloc(sizeof(token_t));
-	t = ( token_t * ) BG_Alloc( sizeof( token_t ) );
+	t = ( token_t * ) BG_Malloc( sizeof( token_t ) );
 
 //  t = freetokens;
-	if ( !t )
-	{
-		Sys::Error( "out of token space" );
-	}
 
 //  freetokens = freetokens->next;
 	*t = *token;
@@ -3899,8 +3893,7 @@ static define_t *Parse_DefineFromString( const char *string )
 	Q_strncpyz( src.filename, "*extern", MAX_QPATH );
 	//src.openFunc is null, as a define can't contain an include
 	src.scriptstack = script;
-	src.definehash = (define_t**) BG_Alloc( DEFINEHASHSIZE * sizeof( define_t * ) );
-	memset( src.definehash, 0, DEFINEHASHSIZE * sizeof( define_t * ) );
+	src.definehash = (define_t**) BG_Calloc( DEFINEHASHSIZE * sizeof( define_t * ) );
 	//create a define from the source
 	res = Parse_Directive_define( &src );
 
@@ -4100,8 +4093,7 @@ static source_t *Parse_LoadSourceFile( const char *filename, int (*openFunc)(Str
 
 	script->next = nullptr;
 
-	source = ( source_t * ) BG_Alloc( sizeof( source_t ) );
-	memset( source, 0, sizeof( source_t ) );
+	source = ( source_t * ) BG_Calloc( sizeof( source_t ) );
 
 	Q_strncpyz( source->filename, filename, MAX_QPATH );
 	source->openFunc = openFunc;
@@ -4111,8 +4103,7 @@ static source_t *Parse_LoadSourceFile( const char *filename, int (*openFunc)(Str
 	source->indentstack = nullptr;
 	source->skip = 0;
 
-	source->definehash = (define_t**) BG_Alloc( DEFINEHASHSIZE * sizeof( define_t * ) );
-	memset( source->definehash, 0, DEFINEHASHSIZE * sizeof( define_t * ) );
+	source->definehash = (define_t**) BG_Calloc( DEFINEHASHSIZE * sizeof( define_t * ) );
 	Parse_AddGlobalDefinesToSource( source );
 	return source;
 }


### PR DESCRIPTION
- `malloc`: check return and call Sys::Error on failure. Cut down on redundant zeroing (memsetting after calloc) a bit.
- `memset`: use it less because it has the same issue with passing nullptr being undefined, line memcpy and memmove.