### PR TITLE
locdamge: Load locational damage config based on class

### DIFF
--- a/pkg/unvanquished_src.dpkdir/configs/classes/builderupg.locdamage.cfg
+++ b/pkg/unvanquished_src.dpkdir/configs/classes/builderupg.locdamage.cfg
@@ -1,0 +1,8 @@
+//whole body
+{
+  minHeight 0.0
+  maxHeight 1.0
+  minAngle 0
+  maxAngle 360
+  modifier 1.0
+}

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -755,7 +755,6 @@ static int ParseDmgScript( damageRegion_t *regions, const char *buf )
 
 void G_InitDamageLocations()
 {
-	const char   *modelName;
 	char         filename[ MAX_QPATH ];
 	int          i;
 	int          len;
@@ -764,8 +763,8 @@ void G_InitDamageLocations()
 
 	for ( i = PCL_NONE + 1; i < PCL_NUM_CLASSES; i++ )
 	{
-		modelName = BG_ClassModelConfig( i )->modelName;
-		Com_sprintf( filename, sizeof( filename ), "configs/classes/%s.locdamage.cfg", modelName );
+
+		Com_sprintf( filename, sizeof( filename ), "configs/classes/%s.locdamage.cfg", BG_Class( i )->name );
 
 		len = BG_FOpenGameOrPakPath( filename, fileHandle );
 


### PR DESCRIPTION
This practically does not affect anything since this mainly affects aliens, which do not consider locational damage, but its still a bug and affects the human-iqm branch since now the human_male model is the same for naked, light armor, and medium armor classes.