### PR TITLE
Move sgame trap call declarations to engine

### DIFF
--- a/src/cgame/cg_key_name.cpp
+++ b/src/cgame/cg_key_name.cpp
@@ -23,7 +23,7 @@ along with Unvanquished. If not, see <http://www.gnu.org/licenses/>.
 
 #include "common/Common.h"
 #include "cg_key_name.h"
-#include "engine/client/cg_api.h"
+#include "shared/client/cg_api.h"
 
 using Keyboard::Key;
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -34,7 +34,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "common/KeyIdentification.h"
 #include "engine/qcommon/q_shared.h"
 #include "engine/renderer/tr_types.h"
-#include "engine/client/cg_api.h"
+#include "shared/client/cg_api.h"
 #include "shared/bg_public.h"
 #include "engine/client/keycodes.h"
 #include "cg_ui.h"

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "common/Common.h"
 #include "cg_local.h"
+#include "common/cm/cm_public.h"
 #include "cg_key_name.h"
 #include "shared/parse.h"
 #include "shared/navgen/navgen.h"

--- a/src/cgame/cg_particles.cpp
+++ b/src/cgame/cg_particles.cpp
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "common/Common.h"
 #include "common/FileSystem.h"
+#include "common/cm/cm_public.h"
 #include "cg_local.h"
 
 static Log::Logger logger("cgame.particles", "[Particle Systems]");

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "common/Common.h"
 #include "common/FileSystem.h"
+#include "common/cm/cm_public.h"
 #include "cg_local.h"
 #include "cg_animdelta.h"
 #include "cg_segmented_skeleton.h"

--- a/src/cgame/cg_predict.cpp
+++ b/src/cgame/cg_predict.cpp
@@ -30,6 +30,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // It also handles local physics interaction, like fragments bouncing off walls
 
 #include "common/Common.h"
+#include "common/cm/cm_public.h"
 #include "cg_local.h"
 
 Log::Logger predictionLog("cgame.prediction", "[client-side prediction]", Log::Level::WARNING);

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -34,6 +34,7 @@ Maryland 20850 USA.
 
 #include "common/Common.h"
 #include "common/FileSystem.h"
+#include "common/cm/cm_public.h"
 #include "cg_local.h"
 #include "cg_key_name.h"
 #include "rocket/rocket.h"

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // for a 3D rendering
 
 #include "common/Common.h"
+#include "common/cm/cm_public.h"
 #include "cg_local.h"
 
 /*

--- a/src/cgame/translation.cpp
+++ b/src/cgame/translation.cpp
@@ -34,7 +34,7 @@ Maryland 20850 USA.
 
 #include "common/Common.h"
 #include "engine/qcommon/qcommon.h"
-#include "engine/client/cg_api.h"
+#include "shared/client/cg_api.h"
 
 #include "tinygettext/log.hpp"
 #include "tinygettext/tinygettext.hpp"

--- a/src/sgame/sg_trapcalls.h
+++ b/src/sgame/sg_trapcalls.h
@@ -28,13 +28,18 @@ along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>
 #include <glm/vec3.hpp>
 
 #include "shared/CommonProxies.h"
+#include "shared/server/sg_api.h"
 
 struct gentity_t;
 
-void             trap_LocateGameData( int numGEntities, int sizeofGEntity_t, int sizeofGClient );
-void             trap_DropClient( int clientNum, const char *reason );
-void             trap_SendServerCommand( int clientNum, const char *text );
-void             trap_SetConfigstring( int num, const char *string );
+// Actually involves a trap call. (But does stuff within the sgame VM too; hence it being
+// implemented in the sgame rather than daemon/src/shared/).
+void             trap_AdjustAreaPortalState( gentity_t *ent, bool open );
+
+/*
+ * All the rest of these are fake trap calls: none of them talk to the engine.
+ */
+
 void             trap_LinkEntity( gentity_t *ent );
 void             trap_UnlinkEntity( gentity_t *ent );
 int              trap_EntitiesInBox( const vec3_t mins, const vec3_t maxs, int *list, int maxcount );
@@ -44,23 +49,5 @@ void             trap_Trace( trace_t *results, const vec3_t start, const vec3_t 
 void             trap_SetBrushModel( gentity_t *ent, const char *name );
 bool         trap_InPVS( const vec3_t p1, const vec3_t p2 );
 bool         trap_InPVSIgnorePortals( const vec3_t p1, const vec3_t p2 );
-void             trap_SetConfigstringRestrictions( int num, const clientList_t *clientList );
-void             trap_GetConfigstring( int num, char *buffer, int bufferSize );
-void             trap_SetUserinfo( int num, const char *buffer );
-void             trap_GetUserinfo( int num, char *buffer, int bufferSize );
-void             trap_GetServerinfo( char *buffer, int bufferSize );
-void             trap_AdjustAreaPortalState( gentity_t *ent, bool open );
-int              trap_BotAllocateClient();
-void             trap_BotFreeClient( int clientNum );
-void             trap_GetUsercmd( int clientNum, usercmd_t *cmd );
-bool         trap_GetEntityToken( char *buffer, int bufferSize );
-int              trap_BotGetServerCommand( int clientNum, char *message, int size );
-
-int              trap_RSA_GenerateMessage( const char *public_key, char *cleartext, char *encrypted );
-
-void             trap_GenFingerprint( const char *pubkey, int size, char *buffer, int bufsize );
-void             trap_GetPlayerPubkey( int clientNum, char *pubkey, int size );
-
-void             trap_GetTimeString( char *buffer, int size, const char *format, const qtime_t *tm );
 
 #endif // SG_TRAPCALLS_H_


### PR DESCRIPTION
Companion: https://github.com/DaemonEngine/Daemon/pull/1178

Most trap_ functions wrapping sgame->engine IPC messages are in daemon/src/shared/server/sg_api.cpp. Move the declarations of these functions to the engine repo's sg_api.h, instead of sgame/sg_trapcalls.h.