### PR TITLE
lua: Lay groundwork for getting Lua into the SGame.

### DIFF
--- a/src.cmake
+++ b/src.cmake
@@ -73,6 +73,7 @@ set(GAMESHAREDLIST
     ${GAMELOGIC_DIR}/shared/bg_teamprogress.cpp
     ${GAMELOGIC_DIR}/shared/bg_utilities.cpp
     ${GAMELOGIC_DIR}/shared/bg_voice.cpp
+    ${GAMELOGIC_DIR}/shared/bg_lua.cpp
     ${GAMELOGIC_DIR}/shared/bot_nav_shared.cpp
     ${GAMELOGIC_DIR}/shared/bot_nav_shared.h
     ${GAMELOGIC_DIR}/shared/parse.cpp

--- a/src.cmake
+++ b/src.cmake
@@ -86,6 +86,8 @@ set(GAMESHAREDLIST
 
     ${GAMELOGIC_DIR}/shared/lua/Utils.h
     ${GAMELOGIC_DIR}/shared/lua/Utils.cpp
+    ${GAMELOGIC_DIR}/shared/lua/LuaLib.h
+    ${GAMELOGIC_DIR}/shared/lua/LuaLib.inl
     ${GAMELOGIC_DIR}/shared/lua/Weapons.h
     ${GAMELOGIC_DIR}/shared/lua/Weapons.cpp
     ${GAMELOGIC_DIR}/shared/lua/Buildables.h
@@ -177,6 +179,8 @@ set(CGAMELIST
     ${GAMELOGIC_DIR}/cgame/rocket/lua/Events.cpp
     ${GAMELOGIC_DIR}/cgame/rocket/lua/Timer.cpp
     ${GAMELOGIC_DIR}/cgame/rocket/lua/register_lua_extensions.h
+    ${GAMELOGIC_DIR}/cgame/rocket/lua/Player.h
+    ${GAMELOGIC_DIR}/cgame/rocket/lua/Player.cpp
 
     ${ENGINE_DIR}/client/cg_api.h
     ${ENGINE_DIR}/client/cg_msgdef.h

--- a/src.cmake
+++ b/src.cmake
@@ -83,6 +83,17 @@ set(GAMESHAREDLIST
     ${GAMELOGIC_DIR}/shared/navgen/brush.cpp
     ${GAMELOGIC_DIR}/shared/navgen/nav.cpp
     ${GAMELOGIC_DIR}/shared/navgen/navgen.h
+
+    ${GAMELOGIC_DIR}/shared/lua/Utils.h
+    ${GAMELOGIC_DIR}/shared/lua/Utils.cpp
+    ${GAMELOGIC_DIR}/shared/lua/Weapons.h
+    ${GAMELOGIC_DIR}/shared/lua/Weapons.cpp
+    ${GAMELOGIC_DIR}/shared/lua/Buildables.h
+    ${GAMELOGIC_DIR}/shared/lua/Buildables.cpp
+    ${GAMELOGIC_DIR}/shared/lua/Classes.h
+    ${GAMELOGIC_DIR}/shared/lua/Classes.cpp
+    ${GAMELOGIC_DIR}/shared/lua/Upgrades.h
+    ${GAMELOGIC_DIR}/shared/lua/Upgrades.cpp
 )
 
 set(CGAMELIST

--- a/src/cgame/rocket/lua/Player.cpp
+++ b/src/cgame/rocket/lua/Player.cpp
@@ -128,6 +128,6 @@ LUACORETYPEDEFINE(Player)
 void CG_InitializeLuaPlayer(lua_State* L)
 {
 	LuaLib<Player>::Register( L );
-	LuaLib<Player>::push( L, &player, false );
+	LuaLib<Player>::push( L, &player );
 	lua_setglobal( L, "player" );
 }

--- a/src/cgame/rocket/lua/Player.cpp
+++ b/src/cgame/rocket/lua/Player.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
-Copyright (C) 2012 Unvanquished Developers
+Unvanquished GPL Source Code
+Copyright (C) 2024 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/lua/Player.cpp
+++ b/src/cgame/rocket/lua/Player.cpp
@@ -1,0 +1,133 @@
+/*
+===========================================================================
+
+Daemon GPL Source Code
+Copyright (C) 2012 Unvanquished Developers
+
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
+
+Daemon Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Daemon Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+
+#include "Player.h"
+#include "../../cg_local.h"
+
+using Shared::Lua::RegType;
+using Shared::Lua::LuaLib;
+
+namespace {
+
+class Player {};
+
+static Player player;
+
+#define GETTER(name) { #name, Get##name }
+
+#define GET_FUNC( name, var, type ) \
+static int Get##name( lua_State* L ) \
+{ \
+	if ( !cg.snap ) \
+	{ \
+		return 0; \
+	} \
+	playerState_t* ps = &cg.snap->ps; \
+	lua_push##type( L, var ); \
+	return 1; \
+}
+
+GET_FUNC( team, BG_TeamName( ps->persistant[ PERS_TEAM ] ), string )
+GET_FUNC( class, BG_Class( ps->stats[ STAT_CLASS ] )->name, string )
+GET_FUNC( weapon, BG_Weapon( ps->stats[ STAT_WEAPON ] )->name, string )
+GET_FUNC( hp, ps->stats[ STAT_HEALTH ], integer )
+GET_FUNC( ammo, ps->ammo, integer )
+GET_FUNC( clips, ps->clips, integer )
+GET_FUNC( credits, ps->persistant[ PERS_CREDIT], integer )
+
+static int Getscore( lua_State* L )
+{
+	if ( !cg.snap )
+	{
+		return 0;
+	}
+	playerState_t* ps = &cg.snap->ps;
+	// We're spectating someone else, so our score will be wrong.
+	// Let's fetch their score. Note that this score will be delayed
+	// based on calls to CG_RequestScores()
+	if ( ps->pm_flags & PMF_FOLLOW )
+	{
+		lua_pushinteger( L, cgs.clientinfo[ ps->clientNum ].score );
+	}
+	else
+	{
+		lua_pushinteger( L, ps->persistant[ PERS_SCORE ] );
+	}
+	return 1;
+}
+
+}  // namespace
+
+namespace Shared {
+namespace Lua {
+
+template<> void ExtraInit<Player>(lua_State* /*L*/, int /*metatable_index*/) {}
+
+RegType<Player> PlayerMethods[] =
+{
+	{ nullptr, nullptr },
+};
+
+luaL_Reg PlayerGetters[] =
+{
+	GETTER(team),
+	GETTER(class),
+	GETTER(weapon),
+	GETTER(hp),
+	GETTER(ammo),
+	GETTER(clips),
+	GETTER(credits),
+	GETTER(score),
+
+	{ nullptr, nullptr }
+};
+
+luaL_Reg PlayerSetters[] =
+{
+	{ nullptr, nullptr },
+};
+
+
+LUACORETYPEDEFINE(Player)
+
+
+}  // namespace Lua
+}  // namespace Shared
+
+void CG_InitializeLuaPlayer(lua_State* L)
+{
+	LuaLib<Player>::Register( L );
+	LuaLib<Player>::push( L, &player, false );
+	lua_setglobal( L, "player" );
+}

--- a/src/cgame/rocket/lua/Player.h
+++ b/src/cgame/rocket/lua/Player.h
@@ -1,0 +1,43 @@
+/*
+===========================================================================
+
+Daemon GPL Source Code
+Copyright (C) 2012 Unvanquished Developers
+
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
+
+Daemon Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Daemon Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+
+#ifndef ROCKET_LUA_PLAYER_H_
+#define ROCKET_LUA_PLAYER_H_
+
+#include "../rocket.h"
+#include "shared/lua/LuaLib.h"
+
+void CG_InitializeLuaPlayer( lua_State* L );
+
+#endif  // ROCKET_LUA_PLAYER_H_

--- a/src/cgame/rocket/lua/Player.h
+++ b/src/cgame/rocket/lua/Player.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
-Copyright (C) 2012 Unvanquished Developers
+Unvanquished GPL Source Code
+Copyright (C) 2024 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/cgame/rocket/rocket.cpp
+++ b/src/cgame/rocket/rocket.cpp
@@ -61,6 +61,7 @@ Maryland 20850 USA.
 #include <RmlUi/Debugger.h>
 #include "lua/register_lua_extensions.h"
 #include "../cg_local.h"
+#include "shared/bg_lua.h"
 
 class DaemonFileInterface : public Rml::FileInterface
 {
@@ -342,6 +343,7 @@ void Rocket_Init()
 	CG_Rocket_RegisterLuaCvar(Rml::Lua::Interpreter::GetLuaState());
 	CG_Rocket_RegisterLuaEvents(Rml::Lua::Interpreter::GetLuaState());
 	CG_Rocket_RegisterLuaTimer(Rml::Lua::Interpreter::GetLuaState());
+	BG_InitializeLuaConstants(Rml::Lua::Interpreter::GetLuaState());
 
 	// Register custom properties.
 	UnvPropertyId::Orientation = Rml::StyleSheetSpecification::RegisterProperty("orientation", "left", false, true)

--- a/src/cgame/rocket/rocket.cpp
+++ b/src/cgame/rocket/rocket.cpp
@@ -60,6 +60,7 @@ Maryland 20850 USA.
 #include "rocketCvarInlineElement.h"
 #include <RmlUi/Debugger.h>
 #include "lua/register_lua_extensions.h"
+#include "lua/Player.h"
 #include "../cg_local.h"
 #include "shared/bg_lua.h"
 
@@ -344,6 +345,7 @@ void Rocket_Init()
 	CG_Rocket_RegisterLuaEvents(Rml::Lua::Interpreter::GetLuaState());
 	CG_Rocket_RegisterLuaTimer(Rml::Lua::Interpreter::GetLuaState());
 	BG_InitializeLuaConstants(Rml::Lua::Interpreter::GetLuaState());
+	CG_InitializeLuaPlayer(Rml::Lua::Interpreter::GetLuaState());
 
 	// Register custom properties.
 	UnvPropertyId::Orientation = Rml::StyleSheetSpecification::RegisterProperty("orientation", "left", false, true)

--- a/src/shared/LuaLib.h
+++ b/src/shared/LuaLib.h
@@ -1,0 +1,196 @@
+/*
+ * This source file is part of libRocket, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://www.librocket.com
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef UNVSHAREDLUALUALIB_H
+#define UNVSHAREDLUALUALIB_H
+
+#include "bg_lua.h"
+//As an example, if you used this macro like
+//LUAMETHOD(Unit,GetId)
+//it would result in code that looks like
+//{ "GetId", UnitGetId },
+//Which would force you to create a global function named UnitGetId in C with the correct function signature, usually int(*)(lua_State*,type*);
+#ifndef LUAMETHOD
+#define LUAMETHOD(type,name) { #name, type##name },
+#endif
+//See above, but the method must match the function signature int(*)(lua_State*) and as example:
+//LUAGETTER(Unit,Id) would mean you need a function named UnitGetAttrId
+//The first stack position will be the userdata
+#ifndef LUAGETTER
+#define LUAGETTER(type,varname) { #varname, type##GetAttr##varname },
+#endif
+
+//Same method signature as above, but as example:
+//LUASETTER(Unit,Id) would mean you need a function named UnitSetAttrId
+//The first stack position will be the userdata, and the second will be value on the other side of the equal sign
+#ifndef LUASETTER
+#define LUASETTER(type,varname) { #varname, type##SetAttr##varname },
+#endif
+
+#ifndef CHECK_BOOL
+#define CHECK_BOOL(L,narg) (lua_toboolean((L),(narg)) > 0 ? true : false )
+#endif
+
+#ifdef LUACHECKOBJ
+#define LUACHECKOBJ(obj) if((obj) == NULL) { lua_pushnil(L); return 1; }
+#endif
+ /** Used to remove repetitive typing at the cost of flexibility. When you use this, you @em must have
+ functions with the same name as defined in the macro. For example, if you used @c Element as type, you would
+ have to have functions named @c ElementMethods, @c ElementGetters, @c ElementSetters that return the appropriate
+ types.
+ @param is_reference_counted true if the type inherits from Rocket::Core::ReferenceCountable, false otherwise*/
+#define LUACORETYPEDEFINE(type,is_ref_counted) \
+    template<> const char* GetTClassName<type>() { return #type; } \
+    template<> RegType<type>* GetMethodTable<type>() { return type##Methods; } \
+    template<> luaL_Reg* GetAttrTable<type>() { return type##Getters; } \
+    template<> luaL_Reg* SetAttrTable<type>() { return type##Setters; } \
+    template<> bool IsReferenceCounted<type>() { return (is_ref_counted); } \
+
+//We can't use LUACORETYPEDEFINE due to namespace issues
+#define LUACONTROLSTYPEDEFINE(type,is_ref_counted) \
+    template<> const char* GetTClassName<type>() { return #type; } \
+    template<> RegType<type>* GetMethodTable<type>() { return Rocket::Controls::Lua::type##Methods; } \
+    template<> luaL_Reg* GetAttrTable<type>() { return Rocket::Controls::Lua::type##Getters; } \
+    template<> luaL_Reg* SetAttrTable<type>() { return Rocket::Controls::Lua::type##Setters; } \
+    template<> bool IsReferenceCounted<type>() { return (is_ref_counted); } \
+
+/** Used to remove repetitive typing at the cost of flexibility. It creates function prototypes for
+getting the name of the type, method tables, and if it is reference counted.
+When you use this, you either must also use
+the LUACORETYPEDEFINE macro, or make sure that the function signatures are @em exact.*/
+#define LUACORETYPEDECLARE(type) \
+    template<> const char* GetTClassName<type>(); \
+    template<> RegType<type>* GetMethodTable<type>(); \
+    template<> luaL_Reg* GetAttrTable<type>(); \
+    template<> luaL_Reg* SetAttrTable<type>(); \
+    template<> bool IsReferenceCounted<type>(); \
+
+/** Used to remove repetitive typing at the cost of flexibility. It creates function prototypes for
+getting the name of the type, method tables, and if it is reference counted.
+When you use this, you either must also use
+the LUACORETYPEDEFINE macro, or make sure that the function signatures are @em exact.*/
+#define LUACONTROLSTYPEDECLARE(type) \
+    template<> const char* GetTClassName<type>(); \
+    template<> RegType<type>* GetMethodTable<type>(); \
+    template<> luaL_Reg* GetAttrTable<type>(); \
+    template<> luaL_Reg* SetAttrTable<type>(); \
+    template<> bool IsReferenceCounted<type>(); \
+
+namespace Unvanquished {
+namespace Shared {
+namespace Lua {
+//replacement for luaL_Reg that uses a different function pointer signature, but similar syntax
+template<typename T>
+struct RegType
+{
+    const char* name;
+    int (*ftnptr)(lua_State*,T*);
+};
+
+/** For all of the methods available from Lua that call to the C functions. */
+template<typename T> RegType<T>* GetMethodTable();
+/** For all of the function that 'get' an attribute/property */
+template<typename T> luaL_Reg* GetAttrTable();
+/** For all of the functions that 'set' an attribute/property  */
+template<typename T> luaL_Reg* SetAttrTable();
+/** String representation of the class */
+template<typename T> const char* GetTClassName();
+/** bool for if it is reference counted */
+template<typename T> bool IsReferenceCounted();
+/** gets called from the LuaLib<T>::Register function, right before @c _regfunctions.
+If you want to inherit from another class, in the function you would want
+to call @c _regfunctions<superclass>, where method is metatable_index - 1. Anything
+that has the same name in the subclass will be overwrite whatever had the
+same name in the superclass.    */
+template<typename T> void ExtraInit(lua_State* L, int metatable_index);
+
+/**
+    This is mostly the definition of the Lua userdata that C++ gives to the user, plus
+    some helper functions.
+
+    @author Nathan Starkey
+*/
+template<typename T>
+class LuaLib
+{
+public:
+    typedef int (*ftnptr)(lua_State* L, T* ptr);
+    /** replacement for luaL_Reg that uses a different function pointer signature, but similar syntax */
+    typedef struct { const char* name; ftnptr func; } RegType;
+
+    /** Registers the type T as a type in the Lua global namespace by creating a
+     metatable with the same name as the class, setting the metatmethods, and adding the
+     functions from _regfunctions */
+    static inline void Register(lua_State *L);
+    /** Pushes on to the Lua stack a userdata representing a pointer of T
+    @param obj[in] The object to push to the stack
+    @param gc[in] If the obj should be deleted or decrease reference count upon the garbage collection
+    metamethod being called from the object in Lua
+    @return Position on the stack where the userdata resides   */
+    static inline int push(lua_State *L, T* obj, bool gc=false);
+    /** Statically casts the item at the position on the Lua stack
+    @param narg[in] Position of the item to cast on the Lua stack
+    @return A pointer to an object of type T or @c NULL   */
+    static inline T* check(lua_State* L, int narg);
+
+    /** For calling a C closure with upvalues. Used by the functions defined by RegType
+    @return The value that RegType.func returns   */
+    static inline int thunk(lua_State* L);
+    /** String representation of the pointer. Called by the __tostring metamethod  */
+    static inline void tostring(char* buff, void* obj);
+    //these are metamethods
+    /** The __gc metamethod. If the object was pushed by push(lua_State*,T*,bool) with the third
+    argument as true, it will either decrease the reference count or call delete depending on if
+    the type is reference counted. If the third argument to push was false, then this does nothing.
+    @return 0, since it pushes nothing on to the stack*/
+    static inline int gc_T(lua_State* L);
+    /** The __tostring metamethod.
+    @return 1, because it pushes a string representation of the userdata on to the stack  */
+    static inline int tostring_T(lua_State* L);
+    /** The __index metamethod. Called whenever the user attempts to access a variable that is
+    not in the immediate table. This handles the method calls and calls tofunctions in __getters    */
+    static inline int index(lua_State* L);
+    /** The __newindex metamethod. Called when the user attempts to set a variable that is not
+    int the immediate table. This handles the calls to functions in __setters  */
+    static inline int newindex(lua_State* L);
+
+    /** Registers methods,getters,and setters to the type. In Lua, the methods exist in the Type name's
+    metatable, and the getters exist in __getters and setters in __setters. The reason for __getters and __setters
+    is to have the objects use a 'dot' syntax for properties and a 'colon' syntax for methods.*/
+    static inline void _regfunctions(lua_State* L, int meta, int method);
+private:
+    LuaLib(); //hide constructor
+
+};
+
+
+}
+}
+}
+
+#include "LuaLib.inl"
+#endif

--- a/src/shared/LuaLib.inl
+++ b/src/shared/LuaLib.inl
@@ -26,326 +26,373 @@
  */
 
 #include "LuaLib.h"
-namespace Unvanquished {
+#include "engine/qcommon/q_shared.h"
+
 namespace Shared {
 namespace Lua {
-template<typename T>
-void LuaLib<T>::Register(lua_State* L)
+
+namespace {
+
+void Report( lua_State* L, std::string& place )
 {
-    //for annotations, starting at 1, but it is a relative value, not always 1
-    lua_newtable(L); //[1] = table
-    int methods = lua_gettop(L); //methods = 1
+	const char* msg = lua_tostring( L, -1 );
+	std::string strmsg;
 
-    luaL_newmetatable(L, GetTClassName<T>()); //[2] = metatable named <ClassName>, referred in here by ClassMT
-    int metatable = lua_gettop(L); //metatable = 2
+	while ( msg )
+	{
+		lua_pop( L, 1 );
 
-    luaL_newmetatable(L, "DO NOT TRASH"); //[3] = metatable named "DO NOT TRASH"
-    lua_pop(L,1); //remove the above metatable -> [-1 = 2]
+		if ( place == "" )
+			strmsg = msg;
+		else
+			strmsg = place.append( " " ).append( msg );
 
-    //store method table in globals so that scripts can add functions written in Lua
-    lua_pushvalue(L, methods); //[methods = 1] -> [3] = copy (reference) of methods table
-    lua_setglobal(L, GetTClassName<T>()); // -> <ClassName> = [3 = 1], pop top [3]
+		Log::Warn( strmsg );
+		msg = lua_tostring( L, -1 );
+	}
+}
 
-    //hide metatable from Lua getmetatable()
-    lua_pushvalue(L, methods); //[methods = 1] -> [3] = copy of methods table, including modifications above
-    lua_setfield(L, metatable, "__metatable"); //[metatable = 2] -> t[k] = v; t = [2 = ClassMT], k = "__metatable", v = [3 = 1]; pop [3]
+}  // namespace
 
-    lua_pushcfunction(L, index); //index = cfunction -> [3] = cfunction
-    lua_setfield(L, metatable, "__index"); //[metatable = 2] -> t[k] = v; t = [2], k = "__index", v = cfunc; pop [3]
+template<typename T>
+void LuaLib<T>::Register( lua_State* L )
+{
+	//for annotations, starting at 1, but it is a relative value, not always 1
+	lua_newtable( L ); //[1] = table
+	int methods = lua_gettop( L ); //methods = 1
 
-    lua_pushcfunction(L, newindex);
-    lua_setfield(L, metatable, "__newindex");
+	luaL_newmetatable( L, GetTClassName<T>() ); //[2] = metatable named <ClassName>, referred in here by ClassMT
+	int metatable = lua_gettop( L ); //metatable = 2
 
-    lua_pushcfunction(L, gc_T);
-    lua_setfield(L, metatable, "__gc");
+	luaL_newmetatable( L, "DO NOT TRASH" ); //[3] = metatable named "DO NOT TRASH"
+	lua_pop( L, 1 ); //remove the above metatable -> [-1 = 2]
 
-    lua_pushcfunction(L, tostring_T);
-    lua_setfield(L, metatable, "__tostring");
+	//store method table in globals so that scripts can add functions written in Lua
+	lua_pushvalue( L, methods ); //[methods = 1] -> [3] = copy (reference) of methods table
+	lua_setglobal( L, GetTClassName<T>() ); // -> <ClassName> = [3 = 1], pop top [3]
 
-    ExtraInit<T>(L,metatable); //optionally implemented by individual types
+	//hide metatable from Lua getmetatable()
+	lua_pushvalue( L, methods ); //[methods = 1] -> [3] = copy of methods table, including modifications above
+	lua_setfield( L, metatable, "__metatable" ); //[metatable = 2] -> t[k] = v; t = [2 = ClassMT], k = "__metatable", v = [3 = 1]; pop [3]
 
-    lua_newtable(L); //for method table -> [3] = this table
-    lua_setmetatable(L, methods); //[methods = 1] -> metatable for [1] is [3]; [3] is popped off, top = [2]
+	lua_pushcfunction( L, index ); //index = cfunction -> [3] = cfunction
+	lua_setfield( L, metatable, "__index" ); //[metatable = 2] -> t[k] = v; t = [2], k = "__index", v = cfunc; pop [3]
 
-    _regfunctions(L,metatable,methods);
+	lua_pushcfunction( L, newindex );
+	lua_setfield( L, metatable, "__newindex" );
 
-    lua_pop(L, 2); //remove the two items from the stack, [1 = methods] and [2 = metatable]
+	lua_pushcfunction( L, gc_T );
+	lua_setfield( L, metatable, "__gc" );
+
+	lua_pushcfunction( L, tostring_T );
+	lua_setfield( L, metatable, "__tostring" );
+
+	ExtraInit<T>( L, metatable ); //optionally implemented by individual types
+
+	lua_newtable( L ); //for method table -> [3] = this table
+	lua_setmetatable( L, methods ); //[methods = 1] -> metatable for [1] is [3]; [3] is popped off, top = [2]
+
+	_regfunctions( L, metatable, methods );
+
+	lua_pop( L, 2 ); //remove the two items from the stack, [1 = methods] and [2 = metatable]
 }
 
 
 template<typename T>
-int LuaLib<T>::push(lua_State *L, T* obj, bool gc)
+int LuaLib<T>::push( lua_State* L, T* obj, bool gc )
 {
-    //for annotations, starting at index 1, but it is a relative number, not always 1
-    if (!obj) { lua_pushnil(L); return lua_gettop(L); }
-    luaL_getmetatable(L, GetTClassName<T>());  // lookup metatable in Lua registry ->[1] = metatable of <ClassName>
-    if (lua_isnil(L, -1)) luaL_error(L, "%s missing metatable", GetTClassName<T>());
-    int mt = lua_gettop(L); //mt = 1
-    T** ptrHold = (T**)lua_newuserdata(L,sizeof(T**)); //->[2] = empty userdata
-    int ud = lua_gettop(L); //ud = 2
-    if(ptrHold != NULL)
-    {
-        *ptrHold = obj;
-        lua_pushvalue(L, mt); // ->[3] = copy of [1]
-        lua_setmetatable(L, -2); //[-2 = 2] -> [2]'s metatable = [3]; pop [3]
-        char name[32];
-        tostring(name,obj);
-        lua_getfield(L,LUA_REGISTRYINDEX,"DO NOT TRASH"); //->[3] = value returned from function
-        if(lua_isnil(L,-1) ) //if [3] hasn't been created yet, then create it
-        {
-            luaL_newmetatable(L,"DO NOT TRASH"); //[4] = the new metatable
-            lua_pop(L,1); //pop [4]
-        }
-        lua_pop(L,1); //pop [3]
-        lua_getfield(L,LUA_REGISTRYINDEX,"DO NOT TRASH"); //->[3] = value returned from function
-        if(gc == false) //if we shouldn't garbage collect it, then put the name in to [3]
-        {
-            lua_pushboolean(L,1);// ->[4] = true
-            lua_setfield(L,-2,name); //represents t[k] = v, [-2 = 3] = t -> v = [4], k = <ClassName>; pop [4]
-        }
-        else
-        {
-            //In case this is an address that has been pushed
-            //to lua before, we need to set it to nil
-            lua_pushnil(L); // ->[4] = nil
-            lua_setfield(L,-2,name); //represents t[k] = v, [-2 = 3] = t -> v = [4], k = <ClassName>; pop [4]
-        }
+	//for annotations, starting at index 1, but it is a relative number, not always 1
+	if ( !obj )
+	{
+		lua_pushnil( L );
+		return lua_gettop( L );
+	}
 
-        if(IsReferenceCounted<T>())
-        {
-			// TODO: Remove
-        }
+	luaL_getmetatable( L, GetTClassName<T>() ); // lookup metatable in Lua registry ->[1] = metatable of <ClassName>
 
-        lua_pop(L,1); // -> pop [3]
-    }
-    lua_settop(L,ud); //[ud = 2] -> remove everything that is above 2, top = [2]
-    lua_replace(L, mt); //[mt = 1] -> move [2] to pos [1], and pop previous [1]
-    lua_settop(L, mt); //remove everything above [1]
-    return mt;  // index of userdata containing pointer to T object
+	if ( lua_isnil( L, -1 ) ) luaL_error( L, "%s missing metatable", GetTClassName<T>() );
+
+	int mt = lua_gettop( L ); //mt = 1
+	T** ptrHold = ( T** )lua_newuserdata( L, sizeof( T** ) ); //->[2] = empty userdata
+	int ud = lua_gettop( L ); //ud = 2
+
+	if ( ptrHold != NULL )
+	{
+		*ptrHold = obj;
+		lua_pushvalue( L, mt ); // ->[3] = copy of [1]
+		lua_setmetatable( L, -2 ); //[-2 = 2] -> [2]'s metatable = [3]; pop [3]
+		char name[32];
+		tostring( name, sizeof( name ), ptrHold );
+		lua_getfield( L, LUA_REGISTRYINDEX, "DO NOT TRASH" ); //->[3] = value returned from function
+
+		if ( lua_isnil( L, -1 ) ) //if [3] hasn't been created yet, then create it
+		{
+			luaL_newmetatable( L, "DO NOT TRASH" ); //[4] = the new metatable
+			lua_pop( L, 1 ); //pop [4]
+		}
+
+		lua_pop( L, 1 ); //pop [3]
+		lua_getfield( L, LUA_REGISTRYINDEX, "DO NOT TRASH" ); //->[3] = value returned from function
+
+		if ( gc == false ) //if we shouldn't garbage collect it, then put the name in to [3]
+		{
+			lua_pushboolean( L, 1 ); // ->[4] = true
+			lua_setfield( L, -2, name ); //represents t[k] = v, [-2 = 3] = t -> v = [4], k = <ClassName>; pop [4]
+		}
+		else
+		{
+			//In case this is an address that has been pushed
+			//to lua before, we need to set it to nil
+			lua_pushnil( L ); // ->[4] = nil
+			lua_setfield( L, -2, name ); //represents t[k] = v, [-2 = 3] = t -> v = [4], k = <ClassName>; pop [4]
+		}
+
+		lua_pop( L, 1 ); // -> pop [3]
+	}
+
+	lua_settop( L, ud ); //[ud = 2] -> remove everything that is above 2, top = [2]
+	lua_replace( L, mt ); //[mt = 1] -> move [2] to pos [1], and pop previous [1]
+	lua_settop( L, mt ); //remove everything above [1]
+	return mt;  // index of userdata containing pointer to T object
 }
 
 
 template<typename T>
-T* LuaLib<T>::check(lua_State* L, int narg)
+T* LuaLib<T>::check( lua_State* L, int narg )
 {
-    T** ptrHold = static_cast<T**>(lua_touserdata(L,narg));
-    if(ptrHold == NULL)
-        return NULL;
-    return (*ptrHold);
+	T** ptrHold = static_cast<T**>( lua_touserdata( L, narg ) );
+
+	if ( ptrHold == NULL )
+		return NULL;
+
+	return ( *ptrHold );
 }
 
 
 //private members
 
 template<typename T>
-int LuaLib<T>::thunk(lua_State* L)
+int LuaLib<T>::thunk( lua_State* L )
 {
-    // stack has userdata, followed by method args
-    T *obj = check(L, 1);  // get 'self', or if you prefer, 'this'
-    lua_remove(L, 1);  // remove self so member function args start at index 1
-    // get member function from upvalue
-    RegType *l = static_cast<RegType*>(lua_touserdata(L, lua_upvalueindex(1)));
-    //at the moment, there isn't a case where NULL is acceptable to be used in the function, so check
-    //for it here, rather than individually for each function
-    if(obj == NULL)
-    {
-        lua_pushnil(L);
-        return 1;
-    }
-    else
-        return l->func(L,obj);  // call member function
+	// stack has userdata, followed by method args
+	T* obj = check( L, 1 ); // get 'self', or if you prefer, 'this'
+	lua_remove( L, 1 ); // remove self so member function args start at index 1
+	// get member function from upvalue
+	RegType* l = static_cast<RegType*>( lua_touserdata( L, lua_upvalueindex( 1 ) ) );
+
+	//at the moment, there isn't a case where NULL is acceptable to be used in the function, so check
+	//for it here, rather than individually for each function
+	if ( obj == NULL )
+	{
+		lua_pushnil( L );
+		return 1;
+	}
+	else
+		return l->func( L, obj ); // call member function
 }
 
 
 
 template<typename T>
-void LuaLib<T>::tostring(char* buff, void* obj)
+void LuaLib<T>::tostring( char* buff, size_t buff_size, void* obj )
 {
-    sprintf(buff,"%p",obj);
-}
-
-
-template<typename T>
-int LuaLib<T>::gc_T(lua_State* L)
-{
-    T * obj = check(L,1); //[1] = this userdata
-    if(obj == NULL)
-        return 0;
-    if(IsReferenceCounted<T>())
-    {
-        // ReferenceCountables do not care about the "DO NOT TRASH" table.
-        // Because userdata is pushed which contains a pointer to the pointer
-        // of 'obj', 'obj' will be garbage collected for every time 'obj' was pushed.
-        // TODO: Remove
-        return 0;
-    }
-    lua_getfield(L,LUA_REGISTRYINDEX,"DO NOT TRASH"); //->[2] = return value from this
-    if(lua_istable(L,-1) ) //[-1 = 2], if it is a table
-    {
-        char name[32];
-        tostring(name,obj);
-        lua_getfield(L,-1, std::string(name).c_str()); //[-1 = 2] -> [3] = the value returned from if <ClassName> exists in the table to not gc
-        if(lua_isnoneornil(L,-1) ) //[-1 = 3] if it doesn't exist, then we are free to garbage collect c++ side
-        {
-            if(!IsReferenceCounted<T>())
-            {
-                delete obj;
-                obj = NULL;
-            }
-        }
-    }
-    lua_pop(L,3); //balance function
-    return 0;
-}
-
-
-template<typename T>
-int LuaLib<T>::tostring_T(lua_State* L)
-{
-    char buff[32];
-    T** ptrHold = (T**)lua_touserdata(L,1);
-    T *obj = *ptrHold;
-    sprintf(buff, "%p", obj);
-    lua_pushfstring(L, "%s (%s)", GetTClassName<T>(), buff);
-    return 1;
+	snprintf(buff, buff_size, "%p", obj);
 }
 
 
 
 template<typename T>
-int LuaLib<T>::index(lua_State* L)
+int LuaLib<T>::gc_T( lua_State* L )
 {
-    /*the table obj and the missing key are currently on the stack(index 1 & 2) as defined by the Lua language*/
-    lua_getglobal(L,GetTClassName<T>()); //stack pos [3] (fairly important, just refered to as [3])
-    // string form of the key.
-	const char* key = luaL_checkstring(L,2);
-    if(lua_istable(L,-1) )  //[-1 = 3]
-    {
-        lua_pushvalue(L,2); //[2] = key, [4] = copy of key
-        lua_rawget(L,-2); //[-2 = 3] -> pop top and push the return value to top [4]
-        //If the key were looking for is not in the table, retrieve its' metatables' index value.
-        if(lua_isnil(L,-1)) //[-1 = 4] is value from rawget above
-        {
-            //try __getters
-            lua_pop(L,1); //remove top item (nil) from the stack
-            lua_pushstring(L, "__getters");
-            lua_rawget(L,-2); //[-2 = 3], <ClassName>._getters -> result to [4]
-            lua_pushvalue(L,2); //[2 = key] -> copy to [5]
-            lua_rawget(L,-2); //[-2 = __getters] -> __getters[key], result to [5]
-            if(lua_type(L,-1) == LUA_TFUNCTION) //[-1 = 5]
-            {
-                lua_pushvalue(L,1); //push the userdata to the stack [6]
-                if(lua_pcall(L,1,1,0) != 0) //remove one, result is at [6]
-                    Report(L, String(GetTClassName<T>()).Append(".__index for ").Append(lua_tostring(L,2)).Append(": "));
-            }
-            else
-            {
-                lua_settop(L,4); //forget everything we did above
-                lua_getmetatable(L,-2); //[-2 = 3] -> metatable from <ClassName> to top [5]
-                if(lua_istable(L,-1) ) //[-1 = 5] = the result of the above
-                {
-                    lua_getfield(L,-1,"__index"); //[-1 = 5] = check the __index metamethod for the metatable-> push result to [6]
-                    if(lua_isfunction(L,-1) ) //[-1 = 6] = __index metamethod
-                    {
-                        lua_pushvalue(L,1); //[1] = object -> [7] = object
-                        lua_pushvalue(L,2); //[2] = key -> [8] = key
-                        if(lua_pcall(L,2,1,0) != 0) //call function at top of stack (__index) -> pop top 2 as args; [7] = return value
-                            Report(L, String(GetTClassName<T>()).Append(".__index for ").Append(lua_tostring(L,2)).Append(": "));
-                    }
-                    else if(lua_istable(L,-1) )
-                        lua_getfield(L,-1,key); //shorthand version of above -> [7] = return value
-                    else
-                        lua_pushnil(L); //[7] = nil
-                }
-                else
-                    lua_pushnil(L); //[6] = nil
-            }
-        }
-        else if(lua_istable(L,-1) )//[-1 = 4] is value from rawget [3]
-        {
-            lua_pushvalue(L,2); //[2] = key, [5] = key
-            lua_rawget(L,-2); //[-2 = 3] = table of <ClassName> -> pop top and push the return value to top [5]
-        }
-    }
-    else
-        lua_pushnil(L); //[4] = nil
+	T* obj = check( L, 1 ); //[1] = this userdata
 
-    lua_insert(L,1); //top element to position 1 -> [1] = top element as calculated in the earlier rest of the function
-    lua_settop(L,1); // -> [1 = -1], removes the other elements
-    return 1;
+	if ( obj == NULL )
+		return 0;
+
+	lua_getfield( L, LUA_REGISTRYINDEX, "DO NOT TRASH" ); //->[2] = return value from this
+
+	if ( lua_istable( L, -1 ) ) //[-1 = 2], if it is a table
+	{
+		char name[32];
+		void* ptrHold = lua_touserdata( L,1 );
+		tostring( name, sizeof( name ), ptrHold );
+		lua_getfield( L, -1, std::string( name ).c_str() ); //[-1 = 2] -> [3] = the value returned from if <ClassName> exists in the table to not gc
+
+		if ( lua_isnoneornil( L, -1 ) ) //[-1 = 3] if it doesn't exist, then we are free to garbage collect c++ side
+		{
+			Log::Debug("GC'ing %s", name);
+			delete obj;
+			obj = NULL;
+		}
+	}
+
+	lua_pop( L, 3 ); //balance function
+	return 0;
+}
+
+
+template<typename T>
+int LuaLib<T>::tostring_T( lua_State* L )
+{
+	char buff[32];
+	T** ptrHold = ( T** )lua_touserdata( L, 1 );
+	T* obj = *ptrHold;
+	sprintf( buff, "%p", obj );
+	lua_pushfstring( L, "%s (%s)", GetTClassName<T>(), buff );
+	return 1;
 }
 
 
 
 template<typename T>
-int LuaLib<T>::newindex(lua_State* L)
+int LuaLib<T>::index( lua_State* L )
 {
-    //[1] = obj, [2] = key, [3] = value
-    //look for it in __setters
-    lua_getglobal(L,GetTClassName<T>()); //[4] = this table
-    lua_pushstring(L,"__setters"); //[5]
-    lua_rawget(L,-2); //[-2 = 4] -> <ClassName>.__setters to [5]
-    lua_pushvalue(L,2); //[2 = key] -> [6] = copy of key
-    lua_rawget(L,-2); //[-2 = __setters] -> __setters[key] to [6]
-    if(lua_type(L,-1) == LUA_TFUNCTION)
-    {
-        lua_pushvalue(L,1); //userdata at [7]
-        lua_pushvalue(L,3); //[8] = copy of [3]
-        if(lua_pcall(L,2,0,0) != 0) //call function, pop 2 off push 0 on
-            Report(L, String(GetTClassName<T>()).Append(".__newindex for ").Append(lua_tostring(L,2)).Append(": "));
-    }
-    else
-        lua_pop(L,1); //not a setter function.
-    lua_pop(L,2); //pop __setters and the <Classname> table
-    return 0;
+	/*the table obj and the missing key are currently on the stack(index 1 & 2) as defined by the Lua language*/
+	lua_getglobal( L, GetTClassName<T>() ); //stack pos [3] (fairly important, just refered to as [3])
+	// string form of the key.
+	const char* key = luaL_checkstring( L, 2 );
+
+	if ( lua_istable( L, -1 ) ) //[-1 = 3]
+	{
+		lua_pushvalue( L, 2 ); //[2] = key, [4] = copy of key
+		lua_rawget( L, -2 ); //[-2 = 3] -> pop top and push the return value to top [4]
+
+		//If the key were looking for is not in the table, retrieve its' metatables' index value.
+		if ( lua_isnil( L, -1 ) ) //[-1 = 4] is value from rawget above
+		{
+			//try __getters
+			lua_pop( L, 1 ); //remove top item (nil) from the stack
+			lua_pushstring( L, "__getters" );
+			lua_rawget( L, -2 ); //[-2 = 3], <ClassName>._getters -> result to [4]
+			lua_pushvalue( L, 2 ); //[2 = key] -> copy to [5]
+			lua_rawget( L, -2 ); //[-2 = __getters] -> __getters[key], result to [5]
+
+			if ( lua_type( L, -1 ) == LUA_TFUNCTION ) //[-1 = 5]
+			{
+				lua_pushvalue( L, 1 ); //push the userdata to the stack [6]
+
+				if ( lua_pcall( L, 1, 1, 0 ) != 0 ) //remove one, result is at [6]
+					Report( L, std::string( GetTClassName<T>() ).append( ".__index for " ).append( lua_tostring( L, 2 ) ).append( ": " ) );
+			}
+			else
+			{
+				lua_settop( L, 4 ); //forget everything we did above
+				lua_getmetatable( L, -2 ); //[-2 = 3] -> metatable from <ClassName> to top [5]
+
+				if ( lua_istable( L, -1 ) ) //[-1 = 5] = the result of the above
+				{
+					lua_getfield( L, -1, "__index" ); //[-1 = 5] = check the __index metamethod for the metatable-> push result to [6]
+
+					if ( lua_isfunction( L, -1 ) ) //[-1 = 6] = __index metamethod
+					{
+						lua_pushvalue( L, 1 ); //[1] = object -> [7] = object
+						lua_pushvalue( L, 2 ); //[2] = key -> [8] = key
+
+						if ( lua_pcall( L, 2, 1, 0 ) != 0 ) //call function at top of stack (__index) -> pop top 2 as args; [7] = return value
+							Report( L, std::string( GetTClassName<T>() ).append( ".__index for " ).append( lua_tostring( L, 2 ) ).append( ": " ) );
+					}
+					else if ( lua_istable( L, -1 ) )
+						lua_getfield( L, -1, key ); //shorthand version of above -> [7] = return value
+					else
+						lua_pushnil( L ); //[7] = nil
+				}
+				else
+					lua_pushnil( L ); //[6] = nil
+			}
+		}
+		else if ( lua_istable( L, -1 ) ) //[-1 = 4] is value from rawget [3]
+		{
+			lua_pushvalue( L, 2 ); //[2] = key, [5] = key
+			lua_rawget( L, -2 ); //[-2 = 3] = table of <ClassName> -> pop top and push the return value to top [5]
+		}
+	}
+	else
+		lua_pushnil( L ); //[4] = nil
+
+	lua_insert( L, 1 ); //top element to position 1 -> [1] = top element as calculated in the earlier rest of the function
+	lua_settop( L, 1 ); // -> [1 = -1], removes the other elements
+	return 1;
+}
+
+
+
+template<typename T>
+int LuaLib<T>::newindex( lua_State* L )
+{
+	//[1] = obj, [2] = key, [3] = value
+	//look for it in __setters
+	lua_getglobal( L, GetTClassName<T>() ); //[4] = this table
+	lua_pushstring( L, "__setters" ); //[5]
+	lua_rawget( L, -2 ); //[-2 = 4] -> <ClassName>.__setters to [5]
+	lua_pushvalue( L, 2 ); //[2 = key] -> [6] = copy of key
+	lua_rawget( L, -2 ); //[-2 = __setters] -> __setters[key] to [6]
+
+	if ( lua_type( L, -1 ) == LUA_TFUNCTION )
+	{
+		lua_pushvalue( L, 1 ); //userdata at [7]
+		lua_pushvalue( L, 3 ); //[8] = copy of [3]
+
+		if ( lua_pcall( L, 2, 0, 0 ) != 0 ) //call function, pop 2 off push 0 on
+			Report( L, std::string( GetTClassName<T>() ).append( ".__newindex for " ).append( lua_tostring( L, 2 ) ).append( ": " ) );
+	}
+	else
+		lua_pop( L, 1 ); //not a setter function.
+
+	lua_pop( L, 2 ); //pop __setters and the <Classname> table
+	return 0;
 }
 
 
 template<typename T>
 void LuaLib<T>::_regfunctions(lua_State* L, int /*meta*/, int methods)
 {
-    //fill method table with methods.
-    for(RegType* m = (RegType*)GetMethodTable<T>(); m->name; m++)
-    {
-        lua_pushstring(L, m->name); // ->[1] = name of function Lua side
-        lua_pushlightuserdata(L, (void*)m); // ->[2] = pointer to the object containing the name and the function pointer as light userdata
-        lua_pushcclosure(L, thunk, 1); //thunk = function pointer -> pop 1 item from stack, [2] = closure
-        lua_settable(L, methods); // represents t[k] = v, t = [methods] -> pop [2 = closure] to be v, pop [1 = name] to be k
-    }
+	//fill method table with methods.
+	for ( RegType* m = ( RegType* )GetMethodTable<T>(); m->name; m++ )
+	{
+		lua_pushstring( L, m->name ); // ->[1] = name of function Lua side
+		lua_pushlightuserdata( L, ( void* )m ); // ->[2] = pointer to the object containing the name and the function pointer as light userdata
+		lua_pushcclosure( L, thunk, 1 ); //thunk = function pointer -> pop 1 item from stack, [2] = closure
+		lua_settable( L, methods ); // represents t[k] = v, t = [methods] -> pop [2 = closure] to be v, pop [1 = name] to be k
+	}
 
 
-    lua_getfield(L,methods, "__getters"); // -> table[1]
-    if(lua_isnoneornil(L,-1))
-    {
-        lua_pop(L,1); //pop unsuccessful get
-        lua_newtable(L); // -> table [1]
-        lua_setfield(L,methods,"__getters"); // pop [1]
-        lua_getfield(L,methods,"__getters"); // -> table [1]
-    }
-    for(luaL_Reg* m = (luaL_Reg*)GetAttrTable<T>(); m->name; m++)
-    {
-        lua_pushcfunction(L,m->func); // -> [2] is this function
-        lua_setfield(L,-2,m->name); //[-2 = 1] -> __getters.name = function
-    }
-    lua_pop(L,1); //pop __getters
+	lua_getfield( L, methods, "__getters" ); // -> table[1]
+
+	if ( lua_isnoneornil( L, -1 ) )
+	{
+		lua_pop( L, 1 ); //pop unsuccessful get
+		lua_newtable( L ); // -> table [1]
+		lua_setfield( L, methods, "__getters" ); // pop [1]
+		lua_getfield( L, methods, "__getters" ); // -> table [1]
+	}
+
+	for ( luaL_Reg* m = ( luaL_Reg* )GetAttrTable<T>(); m->name; m++ )
+	{
+		lua_pushcfunction( L, m->func ); // -> [2] is this function
+		lua_setfield( L, -2, m->name ); //[-2 = 1] -> __getters.name = function
+	}
+
+	lua_pop( L, 1 ); //pop __getters
 
 
-    lua_getfield(L,methods, "__setters"); // -> table[1]
-    if(lua_isnoneornil(L,-1))
-    {
-        lua_pop(L,1); //pop unsuccessful get
-        lua_newtable(L); // -> table [1]
-        lua_setfield(L,methods,"__setters"); // pop [1]
-        lua_getfield(L,methods,"__setters"); // -> table [1]
-    }
-    for(luaL_Reg* m = (luaL_Reg*)SetAttrTable<T>(); m->name; m++)
-    {
-        lua_pushcfunction(L,m->func); // -> [2] is this function
-        lua_setfield(L,-2,m->name); //[-2 = 1] -> __setters.name = function
-    }
-    lua_pop(L,1); //pop __setters
+	lua_getfield( L, methods, "__setters" ); // -> table[1]
+
+	if ( lua_isnoneornil( L, -1 ) )
+	{
+		lua_pop( L, 1 ); //pop unsuccessful get
+		lua_newtable( L ); // -> table [1]
+		lua_setfield( L, methods, "__setters" ); // pop [1]
+		lua_getfield( L, methods, "__setters" ); // -> table [1]
+	}
+
+	for ( luaL_Reg* m = ( luaL_Reg* )SetAttrTable<T>(); m->name; m++ )
+	{
+		lua_pushcfunction( L, m->func ); // -> [2] is this function
+		lua_setfield( L, -2, m->name ); //[-2 = 1] -> __setters.name = function
+	}
+
+	lua_pop( L, 1 ); //pop __setters
 }
 
-}
-}
-}
+}  // namespace Lua
+}  // namespace Shared

--- a/src/shared/LuaLib.inl
+++ b/src/shared/LuaLib.inl
@@ -1,0 +1,351 @@
+/*
+ * This source file is part of libRocket, the HTML/CSS Interface Middleware
+ *
+ * For the latest information, see http://www.librocket.com
+ *
+ * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include "LuaLib.h"
+namespace Unvanquished {
+namespace Shared {
+namespace Lua {
+template<typename T>
+void LuaLib<T>::Register(lua_State* L)
+{
+    //for annotations, starting at 1, but it is a relative value, not always 1
+    lua_newtable(L); //[1] = table
+    int methods = lua_gettop(L); //methods = 1
+
+    luaL_newmetatable(L, GetTClassName<T>()); //[2] = metatable named <ClassName>, referred in here by ClassMT
+    int metatable = lua_gettop(L); //metatable = 2
+
+    luaL_newmetatable(L, "DO NOT TRASH"); //[3] = metatable named "DO NOT TRASH"
+    lua_pop(L,1); //remove the above metatable -> [-1 = 2]
+
+    //store method table in globals so that scripts can add functions written in Lua
+    lua_pushvalue(L, methods); //[methods = 1] -> [3] = copy (reference) of methods table
+    lua_setglobal(L, GetTClassName<T>()); // -> <ClassName> = [3 = 1], pop top [3]
+
+    //hide metatable from Lua getmetatable()
+    lua_pushvalue(L, methods); //[methods = 1] -> [3] = copy of methods table, including modifications above
+    lua_setfield(L, metatable, "__metatable"); //[metatable = 2] -> t[k] = v; t = [2 = ClassMT], k = "__metatable", v = [3 = 1]; pop [3]
+
+    lua_pushcfunction(L, index); //index = cfunction -> [3] = cfunction
+    lua_setfield(L, metatable, "__index"); //[metatable = 2] -> t[k] = v; t = [2], k = "__index", v = cfunc; pop [3]
+
+    lua_pushcfunction(L, newindex);
+    lua_setfield(L, metatable, "__newindex");
+
+    lua_pushcfunction(L, gc_T);
+    lua_setfield(L, metatable, "__gc");
+
+    lua_pushcfunction(L, tostring_T);
+    lua_setfield(L, metatable, "__tostring");
+
+    ExtraInit<T>(L,metatable); //optionally implemented by individual types
+
+    lua_newtable(L); //for method table -> [3] = this table
+    lua_setmetatable(L, methods); //[methods = 1] -> metatable for [1] is [3]; [3] is popped off, top = [2]
+
+    _regfunctions(L,metatable,methods);
+
+    lua_pop(L, 2); //remove the two items from the stack, [1 = methods] and [2 = metatable]
+}
+
+
+template<typename T>
+int LuaLib<T>::push(lua_State *L, T* obj, bool gc)
+{
+    //for annotations, starting at index 1, but it is a relative number, not always 1
+    if (!obj) { lua_pushnil(L); return lua_gettop(L); }
+    luaL_getmetatable(L, GetTClassName<T>());  // lookup metatable in Lua registry ->[1] = metatable of <ClassName>
+    if (lua_isnil(L, -1)) luaL_error(L, "%s missing metatable", GetTClassName<T>());
+    int mt = lua_gettop(L); //mt = 1
+    T** ptrHold = (T**)lua_newuserdata(L,sizeof(T**)); //->[2] = empty userdata
+    int ud = lua_gettop(L); //ud = 2
+    if(ptrHold != NULL)
+    {
+        *ptrHold = obj;
+        lua_pushvalue(L, mt); // ->[3] = copy of [1]
+        lua_setmetatable(L, -2); //[-2 = 2] -> [2]'s metatable = [3]; pop [3]
+        char name[32];
+        tostring(name,obj);
+        lua_getfield(L,LUA_REGISTRYINDEX,"DO NOT TRASH"); //->[3] = value returned from function
+        if(lua_isnil(L,-1) ) //if [3] hasn't been created yet, then create it
+        {
+            luaL_newmetatable(L,"DO NOT TRASH"); //[4] = the new metatable
+            lua_pop(L,1); //pop [4]
+        }
+        lua_pop(L,1); //pop [3]
+        lua_getfield(L,LUA_REGISTRYINDEX,"DO NOT TRASH"); //->[3] = value returned from function
+        if(gc == false) //if we shouldn't garbage collect it, then put the name in to [3]
+        {
+            lua_pushboolean(L,1);// ->[4] = true
+            lua_setfield(L,-2,name); //represents t[k] = v, [-2 = 3] = t -> v = [4], k = <ClassName>; pop [4]
+        }
+        else
+        {
+            //In case this is an address that has been pushed
+            //to lua before, we need to set it to nil
+            lua_pushnil(L); // ->[4] = nil
+            lua_setfield(L,-2,name); //represents t[k] = v, [-2 = 3] = t -> v = [4], k = <ClassName>; pop [4]
+        }
+
+        if(IsReferenceCounted<T>())
+        {
+			// TODO: Remove
+        }
+
+        lua_pop(L,1); // -> pop [3]
+    }
+    lua_settop(L,ud); //[ud = 2] -> remove everything that is above 2, top = [2]
+    lua_replace(L, mt); //[mt = 1] -> move [2] to pos [1], and pop previous [1]
+    lua_settop(L, mt); //remove everything above [1]
+    return mt;  // index of userdata containing pointer to T object
+}
+
+
+template<typename T>
+T* LuaLib<T>::check(lua_State* L, int narg)
+{
+    T** ptrHold = static_cast<T**>(lua_touserdata(L,narg));
+    if(ptrHold == NULL)
+        return NULL;
+    return (*ptrHold);
+}
+
+
+//private members
+
+template<typename T>
+int LuaLib<T>::thunk(lua_State* L)
+{
+    // stack has userdata, followed by method args
+    T *obj = check(L, 1);  // get 'self', or if you prefer, 'this'
+    lua_remove(L, 1);  // remove self so member function args start at index 1
+    // get member function from upvalue
+    RegType *l = static_cast<RegType*>(lua_touserdata(L, lua_upvalueindex(1)));
+    //at the moment, there isn't a case where NULL is acceptable to be used in the function, so check
+    //for it here, rather than individually for each function
+    if(obj == NULL)
+    {
+        lua_pushnil(L);
+        return 1;
+    }
+    else
+        return l->func(L,obj);  // call member function
+}
+
+
+
+template<typename T>
+void LuaLib<T>::tostring(char* buff, void* obj)
+{
+    sprintf(buff,"%p",obj);
+}
+
+
+template<typename T>
+int LuaLib<T>::gc_T(lua_State* L)
+{
+    T * obj = check(L,1); //[1] = this userdata
+    if(obj == NULL)
+        return 0;
+    if(IsReferenceCounted<T>())
+    {
+        // ReferenceCountables do not care about the "DO NOT TRASH" table.
+        // Because userdata is pushed which contains a pointer to the pointer
+        // of 'obj', 'obj' will be garbage collected for every time 'obj' was pushed.
+        // TODO: Remove
+        return 0;
+    }
+    lua_getfield(L,LUA_REGISTRYINDEX,"DO NOT TRASH"); //->[2] = return value from this
+    if(lua_istable(L,-1) ) //[-1 = 2], if it is a table
+    {
+        char name[32];
+        tostring(name,obj);
+        lua_getfield(L,-1, std::string(name).c_str()); //[-1 = 2] -> [3] = the value returned from if <ClassName> exists in the table to not gc
+        if(lua_isnoneornil(L,-1) ) //[-1 = 3] if it doesn't exist, then we are free to garbage collect c++ side
+        {
+            if(!IsReferenceCounted<T>())
+            {
+                delete obj;
+                obj = NULL;
+            }
+        }
+    }
+    lua_pop(L,3); //balance function
+    return 0;
+}
+
+
+template<typename T>
+int LuaLib<T>::tostring_T(lua_State* L)
+{
+    char buff[32];
+    T** ptrHold = (T**)lua_touserdata(L,1);
+    T *obj = *ptrHold;
+    sprintf(buff, "%p", obj);
+    lua_pushfstring(L, "%s (%s)", GetTClassName<T>(), buff);
+    return 1;
+}
+
+
+
+template<typename T>
+int LuaLib<T>::index(lua_State* L)
+{
+    /*the table obj and the missing key are currently on the stack(index 1 & 2) as defined by the Lua language*/
+    lua_getglobal(L,GetTClassName<T>()); //stack pos [3] (fairly important, just refered to as [3])
+    // string form of the key.
+	const char* key = luaL_checkstring(L,2);
+    if(lua_istable(L,-1) )  //[-1 = 3]
+    {
+        lua_pushvalue(L,2); //[2] = key, [4] = copy of key
+        lua_rawget(L,-2); //[-2 = 3] -> pop top and push the return value to top [4]
+        //If the key were looking for is not in the table, retrieve its' metatables' index value.
+        if(lua_isnil(L,-1)) //[-1 = 4] is value from rawget above
+        {
+            //try __getters
+            lua_pop(L,1); //remove top item (nil) from the stack
+            lua_pushstring(L, "__getters");
+            lua_rawget(L,-2); //[-2 = 3], <ClassName>._getters -> result to [4]
+            lua_pushvalue(L,2); //[2 = key] -> copy to [5]
+            lua_rawget(L,-2); //[-2 = __getters] -> __getters[key], result to [5]
+            if(lua_type(L,-1) == LUA_TFUNCTION) //[-1 = 5]
+            {
+                lua_pushvalue(L,1); //push the userdata to the stack [6]
+                if(lua_pcall(L,1,1,0) != 0) //remove one, result is at [6]
+                    Report(L, String(GetTClassName<T>()).Append(".__index for ").Append(lua_tostring(L,2)).Append(": "));
+            }
+            else
+            {
+                lua_settop(L,4); //forget everything we did above
+                lua_getmetatable(L,-2); //[-2 = 3] -> metatable from <ClassName> to top [5]
+                if(lua_istable(L,-1) ) //[-1 = 5] = the result of the above
+                {
+                    lua_getfield(L,-1,"__index"); //[-1 = 5] = check the __index metamethod for the metatable-> push result to [6]
+                    if(lua_isfunction(L,-1) ) //[-1 = 6] = __index metamethod
+                    {
+                        lua_pushvalue(L,1); //[1] = object -> [7] = object
+                        lua_pushvalue(L,2); //[2] = key -> [8] = key
+                        if(lua_pcall(L,2,1,0) != 0) //call function at top of stack (__index) -> pop top 2 as args; [7] = return value
+                            Report(L, String(GetTClassName<T>()).Append(".__index for ").Append(lua_tostring(L,2)).Append(": "));
+                    }
+                    else if(lua_istable(L,-1) )
+                        lua_getfield(L,-1,key); //shorthand version of above -> [7] = return value
+                    else
+                        lua_pushnil(L); //[7] = nil
+                }
+                else
+                    lua_pushnil(L); //[6] = nil
+            }
+        }
+        else if(lua_istable(L,-1) )//[-1 = 4] is value from rawget [3]
+        {
+            lua_pushvalue(L,2); //[2] = key, [5] = key
+            lua_rawget(L,-2); //[-2 = 3] = table of <ClassName> -> pop top and push the return value to top [5]
+        }
+    }
+    else
+        lua_pushnil(L); //[4] = nil
+
+    lua_insert(L,1); //top element to position 1 -> [1] = top element as calculated in the earlier rest of the function
+    lua_settop(L,1); // -> [1 = -1], removes the other elements
+    return 1;
+}
+
+
+
+template<typename T>
+int LuaLib<T>::newindex(lua_State* L)
+{
+    //[1] = obj, [2] = key, [3] = value
+    //look for it in __setters
+    lua_getglobal(L,GetTClassName<T>()); //[4] = this table
+    lua_pushstring(L,"__setters"); //[5]
+    lua_rawget(L,-2); //[-2 = 4] -> <ClassName>.__setters to [5]
+    lua_pushvalue(L,2); //[2 = key] -> [6] = copy of key
+    lua_rawget(L,-2); //[-2 = __setters] -> __setters[key] to [6]
+    if(lua_type(L,-1) == LUA_TFUNCTION)
+    {
+        lua_pushvalue(L,1); //userdata at [7]
+        lua_pushvalue(L,3); //[8] = copy of [3]
+        if(lua_pcall(L,2,0,0) != 0) //call function, pop 2 off push 0 on
+            Report(L, String(GetTClassName<T>()).Append(".__newindex for ").Append(lua_tostring(L,2)).Append(": "));
+    }
+    else
+        lua_pop(L,1); //not a setter function.
+    lua_pop(L,2); //pop __setters and the <Classname> table
+    return 0;
+}
+
+
+template<typename T>
+void LuaLib<T>::_regfunctions(lua_State* L, int /*meta*/, int methods)
+{
+    //fill method table with methods.
+    for(RegType* m = (RegType*)GetMethodTable<T>(); m->name; m++)
+    {
+        lua_pushstring(L, m->name); // ->[1] = name of function Lua side
+        lua_pushlightuserdata(L, (void*)m); // ->[2] = pointer to the object containing the name and the function pointer as light userdata
+        lua_pushcclosure(L, thunk, 1); //thunk = function pointer -> pop 1 item from stack, [2] = closure
+        lua_settable(L, methods); // represents t[k] = v, t = [methods] -> pop [2 = closure] to be v, pop [1 = name] to be k
+    }
+
+
+    lua_getfield(L,methods, "__getters"); // -> table[1]
+    if(lua_isnoneornil(L,-1))
+    {
+        lua_pop(L,1); //pop unsuccessful get
+        lua_newtable(L); // -> table [1]
+        lua_setfield(L,methods,"__getters"); // pop [1]
+        lua_getfield(L,methods,"__getters"); // -> table [1]
+    }
+    for(luaL_Reg* m = (luaL_Reg*)GetAttrTable<T>(); m->name; m++)
+    {
+        lua_pushcfunction(L,m->func); // -> [2] is this function
+        lua_setfield(L,-2,m->name); //[-2 = 1] -> __getters.name = function
+    }
+    lua_pop(L,1); //pop __getters
+
+
+    lua_getfield(L,methods, "__setters"); // -> table[1]
+    if(lua_isnoneornil(L,-1))
+    {
+        lua_pop(L,1); //pop unsuccessful get
+        lua_newtable(L); // -> table [1]
+        lua_setfield(L,methods,"__setters"); // pop [1]
+        lua_getfield(L,methods,"__setters"); // -> table [1]
+    }
+    for(luaL_Reg* m = (luaL_Reg*)SetAttrTable<T>(); m->name; m++)
+    {
+        lua_pushcfunction(L,m->func); // -> [2] is this function
+        lua_setfield(L,-2,m->name); //[-2 = 1] -> __setters.name = function
+    }
+    lua_pop(L,1); //pop __setters
+}
+
+}
+}
+}

--- a/src/shared/bg_lua.cpp
+++ b/src/shared/bg_lua.cpp
@@ -121,7 +121,7 @@ void BG_InitializeLuaConstants( lua_State* L )
 	LuaLib< Upgrades >::Register( L );
 	LuaLib< UpgradeProxy >::Register( L );
 	LuaLib< UnvGlobal>::push( L, &global );
-	lua_setglobal( L, "unv" );
+	lua_setglobal( L, "Unv" );
 }
 
 #endif // BUILD_CGAME

--- a/src/shared/bg_lua.cpp
+++ b/src/shared/bg_lua.cpp
@@ -33,36 +33,48 @@ Maryland 20850 USA.
 */
 #if defined(BUILD_CGAME)
 
-#include "bg_lua.h"
-#include "LuaLib.h"
+#include "shared/bg_lua.h"
+#include "shared/lua/LuaLib.h"
+#include "shared/lua/Buildables.h"
+#include "shared/lua/Weapons.h"
+#include "shared/lua/Classes.h"
+#include "shared/lua/Upgrades.h"
 #include "common/Log.h"
 
 
 namespace Shared {
 namespace Lua {
 
+static Weapons weapons;
+static Buildables buildables;
+static Classes classes;
+static Upgrades upgrades;
+
 class UnvGlobal
 {
 public:
-	static int GetWeapons( lua_State* /*L*/ )
+	static int GetWeapons( lua_State* L )
 	{
-		// TODO: return weapon obj
-		Log::Debug("weapons");
-		return 0;
+		LuaLib<Weapons>::push( L, &weapons, false );
+		return 1;
 	}
 
-	static int GetUpgrades( lua_State* /*L*/ )
+	static int GetUpgrades( lua_State* L )
 	{
-		// TODO: return upgrades obj
-		Log::Debug("upgrades");
-		return 0;
+		LuaLib<Upgrades>::push( L, &upgrades, false );
+		return 1;
 	}
 
-	static int GetBuildables( lua_State* /*L*/ )
+	static int GetBuildables( lua_State* L )
 	{
-		// TODO: return buildables obj
-		Log::Debug("buildables");
-		return 0;
+		LuaLib<Buildables>::push( L, &buildables, false );
+		return 1;
+	}
+
+	static int GetClasses( lua_State* L )
+	{
+			LuaLib<Classes>::push( L, &classes, false );
+			return 1;
 	}
 };
 
@@ -81,6 +93,9 @@ luaL_Reg UnvGlobalGetters[] =
 	{ "weapons", UnvGlobal::GetWeapons },
 	{ "upgrades", UnvGlobal::GetUpgrades },
 	{ "buildables", UnvGlobal::GetBuildables },
+	{ "classes", UnvGlobal::GetClasses },
+
+     { nullptr, nullptr  },
 };
 
 luaL_Reg UnvGlobalSetters[] =
@@ -88,7 +103,7 @@ luaL_Reg UnvGlobalSetters[] =
 	{ nullptr, nullptr },
 };
 
-LUACORETYPEDEFINE(UnvGlobal, false)
+LUACORETYPEDEFINE(UnvGlobal)
 
 } // namespace Lua
 } // namespace Shared
@@ -96,8 +111,17 @@ LUACORETYPEDEFINE(UnvGlobal, false)
 void BG_InitializeLuaConstants( lua_State* L )
 {
 	using namespace Shared::Lua;
-	LuaLib<UnvGlobal>::Register( L );
-	LuaLib<UnvGlobal>::push( L, &global, false );
+	LuaLib< UnvGlobal >::Register( L );
+	LuaLib< Weapons >::Register( L );
+	LuaLib< WeaponProxy >::Register( L );
+	LuaLib< Buildables >::Register( L );
+	LuaLib< BuildableProxy >::Register( L );
+	LuaLib< Classes >::Register( L );
+	LuaLib< ClassProxy >::Register( L );
+	LuaLib< Upgrades >::Register( L );
+	LuaLib< UpgradeProxy >::Register( L );
+	LuaLib< UnvGlobal>::push( L, &global, false );
 	lua_setglobal( L, "unv" );
 }
-#endif
+
+#endif // BUILD_CGAME

--- a/src/shared/bg_lua.cpp
+++ b/src/shared/bg_lua.cpp
@@ -2,7 +2,7 @@
 ===========================================================================
 
 Daemon GPL Source Code
-Copyright (C) 2012 Unvanquished Developers
+Copyright (C) 2012 Unv Developers
 
 This file is part of the Daemon GPL Source Code (Daemon Source Code).
 
@@ -32,11 +32,72 @@ Maryland 20850 USA.
 ===========================================================================
 */
 #if defined(BUILD_CGAME)
+
 #include "bg_lua.h"
 #include "LuaLib.h"
+#include "common/Log.h"
 
-void BG_InitializeLuaConstants( lua_State* /*L*/ )
+
+namespace Shared {
+namespace Lua {
+
+class UnvGlobal
 {
-}
+public:
+	static int GetWeapons( lua_State* /*L*/ )
+	{
+		// TODO: return weapon obj
+		Log::Debug("weapons");
+		return 0;
+	}
 
+	static int GetUpgrades( lua_State* /*L*/ )
+	{
+		// TODO: return upgrades obj
+		Log::Debug("upgrades");
+		return 0;
+	}
+
+	static int GetBuildables( lua_State* /*L*/ )
+	{
+		// TODO: return buildables obj
+		Log::Debug("buildables");
+		return 0;
+	}
+};
+
+
+UnvGlobal global;
+
+template<> void ExtraInit<UnvGlobal>( lua_State* /*L*/, int /*metatable_index*/ ) {}
+
+RegType<UnvGlobal> UnvGlobalMethods[] =
+{
+	{ nullptr, nullptr },
+};
+
+luaL_Reg UnvGlobalGetters[] =
+{
+	{ "weapons", UnvGlobal::GetWeapons },
+	{ "upgrades", UnvGlobal::GetUpgrades },
+	{ "buildables", UnvGlobal::GetBuildables },
+};
+
+luaL_Reg UnvGlobalSetters[] =
+{
+	{ nullptr, nullptr },
+};
+
+LUACORETYPEDEFINE(UnvGlobal, false)
+
+} // namespace Lua
+} // namespace Shared
+
+void BG_InitializeLuaConstants( lua_State* L )
+{
+	using namespace Shared::Lua;
+	LuaLib<UnvGlobal>::Register( L );
+	LuaLib<UnvGlobal>::push( L, &global, false );
+	lua_setglobal( L, "unv" );
+}
 #endif

--- a/src/shared/bg_lua.cpp
+++ b/src/shared/bg_lua.cpp
@@ -1,0 +1,42 @@
+/*
+===========================================================================
+
+Daemon GPL Source Code
+Copyright (C) 2012 Unvanquished Developers
+
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
+
+Daemon Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Daemon Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+#if defined(BUILD_CGAME)
+#include "bg_lua.h"
+#include "LuaLib.h"
+
+void BG_InitializeLuaConstants( lua_State* /*L*/ )
+{
+}
+
+#endif

--- a/src/shared/bg_lua.cpp
+++ b/src/shared/bg_lua.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
-Copyright (C) 2012 Unv Developers
+Unvanquished GPL Source Code
+Copyright (C) 2024 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/shared/bg_lua.cpp
+++ b/src/shared/bg_lua.cpp
@@ -55,25 +55,25 @@ class UnvGlobal
 public:
 	static int GetWeapons( lua_State* L )
 	{
-		LuaLib<Weapons>::push( L, &weapons, false );
+		LuaLib<Weapons>::push( L, &weapons );
 		return 1;
 	}
 
 	static int GetUpgrades( lua_State* L )
 	{
-		LuaLib<Upgrades>::push( L, &upgrades, false );
+		LuaLib<Upgrades>::push( L, &upgrades );
 		return 1;
 	}
 
 	static int GetBuildables( lua_State* L )
 	{
-		LuaLib<Buildables>::push( L, &buildables, false );
+		LuaLib<Buildables>::push( L, &buildables );
 		return 1;
 	}
 
 	static int GetClasses( lua_State* L )
 	{
-			LuaLib<Classes>::push( L, &classes, false );
+			LuaLib<Classes>::push( L, &classes );
 			return 1;
 	}
 };
@@ -120,7 +120,7 @@ void BG_InitializeLuaConstants( lua_State* L )
 	LuaLib< ClassProxy >::Register( L );
 	LuaLib< Upgrades >::Register( L );
 	LuaLib< UpgradeProxy >::Register( L );
-	LuaLib< UnvGlobal>::push( L, &global, false );
+	LuaLib< UnvGlobal>::push( L, &global );
 	lua_setglobal( L, "unv" );
 }
 

--- a/src/shared/bg_lua.h
+++ b/src/shared/bg_lua.h
@@ -1,0 +1,44 @@
+/*
+===========================================================================
+
+Daemon GPL Source Code
+Copyright (C) 2012 Unvanquished Developers
+
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
+
+Daemon Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Daemon Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifndef BG_LUA_H
+#define BG_LUA_H
+extern "C"
+{
+	#include "lua.h"
+	#include "lauxlib.h"
+	#include "lualib.h"
+}
+
+void BG_InitializeLuaConstants(lua_State* L);
+#endif

--- a/src/shared/bg_lua.h
+++ b/src/shared/bg_lua.h
@@ -35,9 +35,9 @@ Maryland 20850 USA.
 #define BG_LUA_H
 extern "C"
 {
-	#include "lua.h"
-	#include "lauxlib.h"
-	#include "lualib.h"
+	#include <lua.h>
+	#include <lauxlib.h>
+	#include <lualib.h>
 }
 
 void BG_InitializeLuaConstants(lua_State* L);

--- a/src/shared/bg_lua.h
+++ b/src/shared/bg_lua.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
-Copyright (C) 2012 Unvanquished Developers
+Unvanquished GPL Source Code
+Copyright (C) 2024 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/shared/lua/Buildables.cpp
+++ b/src/shared/lua/Buildables.cpp
@@ -114,7 +114,7 @@ int Buildables::index( lua_State* L )
 	buildable_t buildable = BG_BuildableByName( buildableName )->number;
 	if ( buildable > 0 && static_cast<size_t>( buildable ) - 1 < buildables.size() )
 	{
-		LuaLib<BuildableProxy>::push( L, &buildables[ buildable - 1 ], false );
+		LuaLib<BuildableProxy>::push( L, &buildables[ buildable - 1 ] );
 		return 1;
 	}
 	return 0;
@@ -132,7 +132,7 @@ int Buildables::pairs( lua_State* L )
 	else
 	{
 		lua_pushstring( L, buildables[ *pindex ].attributes->name );
-		LuaLib<BuildableProxy>::push( L, &buildables[ (*pindex)++ ], false );
+		LuaLib<BuildableProxy>::push( L, &buildables[ (*pindex)++ ] );
 	}
 	return 2;
 }

--- a/src/shared/lua/Buildables.cpp
+++ b/src/shared/lua/Buildables.cpp
@@ -1,0 +1,176 @@
+/*
+===========================================================================
+
+Daemon GPL Source Code
+Copyright (C) 2012 Unv Developers
+
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
+
+Daemon Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Daemon Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifdef BUILD_CGAME
+
+#include "shared/lua/Buildables.h"
+
+namespace Shared {
+namespace Lua {
+
+
+#define GETTER(name) { #name, Get##name }
+
+BuildableProxy::BuildableProxy( int buildable ) :
+	attributes( BG_Buildable( buildable ) ) {}
+
+#define GET_FUNC( var, type ) \
+static int Get##var( lua_State* L ) \
+{ \
+	BuildableProxy* proxy = LuaLib<BuildableProxy>::check( L, 1 ); \
+	lua_push##type( L, proxy->attributes->var ); \
+	return 1; \
+}
+
+#define GET_FUNC2( name, var, type ) \
+static int Get##name( lua_State* L ) \
+{ \
+	BuildableProxy* proxy = LuaLib<BuildableProxy>::check( L, 1 ); \
+	lua_push##type( L, var ); \
+	return 1; \
+}
+
+GET_FUNC2( name, proxy->attributes->humanName, string )
+GET_FUNC( info, string )
+GET_FUNC( icon, string )
+GET_FUNC2( build_points, proxy->attributes->buildPoints, integer )
+GET_FUNC2( unlock_threshold, proxy->attributes->unlockThreshold, integer )
+GET_FUNC( health, integer )
+GET_FUNC2( regen_rate, proxy->attributes->regenRate, integer )
+GET_FUNC2( splash_damage, proxy->attributes->splashDamage, integer )
+GET_FUNC2( splash_radius, proxy->attributes->splashRadius, integer )
+GET_FUNC2( weapon, BG_Weapon( proxy->attributes->weapon )->name, string )
+GET_FUNC2( build_weapon, BG_Weapon( proxy->attributes->buildWeapon )->name, string )
+GET_FUNC2( build_time, proxy->attributes->buildTime, integer )
+GET_FUNC( usable, boolean )
+GET_FUNC2( team, BG_TeamName( proxy->attributes->team ), string )
+
+template<> void ExtraInit<BuildableProxy>( lua_State* /*L*/, int /*metatable_index*/ ) {}
+
+RegType<BuildableProxy> BuildableProxyMethods[] =
+{
+	{ nullptr, nullptr },
+};
+
+luaL_Reg BuildableProxyGetters[] =
+{
+	GETTER(name),
+	GETTER(info),
+	GETTER(icon),
+	GETTER(build_points),
+	GETTER(unlock_threshold),
+	GETTER(health),
+	GETTER(regen_rate),
+	GETTER(splash_damage),
+	GETTER(splash_radius),
+	GETTER(weapon),
+	GETTER(build_weapon),
+	GETTER(build_time),
+	GETTER(usable),
+	GETTER(team),
+
+	{ nullptr, nullptr },
+};
+
+luaL_Reg BuildableProxySetters[] =
+{
+	{ nullptr, nullptr },
+};
+LUACORETYPEDEFINE(BuildableProxy)
+
+int Buildables::index( lua_State* L )
+{
+	const char *buildableName = luaL_checkstring( L, -1 );
+	buildable_t buildable = BG_BuildableByName( buildableName )->number;
+	if ( buildable > 0 && static_cast<size_t>( buildable ) - 1 < buildables.size() )
+	{
+		LuaLib<BuildableProxy>::push( L, &buildables[ buildable - 1 ], false );
+		return 1;
+	}
+	return 0;
+}
+
+int Buildables::pairs( lua_State* L )
+{
+	int* pindex = static_cast<int*>( lua_touserdata( L, 3 ) );
+	if ( *pindex < 0 ) *pindex = 0;
+	if ( static_cast<size_t>( *pindex ) >= buildables.size() )
+	{
+		lua_pushnil( L );
+		lua_pushnil( L );
+	}
+	else
+	{
+		lua_pushstring( L, buildables[ *pindex ].attributes->name );
+		LuaLib<BuildableProxy>::push( L, &buildables[ (*pindex)++ ], false );
+	}
+	return 2;
+}
+
+std::vector<BuildableProxy> Buildables::buildables;
+
+template<> void ExtraInit<Buildables>( lua_State* L, int metatable_index )
+{
+	// overwrite index function
+	lua_pushcfunction( L, Buildables::index );
+	lua_setfield( L, metatable_index, "__index" );
+	lua_pushcfunction( L, Buildables::pairs );
+	lua_setfield( L, metatable_index, "__pairs" );
+
+	for ( int i = BA_NONE + 1; i < BA_NUM_BUILDABLES; ++i)
+	{
+		Buildables::buildables.push_back( BuildableProxy( i ) );
+	}
+}
+
+RegType<Buildables> BuildablesMethods[] =
+{
+	{ nullptr, nullptr },
+};
+
+luaL_Reg BuildablesGetters[] =
+{
+	{ nullptr, nullptr },
+};
+
+luaL_Reg BuildablesSetters[] =
+{
+	{ nullptr, nullptr },
+};
+
+LUACORETYPEDEFINE(Buildables)
+
+} // namespace Lua
+} // namespace Shared
+
+#endif // BUILD_CGAME

--- a/src/shared/lua/Buildables.cpp
+++ b/src/shared/lua/Buildables.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
-Copyright (C) 2012 Unv Developers
+Unvanquished GPL Source Code
+Copyright (C) 2024 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/shared/lua/Buildables.h
+++ b/src/shared/lua/Buildables.h
@@ -1,0 +1,71 @@
+/*
+===========================================================================
+
+Daemon GPL Source Code
+Copyright (C) 2012 Unv Developers
+
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
+
+Daemon Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Daemon Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifdef BUILD_CGAME
+
+#ifndef SHARED_LUA_BUILDABLES_H_
+#define SHARED_LUA_BUILDABLES_H_
+
+#include "common/Common.h"
+#include "shared/bg_lua.h"
+#include "shared/bg_public.h"
+#include "shared/lua/LuaLib.h"
+
+namespace Shared {
+namespace Lua {
+
+struct BuildableProxy
+{
+	BuildableProxy( int buildable );
+
+	const buildableAttributes_t* attributes;
+};
+
+struct Buildables
+{
+	static int index( lua_State* L );
+	static int pairs( lua_State* L );
+
+	static std::vector<BuildableProxy> buildables;
+};
+
+template<>
+void ExtraInit<Buildables>( lua_State* L, int metatable_index );
+template<>
+void ExtraInit<BuildableProxy>( lua_State* L, int metatable_index );
+
+} // namespace Lua
+} // namespace Shared
+
+#endif  // SHARED_LUA_BUILDABLES_H_
+#endif  // BUILD_CGAME

--- a/src/shared/lua/Buildables.h
+++ b/src/shared/lua/Buildables.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
-Copyright (C) 2012 Unv Developers
+Unvanquished GPL Source Code
+Copyright (C) 2024 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/shared/lua/Classes.cpp
+++ b/src/shared/lua/Classes.cpp
@@ -1,0 +1,172 @@
+/*
+ * ===========================================================================
+ *
+ * Daemon GPL Source Code
+ * Copyright (C) 2012 Unv Developers
+ *
+ * This file is part of the Daemon GPL Source Code (Daemon Source Code).
+ *
+ * Daemon Source Code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Daemon Source Code is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * In addition, the Daemon Source Code is also subject to certain additional terms.
+ * You should have received a copy of these additional terms immediately following the
+ * terms and conditions of the GNU General Public License which accompanied the Daemon
+ * Source Code.  If not, please request a copy in writing from id Software at the address
+ * below.
+ *
+ * If you have questions concerning this license or the applicable additional terms, you
+ * may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+ * Maryland 20850 USA.
+ *
+ * ===========================================================================
+ */
+#ifdef BUILD_CGAME
+
+#include "shared/lua/Classes.h"
+
+namespace Shared {
+namespace Lua {
+
+#define GETTER(name) { #name, Get##name }
+
+ClassProxy::ClassProxy( int clazz ) :
+	attributes( BG_Class( clazz ) ) {}
+
+#define GET_FUNC( var, type ) \
+static int Get##var( lua_State* L ) \
+{ \
+	ClassProxy* proxy = LuaLib<ClassProxy>::check( L, 1 ); \
+	lua_push##type( L, proxy->attributes->var ); \
+	return 1; \
+}
+
+#define GET_FUNC2( name, var, type ) \
+static int Get##name( lua_State* L ) \
+{ \
+	ClassProxy* proxy = LuaLib<ClassProxy>::check( L, 1 ); \
+	lua_push##type( L, var ); \
+	return 1; \
+}
+
+GET_FUNC( name, string )
+GET_FUNC( info, string )
+GET_FUNC( icon, string )
+GET_FUNC2( fov_cvar, proxy->attributes->fovCvar, string )
+GET_FUNC2( unlock_threshold, proxy->attributes->unlockThreshold, integer )
+GET_FUNC( health, integer )
+GET_FUNC2( regen_rate, proxy->attributes->regenRate, integer )
+GET_FUNC( speed, integer )
+GET_FUNC( mass, integer )
+GET_FUNC2( jump_magnitude, proxy->attributes->jumpMagnitude, integer )
+GET_FUNC( price, integer )
+GET_FUNC2( team, BG_TeamName( proxy->attributes->team ), string )
+
+template<> void ExtraInit<ClassProxy>( lua_State* /*L*/, int /*metatable_index*/ ) {}
+
+RegType<ClassProxy> ClassProxyMethods[] =
+{
+	{ nullptr, nullptr },
+};
+
+luaL_Reg ClassProxyGetters[] =
+{
+	GETTER(name),
+	GETTER(info),
+	GETTER(icon),
+	GETTER(fov_cvar),
+	GETTER(team),
+	GETTER(unlock_threshold),
+	GETTER(health),
+	GETTER(regen_rate),
+	GETTER(speed),
+	GETTER(mass),
+	GETTER(jump_magnitude),
+	GETTER(price),
+
+	{ nullptr, nullptr }
+};
+
+luaL_Reg ClassProxySetters[] =
+{
+	{ nullptr, nullptr },
+};
+
+LUACORETYPEDEFINE(ClassProxy)
+
+int Classes::index( lua_State* L )
+{
+	const char *className = luaL_checkstring( L, -1 );
+	class_t clazz = BG_ClassByName( className )->number;
+	if ( clazz > 0 && static_cast<size_t>( clazz ) - 1 < classes.size() )
+	{
+		LuaLib<ClassProxy>::push( L, &classes[ clazz - 1 ], false );
+		return 1;
+	}
+	return 0;
+}
+
+int Classes::pairs( lua_State* L )
+{
+	int* pindex = static_cast<int*>( lua_touserdata( L, 3 ) );
+	if ( *pindex < 0 ) *pindex = 0;
+	if ( static_cast<size_t>( *pindex ) >= classes.size() )
+	{
+		lua_pushnil( L );
+		lua_pushnil( L );
+	}
+	else
+	{
+		lua_pushstring( L, classes[ *pindex ].attributes->name );
+		LuaLib<ClassProxy>::push( L, &classes[ (*pindex)++ ], false );
+	}
+	return 2;
+}
+
+std::vector<ClassProxy> Classes::classes;
+
+template<> void ExtraInit<Classes>( lua_State* L, int metatable_index )
+{
+	// overwrite index function
+	lua_pushcfunction( L, Classes::index );
+	lua_setfield( L, metatable_index, "__index" );
+	lua_pushcfunction( L, Classes::pairs );
+	lua_setfield( L, metatable_index, "__pairs" );
+
+	for ( int i = PCL_NONE + 1; i < PCL_NUM_CLASSES; ++i)
+	{
+		Classes::classes.push_back( ClassProxy( i ) );
+	}
+}
+
+RegType<Classes> ClassesMethods[] =
+{
+	{ nullptr, nullptr },
+};
+
+luaL_Reg ClassesGetters[] =
+{
+	{ nullptr, nullptr },
+};
+
+luaL_Reg ClassesSetters[] =
+{
+	{ nullptr, nullptr },
+};
+
+LUACORETYPEDEFINE(Classes)
+
+} // namespace Lua
+}  // namespace Shared
+
+ #endif // BUILD_CGAME

--- a/src/shared/lua/Classes.cpp
+++ b/src/shared/lua/Classes.cpp
@@ -110,7 +110,7 @@ int Classes::index( lua_State* L )
 	class_t clazz = BG_ClassByName( className )->number;
 	if ( clazz > 0 && static_cast<size_t>( clazz ) - 1 < classes.size() )
 	{
-		LuaLib<ClassProxy>::push( L, &classes[ clazz - 1 ], false );
+		LuaLib<ClassProxy>::push( L, &classes[ clazz - 1 ] );
 		return 1;
 	}
 	return 0;
@@ -128,7 +128,7 @@ int Classes::pairs( lua_State* L )
 	else
 	{
 		lua_pushstring( L, classes[ *pindex ].attributes->name );
-		LuaLib<ClassProxy>::push( L, &classes[ (*pindex)++ ], false );
+		LuaLib<ClassProxy>::push( L, &classes[ (*pindex)++ ] );
 	}
 	return 2;
 }

--- a/src/shared/lua/Classes.cpp
+++ b/src/shared/lua/Classes.cpp
@@ -1,36 +1,36 @@
 /*
- * ===========================================================================
- *
- * Daemon GPL Source Code
- * Copyright (C) 2012 Unv Developers
- *
- * This file is part of the Daemon GPL Source Code (Daemon Source Code).
- *
- * Daemon Source Code is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Daemon Source Code is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
- *
- * In addition, the Daemon Source Code is also subject to certain additional terms.
- * You should have received a copy of these additional terms immediately following the
- * terms and conditions of the GNU General Public License which accompanied the Daemon
- * Source Code.  If not, please request a copy in writing from id Software at the address
- * below.
- *
- * If you have questions concerning this license or the applicable additional terms, you
- * may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
- * Maryland 20850 USA.
- *
- * ===========================================================================
- */
+===========================================================================
+
+Unvanquished GPL Source Code
+Copyright (C) 2024 Unvanquished Developers
+
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
+
+Unvanquished Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Unvanquished Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
 #ifdef BUILD_CGAME
 
 #include "shared/lua/Classes.h"

--- a/src/shared/lua/Classes.h
+++ b/src/shared/lua/Classes.h
@@ -1,0 +1,71 @@
+/*
+===========================================================================
+
+Daemon GPL Source Code
+Copyright (C) 2012 Unv Developers
+
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
+
+Daemon Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Daemon Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifdef BUILD_CGAME
+
+#ifndef SHARED_LUA_CLASSES_H_
+#define SHARED_LUA_CLASSES_H_
+
+#include "common/Common.h"
+#include "shared/bg_lua.h"
+#include "shared/bg_public.h"
+#include "shared/lua/LuaLib.h"
+
+namespace Shared {
+namespace Lua {
+
+struct ClassProxy
+{
+	ClassProxy( int clazz );
+
+	const classAttributes_t* attributes;
+};
+
+struct Classes
+{
+	static int index( lua_State* L );
+	static int pairs( lua_State* L );
+
+	static std::vector<ClassProxy> classes;
+};
+
+template<>
+void ExtraInit<Classes>( lua_State* /*L*/, int /*metatable_index*/ );
+template<>
+void ExtraInit<ClassProxy>( lua_State* /*L*/, int /*metatable_index*/ );
+
+}  // namespace Lua
+}  // namespace Shared
+
+#endif  // SHARED_LUA_CLASSES_H_
+#endif  // BUILD_CGAME

--- a/src/shared/lua/Classes.h
+++ b/src/shared/lua/Classes.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
-Copyright (C) 2012 Unv Developers
+Unvanquished GPL Source Code
+Copyright (C) 2024 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/shared/lua/LuaLib.h
+++ b/src/shared/lua/LuaLib.h
@@ -25,10 +25,11 @@
  *
  */
 
-#ifndef UNVSHAREDLUALUALIB_H
-#define UNVSHAREDLUALUALIB_H
+#ifndef SHARED_LUA_LUALIB_H_
+#define SHARED_LUA_LUALIB_H_
 
-#include "bg_lua.h"
+#include "common/Common.h"
+#include "shared/bg_lua.h"
 //As an example, if you used this macro like
 //LUAMETHOD(Unit,GetId)
 //it would result in code that looks like
@@ -168,4 +169,5 @@ private:
 }  // namespace Shared
 
 #include "LuaLib.inl"
-#endif
+
+#endif  // SHARED_LUA_LUALIB_H_

--- a/src/shared/lua/LuaLib.h
+++ b/src/shared/lua/LuaLib.h
@@ -164,7 +164,6 @@ private:
 
 };
 
-
 }  // namespace Lua
 }  // namespace Shared
 

--- a/src/shared/lua/LuaLib.h
+++ b/src/shared/lua/LuaLib.h
@@ -1,30 +1,36 @@
 /*
- * This source file is part of libRocket, the HTML/CSS Interface Middleware
- *
- * For the latest information, see http://www.librocket.com
- *
- * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- *
- */
+===========================================================================
 
+Unvanquished GPL Source Code
+Copyright (C) 2024 Unvanquished Developers
+
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
+
+Unvanquished Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Unvanquished Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
 #ifndef SHARED_LUA_LUALIB_H_
 #define SHARED_LUA_LUALIB_H_
 

--- a/src/shared/lua/LuaLib.h
+++ b/src/shared/lua/LuaLib.h
@@ -131,10 +131,9 @@ public:
     static inline void Register(lua_State *L);
     /** Pushes on to the Lua stack a userdata representing a pointer of T
     @param obj[in] The object to push to the stack
-    @param gc[in] If the obj should be deleted or decrease reference count upon the garbage collection
     metamethod being called from the object in Lua
     @return Position on the stack where the userdata resides   */
-    static inline int push(lua_State *L, T* obj, bool gc=false);
+    static inline int push(lua_State *L, T* obj);
     /** Statically casts the item at the position on the Lua stack
     @param narg[in] Position of the item to cast on the Lua stack
     @return A pointer to an object of type T or @c NULL   */

--- a/src/shared/lua/LuaLib.inl
+++ b/src/shared/lua/LuaLib.inl
@@ -1,30 +1,36 @@
 /*
- * This source file is part of libRocket, the HTML/CSS Interface Middleware
- *
- * For the latest information, see http://www.librocket.com
- *
- * Copyright (c) 2008-2010 CodePoint Ltd, Shift Technology Ltd
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- *
- */
+===========================================================================
 
+Unvanquished GPL Source Code
+Copyright (C) 2024 Unvanquished Developers
+
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
+
+Unvanquished Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Unvanquished Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
 #include "engine/qcommon/q_shared.h"
 
 #include "shared/lua/LuaLib.h"

--- a/src/shared/lua/LuaLib.inl
+++ b/src/shared/lua/LuaLib.inl
@@ -96,7 +96,7 @@ int LuaLib<T>::push( lua_State* L, T* obj )
 	T** ptrHold = ( T** )lua_newuserdata( L, sizeof( T** ) ); //->[2] = empty userdata
 	int ud = lua_gettop( L ); //ud = 2
 
-	if ( ptrHold != NULL )
+	if ( ptrHold != nullptr )
 	{
 		*ptrHold = obj;
 		lua_pushvalue( L, mt ); // ->[3] = copy of [1]
@@ -115,8 +115,8 @@ T* LuaLib<T>::check( lua_State* L, int narg )
 {
 	T** ptrHold = static_cast<T**>( lua_touserdata( L, narg ) );
 
-	if ( ptrHold == NULL )
-		return NULL;
+	if ( ptrHold == nullptr )
+		return nullptr;
 
 	return ( *ptrHold );
 }
@@ -133,9 +133,9 @@ int LuaLib<T>::thunk( lua_State* L )
 	// get member function from upvalue
 	RegType* l = static_cast<RegType*>( lua_touserdata( L, lua_upvalueindex( 1 ) ) );
 
-	//at the moment, there isn't a case where NULL is acceptable to be used in the function, so check
+	//at the moment, there isn't a case where nullptr is acceptable to be used in the function, so check
 	//for it here, rather than individually for each function
-	if ( obj == NULL )
+	if ( obj == nullptr )
 	{
 		lua_pushnil( L );
 		return 1;

--- a/src/shared/lua/LuaLib.inl
+++ b/src/shared/lua/LuaLib.inl
@@ -375,4 +375,4 @@ void LuaLib<T>::_regfunctions(lua_State* L, int /*meta*/, int methods)
 }
 
 }  // namespace Lua
-}  // namespace Shared
+}  // naemspace Shared

--- a/src/shared/lua/LuaLib.inl
+++ b/src/shared/lua/LuaLib.inl
@@ -116,7 +116,9 @@ T* LuaLib<T>::check( lua_State* L, int narg )
 	T** ptrHold = static_cast<T**>( lua_touserdata( L, narg ) );
 
 	if ( ptrHold == nullptr )
-		return nullptr;
+	{
+		Sys::Drop( "null value when checking %s", GetTClassName<T>() );
+	}
 
 	return ( *ptrHold );
 }

--- a/src/shared/lua/LuaLib.inl
+++ b/src/shared/lua/LuaLib.inl
@@ -25,34 +25,14 @@
  *
  */
 
-#include "LuaLib.h"
 #include "engine/qcommon/q_shared.h"
+
+#include "shared/lua/LuaLib.h"
+#include "shared/lua/Utils.h"
+
 
 namespace Shared {
 namespace Lua {
-
-namespace {
-
-void Report( lua_State* L, std::string& place )
-{
-	const char* msg = lua_tostring( L, -1 );
-	std::string strmsg;
-
-	while ( msg )
-	{
-		lua_pop( L, 1 );
-
-		if ( place == "" )
-			strmsg = msg;
-		else
-			strmsg = place.append( " " ).append( msg );
-
-		Log::Warn( strmsg );
-		msg = lua_tostring( L, -1 );
-	}
-}
-
-}  // namespace
 
 template<typename T>
 void LuaLib<T>::Register( lua_State* L )

--- a/src/shared/lua/Upgrades.cpp
+++ b/src/shared/lua/Upgrades.cpp
@@ -1,0 +1,166 @@
+/*
+===========================================================================
+
+Daemon GPL Source Code
+Copyright (C) 2012 Unv Developers
+
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
+
+Daemon Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Daemon Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifdef BUILD_CGAME
+#include "shared/lua/Upgrades.h"
+
+namespace Shared {
+namespace Lua {
+
+
+#define GETTER(name) { #name, Get##name }
+
+UpgradeProxy::UpgradeProxy( int upgrade ) :
+	attributes( BG_Upgrade( upgrade ) ) {}
+
+#define GET_FUNC( var, type ) \
+static int Get##var( lua_State* L ) \
+{ \
+	UpgradeProxy* proxy = LuaLib<UpgradeProxy>::check( L, 1 ); \
+	lua_push##type( L, proxy->attributes->var ); \
+	return 1; \
+}
+
+#define GET_FUNC2( name, var, type ) \
+static int Get##name( lua_State* L ) \
+{ \
+	UpgradeProxy* proxy = LuaLib<UpgradeProxy>::check( L, 1 ); \
+	lua_push##type( L, var ); \
+	return 1; \
+}
+
+GET_FUNC2( name, proxy->attributes->humanName, string )
+GET_FUNC( price, integer )
+GET_FUNC( info, string )
+GET_FUNC( icon, string )
+GET_FUNC( slots, integer )
+GET_FUNC2( unlock_threshold, proxy->attributes->unlockThreshold, integer )
+GET_FUNC( purchasable, boolean )
+GET_FUNC( usable, boolean )
+GET_FUNC2( team, BG_TeamName( proxy->attributes->team ), string )
+
+template<> void ExtraInit<UpgradeProxy>( lua_State* /*L*/, int /*metatable_index*/ ) {}
+
+RegType<UpgradeProxy> UpgradeProxyMethods[] =
+{
+	{ nullptr, nullptr },
+};
+
+luaL_Reg UpgradeProxyGetters[] =
+{
+	GETTER(name),
+	GETTER(price),
+	GETTER(unlock_threshold),
+	GETTER(info),
+	GETTER(icon),
+	GETTER(slots),
+	GETTER(purchasable),
+	GETTER(usable),
+	GETTER(team),
+
+	{ nullptr, nullptr }
+};
+
+luaL_Reg UpgradeProxySetters[] =
+{
+	{ nullptr, nullptr },
+};
+
+LUACORETYPEDEFINE(UpgradeProxy)
+
+int Upgrades::index( lua_State* L )
+{
+	const char *upgradeName = luaL_checkstring( L, -1 );
+	upgrade_t upgrade = BG_UpgradeByName( upgradeName )->number;
+	if ( upgrade > 0 && static_cast<size_t>( upgrade ) - 1 < upgrades.size() )
+	{
+		LuaLib<UpgradeProxy>::push( L, &upgrades[ upgrade - 1 ], false );
+		return 1;
+	}
+	return 0;
+}
+
+int Upgrades::pairs( lua_State* L )
+{
+	int* pindex = static_cast<int*>( lua_touserdata( L, 3 ) );
+	if ( *pindex < 0 ) *pindex = 0;
+	if ( static_cast<size_t>( *pindex ) >= upgrades.size() )
+	{
+		lua_pushnil( L );
+		lua_pushnil( L );
+	}
+	else
+	{
+		lua_pushstring( L, upgrades[ *pindex ].attributes->name );
+		LuaLib<UpgradeProxy>::push( L, &upgrades[ (*pindex)++ ], false );
+	}
+	return 2;
+}
+
+std::vector<UpgradeProxy> Upgrades::upgrades;
+
+template<> void ExtraInit<Upgrades>( lua_State* L, int metatable_index )
+{
+	// overwrite index function
+	lua_pushcfunction( L, Upgrades::index );
+	lua_setfield( L, metatable_index, "__index" );
+	lua_pushcfunction( L, Upgrades::pairs );
+	lua_setfield( L, metatable_index, "__pairs" );
+
+	for ( int i = BA_NONE + 1; i < UP_NUM_UPGRADES; ++i)
+	{
+		Upgrades::upgrades.push_back( UpgradeProxy( i ) );
+	}
+}
+
+RegType<Upgrades> UpgradesMethods[] =
+{
+	{ nullptr, nullptr },
+};
+
+luaL_Reg UpgradesGetters[] =
+{
+	{ nullptr, nullptr },
+};
+
+luaL_Reg UpgradesSetters[] =
+{
+	{ nullptr, nullptr },
+};
+
+LUACORETYPEDEFINE(Upgrades)
+
+}  // namespace Lua
+}  // namespace Shared
+
+#endif // BUILD_CGAME

--- a/src/shared/lua/Upgrades.cpp
+++ b/src/shared/lua/Upgrades.cpp
@@ -104,7 +104,7 @@ int Upgrades::index( lua_State* L )
 	upgrade_t upgrade = BG_UpgradeByName( upgradeName )->number;
 	if ( upgrade > 0 && static_cast<size_t>( upgrade ) - 1 < upgrades.size() )
 	{
-		LuaLib<UpgradeProxy>::push( L, &upgrades[ upgrade - 1 ], false );
+		LuaLib<UpgradeProxy>::push( L, &upgrades[ upgrade - 1 ] );
 		return 1;
 	}
 	return 0;
@@ -122,7 +122,7 @@ int Upgrades::pairs( lua_State* L )
 	else
 	{
 		lua_pushstring( L, upgrades[ *pindex ].attributes->name );
-		LuaLib<UpgradeProxy>::push( L, &upgrades[ (*pindex)++ ], false );
+		LuaLib<UpgradeProxy>::push( L, &upgrades[ (*pindex)++ ] );
 	}
 	return 2;
 }

--- a/src/shared/lua/Upgrades.cpp
+++ b/src/shared/lua/Upgrades.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
-Copyright (C) 2012 Unv Developers
+Unvanquished GPL Source Code
+Copyright (C) 2024 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/shared/lua/Upgrades.h
+++ b/src/shared/lua/Upgrades.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
-Copyright (C) 2012 Unv Developers
+Unvanquished GPL Source Code
+Copyright (C) 2024 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/shared/lua/Upgrades.h
+++ b/src/shared/lua/Upgrades.h
@@ -1,0 +1,71 @@
+/*
+===========================================================================
+
+Daemon GPL Source Code
+Copyright (C) 2012 Unv Developers
+
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
+
+Daemon Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Daemon Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifdef BUILD_CGAME
+
+#ifndef SHARED_LUA_UPGRADES_H_
+#define SHARED_LUA_UPGRADES_H_
+
+#include "common/Common.h"
+#include "shared/bg_lua.h"
+#include "shared/bg_public.h"
+#include "shared/lua/LuaLib.h"
+
+namespace Shared {
+namespace Lua {
+
+struct UpgradeProxy
+{
+	UpgradeProxy( int upgrade );
+
+	const upgradeAttributes_t* attributes;
+};
+
+struct Upgrades
+{
+	static int index( lua_State* L );
+	static int pairs( lua_State* L );
+
+	static std::vector<UpgradeProxy> upgrades;
+};
+
+template<>
+void ExtraInit<Upgrades>( lua_State* L, int metatable_index );
+template<>
+void ExtraInit<UpgradeProxy>( lua_State* L, int metatable_index );
+
+}  // namespace Lua
+}  // namespace Shared
+
+#endif  // SHARED_LUA_UPGRADES_H_
+#endif  // BUILD_CGAME

--- a/src/shared/lua/Utils.cpp
+++ b/src/shared/lua/Utils.cpp
@@ -1,0 +1,96 @@
+/*
+===========================================================================
+
+Unvanquished GPL Source Code
+Copyright (C) 2024 Unvanquished Developers
+
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
+
+Unvanquished Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Unvanquished Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifdef BUILD_CGAME
+
+#include "shared/lua/Utils.h"
+
+#include "shared/bg_public.h"
+
+namespace Shared {
+namespace Lua {
+
+void Report( lua_State* L, Str::StringRef place )
+{
+	Log::Warn( place );
+
+	while ( true )
+	{
+		lua_gettop( L );
+		const char* msg = lua_tostring( L, -1 );
+		if (msg)
+		{
+			Log::Warn( msg );
+			lua_pop( L, 1 );
+			continue;
+		}
+		break;
+	}
+}
+
+void PushVec3(lua_State* L, const vec3_t vec)
+{
+	lua_newtable(L);
+	for (int i = 0; i < 3; ++i)
+	{
+		lua_pushnumber(L, vec[i]);
+		lua_rawseti(L, -2, i + 1); // lua arrays start at 1
+	}
+}
+
+bool CheckVec3(lua_State* L, int pos, vec3_t vec)
+{
+	if (!lua_istable(L, pos))
+	{
+		Log::Warn("CheckVec3: Input must be a table.");
+		return false;
+	}
+	int index = 0;
+	lua_pushnil(L);
+	while (lua_next(L, pos) != 0) {
+		/* uses 'key' (at index -2) and 'value' (at index -1) */
+		vec[index++] = luaL_checknumber(L, -1);
+		/* removes 'value'; keeps 'key' for next iteration */
+		lua_pop(L, 1);
+
+		if (index >= 3) {
+			break;
+		}
+	}
+	return true;
+}
+
+}  // namespace Lua
+}  // namespace Shared
+
+#endif  // BUILD_CGAME

--- a/src/shared/lua/Utils.h
+++ b/src/shared/lua/Utils.h
@@ -1,0 +1,61 @@
+/*
+===========================================================================
+
+Unvanquished GPL Source Code
+Copyright (C) 2024 Unvanquished Developers
+
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
+
+Unvanquished Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Unvanquished Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifdef BUILD_CGAME
+
+#ifndef SHARED_LUA_UTILS_H_
+#define SHARED_LUA_UTILS_H_
+
+#include "common/Common.h"
+#include "shared/bg_public.h"
+#include "shared/bg_lua.h"
+
+namespace Shared {
+namespace Lua {
+
+// Report errors
+void Report(lua_State* L, Str::StringRef place);
+
+// Push a vec3 onto the stack as a table.
+void PushVec3(lua_State* L, const vec3_t vec);
+
+// Convert a lua table into a vec3.
+bool CheckVec3(lua_State* L, int pos, vec3_t vec);
+
+} // namespace Lua
+} // namespace Shared
+
+
+#endif  // SHARED_LUA_UTILS_H_
+
+#endif  // BUILD_CGAME

--- a/src/shared/lua/Weapons.cpp
+++ b/src/shared/lua/Weapons.cpp
@@ -1,0 +1,185 @@
+/*
+===========================================================================
+
+Daemon GPL Source Code
+Copyright (C) 2012 Unv Developers
+
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
+
+Daemon Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Daemon Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifdef BUILD_CGAME
+
+#include "common/Common.h"
+#include "shared/lua/Weapons.h"
+
+namespace Shared {
+namespace Lua {
+
+#define GETTER(name) { #name, Get##name }
+
+WeaponProxy::WeaponProxy( int weapon ) :
+	attributes( BG_Weapon( weapon ) ) {}
+
+#define GET_FUNC( var, type ) \
+static int Get##var( lua_State* L ) \
+{ \
+	WeaponProxy* proxy = LuaLib<WeaponProxy>::check( L, 1 ); \
+	lua_push##type( L, proxy->attributes->var ); \
+	return 1; \
+}
+
+#define GET_FUNC2( name, var, type ) \
+static int Get##name( lua_State* L ) \
+{ \
+	WeaponProxy* proxy = LuaLib<WeaponProxy>::check( L, 1 ); \
+	lua_push##type( L, var ); \
+	return 1; \
+}
+
+GET_FUNC( price, integer )
+GET_FUNC2( unlock_threshold, proxy->attributes->unlockThreshold, integer )
+GET_FUNC2( name, proxy->attributes->humanName, string )
+GET_FUNC( info, string )
+GET_FUNC( slots, integer )
+GET_FUNC2( ammo, proxy->attributes->maxAmmo, integer )
+GET_FUNC2( clips, proxy->attributes->maxClips, integer )
+GET_FUNC2( infinite_ammo, proxy->attributes->infiniteAmmo, boolean )
+GET_FUNC2( energy, proxy->attributes->usesEnergy, boolean )
+GET_FUNC2( repeat_rate1, proxy->attributes->repeatRate1, integer )
+GET_FUNC2( repeat_rate2, proxy->attributes->repeatRate2, integer )
+GET_FUNC2( repeat_rate3, proxy->attributes->repeatRate3, integer )
+GET_FUNC2( reload_time, proxy->attributes->reloadTime, integer )
+GET_FUNC2( alt_mode, proxy->attributes->hasAltMode, boolean )
+GET_FUNC2( zoom, proxy->attributes->canZoom, boolean )
+GET_FUNC( purchasable, boolean )
+GET_FUNC2( long_ranged, proxy->attributes->longRanged, boolean )
+GET_FUNC2( team, BG_TeamName( proxy->attributes->team ), string )
+
+template<> void ExtraInit<WeaponProxy>( lua_State* /*L*/, int /*metatable_index*/ ) {}
+
+RegType<WeaponProxy> WeaponProxyMethods[] =
+{
+	{ nullptr, nullptr },
+};
+
+luaL_Reg WeaponProxyGetters[] =
+{
+	GETTER(price),
+	GETTER(unlock_threshold),
+	GETTER(name),
+	GETTER(info),
+	GETTER(slots),
+	GETTER(ammo),
+	GETTER(clips),
+	GETTER(infinite_ammo),
+	GETTER(energy),
+	GETTER(repeat_rate1),
+	GETTER(repeat_rate2),
+	GETTER(repeat_rate3),
+	GETTER(reload_time),
+	GETTER(alt_mode),
+	GETTER(zoom),
+	GETTER(purchasable),
+	GETTER(long_ranged),
+	GETTER(team),
+
+	{ nullptr, nullptr },
+};
+
+luaL_Reg WeaponProxySetters[] =
+{
+	{ nullptr, nullptr },
+};
+
+LUACORETYPEDEFINE(WeaponProxy)
+
+int Weapons::index( lua_State* L )
+{
+	const char *weaponName = luaL_checkstring( L, -1 );
+	weapon_t weapon = BG_WeaponNumberByName( weaponName );
+	if ( weapon > 0 && static_cast<size_t>( weapon ) - 1 < weapons.size() )
+	{
+		LuaLib<WeaponProxy>::push( L, &weapons[ weapon - 1 ], false );
+		return 1;
+	}
+	return 0;
+}
+
+int Weapons::pairs( lua_State* L )
+{
+	int* pindex = static_cast<int*>( lua_touserdata( L, 3 ) );
+	if ( *pindex < 0 ) *pindex = 0;
+	if ( static_cast<size_t>( *pindex ) >= weapons.size() )
+	{
+		lua_pushnil( L );
+		lua_pushnil( L );
+	}
+	else
+	{
+		lua_pushstring( L, weapons[ *pindex ].attributes->name );
+		LuaLib<WeaponProxy>::push( L, &weapons[ (*pindex)++ ], false );
+	}
+	return 2;
+}
+
+std::vector<WeaponProxy> Weapons::weapons;
+
+template<> void ExtraInit<Weapons>( lua_State* L, int metatable_index )
+{
+	// overwrite index function
+	lua_pushcfunction( L, Weapons::index );
+	lua_setfield( L, metatable_index, "__index" );
+	lua_pushcfunction( L, Weapons::pairs );
+	lua_setfield( L, metatable_index, "__pairs" );
+
+	for ( int i = WP_NONE + 1; i < WP_NUM_WEAPONS; ++i)
+	{
+		Weapons::weapons.push_back( WeaponProxy( i ) );
+	}
+}
+
+RegType<Weapons> WeaponsMethods[] =
+{
+	{ nullptr, nullptr },
+};
+
+luaL_Reg WeaponsGetters[] =
+{
+	{ nullptr, nullptr },
+};
+
+luaL_Reg WeaponsSetters[] =
+{
+	{ nullptr, nullptr },
+};
+
+LUACORETYPEDEFINE(Weapons)
+
+}  // namespace Lua
+}  // namespace Shared
+
+#endif // BUILD_CGAME

--- a/src/shared/lua/Weapons.cpp
+++ b/src/shared/lua/Weapons.cpp
@@ -123,7 +123,7 @@ int Weapons::index( lua_State* L )
 	weapon_t weapon = BG_WeaponNumberByName( weaponName );
 	if ( weapon > 0 && static_cast<size_t>( weapon ) - 1 < weapons.size() )
 	{
-		LuaLib<WeaponProxy>::push( L, &weapons[ weapon - 1 ], false );
+		LuaLib<WeaponProxy>::push( L, &weapons[ weapon - 1 ] );
 		return 1;
 	}
 	return 0;
@@ -141,7 +141,7 @@ int Weapons::pairs( lua_State* L )
 	else
 	{
 		lua_pushstring( L, weapons[ *pindex ].attributes->name );
-		LuaLib<WeaponProxy>::push( L, &weapons[ (*pindex)++ ], false );
+		LuaLib<WeaponProxy>::push( L, &weapons[ (*pindex)++ ] );
 	}
 	return 2;
 }

--- a/src/shared/lua/Weapons.cpp
+++ b/src/shared/lua/Weapons.cpp
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
-Copyright (C) 2012 Unv Developers
+Unvanquished GPL Source Code
+Copyright (C) 2024 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 

--- a/src/shared/lua/Weapons.h
+++ b/src/shared/lua/Weapons.h
@@ -1,0 +1,71 @@
+/*
+===========================================================================
+
+Daemon GPL Source Code
+Copyright (C) 2012 Unv Developers
+
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
+
+Daemon Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Daemon Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+#ifdef BUILD_CGAME
+
+#ifndef SHARED_LUA_WEAPONS_H_
+#define SHARED_LUA_WEAPONS_H_
+
+#include "common/Common.h"
+#include "shared/bg_lua.h"
+#include "shared/bg_public.h"
+#include "shared/lua/LuaLib.h"
+
+namespace Shared {
+namespace Lua {
+
+struct WeaponProxy
+{
+	WeaponProxy( int weapon );
+
+	const weaponAttributes_t* attributes;
+};
+
+struct Weapons
+{
+	static int index( lua_State* L );
+	static int pairs( lua_State* L );
+
+	static std::vector<WeaponProxy> weapons;
+};
+
+template<>
+void ExtraInit<Weapons>( lua_State* L, int metatable_index );
+template<>
+void ExtraInit<WeaponProxy>( lua_State* L, int metatable_index );
+
+}  // namespace Lua
+}  // namespace Shared
+
+#endif  // SHARED_LUA_WEAPONS_H_
+#endif  // BUILD_CGAME

--- a/src/shared/lua/Weapons.h
+++ b/src/shared/lua/Weapons.h
@@ -1,27 +1,27 @@
 /*
 ===========================================================================
 
-Daemon GPL Source Code
-Copyright (C) 2012 Unv Developers
+Unvanquished GPL Source Code
+Copyright (C) 2024 Unvanquished Developers
 
-This file is part of the Daemon GPL Source Code (Daemon Source Code).
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
 
-Daemon Source Code is free software: you can redistribute it and/or modify
+Unvanquished Source Code is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-Daemon Source Code is distributed in the hope that it will be useful,
+Unvanquished Source Code is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
 
-In addition, the Daemon Source Code is also subject to certain additional terms.
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
 You should have received a copy of these additional terms immediately following the
-terms and conditions of the GNU General Public License which accompanied the Daemon
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
 Source Code.  If not, please request a copy in writing from id Software at the address
 below.
 


### PR DESCRIPTION
This adds a few APIs around the BG_* methods and a CGame API for accessing player information. Note that for the shared library, the methods for registration *must* be in the `Shared::Lua` namespace to be found.