### PR TITLE
Replace ProjectPointOntoLineOutwards

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/beacons.cfg
+++ b/pkg/unvanquished_src.dpkdir/ui/beacons.cfg
@@ -12,10 +12,11 @@ fadeInScale       1.4
 
 hudSize           1
 hudMinSize        0.025
-hudMaxSize        1
+hudMaxSize        0.7
 hudAlpha          0.35
 hudAlphaImportant 0.7
-hudMargin         0.14
+hudMargin         0.14 // must obey hudMaxSize + 2 * hudMargin < 1
+                       // so that a max size beacon can fit in the "HUD rectangle"
 
 minimapScale      1
 minimapAlpha      1

--- a/src/cgame/cg_beacon.cpp
+++ b/src/cgame/cg_beacon.cpp
@@ -559,23 +559,16 @@ static void DrawBeacon( cbeacon_t *b )
 	b->pos[ 1 ] *= cgs.glconfig.vidHeight / 480.0;
 
 	// clamp to edges
-	if( !front ||
-	    b->pos[ 0 ] < cgs.bc.hudRect[0][0] + b->size/2 ||
-	    b->pos[ 0 ] > cgs.bc.hudRect[1][0] - b->size/2 ||
-	    b->pos[ 1 ] < cgs.bc.hudRect[0][1] + b->size/2 ||
-	    b->pos[ 1 ] > cgs.bc.hudRect[1][1] - b->size/2 )
+	glm::vec2 mins = VEC2GLM2( cgs.bc.hudRect[0] ) + b->size/2;
+	glm::vec2 maxs = VEC2GLM2( cgs.bc.hudRect[1] ) - b->size/2;
+	glm::vec2 pos = VEC2GLM2( b->pos );
+	b->clamped =
+		CG_ClampToRectangleAlongLine( mins, maxs, VEC2GLM2( cgs.bc.hudCenter ), front, pos );
+	if ( b->clamped )
 	{
-		vec2_t screen[ 2 ];
-		Vector2Set( screen[ 0 ], cgs.bc.hudRect[0][0] + b->size/2,
-		                         cgs.bc.hudRect[0][1] + b->size/2 );
-		Vector2Set( screen[ 1 ], cgs.bc.hudRect[1][0] - b->size/2,
-		                         cgs.bc.hudRect[1][1] - b->size/2 );
-		Vector2Subtract( b->pos, cgs.bc.hudCenter, b->clamp_dir );
-		ProjectPointOntoRectangleOutwards( b->pos, cgs.bc.hudCenter, b->clamp_dir, (const vec2_t*)screen );
-		b->clamped = true;
+		Vector2Copy( pos - VEC2GLM2( cgs.bc.hudCenter ), b->clamp_dir );
 	}
-	else
-		b->clamped = false;
+	Vector2Copy( pos, b->pos );
 }
 
 /**

--- a/src/cgame/cg_draw.cpp
+++ b/src/cgame/cg_draw.cpp
@@ -30,6 +30,63 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "common/Common.h"
 #include "cg_local.h"
 
+// Moves `point` to (if !allowInterior) an edge of the rectangle, or (if allowInterior) to
+// any point on/inside the rectangle. Returns whether point was clamped.
+//
+// If `allowInterior` is false OR `point` is outside the bounds, set `point` to the intersection
+// of the bounding rectangle and the ray from `center` toward `point`. Otherwise, return false
+// and leave `point` unchanged.
+// `center` must be inside the bounds but doesn't have to be the true center.
+bool CG_ClampToRectangleAlongLine(
+	const glm::vec2 &mins, const glm::vec2 &maxs, const glm::vec2 &center, bool allowInterior, glm::vec2 &point )
+{
+	ASSERT( center.x >= mins.x && center.x <= maxs.x );
+	ASSERT( center.y >= mins.y && center.y <= maxs.y );
+
+	glm::vec2 dir = point - center;
+	float fraction = std::numeric_limits<float>::max();
+
+	if ( dir.x > 0 )
+	{
+		fraction = ( maxs.x - center.x ) / dir.x;
+	}
+	else if ( dir.x < 0 )
+	{
+		fraction = ( mins.x - center.x ) / dir.x;
+	}
+
+	if ( dir.y > 0 )
+	{
+		fraction = std::min( fraction, ( maxs.y - center.y ) / dir.y );
+	}
+	else if ( dir.y < 0 )
+	{
+		fraction = std::min( fraction, ( mins.y - center.y ) / dir.y );
+	}
+
+	ASSERT_GT( fraction, 0.0f );
+
+	if ( allowInterior )
+	{
+		if ( fraction >= 1.0f )
+		{
+			return false;
+		}
+	}
+	else
+	{
+		if ( fraction > 1.0e6f )
+		{
+			// ill-conditioned, return an arbitrary boundary point
+			point.y = maxs.y;
+			return true;
+		}
+	}
+
+	point = center + dir * fraction;
+	return true;
+}
+
 /*
 ==============
 CG_DrawField
@@ -244,13 +301,14 @@ static void CG_DrawBeacon( cbeacon_t *b )
 		{
 			float h, tw;
 			const char *p;
-			vec2_t pos, dir, rect[ 2 ];
 			int i, l, frame;
 
 			h = b->size * 0.4f;
 			p = va( "%d", num );
 			l = strlen( p );
 			tw = h * l;
+
+			glm::vec2 pos;
 
 			if( !b->clamped )
 			{
@@ -259,15 +317,12 @@ static void CG_DrawBeacon( cbeacon_t *b )
 			}
 			else
 			{
-				rect[ 0 ][ 0 ] = b->pos[ 0 ] - b->size/2 - tw/2;
-				rect[ 1 ][ 0 ] = b->pos[ 0 ] + b->size/2 + tw/2;
-				rect[ 0 ][ 1 ] = b->pos[ 1 ] - b->size/2 - h/2;
-				rect[ 1 ][ 1 ] = b->pos[ 1 ] + b->size/2 + h/2;
-
-				for( i = 0; i < 2; i++ )
-					dir[ i ] = - b->clamp_dir[ i ];
-
-				ProjectPointOntoRectangleOutwards( pos, b->pos, dir, (const vec2_t*)rect );
+				glm::vec2 pos0 = VEC2GLM2( b->pos );
+				glm::vec2 extent(0.5f * ( b->size + tw ), 0.5f * ( b->size + h ));
+				glm::vec2 rectMins = pos0 - extent;
+				glm::vec2 rectMaxs = pos0 + extent;
+				pos = VEC2GLM2( cgs.bc.hudCenter );
+				CG_ClampToRectangleAlongLine( rectMins, rectMaxs, pos0, false, pos );
 			}
 
 			pos[ 0 ] -= tw/2;

--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -436,12 +436,12 @@ bool CG_WorldToScreen( const vec3_t point, float *x, float *y )
 
 	if ( x )
 	{
-		*x = 320.0f - DotProduct( trans, cg.refdef.viewaxis[ 1 ] ) * xc / ( z * px );
+		*x = !z ? -999999 : 320.0f - DotProduct( trans, cg.refdef.viewaxis[ 1 ] ) * xc / ( z * px );
 	}
 
 	if ( y )
 	{
-		*y = 240.0f - DotProduct( trans, cg.refdef.viewaxis[ 2 ] ) * yc / ( z * py );
+		*y = !z ? -999999 : 240.0f - DotProduct( trans, cg.refdef.viewaxis[ 2 ] ) * yc / ( z * py );
 	}
 
 	return front;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1995,6 +1995,8 @@ void CG_DrawActive();
 void       CG_RunMenuScript( char **args );
 void       CG_ResetPainBlend();
 void       CG_DrawField( float x, float y, int width, float cw, float ch, int value );
+bool CG_ClampToRectangleAlongLine(
+	const glm::vec2 &mins, const glm::vec2 &maxs, const glm::vec2 &center, bool allowInterior, glm::vec2 &point );
 
 //
 // cg_players.c

--- a/src/cgame/cg_minimap.cpp
+++ b/src/cgame/cg_minimap.cpp
@@ -536,32 +536,20 @@ CG_MinimapDrawBeacon
 */
 static void CG_MinimapDrawBeacon( const cbeacon_t *b, float size, const vec2_t center, const vec2_t *bounds )
 {
-	vec2_t offset, pos2d, dir;
-	bool clamped;
+	vec2_t offset;
 
 	size *= b->scale;
 
 	CG_WorldToMinimap( b->origin, offset );
+	glm::vec2 pos2d;
 	pos2d[ 0 ] = - size/2 + offset[ 0 ];
 	pos2d[ 1 ] = - size/2 + offset[ 1 ];
 
-	if( pos2d[ 0 ] < bounds[ 0 ][ 0 ] ||
-	    pos2d[ 0 ] > bounds[ 1 ][ 0 ] ||
-	    pos2d[ 1 ] < bounds[ 0 ][ 1 ] ||
-	    pos2d[ 1 ] > bounds[ 1 ][ 1 ] )
-	{
-		clamped = true;
+	bool clamped = CG_ClampToRectangleAlongLine(
+		VEC2GLM2( bounds[ 0 ] ), VEC2GLM2( bounds[ 1 ] ), VEC2GLM2( center ), true, pos2d );
 
-		if( b->type == BCT_TAG )
-			return;
-
-		Vector2Subtract( pos2d, center, dir );
-		ProjectPointOntoRectangleOutwards( pos2d, center, dir, bounds );
-	}
-	else
-	{
-		clamped = false;
-	}
+	if ( clamped && b->type == BCT_TAG )
+		return;
 
 	Color::Color color = b->color;
 	color.SetAlpha( cgs.bc.minimapAlpha );
@@ -575,12 +563,15 @@ static void CG_MinimapDrawBeacon( const cbeacon_t *b, float size, const vec2_t c
 		                       0, 0, 1, 1,
 		                       cgs.media.beaconNoTarget );
 	if( clamped )
+	{
+		glm::vec2 dir = pos2d - VEC2GLM2( center );
 		trap_R_DrawRotatedPic( pos2d[ 0 ] - size * 0.25f,
 		                       pos2d[ 1 ] - size * 0.25f,
 		                       size * 1.5, size * 1.5f,
 		                       0.0f, 0.0f, 1.0f, 1.0f,
 		                       cgs.media.beaconIconArrow,
 		                       270.0f - atan2f( dir[ 1 ], dir[ 0 ] ) * 180 / M_PI );
+	}
 }
 
 /*

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -38,8 +38,15 @@ template<typename T>
 inline glm::vec3 VEC2GLM( const T& v ) {
 	return glm::vec3( v[0], v[1], v[2] );
 }
+template<typename T>
+inline glm::vec2 VEC2GLM2( const T& v ) {
+	return glm::vec2( v[0], v[1] );
+}
 // A specialised version to warn about useless VEC2GLM mistakes
 DEPRECATED inline glm::vec3 VEC2GLM( glm::vec3 v ) {
+	return v;
+}
+DEPRECATED inline glm::vec2 VEC2GLM2( glm::vec2 v ) {
 	return v;
 }
 


### PR DESCRIPTION
People were complaining about that function because it divides by 0. Replace with an alternative that avoids that, and uses GLM. ProjectPointOntoLineOutwards can be nuked from the engine after.