### PR TITLE
Fix evolve room-finding when flush with wall

### DIFF
--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -1751,7 +1751,7 @@ static bool FindRoomForClassChangeVertically(
 	temp[ 2 ] += nudgeHeight;
 	trap_Trace( &tr, newOrigin, toMins, toMaxs, temp, ent->num(), MASK_PLAYERSOLID, 0 );
 
-	if ( tr.fraction == 0.0f )
+	if ( tr.allsolid )
 	{
 		// it's not helping, we are probably too close to something horizontally
 		return false;
@@ -1783,7 +1783,7 @@ static bool FindRoomForClassChangeLaterally(
 	// each 4 directions, but this is close enough.
 	// This is correct assuming the bbox is centered on the
 	// origin on x and y.
-	float distance = std::min(max_x, max_y);
+	float distance = std::min(max_x, max_y) + 0.5f;
 
 	vec3_t origin;
 	origin[0] = ent->client->ps.origin[0];
@@ -1802,7 +1802,7 @@ static bool FindRoomForClassChangeLaterally(
 		trap_Trace( &trace, start_point, toMins, toMaxs,
 				origin, ent->num(),
 				MASK_PLAYERSOLID, 0 );
-		if ( trace.fraction == 0.0f )
+		if ( trace.allsolid )
 		{
 			continue;
 		}


### PR DESCRIPTION
Fixes a regression in 47702c121585f1cd39d8b12a3192b2e4766f0e31 which made it so that the game can't automatically find room to evolve if you are exactly against an (axis-aligned) wall.

The room-finding algorithm was moving away from the origin only by the exact minimum difference between bounding box sizes (thus dubiously relying on the exactness of a floating-point calculation). I assumed that if the trace goes 0 distance, it must be stuck and we can assume failure for the given position. But it turns out the trace often goes 0 distance but is NOT stuck in an obstacle because it was positioned such that the new bounding box will be flush with the wall if the old one is.

I added 0.5 qu to the distance to avoid this problem. Also the change from (fraction == 0.0f) to (trace.allsolid) would fix the problem on its own, but it's better not to rely on exact distances.

Thanks to freem for identifying the blameful commit.