### PR TITLE
lua: Use traditional Lua iterators

### DIFF
--- a/src/shared/lua/Buildables.cpp
+++ b/src/shared/lua/Buildables.cpp
@@ -34,6 +34,7 @@ Maryland 20850 USA.
 #ifdef BUILD_CGAME
 
 #include "shared/lua/Buildables.h"
+#include "shared/lua/Utils.h"
 
 namespace Shared {
 namespace Lua {
@@ -122,19 +123,15 @@ int Buildables::index( lua_State* L )
 
 int Buildables::pairs( lua_State* L )
 {
-	int* pindex = static_cast<int*>( lua_touserdata( L, 3 ) );
-	if ( *pindex < 0 ) *pindex = 0;
-	if ( static_cast<size_t>( *pindex ) >= buildables.size() )
-	{
-		lua_pushnil( L );
-		lua_pushnil( L );
-	}
-	else
-	{
-		lua_pushstring( L, buildables[ *pindex ].attributes->name );
-		LuaLib<BuildableProxy>::push( L, &buildables[ (*pindex)++ ] );
-	}
-	return 2;
+	return CreatePairsHelper( L, [](lua_State* L, size_t i ) {
+		if ( i >= buildables.size() )
+		{
+			return 0;
+		}
+		lua_pushstring( L, buildables[ i ].attributes->name );
+		LuaLib<BuildableProxy>::push( L, &buildables[ i ] );
+		return 2;
+	});
 }
 
 std::vector<BuildableProxy> Buildables::buildables;

--- a/src/shared/lua/Classes.cpp
+++ b/src/shared/lua/Classes.cpp
@@ -34,6 +34,7 @@ Maryland 20850 USA.
 #ifdef BUILD_CGAME
 
 #include "shared/lua/Classes.h"
+#include "shared/lua/Utils.h"
 
 namespace Shared {
 namespace Lua {
@@ -118,19 +119,15 @@ int Classes::index( lua_State* L )
 
 int Classes::pairs( lua_State* L )
 {
-	int* pindex = static_cast<int*>( lua_touserdata( L, 3 ) );
-	if ( *pindex < 0 ) *pindex = 0;
-	if ( static_cast<size_t>( *pindex ) >= classes.size() )
-	{
-		lua_pushnil( L );
-		lua_pushnil( L );
-	}
-	else
-	{
-		lua_pushstring( L, classes[ *pindex ].attributes->name );
-		LuaLib<ClassProxy>::push( L, &classes[ (*pindex)++ ] );
-	}
-	return 2;
+	return CreatePairsHelper( L, [](lua_State* L, size_t i ) {
+		if ( i >= classes.size() )
+		{
+			return 0;
+		}
+		lua_pushstring( L, classes[ i ].attributes->name );
+		LuaLib<ClassProxy>::push( L, &classes[ i ] );
+		return 2;
+	});
 }
 
 std::vector<ClassProxy> Classes::classes;

--- a/src/shared/lua/Upgrades.cpp
+++ b/src/shared/lua/Upgrades.cpp
@@ -32,7 +32,9 @@ Maryland 20850 USA.
 ===========================================================================
 */
 #ifdef BUILD_CGAME
+
 #include "shared/lua/Upgrades.h"
+#include "shared/lua/Utils.h"
 
 namespace Shared {
 namespace Lua {
@@ -112,19 +114,15 @@ int Upgrades::index( lua_State* L )
 
 int Upgrades::pairs( lua_State* L )
 {
-	int* pindex = static_cast<int*>( lua_touserdata( L, 3 ) );
-	if ( *pindex < 0 ) *pindex = 0;
-	if ( static_cast<size_t>( *pindex ) >= upgrades.size() )
-	{
-		lua_pushnil( L );
-		lua_pushnil( L );
-	}
-	else
-	{
-		lua_pushstring( L, upgrades[ *pindex ].attributes->name );
-		LuaLib<UpgradeProxy>::push( L, &upgrades[ (*pindex)++ ] );
-	}
-	return 2;
+	return CreatePairsHelper( L, [](lua_State* L, size_t i ) {
+		if ( i >= upgrades.size() )
+		{
+			return 0;
+		}
+		lua_pushstring( L, upgrades[ i ].attributes->name );
+		LuaLib<UpgradeProxy>::push( L, &upgrades[ i ] );
+		return 2;
+	});
 }
 
 std::vector<UpgradeProxy> Upgrades::upgrades;

--- a/src/shared/lua/Utils.cpp
+++ b/src/shared/lua/Utils.cpp
@@ -90,6 +90,45 @@ bool CheckVec3(lua_State* L, int pos, vec3_t vec)
 	return true;
 }
 
+namespace {
+
+struct PairsHelper
+{
+	size_t cur;
+	std::function<int( lua_State* L, size_t index )> next_func;
+};
+
+int next( lua_State* L )
+{
+	PairsHelper* self = static_cast<PairsHelper*>( lua_touserdata( L, lua_upvalueindex( 1 ) ) );
+	return self->next_func( L, self->cur++ );
+}
+
+int destroy( lua_State* L )
+{
+	static_cast<PairsHelper*>( lua_touserdata( L, 1 ) )->~PairsHelper();
+	return 0;
+}
+
+}  // namespace
+
+int CreatePairsHelper( lua_State* L, std::function<int( lua_State* L, size_t index )> next_func )
+{
+	void* storage = lua_newuserdata( L, sizeof( PairsHelper ) );
+	if ( luaL_newmetatable( L, "Shared::Lua::PairsHelper" ) )
+	{
+		static luaL_Reg mt[] = {
+			{ "__gc", destroy },
+			{ NULL, NULL },
+		};
+		luaL_setfuncs( L, mt, 0 );
+	}
+	lua_setmetatable( L, -2 );
+	lua_pushcclosure( L, next, 1 );
+	new ( storage ) PairsHelper{ 0, next_func };
+	return 1;
+}
+
 }  // namespace Lua
 }  // namespace Shared
 

--- a/src/shared/lua/Utils.h
+++ b/src/shared/lua/Utils.h
@@ -52,6 +52,8 @@ void PushVec3(lua_State* L, const vec3_t vec);
 // Convert a lua table into a vec3.
 bool CheckVec3(lua_State* L, int pos, vec3_t vec);
 
+int CreatePairsHelper(lua_State* L, std::function<int(lua_State*, size_t)> next_funcmake);
+
 } // namespace Lua
 } // namespace Shared
 

--- a/src/shared/lua/Weapons.cpp
+++ b/src/shared/lua/Weapons.cpp
@@ -35,6 +35,7 @@ Maryland 20850 USA.
 
 #include "common/Common.h"
 #include "shared/lua/Weapons.h"
+#include "shared/lua/Utils.h"
 
 namespace Shared {
 namespace Lua {
@@ -131,19 +132,15 @@ int Weapons::index( lua_State* L )
 
 int Weapons::pairs( lua_State* L )
 {
-	int* pindex = static_cast<int*>( lua_touserdata( L, 3 ) );
-	if ( *pindex < 0 ) *pindex = 0;
-	if ( static_cast<size_t>( *pindex ) >= weapons.size() )
-	{
-		lua_pushnil( L );
-		lua_pushnil( L );
-	}
-	else
-	{
-		lua_pushstring( L, weapons[ *pindex ].attributes->name );
-		LuaLib<WeaponProxy>::push( L, &weapons[ (*pindex)++ ] );
-	}
-	return 2;
+	return CreatePairsHelper( L, [](lua_State* L, size_t i ) {
+		if ( i >= weapons.size() )
+		{
+			return 0;
+		}
+		lua_pushstring( L, weapons[ i ].attributes->name );
+		LuaLib<WeaponProxy>::push( L, &weapons[ i ] );
+		return 2;
+	});
 }
 
 std::vector<WeaponProxy> Weapons::weapons;


### PR DESCRIPTION
LibRocket overrode the builtin Lua iterator behavior with its custom version that would push an index. This did not play with with third party libraries, so RmlUI removed this behavior and used the traditional pairs() behavior.

Tradtionally, the way pairs works is it looks for a __pairs() metamethod that returns a next() function, a metatable, and a nil, so just create a C++ helper that does that. This was adapted from the RmlUI Pairs.h file.