### PR TITLE
remove an assertion

### DIFF
--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -872,8 +872,6 @@ static int WallclimbStopTime( gentity_t *self )
 // check if a wall climbing bot is running into an attackable human entity, if so: attack it
 static void BotMaybeAttackWhileClimbing( gentity_t *self )
 {
-	ASSERT( self->botMind->lastNavconDistance > 0 );
-
 	int ownClass = self->client->ps.stats[ STAT_CLASS ];
 	glm::vec3 playerMins, playerMaxs;
 	BG_BoundingBox( static_cast<class_t>( ownClass ), &playerMins, &playerMaxs, nullptr, nullptr, nullptr );


### PR DESCRIPTION
The BotMaybeAttackWhileClimbing function does an assertion that the last taken navcon should be "upward" (endpoint z coordinate >= start point z coordinate). However the function may be entered without any check that a navcon is active. BotMaybeAttackWhileClimbing is called only by BotClimbToGoal, which is called only by BotMoveUpward. If the bot is a Mantis, BotMoveUpward checks that a navcon is active before calling BotClimbToGoal. But if it is a Dretch, no such check is performed.

Fix https://github.com/Unvanquished/Unvanquished/issues/3002 and https://github.com/Unvanquished/Unvanquished/issues/3037