### PR TITLE
lua: Add the concept of an "id" for an entity

### DIFF
--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -190,6 +190,11 @@ void G_FreeEntity( gentity_t *entity )
 
 	unsigned generation = entity->generation;
 
+	if ( entity->id )
+	{
+		BG_Free( entity->id );
+	}
+
 	entity->~gentity_t();
 	new(entity) gentity_t{};
 

--- a/src/sgame/sg_spawn.cpp
+++ b/src/sgame/sg_spawn.cpp
@@ -200,6 +200,7 @@ static const fieldDescriptor_t fields[] =
 	{ "dmg",                 FOFS( mapEntity.config.damage ),        F_INT,        ENT_V_UNCLEAR, nullptr },
 	{ "gravity",             FOFS( mapEntity.config.amount ),        F_INT,        ENT_V_UNCLEAR, "amount" },
 	{ "health",              FOFS( mapEntity.config.health ),        F_INT,        ENT_V_UNCLEAR, nullptr },
+	{ "id",                  FOFS( id ),                             F_STRING,     ENT_V_UNCLEAR, nullptr },
 	{ "message",             FOFS( mapEntity.message ),              F_STRING,     ENT_V_UNCLEAR, nullptr },
 	{ "model",               FOFS( mapEntity.model ),                F_STRING,     ENT_V_UNCLEAR, nullptr },
 	{ "model2",              FOFS( mapEntity.model2 ),               F_STRING,     ENT_V_UNCLEAR, nullptr },

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -133,6 +133,8 @@ struct gentity_t
 
 	int          flags; // FL_* variables
 
+	char     *id;  // arbitrary id currently only used by Lua. Expected to be unique, but not enforced.
+
 	//entity creation time, i.e. when a building was build or a missile was fired (for diminishing missile damage)
 	int          creationTime;
 


### PR DESCRIPTION
Recently developments have lead to people wanting to refer to entities for various actions (lock/unlock, Lua actions, etc). This is a mechanism for doing so. Right now, we can set it via Lua or via map builtins.