### PR TITLE
Cleanup: call entityNum entityNum consistently in logs instead of entityId

### DIFF
--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -1658,7 +1658,7 @@ static void Cmd_SetViewpos_f( gentity_t *ent )
 
 		if (entityId >= level.num_entities || entityId < MAX_CLIENTS)
 		{
-			Log::Warn("entityId %d is out of range", entityId);
+			Log::Warn("entityNum %d is out of range", entityId);
 			return;
 		}
 		selection = &g_entities[entityId];

--- a/src/sgame/sg_svcmds.cpp
+++ b/src/sgame/sg_svcmds.cpp
@@ -100,7 +100,7 @@ static void Svcmd_EntityFire_f()
 
 	if ( entityNum >= level.num_entities || entityNum < MAX_CLIENTS )
 	{
-		Log::Notice( "invalid entityId %d", entityNum );
+		Log::Notice( "invalid entityNum %d", entityNum );
 		return;
 	}
 
@@ -155,7 +155,7 @@ static void Svcmd_EntityShow_f()
 
 	if (trap_Argc() != 2)
 	{
-		Log::Notice("usage: entityShow <entityId>");
+		Log::Notice("usage: entityShow <entityNum>");
 		return;
 	}
 
@@ -164,7 +164,7 @@ static void Svcmd_EntityShow_f()
 
 	if (entityNum >= level.num_entities || entityNum < MAX_CLIENTS)
 	{
-		Log::Notice("entityId %d is out of range", entityNum);
+		Log::Notice("entityNum %d is out of range", entityNum);
 		return;
 	}
 


### PR DESCRIPTION
only renamed in logs that admins wont get confused
not tested

must be squashed, no idea if its possible to edit multiple files in one commit with github 🤷 