### PR TITLE
admin: Don't print admin text twice for local clients

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -608,23 +608,30 @@ void G_admin_action( const char *action, const char *translation,
 
 	for ( int i = 0; i < level.maxclients; i++ )
 	{
+		gentity_t *ent = &g_entities[ i ];
+
+		// If the client is local, don't send it to them again, because they see console output.
+		if ( ( level.inClient && i == 0 ) || !ent->inuse )
+		{
+			continue;
+		}
 		std::string name = qAdminNetName;
 
 		if ( G_admin_stealthed( admin ) == 1
-		     && !G_admin_permission( &g_entities[ i ], ADMF_SEES_STEALTH ) )
+		     && !G_admin_permission( ent, ADMF_SEES_STEALTH ) )
 		{
 			name = qAdminAdminName;
 		}
 
 		if ( G_admin_stealthed( admin ) == 2
-		     && !G_admin_permission( &g_entities[ i ], ADMF_SEES_STEALTH ) )
+		     && !G_admin_permission( ent, ADMF_SEES_STEALTH ) )
 		{
 			name = qAdminStealthName;
 		}
 
 		if ( ( G_admin_stealthed( admin ) > 0
-		       && G_admin_permission( &g_entities[ i ], ADMF_SEES_STEALTH ) )
-		     || admin == &g_entities[ i ] ) // let the admin know they are stealthed
+		       && G_admin_permission( ent, ADMF_SEES_STEALTH ) )
+		     || admin == ent ) // let the admin know they are stealthed
 		{
 			name = qAdminTaggedName;
 		}

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -1094,7 +1094,7 @@ const char *ClientConnect( int clientNum, bool firstTime )
 	value = Info_ValueForKey( userinfo, "ip" );
 
 	// check for local client
-	if ( !strcmp( value, "localhost" ) )
+	if ( !strcmp( value, "localhost" ) || !strcmp( value, "loopback" ) )
 	{
 		client->pers.localClient = true;
 	}


### PR DESCRIPTION
Also fix a bug where clients with a "loopback" IP are not registered as local clients.