### PR TITLE
teleport: Fix players walking on ice after teleport.

### DIFF
--- a/src/sgame/sg_utils.cpp
+++ b/src/sgame/sg_utils.cpp
@@ -281,6 +281,8 @@ void G_TeleportPlayer( gentity_t *player, glm::vec3 const& origin, glm::vec3 con
 		player->client->ps.pm_time = 160;
 	if ( player->client->ps.pm_time != 0 )
 		player->client->ps.pm_flags |= PMF_TIME_KNOCKBACK;
+	else
+		player->client->ps.pm_flags &= ~PMF_ALL_TIMES;
 
 	// toggle the teleport bit so the client knows to not lerp
 	player->client->ps.eFlags ^= EF_TELEPORT_BIT;


### PR DESCRIPTION
We need to reset the pm_flags after teleporting.