### PR TITLE
Don't draw blueprint buildables in portals

### DIFF
--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -1128,6 +1128,7 @@ void CG_GhostBuildable( int buildableInfo )
 	ps = &cg.predictedPlayerState;
 
 	refEntity_t ent{};
+	ent.renderfx = RF_FIRST_PERSON; // Don't draw in portals
 
 	BG_BuildableBoundingBox( buildable, mins, maxs );
 


### PR DESCRIPTION
Blueprint buildables are like a HUD thing that is only visible to the player using the ckit, so it seems they shouldn't be drawn in mirrors/portals.