### PR TITLE
Fixed uninitialized field in NavmeshGenerator

### DIFF
--- a/src/shared/navgen/navgen.h
+++ b/src/shared/navgen/navgen.h
@@ -201,7 +201,7 @@ public:
 private:
 	std::vector<std::thread> threads_;
 	int numActiveThreads_;
-	std::atomic<bool> canceled_;
+	std::atomic<bool> canceled_{false};
 	std::vector<std::unique_ptr<NavgenTask>> finishedTasks_;
 
 	// guards taskQueue_, finishedTasks_, numActiveThreads_ during multithreading


### PR DESCRIPTION
Ishq discovered that all the threads could sometimes be immediately canceled, due to the uninitialized canceled_ starting as true.