### PR TITLE
Telenode is not an alienBuildable.

### DIFF
--- a/pkg/unvanquished_src.dpkdir/configs/buildables/telenode.attr.cfg
+++ b/pkg/unvanquished_src.dpkdir/configs/buildables/telenode.attr.cfg
@@ -22,7 +22,7 @@ regen             10
 // Explosion
 splashDamage      50
 splashRadius      100
-meansOfDeath      alienBuildable
+meansOfDeath      humanBuildable
 
 // Misc
 transparentTest


### PR DESCRIPTION
This fixes: `<alienPlayer> was caught in the acid` obituary messages due to death being attributed to the wrong MOD.