### PR TITLE
buildables: make g_indestructibleBuildables change existing buildables

### DIFF
--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -34,10 +34,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "CBSE.h"
 #include "sg_cm_world.h"
 
-static Cvar::Cvar<bool> g_indestructibleBuildables(
-		"g_indestructibleBuildables",
-		"make buildables impossible to destroy (Note: this only applies only to buildings built after the variable is set, This also means it must be set before map load for the default buildables to be protected)", Cvar::NONE, false);
-
 /**
  * @return Whether the means of death allow for an under-attack warning.
  */

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -103,6 +103,7 @@ extern Cvar::Cvar<float> g_momentumDestroyMod;
 
 extern Cvar::Cvar<bool> g_humanAllowBuilding;
 extern Cvar::Cvar<bool> g_alienAllowBuilding;
+extern Cvar::Callback<Cvar::Cvar<bool>> g_indestructibleBuildables;
 
 extern Cvar::Cvar<float> g_alienOffCreepRegenHalfLife;
 

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -167,6 +167,29 @@ Cvar::Cvar<bool> g_alienAllowBuilding(
 		Cvar::NONE,
 		true);
 
+Cvar::Callback<Cvar::Cvar<bool>> g_indestructibleBuildables(
+		"g_indestructibleBuildables",
+		"make buildables impossible to destroy.",
+		Cvar::NONE,
+		false,
+		[](bool enabled) {
+			gentity_t *ent = nullptr;
+			int flags = FL_GODMODE | FL_NOTARGET;
+			while( ( ent = G_IterateEntities( ent ) ) )
+			{
+				if ( ent->s.eType != entityType_t::ET_BUILDABLE ) continue;
+				if ( enabled )
+				{
+					ent->flags |= flags;
+				}
+				else
+				{
+					ent->flags &= ~( flags );
+				}
+			}
+		});
+
+
 Cvar::Cvar<float> g_alienOffCreepRegenHalfLife("g_alienOffCreepRegenHalfLife", "half-life in seconds for decay of creep's healing bonus", Cvar::NONE, 0);
 
 Cvar::Cvar<int> g_teamImbalanceWarnings("g_teamImbalanceWarnings", "send 'Teams are imbalanced' messages every x seconds if >0", Cvar::NONE, 0);


### PR DESCRIPTION
Previously, g_indestructibleBuildables only took effect for buildables set after the value was set. This was annoying to use because it meant that this value *must* be set before a map is loaded to make it take effect. Further, if you want to disable it, it means you need to change the map for it to stop making buildables invincible.

The new behavior makes the cvar take effect immediately, which is less surprising and more inline with other cvars.