### PR TITLE
add cvar g_bot_defaultBehavior

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -6149,7 +6149,7 @@ static bool BotAddCmd( gentity_t* ent, const Cmd::Args& args )
 		skill = BotSkillFromString( ent, args[4].data() );
 	}
 
-	const char* behavior = args.Argc() >= 6 ? args[5].data() : BOT_DEFAULT_BEHAVIOR;
+	const char* behavior = args.Argc() >= 6 ? args[5].data() : g_bot_defaultBehavior.Get().c_str();
 
 	if ( level.inClient && g_clients[ 0 ].pers.connected < CON_CONNECTED )
 	{

--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -6149,7 +6149,8 @@ static bool BotAddCmd( gentity_t* ent, const Cmd::Args& args )
 		skill = BotSkillFromString( ent, args[4].data() );
 	}
 
-	const char* behavior = args.Argc() >= 6 ? args[5].data() : g_bot_defaultBehavior.Get().c_str();
+	const std::string behaviorString = g_bot_defaultBehavior.Get();
+	const char* behavior = args.Argc() >= 6 ? args[5].data() : behaviorString.c_str();
 
 	if ( level.inClient && g_clients[ 0 ].pers.connected < CON_CONNECTED )
 	{

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -228,7 +228,8 @@ bool G_BotSetBehavior( botMemory_t *botMind, Str::StringRef behavior )
 	if ( !botMind->behaviorTree )
 	{
 		Log::Warn( "Problem when loading behavior tree %s, trying default", behavior );
-		botMind->behaviorTree = ReadBehaviorTree( g_bot_defaultBehavior.Get().c_str(), &treeList );
+		const std::string behaviorString = g_bot_defaultBehavior.Get();
+		botMind->behaviorTree = ReadBehaviorTree( behaviorString.c_str(), &treeList );
 
 		if ( !botMind->behaviorTree )
 		{
@@ -745,6 +746,7 @@ void G_BotFill(bool immediately)
 		}
 	}
 
+	const std::string behaviorString = g_bot_defaultBehavior.Get();
 	while ( missingFillers )
 	{
 		for ( team_t team : {TEAM_ALIENS, TEAM_HUMANS} )
@@ -752,7 +754,7 @@ void G_BotFill(bool immediately)
 			if ( fillers[ team ].target > 0 )
 			{
 				fillers[ team ].target--;
-				if ( !G_BotAdd( BOT_NAME_FROM_LIST, team, level.team[team].botFillSkillLevel, g_bot_defaultBehavior.Get().c_str(), true ) )
+				if ( !G_BotAdd( BOT_NAME_FROM_LIST, team, level.team[team].botFillSkillLevel, behaviorString.c_str(), true ) )
 				{
 					//TODO modify the "/bot fill" number so that further warnings will be ignored.
 					//     Note that this means players disconnecting would possibly not be replaced by bot

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -228,7 +228,7 @@ bool G_BotSetBehavior( botMemory_t *botMind, Str::StringRef behavior )
 	if ( !botMind->behaviorTree )
 	{
 		Log::Warn( "Problem when loading behavior tree %s, trying default", behavior );
-		botMind->behaviorTree = ReadBehaviorTree( BOT_DEFAULT_BEHAVIOR, &treeList );
+		botMind->behaviorTree = ReadBehaviorTree( g_bot_defaultBehavior.Get().c_str(), &treeList );
 
 		if ( !botMind->behaviorTree )
 		{
@@ -752,7 +752,7 @@ void G_BotFill(bool immediately)
 			if ( fillers[ team ].target > 0 )
 			{
 				fillers[ team ].target--;
-				if ( !G_BotAdd( BOT_NAME_FROM_LIST, team, level.team[team].botFillSkillLevel, BOT_DEFAULT_BEHAVIOR, true ) )
+				if ( !G_BotAdd( BOT_NAME_FROM_LIST, team, level.team[team].botFillSkillLevel, g_bot_defaultBehavior.Get().c_str(), true ) )
 				{
 					//TODO modify the "/bot fill" number so that further warnings will be ignored.
 					//     Note that this means players disconnecting would possibly not be replaced by bot

--- a/src/sgame/sg_extern.h
+++ b/src/sgame/sg_extern.h
@@ -220,5 +220,6 @@ extern Cvar::Cvar<bool> g_bot_infiniteMomentum;
 extern Cvar::Cvar<int> g_bot_aliensenseRange;
 extern Cvar::Modified<Cvar::Cvar<int>> g_bot_defaultFill;
 extern Cvar::Cvar<bool> g_bot_navmeshReduceTypes;
+extern Cvar::Cvar<std::string> g_bot_defaultBehavior;
 
 #endif // SG_EXTERN_H_

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -296,6 +296,7 @@ Cvar::Cvar<int> g_bot_reactiontime("g_bot_reactiontime", "bots' reaction time to
 Cvar::Cvar<bool> g_bot_infiniteFunds("g_bot_infiniteFunds", "give bots unlimited funds", Cvar::NONE, false);
 Cvar::Cvar<bool> g_bot_infiniteMomentum("g_bot_infiniteMomentum", "allow bots to ignore momentum, but not other restrictions", Cvar::NONE, false);
 Cvar::Cvar<int> g_bot_aliensenseRange("g_bot_aliensenseRange", "custom aliensense range for bots", Cvar::NONE, ALIENSENSE_RANGE);
+Cvar::Cvar<std::string> g_bot_defaultBehavior("g_bot_defaultBehavior", "name of the default .bt file", Cvar::NONE, BOT_DEFAULT_BEHAVIOR);
 
 //</bot stuff>
 


### PR DESCRIPTION
Replace the hardcoded `BOT_DEFAULT_BEHAVIOR` by a cvar. This might be a good idea even when making use of extensive lua configs. The default behavior is used in these cases (excluding admin commands):

- Bots are added on map load
- Bots are added by vote
- A filler bot is added because a player leaves a  team

I hope this list is exhaustive.
