### PR TITLE
shared: Set count after printing warning in BG_PackEntityNumbers

### DIFF
--- a/src/shared/bg_misc.cpp
+++ b/src/shared/bg_misc.cpp
@@ -2015,10 +2015,10 @@ void BG_PackEntityNumbers( entityState_t *es, const int *entityNums, unsigned in
 
 	if ( count > MAX_NUM_PACKED_ENTITY_NUMS )
 	{
-		count = MAX_NUM_PACKED_ENTITY_NUMS;
 		Log::Warn( "A maximum of %d entity numbers can be "
 		            "packed, but BG_PackEntityNumbers was passed %d entities",
 		            MAX_NUM_PACKED_ENTITY_NUMS, count );
+		count = MAX_NUM_PACKED_ENTITY_NUMS;
 	}
 
 	es->misc = es->time = es->time2 = es->constantLight = 0;


### PR DESCRIPTION
Otherwise the count wrong in the warning making it less helpful.