### PR TITLE
Kill ghost buildings to ensure decrementing the spawn counters

### DIFF
--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -1838,7 +1838,7 @@ static gentity_t *FinishSpawningBuildable( gentity_t *ent, bool force )
 	{
 		Log::Debug( "^3G_FinishSpawningBuildable: %s startsolid at %s",
 		          built->classname, vtos( built->s.origin ) );
-		Entities::Kill(built, MOD_SUICIDE);
+		Entities::Kill( built, MOD_SUICIDE );
 		G_FreeEntity( built );
 		return nullptr;
 	}

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -1838,6 +1838,7 @@ static gentity_t *FinishSpawningBuildable( gentity_t *ent, bool force )
 	{
 		Log::Debug( "^3G_FinishSpawningBuildable: %s startsolid at %s",
 		          built->classname, vtos( built->s.origin ) );
+		Entities::Kill(built, MOD_SUICIDE);
 		G_FreeEntity( built );
 		return nullptr;
 	}


### PR DESCRIPTION
You can encounter ghost eggs frequently in the wild. They are very annoying. The egg does not exist, but the spawn counter will never go down to zero. They might be in a map's builtin layout or in a layout someone saved two years ago. One example is map moonbase.

Why are there ghost eggs at all? I do not know. Probably because of changes to the trace code.

Policy dicatates to modify the spawn counters only in the CBSE components. I am not a CBSE expert, so I cannot promise this is correct. Are there any CBSE experts?