### PR TITLE
cbse: tell python the regexp string is a raw string

### DIFF
--- a/tools/cbse/CBSE.py
+++ b/tools/cbse/CBSE.py
@@ -508,8 +508,8 @@ class PreprocessingLoader(jinja2.BaseLoader):
                 line = line[1:]
         return line
 
-    blockstart = re.compile('^\s*{%-?\s*(if|for).*$')
-    blockend = re.compile('^\s*{%-?\s*end(if|for).*$')
+    blockstart = re.compile(r'^\s*{%-?\s*(if|for).*$')
+    blockend = re.compile(r'^\s*{%-?\s*end(if|for).*$')
 
     def my_filter(self, text):
         lines = []


### PR DESCRIPTION
Avoids:

> SyntaxWarning: invalid escape sequence

Fixes #3073:

- https://github.com/Unvanquished/Unvanquished/issues/3073