### PR TITLE
do not try to make alien bots crouch at obstacles

### DIFF
--- a/src/sgame/sg_bot_nav.cpp
+++ b/src/sgame/sg_bot_nav.cpp
@@ -736,7 +736,7 @@ static bool BotAvoidObstacles( gentity_t *self, glm::vec3 &dir, bool ignoreGeome
 	}
 
 	// check for crouching
-	if ( g_bot_autocrouch.Get() )
+	if ( G_Team( self ) == TEAM_HUMANS && g_bot_autocrouch.Get() )
 	{
 		glm::vec3 playerMins;
 		glm::vec3 playerCMaxs;


### PR DESCRIPTION
There is a mistake in the code deciding whether a human bot should crouch. The crouch activation is done for alien classes too, resulting in wall climbers randomly activating their climb and sometimes getting stuck on walls or ceilings. Fix this.