### PR TITLE
NUKE sensor_stage entities after firing

### DIFF
--- a/src/sgame/sg_spawn_sensor.cpp
+++ b/src/sgame/sg_spawn_sensor.cpp
@@ -262,6 +262,9 @@ void G_notify_sensor_stage( team_t team, int previousStage, int newStage )
 			// remove this entity now to prevent subsequent activation
 			// TODO: when implementing stage down triggers, we will probably
 			// want to keep the entity forever, and remove this line
+			// comparison to tremulous: trigger_stage could be fired more than
+			// once by not specifying a team (thus, it could be fired twice - once for each team)
+			// but there is no known tremulous map doing this
 			G_FreeEntity( entities );
 		}
 	}

--- a/src/sgame/sg_spawn_sensor.cpp
+++ b/src/sgame/sg_spawn_sensor.cpp
@@ -259,6 +259,10 @@ void G_notify_sensor_stage( team_t team, int previousStage, int newStage )
 				== !entities->mapEntity.conditions.negated)
 		{
 			G_FireEntity(entities, entities);
+			// remove this entity now to prevent subsequent activation
+			// TODO: when implementing stage down triggers, we will probably
+			// want to keep the entity forever, and remove this line
+			G_FreeEntity( entities );
 		}
 	}
 }


### PR DESCRIPTION
The only use case I have seen in the wild is opening some door once a team reaches a stage. These doors must not be fired a second time, because some door-like entities will respond by closing the door. See map-pierogi for example.