### PR TITLE
firing a func_rotating entity stops/resumes its rotation

### DIFF
--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -2688,12 +2688,6 @@ static void FuncRotating_act( gentity_t *ent, gentity_t *other, gentity_t *activ
 {
 	gentity_t *master;
 
-	// if this is a non-client-usable thing, return
-	if ( ent->mapEntity.names[ 0 ] && other && other->client )
-	{
-		return;
-	}
-
 	// only the master should be used
 	if ( ent->flags & FL_GROUPSLAVE )
 	{

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -2711,16 +2711,9 @@ static void FuncRotating_act( gentity_t *ent, gentity_t *other, gentity_t *activ
 		if ( ent->s.apos.trDelta[ 0 ] == 0.f && ent->s.apos.trDelta[ 1 ] == 0.f && ent->s.apos.trDelta[ 2 ] == 0.f )
 		{
 			// we are out of phase with a rotation that started with euler angle = 0 at
-			// level.time = 0 now, since we had stopped the rotator for some time.
-			// so we calculate the phase shift of the new rotation, and correct the new
-			// value of the euler angle accordingly.
-
-			int periodLength = 360000 / ent->mapEntity.speed;  // milliseconds
-			int positionInPeriod = level.time % periodLength;
-			int phaseShiftAngle = 360 * positionInPeriod / periodLength;
-
-			ent->s.apos.trBase[ FuncRotatingVectorComponentOffset( ent ) ] -= phaseShiftAngle;
-			VectorCopy( ent->s.apos.trBase, ent->r.currentAngles );
+			// level.time = 0 now, since we had stopped the rotator for some time
+			// set trTime to account for this
+			ent->s.apos.trTime = level.time;
 			FuncRotatingSetSpeedAccordingToSpawnflags( ent );
 		}
 		else
@@ -2730,7 +2723,7 @@ static void FuncRotating_act( gentity_t *ent, gentity_t *other, gentity_t *activ
 				// set the rotation speed to zero
 				ent->s.apos.trDelta[ i ] = 0.f;
 
-				// set the current angle as new base position angle
+				// set the current euler angle as new base euler angle
 				// restricting the angle to the interval 0..360 is not
 				// strictly neccessary, but feels like a safe choice
 				ent->s.apos.trBase[ i ] = fmod( ent->r.currentAngles[ i ], 360.f );

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -2746,7 +2746,6 @@ void SP_func_rotating( gentity_t *self )
 	trap_SetBrushModel( self, self->mapEntity.model );
 	InitMover( self );
 	self->act = FuncRotating_act;
-	reset_moverspeed( self, 100 );
 
 	VectorCopy( self->s.origin, self->s.pos.trBase );
 	VectorCopy( self->s.pos.trBase, self->r.currentOrigin );

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -1083,7 +1083,7 @@ void BinaryMover_act( gentity_t *ent, gentity_t *other, gentity_t *activator )
 	// only the master should be used
 	if ( ent->flags & FL_GROUPSLAVE )
 	{
-		BinaryMover_act( ent->mapEntity.groupMaster, other, activator );
+		ent->mapEntity.groupMaster->act( ent->mapEntity.groupMaster, other, activator );
 		return;
 	}
 
@@ -2697,7 +2697,7 @@ static void FuncRotating_act( gentity_t *ent, gentity_t *other, gentity_t *activ
 	// only the master should be used
 	if ( ent->flags & FL_GROUPSLAVE )
 	{
-		FuncRotating_act( ent->mapEntity.groupMaster, other, activator );
+		ent->mapEntity.groupMaster->act( ent->mapEntity.groupMaster, other, activator );
 		return;
 	}
 

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -1083,7 +1083,7 @@ void BinaryMover_act( gentity_t *ent, gentity_t *other, gentity_t *activator )
 	// only the master should be used
 	if ( ent->flags & FL_GROUPSLAVE )
 	{
-		ent->mapEntity.groupMaster->act( ent->mapEntity.groupMaster, other, activator );
+		BinaryMover_act( ent->mapEntity.groupMaster, other, activator );
 		return;
 	}
 
@@ -2697,7 +2697,7 @@ static void FuncRotating_act( gentity_t *ent, gentity_t *other, gentity_t *activ
 	// only the master should be used
 	if ( ent->flags & FL_GROUPSLAVE )
 	{
-		ent->mapEntity.groupMaster->act( ent->mapEntity.groupMaster, other, activator );
+		FuncRotating_act( ent->mapEntity.groupMaster, other, activator );
 		return;
 	}
 


### PR DESCRIPTION
As recently requested. Old code would use `BinaryMover_act` on it, which got very confused, believing this is a door-like thing with start and end positions. This resulted in the brushes ~~vanishing from the map~~ teleporting to the origin.

TODO: test with groups of entities