### PR TITLE
Don't transmit some fake entities to clients

### DIFF
--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -1867,6 +1867,7 @@ static void SpawnBuildableThink( gentity_t *ent )
 void G_SpawnBuildable( gentity_t *ent, buildable_t buildable )
 {
 	ent->s.modelindex = buildable;
+	ent->r.svFlags |= SVF_NOCLIENT;
 
 	// some movers spawn on the second frame, so delay item
 	// spawns until the third frame so they can ride trains
@@ -2348,6 +2349,7 @@ void G_BuildLogRevert( int id )
 			VectorCopy( log->angles, buildable->s.angles );
 			VectorCopy( log->origin2, buildable->s.origin2 );
 			VectorCopy( log->angles2, buildable->s.angles2 );
+			buildable->r.svFlags = SVF_NOCLIENT;
 			buildable->s.modelindex = log->modelindex;
 			buildable->deconMarkHack = log->markedForDeconstruction;
 			buildable->builtBy = log->builtBy;

--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -1619,6 +1619,7 @@ static void Think_SpawnNewDoorTrigger( gentity_t *self )
 	VectorCopy( maxs, other->r.maxs );
 	other->parent = self;
 	other->r.contents = CONTENTS_TRIGGER;
+	other->r.svFlags = SVF_NOCLIENT;
 	other->touch = door_trigger_touch;
 	// remember the thinnest axis
 	other->mapEntity.customNumber = best;
@@ -2103,6 +2104,7 @@ static void SpawnPlatSensor( gentity_t *self )
 	sensor->classname = S_PLAT_SENSOR;
 	sensor->touch = Touch_PlatCenterTrigger;
 	sensor->r.contents = CONTENTS_TRIGGER;
+	sensor->r.svFlags = SVF_NOCLIENT;
 	sensor->parent = self;
 
 	tmin[ 0 ] = self->mapEntity.restingPosition[ 0 ] + self->r.mins[ 0 ] + 33;


### PR DESCRIPTION
Don't waste bandwidth on entities that don't do anything for clients.

Hearing about layouts which cause a buffer overflow when they are the built-in layout but not when loaded from a layout file (or vice versa, don't remember which way it was), it occurs to me that this might be related to the fake entities used to spawn buildables. They are known to spawn at different times when a layout file is used, resulting in different entity numbering. So you guys can give this a shot and see if it allows bigger layouts to load