### PR TITLE
Fix muzzle flash dlight without flash model

### DIFF
--- a/src/cgame/cg_attachment.cpp
+++ b/src/cgame/cg_attachment.cpp
@@ -65,8 +65,7 @@ bool CG_AttachmentPoint( attachment_t *a, vec3_t v )
 			}
 
 			AxisCopy( axisDefault, a->re.axis );
-			CG_PositionRotatedEntityOnTag( &a->re, &a->parent,
-			                               a->model, a->tagName );
+			CG_PositionRotatedEntityOnTag( &a->re, &a->parent, a->tagName );
 			VectorCopy( a->re.origin, v );
 			break;
 

--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -141,12 +141,10 @@ tag location
 ======================
 */
 void CG_PositionEntityOnTag( refEntity_t *entity, const refEntity_t *parent,
-                             qhandle_t parentModel, const char *tagName )
+                             const char *tagName )
 {
 	int           i;
 	orientation_t lerped;
-
-	Q_UNUSED(parentModel);
 
 	// lerp the tag
 	trap_R_LerpTag( &lerped, parent, tagName, 0 );
@@ -173,13 +171,12 @@ tag location
 ======================
 */
 void CG_PositionRotatedEntityOnTag( refEntity_t *entity, const refEntity_t *parent,
-                                    qhandle_t parentModel, const char *tagName )
+                                    const char *tagName )
 {
 	int           i;
 	orientation_t lerped;
 	vec3_t        tempAxis[ 3 ];
 
-	Q_UNUSED(parentModel);
 //AxisClear( entity->axis );
 	// lerp the tag
 	trap_R_LerpTag( &lerped, parent, tagName, 0 );

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2077,9 +2077,9 @@ void CG_AddPacketEntities();
 void CG_AdjustPositionForMover( const vec3_t in, int moverNum, int fromTime, int toTime, vec3_t out,
                                 vec3_t angles_in, vec3_t angles_out );
 void CG_PositionEntityOnTag( refEntity_t *entity, const refEntity_t *parent,
-                             qhandle_t parentModel, const char *tagName );
+                             const char *tagName );
 void CG_PositionRotatedEntityOnTag( refEntity_t *entity, const refEntity_t *parent,
-                                    qhandle_t parentModel, const char *tagName );
+                                    const char *tagName );
 void CG_TransformSkeleton( refSkeleton_t *skel, const vec_t scale );
 
 team_t CG_Team(const entityState_t &es);

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -2399,7 +2399,7 @@ static void CG_PlayerUpgrades( centity_t *cent, refEntity_t *torso )
 		AxisCopy( axisDefault, jetpack.axis );
 
 		// FIXME: change to tag_back when it exists
-		CG_PositionRotatedEntityOnTag( &jetpack, torso, torso->hModel, "tag_gear" );
+		CG_PositionRotatedEntityOnTag( &jetpack, torso, "tag_gear" );
 
 		CG_JetpackAnimation( cent, &jetpack.oldframe, &jetpack.frame, &jetpack.backlerp );
 		jetpack.skeleton = jetpackSkeleton;
@@ -2496,7 +2496,7 @@ static void CG_PlayerUpgrades( centity_t *cent, refEntity_t *torso )
 		AxisCopy( axisDefault, radar.axis );
 
 		//FIXME: change to tag_back when it exists
-		CG_PositionRotatedEntityOnTag( &radar, torso, torso->hModel, "tag_head" );
+		CG_PositionRotatedEntityOnTag( &radar, torso, "tag_head" );
 
 		trap_R_AddRefEntityToScene( &radar );
 	}
@@ -3155,7 +3155,7 @@ void CG_Player( centity_t *cent )
 
 		VectorCopy( cent->lerpOrigin, torso.lightingOrigin );
 
-		CG_PositionRotatedEntityOnTag( &torso, &legs, ci->legsModel, "tag_torso" );
+		CG_PositionRotatedEntityOnTag( &torso, &legs, "tag_torso" );
 
 		torso.renderfx = renderfx;
 
@@ -3176,7 +3176,7 @@ void CG_Player( centity_t *cent )
 
 		VectorCopy( cent->lerpOrigin, head.lightingOrigin );
 
-		CG_PositionRotatedEntityOnTag( &head, &torso, ci->torsoModel, "tag_head" );
+		CG_PositionRotatedEntityOnTag( &head, &torso, "tag_head" );
 
 		head.renderfx = renderfx;
 
@@ -3390,7 +3390,7 @@ void CG_Corpse( centity_t *cent )
 
 		VectorCopy( origin, torso.lightingOrigin );
 
-		CG_PositionRotatedEntityOnTag( &torso, &legs, ci->legsModel, "tag_torso" );
+		CG_PositionRotatedEntityOnTag( &torso, &legs, "tag_torso" );
 
 		torso.renderfx = renderfx;
 
@@ -3412,7 +3412,7 @@ void CG_Corpse( centity_t *cent )
 
 		VectorCopy( origin, head.lightingOrigin );
 
-		CG_PositionRotatedEntityOnTag( &head, &torso, ci->torsoModel, "tag_head" );
+		CG_PositionRotatedEntityOnTag( &head, &torso, "tag_head" );
 
 		head.renderfx = renderfx;
 

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -216,7 +216,7 @@ static void CG_AddTestModel()
 	if ( cg.testModelBarrelEntity.hModel )
 	{
 		CG_PositionEntityOnTag( &cg.testModelBarrelEntity, &cg.testModelEntity,
-		                        cg.testModelEntity.hModel, "tag_barrel" );
+		                        "tag_barrel" );
 
 		trap_R_AddRefEntityToScene( &cg.testModelBarrelEntity );
 	}

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -1398,7 +1398,7 @@ void CG_AddPlayerWeapon( refEntity_t *parent, playerState_t *ps, centity_t *cent
 
 	if ( !noGunModel )
 	{
-		CG_PositionEntityOnTag( &gun, parent, parent->hModel, "tag_weapon" );
+		CG_PositionEntityOnTag( &gun, parent, "tag_weapon" );
 		if ( ps )
 		{
 			CG_WeaponAnimation( cent, &gun.oldframe, &gun.frame, &gun.backlerp );
@@ -1477,7 +1477,7 @@ void CG_AddPlayerWeapon( refEntity_t *parent, playerState_t *ps, centity_t *cent
 			angles[ ROLL ] = CG_MachinegunSpinAngle( cent, firing );
 			AnglesToAxis( angles, barrel.axis );
 
-			CG_PositionRotatedEntityOnTag( &barrel, &gun, gun.hModel, "tag_barrel" );
+			CG_PositionRotatedEntityOnTag( &barrel, &gun, "tag_barrel" );
 
 			trap_R_AddRefEntityToScene( &barrel );
 		}
@@ -1541,11 +1541,11 @@ void CG_AddPlayerWeapon( refEntity_t *parent, playerState_t *ps, centity_t *cent
 
 		if ( noGunModel )
 		{
-			CG_PositionRotatedEntityOnTag( &flash, parent, parent->hModel, "tag_weapon" );
+			CG_PositionRotatedEntityOnTag( &flash, parent, "tag_weapon" );
 		}
 		else
 		{
-			CG_PositionRotatedEntityOnTag( &flash, &gun, gun.hModel, "tag_flash" );
+			CG_PositionRotatedEntityOnTag( &flash, &gun, "tag_flash" );
 		}
 
 		trap_R_AddRefEntityToScene( &flash );

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -1532,7 +1532,12 @@ void CG_AddPlayerWeapon( refEntity_t *parent, playerState_t *ps, centity_t *cent
 		flash.hModel = weapon->flashModel;
 	}
 
-	if ( flash.hModel )
+	bool flashDlight = weapon->wim[ weaponMode ].flashDlightColor[ 0 ] ||
+	                   weapon->wim[ weaponMode ].flashDlightColor[ 1 ] ||
+	                   weapon->wim[ weaponMode ].flashDlightColor[ 2 ];
+
+	// If there is no model, we may still use flash.origin for a light.
+	if ( flash.hModel || flashDlight )
 	{
 		angles[ YAW ] = 0;
 		angles[ PITCH ] = 0;
@@ -1548,7 +1553,10 @@ void CG_AddPlayerWeapon( refEntity_t *parent, playerState_t *ps, centity_t *cent
 			CG_PositionRotatedEntityOnTag( &flash, &gun, "tag_flash" );
 		}
 
-		trap_R_AddRefEntityToScene( &flash );
+		if ( flash.hModel )
+		{
+			trap_R_AddRefEntityToScene( &flash );
+		}
 	}
 
 	if ( ps || cg.renderingThirdPerson ||
@@ -1577,9 +1585,7 @@ void CG_AddPlayerWeapon( refEntity_t *parent, playerState_t *ps, centity_t *cent
 		}
 
 		// make a dlight for the flash
-		if ( weapon->wim[ weaponMode ].flashDlightColor[ 0 ] ||
-		     weapon->wim[ weaponMode ].flashDlightColor[ 1 ] ||
-		     weapon->wim[ weaponMode ].flashDlightColor[ 2 ] )
+		if ( flashDlight )
 		{
 			trap_R_AddLightToScene( flash.origin, weapon->wim[ weaponMode ].flashDlight,
 			                        weapon->wim[ weaponMode ].flashDlightIntensity,


### PR DESCRIPTION
Muzzle flash dynamic lights (for weapon firing effects) didn't work if there was no muzzle flash model configured. Before now, asset designers have apparently worked around this situation by putting a flash model with an invisible texture when they want a dlight but not a model.
