### PR TITLE
Fix a G_WideTrace bug (tyrant can't hit medi)

### DIFF
--- a/src/sgame/sg_weapon.cpp
+++ b/src/sgame/sg_weapon.cpp
@@ -349,7 +349,12 @@ static void G_WideTrace(
 	// Line trace against the world, so we never hit through obstacles.
 	// The range is reduced according to the former trace so we don't hit something behind the
 	// current target.
-	float scale = glm::distance( muzzle, VEC2GLM( tr->endpos ) ) + halfDiagonal;
+	glm::vec3 absDir = glm::max( glm::vec3( 1.0e-9f ), glm::abs( forward ) );
+	glm::vec3 elementwiseDistToSide = maxs / absDir;
+	// distToSide is the distance from the center of the trace box to the intersection of the trace line
+	// and a side of the box. Should be between min(width, height) and halfDiagonal
+	float distToSide = std::min({elementwiseDistToSide.x, elementwiseDistToSide.y, elementwiseDistToSide.z});
+	float scale = tr->fraction * range + distToSide;
 	VectorMA( muzzle, scale, forward, end );
 	trap_Trace( tr, muzzle, {}, {}, end, ent->s.number, CONTENTS_SOLID, 0 );
 


### PR DESCRIPTION
It had a bug that the line trace against CONTENTS_SOLID was too long. This could result in choosing the world as the entity when there was actually a closer CONTENTS_BODY entity in front of it.

Thanks to Ishq for finding where in the code the bug is.