### PR TITLE
Reduce reflection cubemap size options

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
@@ -251,12 +251,12 @@
 					<select cvar="r_cubeProbeSize">
 						<option value="32"><translate>Very low</translate>&nbsp;(32)</option>
 						<option value="64"><translate>Low</translate>&nbsp;(64)</option>
-						<option value="256"><translate>Moderate</translate>&nbsp;(256)</option>
-						<option value="1024"><translate>High</translate>&nbsp;(1024)</option>
-						<option value="4096"><translate>Very high</translate>&nbsp;(4096)</option>
+						<option value="96"><translate>Moderate</translate>&nbsp;(96)</option>
+						<option value="128"><translate>High</translate>&nbsp;(128)</option>
+						<option value="160"><translate>Very high</translate>&nbsp;(160)</option>
 					</select>
 					<h3><translate>Quality</translate></h3>
-					<p><translate>Quality of static reflection cubemaps.</translate></p>
+					<p><translate>Quality of static reflection cubemaps. Higher qualities may use up a lot of disk space.</translate></p>
 				</row>
 				<row>
 					<h3><translate>Cubemap grid spacing</translate></h3>


### PR DESCRIPTION
The previous options were resulting in ~1-2Gb of image data saved for even smaller maps like plat23, per map, when using moderate preset and default spacing.

Prevent crashes and using up tons of disk space.