### PR TITLE
fix: `changemap` command not found

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -237,14 +237,14 @@ static const g_admin_cmd_t     g_admin_cmds[] =
 	},
 
 	{
-		"changemap",    G_admin_changemap,   false, "changemap",
-		N_("load a map (and optionally force layout)"),
+		"changedevmap",    G_admin_changedevmap,   false, "changedevmap",
+		N_("load a map with cheats (and optionally force layout)"),
 		N_("[^3mapname^7] (^5layout^7)")
 	},
 
 	{
-		"changedevmap",    G_admin_changedevmap,   false, "changedevmap",
-		N_("load a map with cheats (and optionally force layout)"),
+		"changemap",    G_admin_changemap,   false, "changemap",
+		N_("load a map (and optionally force layout)"),
 		N_("[^3mapname^7] (^5layout^7)")
 	},
 


### PR DESCRIPTION
In some cases, the `changemap` command may not be found due to incorrect ordering of the array in sg_admin.cpp

This bug was found today on Bunker after the update.

I assume this wasn't found while testing #2960 as the server used to test it probably didn't have custom admin commands.

Thanks @sweet235 for spotting the error.