### PR TITLE
Fix chargebar depth

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/hud_chargebar.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/hud_chargebar.rml
@@ -5,6 +5,7 @@
 	body {
 		width: 100%;
 		height: 100%;
+		z-index: 1;
 	}
 	div {
 		position: absolute;


### PR DESCRIPTION
Render it above the momentum bar. Fixes a regression that made it almost invisible under certain conditions.