### PR TITLE
Nudge beacons for human players a bit upwards so that the beacon isn't on their butt

### DIFF
--- a/src/cgame/cg_beacon.cpp
+++ b/src/cgame/cg_beacon.cpp
@@ -172,6 +172,13 @@ static void SetClientBeaconPosition(centity_t *ent, cbeacon_t *beacon)
 	BG_ClassBoundingBox( pClass, mins, maxs, nullptr, nullptr, nullptr );
 	BG_MoveOriginToBBOXCenter( center, mins, maxs );
 
+	if( TargetTeam( beacon ) == TEAM_HUMANS )
+	{
+		// Nudge the center a bit upwards for human players, so we don't look at their butt too much
+		float height = maxs[2] - mins[2];
+		center[2] += 0.3f * height;
+	}
+
 	VectorCopy( center, beacon->origin );
 }
 

--- a/src/cgame/cg_beacon.cpp
+++ b/src/cgame/cg_beacon.cpp
@@ -39,6 +39,18 @@ along with Unvanquished.  If not, see <http://www.gnu.org/licenses/>.
 #define bc_etime time2
 #define bc_mtime apos.trTime
 
+static team_t TargetTeam( const cbeacon_t *beacon )
+{
+	if ( beacon->type != BCT_TAG && beacon->type != BCT_BASE )
+		return TEAM_NONE;
+
+	if ( ( beacon->ownerTeam == TEAM_ALIENS && beacon->flags & EF_BC_ENEMY ) ||
+	     ( beacon->ownerTeam == TEAM_HUMANS && !( beacon->flags & EF_BC_ENEMY ) ) )
+		return TEAM_HUMANS;
+	else
+		return TEAM_ALIENS;
+}
+
 void CG_LoadBeaconsConfig()
 {
 	beaconsConfig_t  *bc = &cgs.bc;
@@ -149,6 +161,21 @@ else if( !Q_stricmp( token.string, #x ) ) \
 }
 
 /**
+ * @brief Sets location on exact center of target player entity.
+ */
+static void SetClientBeaconPosition(centity_t *ent, cbeacon_t *beacon)
+{
+	vec3_t mins, maxs, center;
+	int pClass = ( ( ent->currentState.misc >> 8 ) & 0xFF ); // TODO: Write function for this.
+
+	VectorCopy( ent->lerpOrigin, center );
+	BG_ClassBoundingBox( pClass, mins, maxs, nullptr, nullptr, nullptr );
+	BG_MoveOriginToBBOXCenter( center, mins, maxs );
+
+	VectorCopy( center, beacon->origin );
+}
+
+/**
  * @brief Fills cg.beacons with explicit (ET_BEACON entity) beacons.
  * @return Whether all beacons found space in cg.beacons.
  */
@@ -193,15 +220,8 @@ static bool LoadExplicitBeacons()
 		if ( beacon->target && ( targetCent = &cg_entities[ beacon->target ] )->valid &&
 		     ( targetES = &targetCent->currentState )->eType == entityType_t::ET_PLAYER )
 		{
-			vec3_t mins, maxs, center;
-			int pClass = ( ( targetES->misc >> 8 ) & 0xFF ); // TODO: Write function for this.
-
-			VectorCopy( targetCent->lerpOrigin, center );
-			BG_ClassBoundingBox( pClass, mins, maxs, nullptr, nullptr, nullptr );
-			BG_MoveOriginToBBOXCenter( center, mins, maxs );
-
 			// TODO: Interpolate when target entity pops in.
-			VectorCopy( center, beacon->origin );
+			SetClientBeaconPosition( targetCent, beacon );
 		}
 		else
 		{
@@ -229,34 +249,21 @@ static bool LoadImplicitBeacons()
 	{
 		for ( int clientNum = 0; clientNum < MAX_CLIENTS; clientNum++ )
 		{
-			centity_t     *ent;
-			entityState_t *es;
-			clientInfo_t  *client;
+			centity_t     *ent = &cg_entities[ clientNum ];
+			entityState_t *es = &ent->currentState;
+			clientInfo_t  *client = &cgs.clientinfo[ clientNum ];
 
 			// Can only track valid targets.
 			// TODO: Make beacons expire properly anyway.
-			if ( !( ent = &cg_entities[ clientNum ] )->valid )            continue;
+			if ( !ent->valid )                 continue;
 
 			// Only tag enemies like this, teammates have an explicit beacon.
-			if ( !( client = &cgs.clientinfo[ clientNum ] )->infoValid ) continue;
-			if ( client->team != TEAM_HUMANS )                           continue;
-
-			//ent = &cg_entities[ clientNum ];
-			es = &ent->currentState;
+			if ( !client->infoValid )          continue;
+			if ( client->team != TEAM_HUMANS ) continue;
 
 			cbeacon_t *beacon = &ent->beacon;
 
-			// Set location on exact center of target player entity.
-			{
-				vec3_t mins, maxs, center;
-				int pClass = ( ( es->misc >> 8 ) & 0xFF ); // TODO: Write function for this.
-
-				VectorCopy( ent->lerpOrigin, center );
-				BG_ClassBoundingBox( pClass, mins, maxs, nullptr, nullptr, nullptr );
-				BG_MoveOriginToBBOXCenter( center, mins, maxs );
-
-				VectorCopy( center, beacon->origin );
-			}
+			SetClientBeaconPosition( ent, beacon );
 
 			// Add alpha fade at the borders of the sense range.
 			beacon->alphaMod = Math::Clamp(
@@ -386,18 +393,6 @@ static void SetHighlightedBeacon()
 static inline bool IsHighlighted( const cbeacon_t *b )
 {
 	return cg.highlightedBeacon == b;
-}
-
-static team_t TargetTeam( const cbeacon_t *beacon )
-{
-	if ( beacon->type != BCT_TAG && beacon->type != BCT_BASE )
-		return TEAM_NONE;
-
-	if ( ( beacon->ownerTeam == TEAM_ALIENS && beacon->flags & EF_BC_ENEMY ) ||
-	     ( beacon->ownerTeam == TEAM_HUMANS && !( beacon->flags & EF_BC_ENEMY ) ) )
-		return TEAM_HUMANS;
-	else
-		return TEAM_ALIENS;
 }
 
 /**

--- a/src/sgame/Beacon.cpp
+++ b/src/sgame/Beacon.cpp
@@ -474,10 +474,13 @@ namespace Beacon //this should eventually become a class
 			BG_BoundingBox( static_cast<class_t>( parent->client->ps.stats[ STAT_CLASS ] ), &mins, &maxs, nullptr, nullptr, nullptr );
 			BG_MoveOriginToBBOXCenter( center, mins, maxs );
 
-			// Also update weapon for humans.
 			if( parent->client->pers.team == TEAM_HUMANS )
 			{
+				// Also update weapon for humans.
 				ent->s.bc_data = BG_GetPlayerWeapon( &parent->client->ps );
+				// Nudge the center a bit upwards for human players, so we don't look at their butt too much
+				float height = maxs.z - mins.z;
+				center.z += 0.3f * height;
 			}
 		}
 		else if ( parent->s.eType == entityType_t::ET_BUILDABLE )


### PR DESCRIPTION
## Problem description

>🔹️ onetpl: I'd like to add to the list of what i think should be changed: that the hexagon in the game is positioned on the players' backsides, and it should be moved up to their shoulders. It's super annoying to look on someone ass all game. (edited)
>🔹️ onetpl: ![image](https://github.com/user-attachments/assets/a679a71b-0e1b-4414-ae89-6887c94ee8eb)
>🔹️ illwieckz: 🤣
>🔹️ illwieckz: 🫣
>🔹️ onetpl: I new you will like my request 😄 (knew, would)
> 🔹️ illwieckz: not wrong!
> 🔹️ illwieckz: We may improve that indeed.

## Comparison of proposed solution

Before:

![Screenshot from 2024-10-24 15-17-43](https://github.com/user-attachments/assets/5bce0f2b-1d23-44f8-876a-0af7695680ae)
![Screenshot from 2024-10-24 15-12-14](https://github.com/user-attachments/assets/5977f5a5-83c5-4e34-b863-65af72f4a8dc)
![Screenshot from 2024-10-24 15-12-11](https://github.com/user-attachments/assets/4c39ec79-023d-4708-a171-f9c19409f06a)


After:

![Screenshot from 2024-10-24 15-25-08](https://github.com/user-attachments/assets/a7c478e5-59bd-4ec4-99e1-3295bcb1ae37)
![Screenshot from 2024-10-24 16-15-43](https://github.com/user-attachments/assets/8af1cd25-dd21-419d-8bee-03931262988f)
![Screenshot from 2024-10-24 16-14-34](https://github.com/user-attachments/assets/8c09d082-14a3-4607-8651-fb09899c67c7)
![Screenshot from 2024-10-24 16-14-15](https://github.com/user-attachments/assets/5ca7a694-f039-46d0-86f3-8608c2e7ea89)
