### PR TITLE
Enable SSAO in presets, don't mark it as experimental anymore

### DIFF
--- a/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
@@ -12,6 +12,7 @@ seta r_physicalMapping 1
 seta r_reliefMapping 0
 seta r_heatHaze 1
 seta r_bloom 1
+seta r_ssao 1
 seta r_subdivisions 4
 seta r_imageFitScreen 1
 seta r_imageMaxDimension 2048

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
@@ -12,6 +12,7 @@ seta r_physicalMapping 0
 seta r_reliefMapping 0
 seta r_heatHaze 0
 seta r_bloom 0
+seta r_ssao 0
 seta r_subdivisions 12
 seta r_imageFitScreen 2
 seta r_imageMaxDimension 256

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
@@ -12,6 +12,7 @@ seta r_physicalMapping 0
 seta r_reliefMapping 0
 seta r_heatHaze 0
 seta r_bloom 0
+seta r_ssao 0
 seta r_subdivisions 20
 seta r_imageFitScreen 2
 seta r_imageMaxDimension 16

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
@@ -12,6 +12,7 @@ seta r_physicalMapping 1
 seta r_reliefMapping 0
 seta r_heatHaze 0
 seta r_bloom 1
+seta r_ssao 0
 seta r_subdivisions 8
 seta r_imageFitScreen 1
 seta r_imageMaxDimension 512

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
@@ -12,6 +12,7 @@ seta r_physicalMapping 1
 seta r_reliefMapping 1
 seta r_heatHaze 1
 seta r_bloom 1
+seta r_ssao 1
 seta r_subdivisions 1
 seta r_imageFitScreen 1
 seta r_imageMaxDimension 4096

--- a/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
@@ -303,7 +303,7 @@
 				<row>
 					<h3><translate>Screen space ambient occlusion (SSAO)</translate></h3>
 					<input cvar="r_ssao" type="checkbox" />
-					<p><translate>Simulate dark corners.</translate>&nbsp;<translate>Experimental.</translate></p>
+					<p><translate>Simulate dark corners.</translate></p>
 				</row>
 				<row>
 					<h3><translate>Marks</translate></h3>


### PR DESCRIPTION
Once Fog is not behind SSAO:

- https://github.com/DaemonEngine/Daemon/pull/1408

We can mark this feature as non-experimental and enable it in presets.