### PR TITLE
bot behavior tree tracing: show name of running action

### DIFF
--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -404,7 +404,9 @@ static void ShowRunningNode( gentity_t *self, AINodeStatus_t status )
 	case STATUS_RUNNING:
 		ASSERT( !self->botMind->runningNodes.empty() );
 		ASSERT_EQ( self->botMind->runningNodes[ 0 ]->type, AINode_t::ACTION_NODE );
-		int line = reinterpret_cast<AIActionNode_t *>( self->botMind->runningNodes[ 0 ] )->lineNum;
+		AIActionNode_t *actionNode = reinterpret_cast<AIActionNode_t *>( self->botMind->runningNodes[ 0 ] );
+		int line = actionNode->lineNum;
+		const char *actionName = actionNode->name;
 		const char *tree = "<unknown>";
 		for ( const AIGenericNode_t *node : self->botMind->runningNodes )
 		{
@@ -414,7 +416,7 @@ static void ShowRunningNode( gentity_t *self, AINodeStatus_t status )
 				break;
 			}
 		}
-		Log::defaultLogger.WithoutSuppression().Notice( "%s^* running at %s.bt:%d", name, tree, line );
+		Log::defaultLogger.WithoutSuppression().Notice( "%s^* running at %s.bt:%d, action %s", name, tree, line, actionName );
 		break;
 	}
 }

--- a/src/sgame/sg_bot_ai.h
+++ b/src/sgame/sg_bot_ai.h
@@ -217,6 +217,7 @@ struct AIActionNode_t
 	AIValue_t    *params;
 	int          nparams;
 	int lineNum; // for debugging/tracing
+	const char *name; // for debugging/tracing
 };
 
 bool isBinaryOp( AIOpType_t op );

--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -1160,6 +1160,7 @@ static AIGenericNode_t *ReadActionNode( pc_token_list **tokenlist )
 		*tokenlist = current;
 		return nullptr;
 	}
+	node.name = action->name;
 
 	parenBegin = current->next;
 


### PR DESCRIPTION
This is not really neccessary, we already show the line number in the .bt file. But I find myself doing this frequently when I wonder what a bot is up to. Keeping the line numbers in my mind is an impediment to quick debug sessions.

One might object that this PR increases the debug overhead in `AIActionNode_t` from (roughly) a quarter to a third of its size.