### PR TITLE
add bot action buyPrimary

### DIFF
--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1847,7 +1847,7 @@ AINodeStatus_t BotActionBuyPrimary( gentity_t *self, AIGenericNode_t *node )
 
 	weapon_t weapon = ( weapon_t ) AIUnBoxInt( buy->params[ 0 ] );
 
-	if ( weapon < WP_NONE || weapon >= WP_NUM_WEAPONS )
+	if ( weapon <= WP_NONE || weapon >= WP_NUM_WEAPONS )
 	{
 		Log::Warn("parameter 1 to action buyPrimary out of range" );
 		return STATUS_FAILURE;

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1839,12 +1839,6 @@ AINodeStatus_t BotActionBuy( gentity_t *self, AIGenericNode_t *node )
 AINodeStatus_t BotActionBuyPrimary( gentity_t *self, AIGenericNode_t *node )
 {
 	AIActionNode_t *buy = ( AIActionNode_t * ) node;
-
-	if ( buy->nparams != 1 )
-	{
-		return STATUS_FAILURE;
-	}
-
 	weapon_t weapon = ( weapon_t ) AIUnBoxInt( buy->params[ 0 ] );
 
 	if ( weapon <= WP_NONE || weapon >= WP_NUM_WEAPONS )

--- a/src/sgame/sg_bot_ai.h
+++ b/src/sgame/sg_bot_ai.h
@@ -267,6 +267,7 @@ AINodeStatus_t BotActionEvolveTo( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotActionSay( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotActionBuy( gentity_t *self, AIGenericNode_t *node );
+AINodeStatus_t BotActionBuyPrimary( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotActionRepair( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotActionEvolve ( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotActionHeal( gentity_t *self, AIGenericNode_t *node );

--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -1086,6 +1086,7 @@ static const struct AIActionMap_s
 	{ "blackboardNoteTransient", BotActionBlackboardNoteTransient, 1, 1 },
 	{ "buildNowChosenBuildable", BotActionBuildNowChosenBuildable, 0, 0 },
 	{ "buy",               BotActionBuy,               1, 4 },
+	{ "buyPrimary",        BotActionBuyPrimary,        1, 1 },
 	{ "changeGoal",        BotActionChangeGoal,        1, 3 },
 	{ "classDodge",        BotActionClassDodge,        0, 0 },
 	{ "deactivateUpgrade", BotActionDeactivateUpgrade, 1, 1 },


### PR DESCRIPTION
A seperate bot action to make a human buy a weapon, and leave the rest of its equipment unchanged. Making our existing action `equip/buy` do this does not seem feasible. It already handles two seperate cases: let a bot choose everything to buy, or specifiy everything to buy as arguments.