### PR TITLE
human bots fight back when attacked while attacking an alien buildable

### DIFF
--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -2569,7 +2569,17 @@ void BotPain( gentity_t *self, gentity_t *attacker, int )
 		&& attacker->s.eType == entityType_t::ET_PLAYER
 		&& self->botMind->skillSet[BOT_B_PAIN] )
 	{
-
+		if ( G_Team( self ) == TEAM_HUMANS
+			 && self->botMind->goal.targetsValidEntity()
+			 && G_Team( self->botMind->goal.getTargetedEntity() ) == TEAM_ALIENS
+		     && self->botMind->goal.getTargetedEntity()->s.eType != entityType_t::ET_PLAYER
+		     && attacker->s.eType == entityType_t::ET_PLAYER )
+		{
+			// human bot is attacked by enemy player while busy attacking an
+			// enemy buildable: abort attacking the buildable, fight back instead
+			self->botMind->goal.clear();
+			BotResetEnemyQueue( &self->botMind->enemyQueue );
+		}
 		BotPushEnemy( &self->botMind->enemyQueue, attacker );
 	}
 }


### PR DESCRIPTION
Bots will attack an enemy buildable until it is destroyed or they are killed (or sometimes until they want to retreat to heal/buy/build/repair).

Alien bots will dance like crazy while they are attacking a human building. They are not that easy to kill while doing that.

Human bots, on the other hand, stand still and shoot when they are attacking an alien building. That makes them very easy to kill, as they do not fight back.

This PR makes a human bot abort its attack on an alien buildable as soon as it is damaged by an alien player (or bot). It will target the attacker instead.
