### PR TITLE
bot behaviors: use action buyPrimary

### DIFF
--- a/pkg/unvanquished_src.dpkdir/bots/build.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/build.bt
@@ -27,7 +27,7 @@ selector
 				condition !haveWeapon( WP_HBUILD )
 				selector
 				{
-					action buy( WP_HBUILD )
+					action buyPrimary( WP_HBUILD )
 					action suicide
 				}
 			}

--- a/pkg/unvanquished_src.dpkdir/bots/default_humans.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/default_humans.bt
@@ -37,7 +37,7 @@ selector
 						{
 							action equip
 						}
-						action buy( WP_HBUILD )
+						action buyPrimary( WP_HBUILD )
 					}
 					condition alertedToEnemy
 					{
@@ -73,7 +73,7 @@ selector
 				{
 					condition haveWeapon( WP_LUCIFER_CANNON ) && ( distanceTo( E_H_REACTOR ) <= 400 || distanceTo( E_H_ARMOURY ) <= 400 )
 					{
-						action buy( WP_PULSE_RIFLE )
+						action buyPrimary( WP_PULSE_RIFLE )
 					}
 				}
 				condition haveWeapon( WP_HBUILD ) && ( !buildingIsDamaged || teamateHasWeapon( WP_HBUILD ) )

--- a/pkg/unvanquished_src.dpkdir/bots/defend.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/defend.bt
@@ -40,7 +40,7 @@ selector
 					{
 						condition haveWeapon( WP_LUCIFER_CANNON ) && ( distanceTo( E_H_REACTOR ) <= 400 || distanceTo( E_H_ARMOURY ) <= 400 )
 						{
-							action buy( WP_PULSE_RIFLE )
+							action buyPrimary( WP_PULSE_RIFLE )
 						}
 					}
 					condition haveWeapon( WP_HBUILD ) && ( !buildingIsDamaged || teamateHasWeapon( WP_HBUILD ) )

--- a/pkg/unvanquished_src.dpkdir/bots/repair.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/repair.bt
@@ -17,7 +17,7 @@ sequence
 					{
 						action equip
 					}
-					action buy( WP_HBUILD )
+					action buyPrimary( WP_HBUILD )
 				}
 			}
 


### PR DESCRIPTION
Use the new bot action `buyPrimary` instead `buy`. For reference, we now have 3 methods to make a human bot buy:

- `action equip` - the bot sells everything and chooses what to buy autonomously
- `action buy(WP_SHOTGUN, UP_MEDIUMARMOUR, UP_JETPACK, UP_GRENADE)` - the bot sells everything and buys the listed things
- `action buyPrimary(WP_SHOTGUN)` - the bot only replaces its primary weapon

Currently, we do not intend to use the second method. This PR fixes a bug that makes bots use ckits/prifles without any armour. A bot might still be seen with a ckit and no armor: either if it is too poor for armour or spawned with the ckit.