### PR TITLE
human bots buy jetpacks

### DIFF
--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -508,6 +508,16 @@ void G_BotThink( gentity_t *self )
 		ShowRunningNode( self, status );
 	}
 
+	// if we have a jetpack and are falling too fast: fire it
+	if ( G_Team( self ) == TEAM_HUMANS && BG_InventoryContainsUpgrade( UP_JETPACK, self->client->ps.stats ) )
+	{
+		glm::vec3 ownVelocity = VEC2GLM( self->client->ps.velocity );
+		if ( ownVelocity.z < -300 )
+		{
+			self->botMind->cmdBuffer.upmove = 127;
+		}
+	}
+
 	// if we were nudged...
 	VectorAdd( self->client->ps.velocity, nudge, self->client->ps.velocity );
 

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -873,6 +873,16 @@ static bool TargetInOffmeshAttackRange( gentity_t *self )
 	}
 }
 
+static void BotActivateJetpack( gentity_t *self )
+{
+	if ( BG_InventoryContainsUpgrade( UP_JETPACK, self->client->ps.stats )
+		 && self->client->ps.stats[ STAT_FUEL ] > JETPACK_FUEL_MAX / 4
+		 )
+	{
+		self->botMind->cmdBuffer.upmove = 127;
+	}
+}
+
 // TODO: Move decision making out of these actions and into the rest of the behavior tree
 AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 {
@@ -1032,6 +1042,14 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 
 	// We are human and we either are at fire range, or have
 	// a direct path to goal
+
+	glm::vec3 ownPos = VEC2GLM( self->s.origin );
+	glm::vec3 targetPos = mind->goal.getPos();
+	if ( ownPos.z < targetPos.z + 400 )
+	{
+		// activate the jetpack if we have it, but do not fly too high above the enemy
+		BotActivateJetpack( self );
+	}
 
 	if ( mind->skillLevel >= 3 && goalDist < Square( MAX_HUMAN_DANCE_DIST )
 	        && ( goalDist > Square( MIN_HUMAN_DANCE_DIST ) || mind->skillLevel < 5 )

--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -203,6 +203,7 @@ equipment_t<upgrade_t> armors[] =
 equipment_t<upgrade_t> others[] =
 {
 	{ g_bot_radar   , UP_RADAR },
+	{ g_bot_jetpack , UP_JETPACK },
 	{ g_bot_grenade , UP_GRENADE },
 	{ g_bot_firebomb, UP_FIREBOMB },
 };
@@ -297,7 +298,11 @@ static int GetMaxEquipmentCost( gentity_t const* self )
 					}
 				}
 
-				if( canUseBackpack && g_bot_radar.Get() && BG_UpgradeUnlocked( UP_RADAR ) )
+				if( canUseBackpack && g_bot_jetpack.Get() && BG_UpgradeUnlocked( UP_JETPACK ) )
+				{
+					max_item_val += BG_Upgrade( UP_JETPACK )->price;
+				}
+				else if( canUseBackpack && g_bot_radar.Get() && BG_UpgradeUnlocked( UP_RADAR ) )
 				{
 					max_item_val += BG_Upgrade( UP_RADAR )->price;
 				}
@@ -720,6 +725,17 @@ int BotGetDesiredBuy( gentity_t *self, weapon_t &weapon, upgrade_t upgrades[], s
 		upgrades[numUpgrades] = others[0].item;
 		usableCapital -= others[0].price();
 		usedSlots |= others[0].slots();
+		numUpgrades ++;
+	}
+	else if ( numUpgrades > 0
+			  && others[1].canBuyNow() && usableCapital >= others[1].price()
+			  && ( usedSlots & others[1].slots() ) == 0
+			  && numUpgrades < upgradesSize
+			  && usableCapital >= 600 )
+	{
+		upgrades[numUpgrades] = others[1].item;
+		usableCapital -= others[1].price();
+		usedSlots |= others[1].slots();
 		numUpgrades ++;
 	}
 	};

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -295,7 +295,7 @@ Cvar::Cvar<bool> g_bot_lightarmour("g_bot_lightarmour", "whether bots buy Light 
 Cvar::Cvar<bool> g_bot_radar("g_bot_radar", "whether bots buy the Radar", Cvar::NONE, true);
 // bots won't buy radars if more than this percent allies already have it
 Cvar::Cvar<int> g_bot_radarRatio("g_bot_radarRatio", "bots target x% of team owning radar", Cvar::NONE, 75);
-Cvar::Cvar<bool> g_bot_jetpack("g_bot_jetpack", "whether bots buy the Jetpack", Cvar::NONE, false);
+Cvar::Cvar<bool> g_bot_jetpack("g_bot_jetpack", "whether bots buy the Jetpack", Cvar::NONE, true);
 Cvar::Cvar<bool> g_bot_grenade("g_bot_grenade", "whether bots buy the Grenade", Cvar::NONE, false);
 Cvar::Cvar<bool> g_bot_firebomb("g_bot_firebomb", "whether bots buy the Firebomb", Cvar::NONE, false);
 


### PR DESCRIPTION
Make human bots buy jetpacks, but only if they do not want radars instead (as specified by `g_bot_radarRatio`).

This PR does not provide different navcons for jetpack bots, a future PR will address this. The jetpack bots will only use their jetpacks in two cases for now:

- They are fighting a visible enemy
- They are falling too fast

Once the battlesuit is unlocked, bots will prefer it. So the jetpack bots will be rather rare with this PR.