### PR TITLE
Fix some divisions by zero

### DIFF
--- a/src/cgame/cg_particles.cpp
+++ b/src/cgame/cg_particles.cpp
@@ -2123,9 +2123,8 @@ Calculate the fraction of time passed
 */
 static float CG_CalculateTimeFrac( int birth, int life, int delay )
 {
-	float frac = ( ( float ) cg.time - ( float )( birth + delay ) ) / ( float )( life - delay );
-
-	return Math::Clamp( frac, 0.0f, 1.0f );
+	int diff = life - delay;
+	return diff ? Math::Clamp( (float) (cg.time - birth + delay) / (float) diff, 0.0f, 1.0f ) : 1.0f;
 }
 
 /*

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -1523,8 +1523,8 @@ static void CG_AddReverbEffects( vec3_t loc )
 		}
 
 		dist = CM_DistanceToModel( loc, cgs.gameReverbModels[i] );
-		weight = 1.0f - dist / cgs.gameReverbDistances[i];
-		weight = Math::Clamp( weight, 0.0f, 1.0f ); // Maths::clampFraction( weight )
+
+		weight = 1.0f - dist / std::max( 0.01f, cgs.gameReverbDistances[i] );
 
 		// search 3 greatest weights
 		if( weight <= selectedWeight[2] )

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -175,7 +175,7 @@ void AIDestroyValue( AIValue_t v )
 static botEntityAndDistance_t ClosestBuilding(gentity_t *self, bool alignment)
 {
 	botEntityAndDistance_t result;
-	result.distance = HUGE_QFLT;
+	result.distance = HUGE_DISTANCE;
 	result.ent = nullptr;
 	ForEntities<BuildableComponent>([&](Entity& e, BuildableComponent&) {
 		if (!e.Get<HealthComponent>()->Alive() ||
@@ -193,7 +193,7 @@ static botEntityAndDistance_t ClosestBuilding(gentity_t *self, bool alignment)
 
 botEntityAndDistance_t AIEntityToGentity( gentity_t *self, AIEntity_t e )
 {
-	static const botEntityAndDistance_t nullEntity = { nullptr, HUGE_QFLT };
+	static const botEntityAndDistance_t nullEntity = { nullptr, HUGE_DISTANCE };
 	botEntityAndDistance_t              ret = nullEntity;
 
 	if ( e > E_NONE && e < E_NUM_BUILDABLES )

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -2148,11 +2148,13 @@ static void G_EvaluateAcceleration( gentity_t *ent, int msec )
 	vec3_t deltaVelocity;
 	vec3_t deltaAccel;
 
+	float inv_msec = msec ? 1.0f / msec : 1.0f;
+
 	VectorSubtract( ent->s.pos.trDelta, ent->oldVelocity, deltaVelocity );
-	VectorScale( deltaVelocity, 1.0f / ( float ) msec, ent->acceleration );
+	VectorScale( deltaVelocity, inv_msec, ent->acceleration );
 
 	VectorSubtract( ent->acceleration, ent->oldAccel, deltaAccel );
-	VectorScale( deltaAccel, 1.0f / ( float ) msec, ent->jerk );
+	VectorScale( deltaAccel, inv_msec, ent->jerk );
 
 	VectorCopy( ent->s.pos.trDelta, ent->oldVelocity );
 	VectorCopy( ent->acceleration, ent->oldAccel );

--- a/src/sgame/sg_spawn.cpp
+++ b/src/sgame/sg_spawn.cpp
@@ -1160,10 +1160,15 @@ void G_SpawnEntitiesFromString()
 
 void G_SpawnFakeEntities()
 {
+	/* The previous outOfRange value of 1.7e19f was doing an overflow
+	when calling VectorLengthSquared( eloc->r.currentOrigin )
+	in GetCloseLocationEntity() from sg_team.cpp. */
+	float outOfRange = HUGE_DISTANCE;
+
 	level.fakeLocation = G_NewEntity( NO_CBSE );
 	level.fakeLocation->s.origin[ 0 ] =
 	level.fakeLocation->s.origin[ 1 ] =
-	level.fakeLocation->s.origin[ 2 ] = 1.7e19f; // well out of range
+	level.fakeLocation->s.origin[ 2 ] = outOfRange;
 	level.fakeLocation->mapEntity.message = nullptr;
 
 	level.fakeLocation->s.eType = entityType_t::ET_LOCATION;

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -62,7 +62,6 @@ glm::vec3 VEC2GLM( const rVec& ) = delete;
 // with a mutable vec3_t argument.
 #define GLM4RW( v ) ( glm4rw_impl( v ).data )
 
-
 inline std::array<const vec_t, 3> glm4read_impl( const glm::vec3 &v ) { return { v.x, v.y, v.z }; }
 
 struct glm4rw_impl
@@ -81,6 +80,10 @@ struct glm4rw_impl
 };
 
 #include "engine/qcommon/q_shared.h"
+
+/* Big enough that no one could confuse it with a normal distance,
+but small enough that it won't cause overflows. */
+constexpr float HUGE_DISTANCE = 1e15f;
 
 //Unvanquished balance header
 #include "bg_gameplay.h"


### PR DESCRIPTION
Before those patches, I was getting the following errors when doing `feenableexcept(FE_DIVBYZERO);`.

I added one patch that copy-pastes a fix from one code to another code that looks very close, as maybe it can happen too but would require some other testing scenes.

Clang 19, RelWithDebInfo build (yes, this one looks weird, but it disappears once the patches are applied, probably some optimization obfuscating the produced code too much for the debugger):

```
Thread 27 "daemon" received signal SIGFPE, Arithmetic exception.

0x00007fcdd6ef92b6 in G_RunFrame (levelTime=<optimized out>) at Unvanquished/src/sgame/sg_main.cpp:2252
2252		for ( i = 0; i < level.num_entities; i++, ent++ )

Thread 27 (Thread 0x7fcdd6c006c0 (LWP 1005469) "daemon"):
#0  0x00007fcdd6ef92b6 in G_RunFrame (levelTime=<optimized out>) at Unvanquished/src/sgame/sg_main.cpp:2252
```

```
Thread 28 "daemon" received signal SIGFPE, Arithmetic exception.

0x000077865e78eebf in CG_CalcColorGradingForPoint (loc=<optimized out>) at Unvanquished/src/cgame/cg_view.cpp:1418
1418		cg.refdef.gradingWeights[1] = haveGlobal ? ( 1.0f - totalWeight ) : ( selectedWeight[0] / totalWeight );

Thread 28 (Thread 0x77868cc006c0 (LWP 1383380) "daemon"):
#0  0x000077865e78eebf in CG_CalcColorGradingForPoint (loc=<optimized out>) at Unvanquished/src/cgame/cg_view.cpp:1418
#1  CG_CalcViewValues () at Unvanquished/src/cgame/cg_view.cpp:1685
#2  CG_DrawActiveFrame (serverTime=<optimized out>, demoPlayback=<optimized out>) at Unvanquished/src/cgame/cg_view.cpp:1966
```

Clang 19, Debug build:

```
Thread 28 "daemon" received signal SIGFPE, Arithmetic exception.

0x000074981277eb79 in CG_AddReverbEffects (loc=0x749812bbb2f4 <cg+1140>) at Unvanquished/src/cgame/cg_view.cpp:1554
1554			weight = 1.0f - dist / cgs.gameReverbDistances[i];

Thread 28 (Thread 0x7498374006c0 (LWP 1038016) "daemon"):
#0  0x000074981277eb79 in CG_AddReverbEffects (loc=0x749812bbb2f4 <cg+1140>) at Unvanquished/src/cgame/cg_view.cpp:1554
#1  0x000074981277d8e7 in CG_CalcViewValues () at Unvanquished/src/cgame/cg_view.cpp:1687
#2  0x000074981277d6bf in CG_DrawActiveFrame (serverTime=1125, demoPlayback=false) at Unvanquished/src/cgame/cg_view.cpp:1965
```

GCC 14, RelWithDebInfo build:

```
Thread 27 "daemon" received signal SIGFPE, Arithmetic exception.

0x000076ecef710776 in G_EvaluateAcceleration (ent=<optimized out>, msec=<optimized out>) at Unvanquished/src/sgame/sg_main.cpp:2151
2151		VectorScale( deltaVelocity, 1.0f / ( float ) msec, ent->acceleration );

Thread 27 (Thread 0x76ed07c006c0 (LWP 1337649) "daemon"):
#0  0x000076ecef710776 in G_EvaluateAcceleration (ent=<optimized out>, msec=<optimized out>) at Unvanquished/src/sgame/sg_main.cpp:2151
#1  G_RunFrame (levelTime=<optimized out>) at Unvanquished/src/sgame/sg_main.cpp:2283
#2  0x000076ecef6c5924 in operator() (__closure=<optimized out>, levelTime=<optimized out>) at Unvanquished/src/sgame/sg_api.cpp:131
```

```
Thread 42 "daemon" received signal SIGFPE, Arithmetic exception.

0x0000790e5276263b in CG_CalculateTimeFrac (birth=<optimized out>, life=<optimized out>, delay=<optimized out>) at Unvanquished/src/cgame/cg_particles.cpp:2126

Thread 42 (Thread 0x790ed8c006c0 (LWP 1831090) "daemon"):
#0  0x0000790e5276263b in CG_CalculateTimeFrac (birth=<optimized out>, life=<optimized out>, delay=<optimized out>) at Unvanquished/src/cgame/cg_particles.cpp:2126
#1  CG_RenderParticle (p=p@entry=0x790e53e55b40 <particles+1152>) at Unvanquished/src/cgame/cg_particles.cpp:2521
#2  0x0000790e527655f7 in CG_AddParticles () at Unvanquished/src/cgame/cg_particles.cpp:2668
#3  0x0000790e527ac215 in CG_DrawActiveFrame (serverTime=<optimized out>, demoPlayback=<optimized out>) at Unvanquished/src/cgame/cg_view.cpp:2001
#4  0x0000790e5272b201 in operator() (__closure=<optimized out>, serverTime=<optimized out>, demoPlayback=<optimized out>) at Unvanquished/src/cgame/cg_api.cpp:88
```