### PR TITLE
The jetpack navcon hack

### DIFF
--- a/src/sgame/botlib/bot_nav.cpp
+++ b/src/sgame/botlib/bot_nav.cpp
@@ -99,6 +99,24 @@ void G_BotSetNavMesh( int botClientNum, class_t newClass )
 {
 	newClass = NavmeshForClass( newClass, g_bot_navmeshReduceTypes.Get() );
 
+	gentity_t *self = &g_entities[ botClientNum ];
+	switch ( self->client->ps.stats[ STAT_CLASS ] )
+	{
+	case PCL_HUMAN_NAKED:
+	case PCL_HUMAN_LIGHT:
+	case PCL_HUMAN_MEDIUM:
+		if ( BG_InventoryContainsUpgrade( UP_JETPACK, self->client->ps.stats ) )
+		{
+			newClass = PCL_HUMAN_LIGHT;
+		}
+		else
+		{
+			newClass = PCL_HUMAN_NAKED;
+		}
+	default:
+		break;
+	}
+
 	NavData_t *nav = nullptr;
 
 	for ( int i = 0; i < numNavData; i++ )

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -427,6 +427,8 @@ Bot Thinks
 =======================
 */
 
+static Cvar::Cvar<float> g_bot_jetpackTimeout("g_bot_jetpackTimeout", "time in milliseconds until a jetpack flight is aborted", Cvar::NONE, 10000);
+
 void G_BotThink( gentity_t *self )
 {
 	char buf[MAX_STRING_CHARS];
@@ -515,6 +517,20 @@ void G_BotThink( gentity_t *self )
 		if ( ownVelocity.z < -300 )
 		{
 			self->botMind->cmdBuffer.upmove = 127;
+		}
+		// clear jetpack state after some time
+		switch ( self->botMind->jetpackState )
+		{
+		case BOT_JETPACK_NAVCON_WAITING:
+		case BOT_JETPACK_NAVCON_FLYING:
+		case BOT_JETPACK_NAVCON_LANDING:
+			if ( level.time > self->botMind->lastNavconTime + g_bot_jetpackTimeout.Get() )
+			{
+				self->botMind->jetpackState = BOT_JETPACK_NONE;
+			}
+			break;
+		default:
+			break;
 		}
 	}
 

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -873,14 +873,18 @@ static bool TargetInOffmeshAttackRange( gentity_t *self )
 	}
 }
 
-static void BotActivateJetpack( gentity_t *self )
+static void BotActivateJetpack( gentity_t *self, int fuelLimit )
 {
-	if ( BG_InventoryContainsUpgrade( UP_JETPACK, self->client->ps.stats )
-		 && self->client->ps.stats[ STAT_FUEL ] > JETPACK_FUEL_MAX / 4
-		 )
+	if ( !BG_InventoryContainsUpgrade( UP_JETPACK, self->client->ps.stats ) )
 	{
-		self->botMind->cmdBuffer.upmove = 127;
+		return;
 	}
+	int fuel = self->client->ps.stats[ STAT_FUEL ];
+	if ( fuel < fuelLimit )
+	{
+		return;
+	}
+	self->botMind->cmdBuffer.upmove = 127;
 }
 
 // TODO: Move decision making out of these actions and into the rest of the behavior tree
@@ -1047,8 +1051,7 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 	glm::vec3 targetPos = mind->goal.getPos();
 	if ( ownPos.z < targetPos.z + 400 )
 	{
-		// activate the jetpack if we have it, but do not fly too high above the enemy
-		BotActivateJetpack( self );
+		BotActivateJetpack( self, JETPACK_FUEL_MAX / 4 );
 	}
 
 	if ( mind->skillLevel >= 3 && goalDist < Square( MAX_HUMAN_DANCE_DIST )
@@ -1079,6 +1082,25 @@ AINodeStatus_t BotActionFight( gentity_t *self, AIGenericNode_t *node )
 	if ( inAttackRange && self->botMind->goal.getTargetType() == entityType_t::ET_BUILDABLE )
 	{
 		BotStandStill( self );
+		// try to complete navcon flight: fire jetpack and move to target
+		switch ( self->botMind->jetpackState )
+		{
+		case BOT_JETPACK_NAVCON_FLYING:
+		case BOT_JETPACK_NAVCON_LANDING:
+			BotActivateJetpack( self, 0 );
+			if ( targetPos.z - 100 > ownPos.z )
+			{
+				BotMoveInDir( self, MOVE_FORWARD );
+			}
+			if ( targetPos.z < ownPos.z // maybe use g_bot_jetpackOvershootZ
+				|| self->client->ps.stats[ STAT_FUEL ] < JETPACK_FUEL_MAX / 16 )
+			{
+				self->botMind->jetpackState = BOT_JETPACK_NONE;
+			}
+			break;
+		default:
+			break;
+		}
 	}
 
 	if ( !BotWalkIfStaminaLow( self ) )
@@ -1830,6 +1852,9 @@ AINodeStatus_t BotActionBuy( gentity_t *self, AIGenericNode_t *node )
 
 	if ( GoalInRange( self, ENTITY_USE_RANGE ) )
 	{
+		auto jetpackHackClass = [&] () {
+			G_BotSetNavMesh( self - g_entities, (class_t) self->client->ps.stats[ STAT_CLASS ] );
+		};
 		BotSellUpgrades( self );
 		BotSellWeapons( self );
 
@@ -1837,6 +1862,7 @@ AINodeStatus_t BotActionBuy( gentity_t *self, AIGenericNode_t *node )
 		{
 			if ( !BotBuyUpgrade( self, upgrades[i] ) )
 			{
+				jetpackHackClass();
 				return STATUS_FAILURE;
 			}
 		}
@@ -1845,6 +1871,7 @@ AINodeStatus_t BotActionBuy( gentity_t *self, AIGenericNode_t *node )
 		{
 			if ( !BotBuyWeapon( self, weapon ) )
 			{
+				jetpackHackClass();
 				return STATUS_FAILURE;
 			}
 
@@ -1855,6 +1882,7 @@ AINodeStatus_t BotActionBuy( gentity_t *self, AIGenericNode_t *node )
 			}
 		}
 
+		jetpackHackClass();
 		return STATUS_SUCCESS;
 	}
 

--- a/src/sgame/sg_bot_local.h
+++ b/src/sgame/sg_bot_local.h
@@ -128,6 +128,14 @@ enum bot_skill
 
 using skillSet_t = std::bitset<BOT_NUM_SKILLS>;
 
+enum botJetpackState_t
+{
+	BOT_JETPACK_NONE,
+	BOT_JETPACK_NAVCON_WAITING,
+	BOT_JETPACK_NAVCON_FLYING,
+	BOT_JETPACK_NAVCON_LANDING,
+};
+
 #define MAX_NODE_DEPTH 20
 struct AIBehaviorTree_t;
 struct AIGenericNode_t;
@@ -186,6 +194,8 @@ public:
 	// Transient caches. These are populated before each think and valid for only one frame {
 		botEntityAndDistance_t bestEnemy;
 		botEntityAndDistance_t closestDamagedBuilding; // friendly only
+
+	botJetpackState_t jetpackState;
 
 		// For allied buildable types: closest alive and active buildable
 		// For enemy buildable types: closest alive buildable with a tag beacon

--- a/src/shared/bot_nav_shared.h
+++ b/src/shared/bot_nav_shared.h
@@ -258,7 +258,7 @@ inline class_t NavmeshForClass( class_t species, bool reduceTypes )
 	// Naked, Light, and Medium human forms are truly identical.
 	// Battlesuit is taller, but otherwise the same.
 	case PCL_HUMAN_NAKED:
-	case PCL_HUMAN_LIGHT:
+	//case PCL_HUMAN_LIGHT:
 	case PCL_HUMAN_MEDIUM:
 		return reduceTypes ? PCL_HUMAN_BSUIT : PCL_HUMAN_NAKED;
 


### PR DESCRIPTION
This is a _working_ implementation of jetpack navcons. It is a little more controversial than my usual PRs, but some people are a little exited about this. So I put it here to avoid it being lost in time.

The controversial part: I generate a navmesh for the human_light class, which we are not doing currently (we make the class human_light use the human_naked navmesh). This gives us a free navcon file `<map>-human_light.navcon`, to use as we please. When a bot buys equipment, I make it use the human_light navmesh iff it buys a jetpack.

While it is conceivable to want a different navmesh for jetpacks, this is probably overkill.

The navcon handling itself is similar to what the alien bots do, but uses a 3 state method. The three states are:
- `BOT_JETPACK_NAVCON_WAITING` - wait for enough fuel to make the flight
- `BOT_JETPACK_NAVCON_FLYING` - fly up vertically until the desired height is reached
- `BOT_JETPACK_NAVCON_LANDING` - fly forward to land