### PR TITLE
add BT decorator mapResult, the universal decorator

### DIFF
--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -425,8 +425,8 @@ AINodeStatus_t BotDecoratorMapStatus( gentity_t *self, AIGenericNode_t *node )
 {
 	AIDecoratorNode_t *dec = ( AIDecoratorNode_t * ) node;
 
-	AINodeStatus_t result;
-	switch ( BotEvaluateNode( self, dec->child ) )
+	AINodeStatus_t result = BotEvaluateNode( self, dec->child );
+	switch ( result )
 	{
 	case STATUS_FAILURE:
 		result = ( AINodeStatus_t ) AIUnBoxInt( dec->params[ 0 ] );
@@ -436,6 +436,9 @@ AINodeStatus_t BotDecoratorMapStatus( gentity_t *self, AIGenericNode_t *node )
 		break;
 	case STATUS_RUNNING:
 		result = ( AINodeStatus_t ) AIUnBoxInt( dec->params[ 2 ] );
+		break;
+	default:
+		// the child node's result is none of the three, return it unchanged
 		break;
 	}
 

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -428,13 +428,13 @@ AINodeStatus_t BotDecoratorMapStatus( gentity_t *self, AIGenericNode_t *node )
 	AINodeStatus_t result;
 	switch ( BotEvaluateNode( self, dec->child ) )
 	{
-	case STATUS_RUNNING:
+	case STATUS_FAILURE:
 		result = ( AINodeStatus_t ) AIUnBoxInt( dec->params[ 0 ] );
 		break;
 	case STATUS_SUCCESS:
 		result = ( AINodeStatus_t ) AIUnBoxInt( dec->params[ 1 ] );
 		break;
-	case STATUS_FAILURE:
+	case STATUS_RUNNING:
 		result = ( AINodeStatus_t ) AIUnBoxInt( dec->params[ 2 ] );
 		break;
 	}

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -421,6 +421,27 @@ AINodeStatus_t BotDecoratorReturn( gentity_t *self, AIGenericNode_t *node )
 	return status;
 }
 
+AINodeStatus_t BotDecoratorMapStatus( gentity_t *self, AIGenericNode_t *node )
+{
+	AIDecoratorNode_t *dec = ( AIDecoratorNode_t * ) node;
+
+	AINodeStatus_t result;
+	switch ( BotEvaluateNode( self, dec->child ) )
+	{
+	case STATUS_RUNNING:
+		result = ( AINodeStatus_t ) AIUnBoxInt( dec->params[ 0 ] );
+		break;
+	case STATUS_SUCCESS:
+		result = ( AINodeStatus_t ) AIUnBoxInt( dec->params[ 1 ] );
+		break;
+	case STATUS_FAILURE:
+		result = ( AINodeStatus_t ) AIUnBoxInt( dec->params[ 2 ] );
+		break;
+	}
+
+	return result;
+}
+
 static bool EvalConditionExpression( gentity_t *self, AIExpType_t *exp );
 
 static double EvalFunc( gentity_t *self, AIExpType_t *exp )

--- a/src/sgame/sg_bot_ai.h
+++ b/src/sgame/sg_bot_ai.h
@@ -248,6 +248,7 @@ AINodeStatus_t BotConcurrentNode( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotDecoratorInvert( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotDecoratorTimer( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotDecoratorReturn( gentity_t *self, AIGenericNode_t *node );
+AINodeStatus_t BotDecoratorMapStatus( gentity_t *self, AIGenericNode_t *node );
 
 // included behavior trees
 AINodeStatus_t BotBehaviorNode( gentity_t *self, AIGenericNode_t *node );

--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -988,6 +988,7 @@ static const struct AIDecoratorMap_s
 } AIDecorators[] =
 {
 	{ "invert", BotDecoratorInvert, 0, 0 },
+	{ "mapStatus", BotDecoratorMapStatus, 3, 3},
 	{ "return", BotDecoratorReturn, 1, 1 },
 	{ "timer", BotDecoratorTimer, 1, 1 }
 };


### PR DESCRIPTION
I am trying to tame unconventional control constructs like `fallback` and `concurrent`. Their semantics frequently cause confusion. A lot of what they do can be done by using appropriate decorators. This PR brings the universal decorator, which can implement any decorator.

It is written as `decorator mapStatus( <running>, <success>, <failure> )`. Each of `<running>, <success>, <failure>` can be one of `STATUS_RUNNING, STATUS_SUCCESS, STATUS_FAILURE`. The child node's status is mapped to the status specified that way.

For instance, `decorator return ( STATUS_SUCCESS )` is equivalent to `decorator mapStatus( STATUS_SUCCESS, STATUS_SUCCESS, STATUS_SUCCESS )`.

`decorator invert` is equivalent to `decorator mapStatus( STATUS_RUNNING, STATUS_FAILURE, STATUS_SUCCESS )`.

Any of the 27 possible decorators is equivalent to some invocation of `mapStatus`.

Control constructs like `fallback` can be implemented too.

```
fallback
{
	action fight
	action roam
}
```

Is equivalent to

```
decorator mapStatus( STATUS_RUNNING, STATUS_FAILURE, STATUS_SUCCESS )
{
	sequence
	{
		decorator mapStatus( STATUS_RUNNING, STATUS_FAILURE, STATUS_SUCCESS )
		{
			action fight
		}
		decorator mapStatus( STATUS_RUNNING, STATUS_FAILURE, STATUS_SUCCESS )
		{
			action roam
		}
	}
}
```

(The outermost decorator is not needed if this is the tree's root)

In this case, `decorator invert` would have been enough, but you get the idea.

Using this PR, we could choose to implement the majority of conceivable control structures as syntactic sugar for `sequence, selector, mapStatus`.

More importantly, we do not have to consider adding new and subtly different control structures anymore. A BT programmer only has to understand how `sequence` and `selector` work, as everything else can be constructed when needed.