### PR TITLE
add BT files build.bt, subroutine_become_builder_*.bt

### DIFF
--- a/pkg/unvanquished_src.dpkdir/bots/build.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/build.bt
@@ -1,0 +1,118 @@
+selectClass
+{
+	selector
+	{
+		condition team == TEAM_ALIENS
+		{
+			spawnAs PCL_ALIEN_BUILDER0
+		}
+		condition team == TEAM_HUMANS
+		{
+			spawnAs WP_HBUILD
+		}
+	}
+}
+
+selector
+{
+	condition team == TEAM_HUMANS
+	{
+		selector
+		{
+			behavior subroutine_use_medkit
+
+			sequence
+			{
+				condition cvar( "g_bot_buildHumans" )
+					&& usableBuildPoints >= chosenBuildableCost
+				selector
+				{
+					behavior subroutine_become_builder_humans
+
+					condition distanceTo( E_H_REACTOR ) <= 700
+					{
+						decorator return( STATUS_FAILURE )
+						{
+							action buildNowChosenBuildable
+						}
+					}
+					action roamInRadius( E_H_REACTOR, 700 )
+					action roam
+				}
+			}
+
+			decorator return ( STATUS_FAILURE )
+			{
+				action resetMyTimer
+			}
+
+			behavior subroutine_fight_or_flight_humans
+			behavior subroutine_repair
+			behavior subroutine_reload
+			action equip
+
+			condition percentAmmoClip == 0 && percentClips == 0
+			{
+				// refill at a suitable building
+				// TODO: reload energy weapons at reactor etc
+				action moveTo( E_H_ARMOURY )
+			}
+
+			sequence
+			{
+				// the bot cannot refill or equip, it must fight with the blaster
+				condition alertedToEnemy
+				action fight
+			}
+
+			condition baseRushScore > 0.5
+			{
+				action rush
+			}
+
+			action roam
+		}
+	}
+
+	condition team == TEAM_ALIENS
+	{
+		selector
+		{
+			sequence
+			{
+				condition cvar( "g_bot_buildAliens" )
+					&& usableBuildPoints >= chosenBuildableCost
+				selector
+				{
+					behavior subroutine_become_builder_aliens
+
+					condition distanceTo( E_A_OVERMIND) <= 700
+					{
+						decorator return( STATUS_FAILURE )
+						{
+							action buildNowChosenBuildable
+						}
+					}
+					action roamInRadius( E_A_OVERMIND, 700 )
+					action roam
+				}
+			}
+
+			decorator return ( STATUS_FAILURE )
+			{
+				action resetMyTimer
+			}
+
+			behavior subroutine_extinguish_fire
+			behavior subroutine_evolve
+			behavior subroutine_fight_or_flight_aliens
+
+			condition baseRushScore > 0.5
+			{
+				action rush
+			}
+
+			action roam
+		}
+	}
+}

--- a/pkg/unvanquished_src.dpkdir/bots/build_here.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/build_here.bt
@@ -1,0 +1,118 @@
+selectClass
+{
+	selector
+	{
+		condition team == TEAM_ALIENS
+		{
+			spawnAs PCL_ALIEN_BUILDER0
+		}
+		condition team == TEAM_HUMANS
+		{
+			spawnAs WP_HBUILD
+		}
+	}
+}
+
+selector
+{
+	condition team == TEAM_HUMANS
+	{
+		selector
+		{
+			behavior subroutine_use_medkit
+
+			sequence
+			{
+				condition cvar( "g_bot_buildHumans" )
+					&& usableBuildPoints >= chosenBuildableCost
+				selector
+				{
+					behavior subroutine_become_builder_humans
+
+					condition distanceToSpecifiedPosition <= 700
+					{
+						decorator return( STATUS_FAILURE )
+						{
+							action buildNowChosenBuildable
+						}
+					}
+					action stayHere( 700 )
+					action roam
+				}
+			}
+
+			decorator return ( STATUS_FAILURE )
+			{
+				action resetMyTimer
+			}
+
+			behavior subroutine_fight_or_flight_humans
+			behavior subroutine_repair
+			behavior subroutine_reload
+			action equip
+
+			condition percentAmmoClip == 0 && percentClips == 0
+			{
+				// refill at a suitable building
+				// TODO: reload energy weapons at reactor etc
+				action moveTo( E_H_ARMOURY )
+			}
+
+			sequence
+			{
+				// the bot cannot refill or equip, it must fight with the blaster
+				condition alertedToEnemy
+				action fight
+			}
+
+			condition baseRushScore > 0.5
+			{
+				action rush
+			}
+
+			action roam
+		}
+	}
+
+	condition team == TEAM_ALIENS
+	{
+		selector
+		{
+			sequence
+			{
+				condition cvar( "g_bot_buildAliens" )
+					&& usableBuildPoints >= chosenBuildableCost
+				selector
+				{
+					behavior subroutine_become_builder_aliens
+
+					condition distanceToSpecifiedPosition <= 700
+					{
+						decorator return( STATUS_FAILURE )
+						{
+							action buildNowChosenBuildable
+						}
+					}
+					action stayHere( 700 )
+					action roam
+				}
+			}
+
+			decorator return ( STATUS_FAILURE )
+			{
+				action resetMyTimer
+			}
+
+			behavior subroutine_extinguish_fire
+			behavior subroutine_evolve
+			behavior subroutine_fight_or_flight_aliens
+
+			condition baseRushScore > 0.5
+			{
+				action rush
+			}
+
+			action roam
+		}
+	}
+}

--- a/pkg/unvanquished_src.dpkdir/bots/default_aliens.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/default_aliens.bt
@@ -21,38 +21,14 @@ selector
 				action blackboardNoteTransient( WANTS_TO_BUILD )
 			}
 
-			sequence
-			{
-				condition class != PCL_ALIEN_BUILDER0 && class != PCL_ALIEN_BUILDER0_UPG
-				selector
-				{
-					condition myTimer >= 20000
-					{
-						action suicide
-					}
-					action evolveTo( PCL_ALIEN_BUILDER0_UPG )
-					action evolveTo( PCL_ALIEN_BUILDER0 )
-					action roamInRadius( E_A_OVERMIND, 500 )
-					condition alertedToEnemy
-					{
-						action fight
-					}
-					action rush
-					action roam
-				}
-			}
+			behavior subroutine_become_builder_aliens
 
-			decorator return( STATUS_FAILURE )
+			condition distanceTo( E_A_OVERMIND ) <= 700
 			{
-				condition class == PCL_ALIEN_BUILDER0
+				decorator return( STATUS_FAILURE )
 				{
-					action evolveTo( PCL_ALIEN_BUILDER0_UPG )
+					action buildNowChosenBuildable
 				}
-			}
-
-			decorator return( STATUS_FAILURE )
-			{
-				action buildNowChosenBuildable
 			}
 			action roamInRadius( E_A_OVERMIND, 700 )
 			action roam

--- a/pkg/unvanquished_src.dpkdir/bots/default_humans.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/default_humans.bt
@@ -22,35 +22,14 @@ selector
 				action blackboardNoteTransient( WANTS_TO_BUILD )
 			}
 
-			sequence
-			{
-				condition !haveWeapon( WP_HBUILD )
-				selector
-				{
-					condition myTimer >= 20000
-					{
-						action suicide
-					}
-					sequence
-					{
-						decorator return( STATUS_SUCCESS )
-						{
-							action equip
-						}
-						action buyPrimary( WP_HBUILD )
-					}
-					condition alertedToEnemy
-					{
-						action fight
-					}
-					action rush
-					action roam
-				}
-			}
+			behavior subroutine_become_builder_humans
 
-			decorator return( STATUS_FAILURE )
+			condition distanceTo( E_H_REACTOR ) <= 700
 			{
-				action buildNowChosenBuildable
+				decorator return( STATUS_FAILURE )
+				{
+					action buildNowChosenBuildable
+				}
 			}
 			action roamInRadius( E_H_REACTOR, 700 )
 			action roam

--- a/pkg/unvanquished_src.dpkdir/bots/subroutine_become_builder_aliens.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/subroutine_become_builder_aliens.bt
@@ -1,0 +1,32 @@
+selector
+{
+	sequence
+	{
+		condition class != PCL_ALIEN_BUILDER0 && class != PCL_ALIEN_BUILDER0_UPG
+		selector
+		{
+			condition myTimer >= 20000
+			{
+				action suicide
+			}
+			action evolveTo( PCL_ALIEN_BUILDER0_UPG )
+			action evolveTo( PCL_ALIEN_BUILDER0 )
+			action roamInRadius( E_A_OVERMIND, 500 )
+			condition alertedToEnemy
+			{
+				action fight
+			}
+			action rush
+			action roam
+		}
+	}
+
+	decorator return( STATUS_FAILURE )
+	{
+		condition class == PCL_ALIEN_BUILDER0
+		{
+			action evolveTo( PCL_ALIEN_BUILDER0_UPG )
+		}
+	}
+
+}

--- a/pkg/unvanquished_src.dpkdir/bots/subroutine_become_builder_humans.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/subroutine_become_builder_humans.bt
@@ -1,0 +1,25 @@
+sequence
+{
+	condition !haveWeapon( WP_HBUILD )
+	selector
+	{
+		condition myTimer >= 20000
+		{
+			action suicide
+		}
+		sequence
+		{
+			decorator return( STATUS_SUCCESS )
+			{
+				action equip
+			}
+			action buyPrimary( WP_HBUILD )
+		}
+		condition alertedToEnemy
+		{
+			action fight
+		}
+		action rush
+		action roam
+	}
+}

--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -203,6 +203,17 @@ static AIValue_t distanceTo( gentity_t *self, const AIValue_t *params )
 	return AIBoxFloat( ent.distance );
 }
 
+static AIValue_t distanceToSpecifiedPosition( gentity_t *self, const AIValue_t * )
+{
+	if ( !self->botMind->userSpecifiedPosition)
+	{
+		return AIBoxFloat( 1.7e19f );  // well, out of range
+	}
+	glm::vec3 pos = *self->botMind->userSpecifiedPosition;
+	glm::vec3 ownPos = VEC2GLM( self->s.origin );
+	return AIBoxFloat( glm::distance( ownPos, pos ) );
+}
+
 static AIValue_t baseRushScore( gentity_t *self, const AIValue_t* )
 {
 	return AIBoxFloat( BotGetBaseRushScore( self ) );
@@ -488,6 +499,7 @@ static const struct AIConditionMap_s
 	{ "cvar",              cvar,              1 },
 	{ "directPathTo",      directPathTo,      1 },
 	{ "distanceTo",        distanceTo,        1 },
+	{ "distanceToSpecifiedPosition", distanceToSpecifiedPosition, 0 },
 	{ "goalBuildingType",  goalBuildingType,  0 },
 	{ "goalIsDead",        goalDead,          0 },
 	{ "goalTeam",          goalTeam,          0 },


### PR DESCRIPTION
The behavior `build` is similar to `default`, but makes a bot build at all costs if possible. This is useful to players alone in a team, who do not have the time to build a base by themselves.

Move some of the shared build code to the files `subroutine_become_builder_aliens.bt`, `subroutine_become_builder_humans.bt`.