### PR TITLE
fix g_bot_traceClient not showing the name of the outermost behavior tree

### DIFF
--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -407,7 +407,7 @@ static void ShowRunningNode( gentity_t *self, AINodeStatus_t status )
 		AIActionNode_t *actionNode = reinterpret_cast<AIActionNode_t *>( self->botMind->runningNodes[ 0 ] );
 		int line = actionNode->lineNum;
 		const char *actionName = actionNode->name;
-		const char *tree = "<unknown>";
+		const char *tree = self->botMind->behaviorTree->name;
 		for ( const AIGenericNode_t *node : self->botMind->runningNodes )
 		{
 			if ( node->type == AINode_t::BEHAVIOR_NODE )


### PR DESCRIPTION
To reproduce the bug, enter these commands:

```
bot add GigaGrise h 5 defend
g_bot_traceClient GigaGrise
```

The output is:
```
[bot] Bot#1 running at <unknown>.bt:28, action roamInRadius
```

The reason is that the outermost behavior tree is never put in the list of running nodes. That makes sense, as it is always running by definition.

Fix this, now the output is:

```
[bot] Bot#1 running at defend.bt:28, action roamInRadius
```