### PR TITLE
Fix another bug in the BT parser

### DIFF
--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -1682,12 +1682,18 @@ AIBehaviorTree_t *ReadBehaviorTree( const char *name, AITreeList_t *list )
 		node = ReadNode( &current );
 	}
 
-	if ( node )
+	if ( node && current == nullptr )
 	{
 		tree->root = node;
 	}
 	else
 	{
+		if ( node )
+		{
+			ASSERT( current != nullptr );
+			Log::Warn( "expected end of file, but found `%s` in line %d", current->token.string, current->token.line );
+			FreeNode( node );
+		}
 		auto it = std::find( list->begin(), list->end(), tree );
 		ASSERT_NQ( it, list->end() );
 		list->erase( it );


### PR DESCRIPTION
The old parser accepts inputs like

```
selector
{
    action fight
    action roam
}
action danceInTheSun
```

It silently discards everything after the first tree construct is closed, in this case it discards `action danceInTheSun`.

Change this, now the input is rejected. Instead, this warning is printed:

```
Warn: expected end of file, but found `action` in line 6
```