### PR TITLE
subroutine_extinguish_fire.bt remove use of nonexisting cvar

### DIFF
--- a/pkg/unvanquished_src.dpkdir/bots/subroutine_extinguish_fire.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/subroutine_extinguish_fire.bt
@@ -4,7 +4,6 @@ sequence
 {
 	condition momentum( TEAM_ALIENS ) > 100
 		&& buildingIsBurning
-		&& cvar( "g_bot_extinguishFire" )
 		&& distanceTo( E_A_OVERMIND ) < 1500
 		&& !teamateHasWeapon( WP_ABUILD2 )
 		&& blackboardNumTransient( WANTS_TO_EXTINGUISH ) < 1


### PR DESCRIPTION
There is no cvar `g_bot_extinguishFire`.