### PR TITLE
Add break statement that got removed by accident

### DIFF
--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -1990,6 +1990,7 @@ void BotClassMovement( gentity_t *self, bool inAttackRange )
 			{
 				BotFireWeapon( WPM_SECONDARY, botCmdBuffer );
 			}
+			break;
 		default:
 			break;
 	}


### PR DESCRIPTION
In https://github.com/Unvanquished/Unvanquished/commit/a1ea70b200bc0b6039d8ea2be0a123036088914e#diff-7efa7a4eedeb7b61fdb165d5390858216282e89de0c7009041d7004243d50303L1984, I removed a `break` by accident.

This is not critical in any way.