### PR TITLE
Fix a crash related to the /r command

### DIFF
--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -4241,6 +4241,7 @@ static void Cmd_ReplyPrivateMessage_f( gentity_t *ent )
 		return;
 	}
 
+	// ent cannot be the server console, as players cannot send private messages to it
 	setLastPrivateMessageSenderAndTime( target, ent->num() );
 	ADMP( va( "%s %s %s", QQ( N_("You have responded to $1$^* : ^2$2$ ") ), g_entities[ target ].client->pers.netname, Quote( msg ) ) );
 	G_LogPrintf( "PrivMsg: %d \"%s^*\" \"%s\": %s",
@@ -4467,7 +4468,11 @@ void Cmd_PrivateMessage_f( gentity_t *ent )
 			count++;
 			Q_strcat( recipients, sizeof( recipients ), va( "%s^*, ",
 			          level.clients[ pids[ i ] ].pers.netname ) );
-			setLastPrivateMessageSenderAndTime( pids[ i ], ent->num() );
+			// exclude the server console
+			if ( ent != nullptr )
+			{
+				setLastPrivateMessageSenderAndTime( pids[ i ], ent->num() );
+			}
 		}
 	}
 

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -4242,7 +4242,11 @@ static void Cmd_ReplyPrivateMessage_f( gentity_t *ent )
 	}
 
 	// ent cannot be the server console, as players cannot send private messages to it
-	setLastPrivateMessageSenderAndTime( target, ent->num() );
+	// but it cannot hurt to exclude that case
+	if ( ent != nullptr )
+	{
+		setLastPrivateMessageSenderAndTime( target, ent->num() );
+	}
 	ADMP( va( "%s %s %s", QQ( N_("You have responded to $1$^* : ^2$2$ ") ), g_entities[ target ].client->pers.netname, Quote( msg ) ) );
 	G_LogPrintf( "PrivMsg: %d \"%s^*\" \"%s\": %s",
 		ent->num(), ent->client->pers.netname,


### PR DESCRIPTION
It is possible for users to crash the server using the `/r` command iff they were sent private messages by the server console earlier. To reproduce, start a dedicated server, connect a client. Enter this command at the server console:

```
/m <client> foo
```
To crash the server, enter this command on the client:

```
/r foo
```

The reason for the crash is that we do `ent->num()` with `ent` being the server console. On a dedicated server, the server console is a null pointer. That makes `ent->num()` a huge negative number, which we will save as the message sender. Later we use this number as index in the entity array.

With assertions enabled, the first command should already crash the server.

Fix this by excluding null pointers as saved message senders.