### PR TITLE
Add bot action changeToPrimaryWeapon, fix bots not refilling ammo in some cases

### DIFF
--- a/pkg/unvanquished_src.dpkdir/bots/attack.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/attack.bt
@@ -51,15 +51,7 @@ selector
 				action equip
 			}
 
-			selector
-			{
-				condition percentAmmoClip == 0 && percentClips == 0
-				{
-					// refill at a suitable building
-					// TODO: reload energy weapons at reactor etc
-					action moveTo( E_H_ARMOURY )
-				}
-			}
+			behavior subroutine_refill_ammo
 
 			sequence
 			{

--- a/pkg/unvanquished_src.dpkdir/bots/build.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/build.bt
@@ -50,13 +50,7 @@ selector
 			behavior subroutine_repair
 			behavior subroutine_reload
 			action equip
-
-			condition percentAmmoClip == 0 && percentClips == 0
-			{
-				// refill at a suitable building
-				// TODO: reload energy weapons at reactor etc
-				action moveTo( E_H_ARMOURY )
-			}
+			behavior subroutine_refill_ammo
 
 			sequence
 			{

--- a/pkg/unvanquished_src.dpkdir/bots/build_here.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/build_here.bt
@@ -50,13 +50,7 @@ selector
 			behavior subroutine_repair
 			behavior subroutine_reload
 			action equip
-
-			condition percentAmmoClip == 0 && percentClips == 0
-			{
-				// refill at a suitable building
-				// TODO: reload energy weapons at reactor etc
-				action moveTo( E_H_ARMOURY )
-			}
+			behavior subroutine_refill_ammo
 
 			sequence
 			{

--- a/pkg/unvanquished_src.dpkdir/bots/default.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/default.bt
@@ -145,13 +145,7 @@ selector
 			behavior subroutine_repair
 			behavior subroutine_reload
 			action equip
-
-			condition percentAmmoClip == 0 && percentClips == 0
-			{
-				// refill at a suitable building
-				// TODO: reload energy weapons at reactor etc
-				action moveTo( E_H_ARMOURY )
-			}
+			behavior subroutine_refill_ammo
 
 			sequence
 			{

--- a/pkg/unvanquished_src.dpkdir/bots/subroutine_refill_ammo.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/subroutine_refill_ammo.bt
@@ -1,0 +1,18 @@
+condition percentAmmoClip == 0 && percentClips == 0
+{
+	// refill at a suitable building
+	// TODO: reload energy weapons at reactor etc
+	selector
+	{
+		// game logic does not refill ammo when the
+		// player has the blaster in hands
+		decorator return( STATUS_FAILURE )
+		{
+			condition distanceTo( E_H_ARMOURY ) < 200
+			{
+				action changeToPrimaryWeapon
+			}
+		}
+		action moveTo( E_H_ARMOURY )
+	}
+}

--- a/src/sgame/sg_bot_ai.cpp
+++ b/src/sgame/sg_bot_ai.cpp
@@ -1592,6 +1592,15 @@ AINodeStatus_t BotActionGesture( gentity_t *self, AIGenericNode_t* )
 	return AINodeStatus_t::STATUS_SUCCESS;
 }
 
+AINodeStatus_t BotActionChangeToPrimaryWeapon( gentity_t *self, AIGenericNode_t* )
+{
+	if ( BG_GetPlayerWeapon( &self->client->ps ) == WP_BLASTER )
+	{
+		G_ForceWeaponChange( self, WP_NONE );
+	}
+	return AINodeStatus_t::STATUS_SUCCESS;
+}
+
 /*
 	alien specific actions
 */

--- a/src/sgame/sg_bot_ai.h
+++ b/src/sgame/sg_bot_ai.h
@@ -283,6 +283,7 @@ AINodeStatus_t BotActionSuicide( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotActionJump( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotActionResetStuckTime( gentity_t *self, AIGenericNode_t *node );
 AINodeStatus_t BotActionGesture( gentity_t *self, AIGenericNode_t* );
+AINodeStatus_t BotActionChangeToPrimaryWeapon( gentity_t *self, AIGenericNode_t* );
 AINodeStatus_t BotActionStayHere( gentity_t *self, AIGenericNode_t* );
 AINodeStatus_t BotActionFollow( gentity_t *self, AIGenericNode_t* );
 AINodeStatus_t BotActionBuildNowChosenBuildable( gentity_t *self, AIGenericNode_t *node );

--- a/src/sgame/sg_bot_parse.cpp
+++ b/src/sgame/sg_bot_parse.cpp
@@ -1101,6 +1101,7 @@ static const struct AIActionMap_s
 	{ "buy",               BotActionBuy,               1, 4 },
 	{ "buyPrimary",        BotActionBuyPrimary,        1, 1 },
 	{ "changeGoal",        BotActionChangeGoal,        1, 3 },
+	{ "changeToPrimaryWeapon", BotActionChangeToPrimaryWeapon, 0, 0},
 	{ "classDodge",        BotActionClassDodge,        0, 0 },
 	{ "deactivateUpgrade", BotActionDeactivateUpgrade, 1, 1 },
 	{ "equip",             BotActionBuy,               0, 0 },


### PR DESCRIPTION
If a human bot runs out of ammo, and cannot reach an armoury, it will switch to the blaster and fight with that. If it survives until an armoury has become reachable, it will move there. Unfortunately, it will not receive the ammo refill once it reached the armoury. The reason is that we do not refill ammo for players who have the blaster in hands.

The bot will stand next to the armoury for a long time. It might eventually have enough funds to trigger a new purchase or get killed.

Fix this by making the bot change to the primary weapon once it reached the armoury. This requires a new bot action `changeToPrimaryWeapon`.

Alternatively, we could simply choose to refill ammo for players holding the blaster, as shown in https://github.com/Unvanquished/Unvanquished/pull/3238.