### PR TITLE
Mark strings as translatable

### DIFF
--- a/pkg/unvanquished_src.dpkdir/.urcheon/ignore.txt
+++ b/pkg/unvanquished_src.dpkdir/.urcheon/ignore.txt
@@ -1,1 +1,2 @@
 ar.po
+fa.po

--- a/pkg/unvanquished_src.dpkdir/ui/callvote_fillbots.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/callvote_fillbots.rml
@@ -6,7 +6,7 @@
 	<body id="callvote_fillbots" template="window" style="width: 35em; margin: 1em;">
 		<h1><translate>Fill with bots</translate></h1>
 		<br />
-		<p>How many players (users and bots) should teams have?</p>
+		<p><translate>How many players (users and bots) should teams have?</translate></p>
 		<form onsubmit='Events.pushevent("execForm \"callvote $action$ $amount$\"; hide", event)'>
 			<row>
 				<select name="action">

--- a/pkg/unvanquished_src.dpkdir/ui/help_gameplay.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/help_gameplay.rml
@@ -9,7 +9,7 @@
 		</style>
 	</head>
 	<body template="window" id="help_gameplay" style="width:45em; margin: 15em auto auto auto;">
-		<h1>Gameplay Guide</h1>
+		<h1><translate>Gameplay Guide</translate></h1>
 		<tabset>
 			<!-- the "margin-right" is used to put a scace wetween the emoticon and the text-->
 			<tab>

--- a/pkg/unvanquished_src.dpkdir/ui/menu_ingame.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/menu_ingame.rml
@@ -19,7 +19,7 @@
 			<window id="innersidebar" class="innersidebar" >
 
 				<sidesection  id="sidebar_ingame">
-					<h1> <translate>Match</translate> </h1>
+					<h1><translate>Match</translate></h1>
 					<div style="display:flex;align-items: stretch;">
 						<!--Don't put  ' class="rightfloat ' on the first button because this is allready defined in the "button-menu"-->
 						<button-menu style="width:39%;" onclick='Cmd.exec("disconnect")'><translate>Leave match</translate></button-menu>

--- a/pkg/unvanquished_src.dpkdir/ui/menu_main.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/menu_main.rml
@@ -24,7 +24,7 @@
 
 				<sidesection style="font-size: 1.1em;">
 					<indent>
-						<h1> <translate>Main menu</translate></h1>
+						<h1><translate>Main menu</translate></h1>
 						<button-menu style="width:87%" onclick='Events.pushcmd("show serverbrowser")'><translate>Server listings</translate></button-menu>
 
 						<button-menu style="width:87%" onclick='Events.pushcmd("show createserver")'><translate>Start local/LAN game</translate></button-menu>

--- a/pkg/unvanquished_src.dpkdir/ui/options_ui.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_ui.rml
@@ -21,8 +21,8 @@
 			<panel class="main">
 				<row>
 					<!-- Keep in sync with language menu in options_welcome.rml -->
-					<h3><translate>Language</translate> </h3>
-					<p> <translate>Some languages are not fully translated.</translate> </p>
+					<h3><translate>Language</translate></h3>
+					<p><translate>Some languages are not fully translated.</translate></p>
 
 					<!-- NOTE: it's a bad idea to put languages translated at less than 50% in the list, right? -->
 					<select cvar="language">

--- a/pkg/unvanquished_src.dpkdir/ui/options_welcome.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_welcome.rml
@@ -16,7 +16,7 @@
 		<p><translate>You can change this at any time in the options.</translate></p>
 	        <!-- Keep in sync with language menu in options_ui.rml -->
 	        <h2><translate>What language do you want to use?</translate></h2>
-	        <p> <translate>Some languages are not fully translated.</translate> </p>
+	        <p><translate>Some languages are not fully translated.</translate></p>
 
 	<!-- NOTE: it's a bad idea to put languages translated at less than 50% in the list, right? -->
 		<select cvar="language">

--- a/pkg/unvanquished_src.dpkdir/ui/server_setup.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/server_setup.rml
@@ -250,7 +250,7 @@
 		</panel>
 
 		<!-- HUMANS BOT CONFIG -->
-		<tab><translate>Bots: Humans</translate></tab> <panel>
+		<tab><translate>Bots: Humans</translate></tab><panel>
 			<h2><translate>Overall</translate></h2>
 			<row>
 				<input cvar="g_bot_buy" type="checkbox" />

--- a/pkg/unvanquished_src.dpkdir/ui/server_setup.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/server_setup.rml
@@ -90,7 +90,7 @@
 		</panel>
 
 		<!-- MOMENTUM CONFIG -->
-		<tab> Momentum </tab><panel>
+		<tab><translate>Momentum</translate></tab><panel>
 			<row>
 				<parent>
 					<h3><translate>Half life time</translate></h3>
@@ -150,7 +150,7 @@
 		</panel>
 
 		<!-- BUILDPOINTS CONFIG -->
-		<tab> Build system </tab><panel>
+		<tab><translate>Build system</translate></tab><panel>
 			<row>
 				<parent>
 					<h3><translate>Starting value</translate></h3>
@@ -186,7 +186,7 @@
 		</panel>
 
 		<!-- GENERAL BOT CONFIG -->
-		<tab>Bots: General</tab><panel>
+		<tab><translate>Bots: General</translate></tab><panel>
 			<row>
 				<parent>
 					<h3><translate>Minimum bots per team</translate></h3>
@@ -203,10 +203,10 @@
 				<input type="range" min="1" max="9" step="1" cvar="g_bot_defaultSkill"/>
 				<p><inlinecvar cvar="g_bot_defaultSkill" type="number" format="%g"/>&nbsp;<ilink onclick='Cmd.exec("reset g_bot_defaultSkill")'> (reset) </ilink></p>
 			</row>
-			<h2> Humanity </h2>
+			<h2><translate>Humanity</translate></h2>
 			<row>
 				<input type="range" min="45" max="360" step="1" cvar="g_bot_fov"/>
-				<h3> Field of view </h3>
+				<h3><translate>Field of view</translate></h3>
 				<p class="inline">
 					Current: <inlinecvar cvar="g_bot_fov" type="number" format="%.0f"/> degrees
 					<ilink onclick='Cmd.exec("reset g_bot_fov")'> (reset) </ilink>
@@ -214,35 +214,35 @@
 			</row>
 			<row>
 				<input type="range" min="0" max="2000" step="10" cvar="g_bot_reactiontime"/>
-				<h3> Reaction time </h3>
+				<h3><translate>Reaction time</translate></h3>
 				<p class="inline">
 					Current: <inlinecvar cvar="g_bot_reactiontime" type="number" format="%.0f"/> msecs
 					<ilink onclick='Cmd.exec("reset g_bot_reactiontime")'> (reset) </ilink>
 				</p>
 			</row>
 
-			<h2> Behaviour </h2>
+			<h2><translate>Behaviour</translate></h2>
 			<row>
 				<input cvar="g_bot_attackStruct" type="checkbox" />
-				<h3> Attack structures </h3>
+				<h3><translate>Attack structures</translate></h3>
 			</row>
-			<h2>Cheating</h2>
+			<h2><translate>Cheating</translate></h2>
 			<row>
 				<input cvar="g_bot_infiniteFunds" type="checkbox" />
-				<h3> Infinite funds </h3>
+				<h3><translate>Infinite funds</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_infiniteMomentum" type="checkbox" />
-				<h3> Ignore momentum </h3>
+				<h3><translate>Ignore momentum</translate></h3>
 			</row>
-			<h2>Navmesh generation</h2>
+			<h2><translate>Navmesh generation</translate></h2>
 			<row>
 				<input cvar="cg_navgenOnLoad" type="checkbox" />
-				<h3>Generate navmeshes at load time</h3>
+				<h3><translate>Generate navmeshes at load time</translate></h3>
 			</row>
 			<row>
 				<input type="range" min="1" max="16" step="1" cvar="cg_navgenMaxThreads"/>
-				<h3>Number of worker threads</h3>
+				<h3><translate>Number of worker threads</translate></h3>
 				<p class="inline">
 					Current: <inlinecvar cvar="cg_navgenMaxThreads" type="number" format="%.0f"/>
 				</p>
@@ -250,130 +250,130 @@
 		</panel>
 
 		<!-- HUMANS BOT CONFIG -->
-		<tab>Bots: Humans </tab> <panel>
-			<h2> Overall </h2>
+		<tab><translate>Bots: Humans</translate></tab> <panel>
+			<h2><translate>Overall</translate></h2>
 			<row>
 				<input cvar="g_bot_buy" type="checkbox" />
-				<h3> Human bots purchase equipment </h3>
+				<h3><translate>Human bots purchase equipment</translate></h3>
 			</row>
 			<row>
 				<input type="range" min="0" max="2000" step="10" cvar="g_bot_humanAimDelay"/>
-				<h3> Aim speed modifier (higher is slower)</h3>
+				<h3><translate>Aim speed modifier (higher is slower)</translate></h3>
 				<p class="inline">
 					Current: <inlinecvar cvar="g_bot_humanAimDelay" type="number" format="%.0f"/> msecs
 					<ilink onclick='Cmd.exec("reset g_bot_humanAimDelay")'> (reset) </ilink>
 				</p>
 			</row>
-			<h2> Individually </h2>
-			<h3> Primary Weapons </h3>
+			<h2><translate>Individually</translate></h2>
+			<h3><translate>Primary Weapons</translate></h3>
 			<row>
 				<input cvar="g_bot_ckit" type="checkbox" />
-				<h3> Construction Kit (repairs) </h3>
+				<h3><translate>Construction Kit (repairs)</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_rifle" type="checkbox" />
-				<h3> SMG </h3>
+				<h3><translate>SMG</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_painsaw" type="checkbox" />
-				<h3> Painsaw </h3>
+				<h3><translate>Painsaw</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_shotgun" type="checkbox" />
-				<h3> Shotgun </h3>
+				<h3><translate>Shotgun</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_lasgun" type="checkbox" />
-				<h3> Lasgun </h3>
+				<h3><translate>Lasgun</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_mdriver" type="checkbox" />
-				<h3> Mass Driver </h3>
+				<h3><translate>Mass Driver</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_chain" type="checkbox" />
-				<h3> Chaingun </h3>
+				<h3><translate>Chaingun</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_flamer" type="checkbox" />
-				<h3> Flamethrower </h3>
+				<h3><translate>Flamethrower</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_prifle" type="checkbox" />
-				<h3> Pulse Rifle </h3>
+				<h3><translate>Pulse Rifle</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_lcannon" type="checkbox" />
-				<h3> Lucifer Cannon </h3>
+				<h3><translate>Lucifer Cannon</translate></h3>
 			</row>
-			<h3> Armors </h3>
+			<h3><translate>Armors</translate></h3>
 			<row>
 				<input cvar="g_bot_lightarmour" type="checkbox" />
-				<h3> whether bots buy Light Armour </h3>
+				<h3><translate>whether bots buy Light Armour</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_mediumarmour" type="checkbox" />
-				<h3> whether bots buy Medium Armour </h3>
+				<h3><translate>whether bots buy Medium Armour</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_battlesuit" type="checkbox" />
-				<h3> whether bots buy the Battlesuit </h3>
+				<h3><translate>whether bots buy the Battlesuit</translate></h3>
 			</row>
-			<h3> Misc </h3>
+			<h3><translate>Misc</translate></h3>
 			<row>
 				<input cvar="g_bot_firebomb" type="checkbox" />
-				<h3> Firebomb </h3>
+				<h3><translate>Firebomb</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_grenade" type="checkbox" />
-				<h3> Grenade </h3>
+				<h3><translate>Grenade</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_radar" type="checkbox" />
-				<h3> Radar </h3>
+				<h3><translate>Radar</translate></h3>
 			</row>
 		</panel>
 
 		<!-- ALIENS BOT CONFIG -->
 		<tab>Bots: Aliens </tab> <panel>
-			<h2> Overall </h2>
+			<h2><translate>Overall</translate></h2>
 			<row>
 				<input cvar="g_bot_evolve" type="checkbox" />
-				<h3> Alien bots morph </h3>
+				<h3><translate>Alien bots morph</translate></h3>
 			</row>
 			<row>
 				<input type="range" min="0" max="2000" step="10" cvar="g_bot_alienAimDelay"/>
-				<h3> Aim speed modifier (higher is slower)</h3>
+				<h3><translate>Aim speed modifier (higher is slower)</translate></h3>
 				<p class="inline">
 					Current: <inlinecvar cvar="g_bot_alienAimDelay" type="number" format="%.0f"/> msecs
 					<ilink onclick='Cmd.exec("reset g_bot_alienAimDelay")'> (reset) </ilink>
 				</p>
 			</row>
 
-			<h2> Individually </h2>
+			<h2><translate>Individually</translate></h2>
 			<row>
 				<input cvar="g_bot_level1" type="checkbox" />
-				<h3> Mantis </h3>
+				<h3><translate>Mantis</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_level2" type="checkbox" />
-				<h3> Marauder </h3>
+				<h3><translate>Marauder</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_level2upg" type="checkbox" />
-				<h3> Advanced Marauder </h3>
+				<h3><translate>Advanced Marauder</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_level3" type="checkbox" />
-				<h3> Dragoon </h3>
+				<h3><translate>Dragoon</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_level3upg" type="checkbox" />
-				<h3> Advanced Dragoon </h3>
+				<h3><translate>Advanced Dragoon</translate></h3>
 			</row>
 			<row>
 				<input cvar="g_bot_level4" type="checkbox" />
-				<h3> Tyrant </h3>
+				<h3><translate>Tyrant</translate></h3>
 			</row>
 		</panel>
 

--- a/pkg/unvanquished_src.dpkdir/ui/welcome.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/welcome.rml
@@ -9,7 +9,7 @@
 		</style>
 	</head>
 	<body template="window" id="welcome" style="width:45em; margin: 1em;">
-		<h1>Welcome to Unvanquished</h1>
+		<h1><translate>Welcome to Unvanquished</translate></h1>
 		<tabset>
 			<tab>
 				<img class="emoticon" src="/emoticons/official" />


### PR DESCRIPTION
- ui: mark strings as translatable
- ui: strip leading and trailing spaces
- translation: do not ship Farsi language files until we can render right-to-left glyphs properly
  * We already had to do it for Arab language for the same reason:
    https://github.com/Unvanquished/Unvanquished/pull/3169
  * We need to fix this to be able to render those languages:
    https://github.com/Unvanquished/Unvanquished/issues/3223