### PR TITLE
command addcon: allow setting the jetpack poly flag

### DIFF
--- a/src/sgame/botlib/bot_nav_edit.cpp
+++ b/src/sgame/botlib/bot_nav_edit.cpp
@@ -393,6 +393,7 @@ public:
 					else
 					{
 						Print( "Invalid argument for flags, must be jetpack if specified" );
+						return;
 					}
 				}
 				cmd.offBegin = true;

--- a/src/sgame/botlib/bot_nav_edit.cpp
+++ b/src/sgame/botlib/bot_nav_edit.cpp
@@ -385,8 +385,8 @@ public:
 				if ( args.Argc() == 5 )
 				{
 					// TODO: only allow this for the human_naked class
-					const std::string &arg = args.Argv( 4 );
-					if ( arg == "jetpack" )
+					const std::string &subArg = args.Argv( 4 );
+					if ( Q_stricmp( subArg.c_str(), "jetpack" ) == 0 )
 					{
 						cmd.pc.flag = POLYFLAGS_JETPACK;
 					}

--- a/src/sgame/botlib/bot_nav_edit.cpp
+++ b/src/sgame/botlib/bot_nav_edit.cpp
@@ -374,8 +374,8 @@ public:
 
 				if ( args.Argc() >= 4 )
 				{
-					int val = 0;
-					if ( !Str::ParseInt( val, args.Argv( 3 ) ) || val < 10 )
+					float val = 0.f;
+					if ( !Str::ToFloat( args.Argv( 3 ), val ) || val < 10.f )
 					{
 						Print( "Invalid argument for radius, must be 10 or more" );
 						return;

--- a/src/sgame/botlib/bot_nav_edit.cpp
+++ b/src/sgame/botlib/bot_nav_edit.cpp
@@ -324,7 +324,7 @@ public:
 
 	void Run( const Cmd::Args &args ) const override
 	{
-		const char usage[] = "Usage: addcon start <dir> (radius)\n"
+		const char usage[] = "Usage: addcon start <dir> (<radius> (jetpack))\n"
 		                     " addcon end";
 		const char *arg = nullptr;
 
@@ -370,14 +370,30 @@ public:
 				cmd.pc.area = DT_TILECACHE_WALKABLE_AREA;
 				cmd.pc.flag = POLYFLAGS_WALK;
 				cmd.pc.userid = 0;
+				cmd.pc.radius = DEFAULT_CONNECTION_SIZE;
 
-				if ( args.Argc() == 4 )
+				if ( args.Argc() >= 4 )
 				{
-					cmd.pc.radius = std::max( atoi( args.Argv( 3 ).c_str() ), 10 );
+					int val = 0;
+					if ( !Str::ParseInt( val, args.Argv( 3 ).c_str() ) || val < 10 )
+					{
+						Print( "Invalid argument for radius, must be 10 or more" );
+						return;
+					}
+					cmd.pc.radius = val;
 				}
-				else
+				if ( args.Argc() == 5 )
 				{
-					cmd.pc.radius = DEFAULT_CONNECTION_SIZE;
+					// TODO: only allow this for the human_naked class
+					const std::string &arg = args.Argv( 4 );
+					if ( arg == "jetpack" )
+					{
+						cmd.pc.flag = POLYFLAGS_JETPACK;
+					}
+					else
+					{
+						Print( "Invalid argument for flags, must be jetpack if specified" );
+					}
 				}
 				cmd.offBegin = true;
 			}

--- a/src/sgame/botlib/bot_nav_edit.cpp
+++ b/src/sgame/botlib/bot_nav_edit.cpp
@@ -375,7 +375,7 @@ public:
 				if ( args.Argc() >= 4 )
 				{
 					int val = 0;
-					if ( !Str::ParseInt( val, args.Argv( 3 ).c_str() ) || val < 10 )
+					if ( !Str::ParseInt( val, args.Argv( 3 ) ) || val < 10 )
 					{
 						Print( "Invalid argument for radius, must be 10 or more" );
 						return;


### PR DESCRIPTION
This is required for 0.55.2, as there is at least one user who is making their own navcon files. Since we will have working jetpack navcons, we will also need a working addcon command for jetpacks.

Recall that the addcon command is used like in

```
addcon start oneway 25
```

Extend it to allow also

```
addcon start oneway 25 jetpack
```

This will set the `POLYFLAGS_JETPACK` flag for the navcon.