### PR TITLE
add commands viewcon, delcon

### DIFF
--- a/src/sgame/botlib/bot_local.h
+++ b/src/sgame/botlib/bot_local.h
@@ -101,9 +101,9 @@ struct OffMeshConnections
 			return;
 		}
 
-		for ( int i = index * 6; i < offMeshConCount * 6 - 1; i++ )
+		for ( int i = index * 6; i < ( offMeshConCount - 1 ) * 6; i++ )
 		{
-			verts[ i ] = verts[ i + 1 ];
+			verts[ i ] = verts[ i + 6 ];
 		}
 
 		for ( int i = index; i < offMeshConCount - 1; i++ )

--- a/src/sgame/botlib/bot_nav_edit.cpp
+++ b/src/sgame/botlib/bot_nav_edit.cpp
@@ -428,7 +428,8 @@ public:
 };
 
 // return the navcon number and true if the targetPoint is at the navcon start,
-// false otherwise
+// false if it is at the end
+// return -1 and an unspecified boolean value if the targetPoint is at neither of them
 static std::tuple< int, bool > findClosestNavcon( OffMeshConnections &cons, rVec &targetPoint )
 {
 	int resultIndex = -1;

--- a/src/sgame/botlib/bot_nav_edit.cpp
+++ b/src/sgame/botlib/bot_nav_edit.cpp
@@ -487,12 +487,12 @@ public:
 				return;
 			}
 			int n = i * 6;
-			Print( "from ( %.0f, %.0f, %.0f ) to ( %.0f, %.0f, %.0f ), %s, radius: %.0f%s",
+			Print( "navcon %s^*, from ( %.0f, %.0f, %.0f ) to ( %.0f, %.0f, %.0f ), %s, radius %.0f%s",
+			       isStart ? "^2start" : "^3end",
 			       cons.verts[ n ], cons.verts[ n + 2 ], cons.verts[ n + 1 ],
 			       cons.verts[ n + 3 ], cons.verts[ n + 5 ], cons.verts[ n + 4 ],
 			       cons.dirs[ i ] == 0 ? "oneway" : "twoway", cons.rad[ i ],
 			       cons.flags[ i ] == POLYFLAGS_JETPACK ? ", jetpack" : "");
-			Print( "this is the %s", isStart ? "start" : "end" );
 		}
 	}
 };

--- a/src/sgame/botlib/bot_nav_edit.cpp
+++ b/src/sgame/botlib/bot_nav_edit.cpp
@@ -534,9 +534,9 @@ public:
 			cons.delConnection( i );
 
 			rVec boxMins, boxMaxs;
-			for ( int i = 0; i < 3; i++ )
+			for ( int k = 0; k < 3; k++ )
 			{
-				std::tie( boxMins[ i ], boxMaxs[ i ] ) = std::minmax( start[ i ], end[ i ] );
+				std::tie( boxMins[ k ], boxMaxs[ k ] ) = std::minmax( start[ k ], end[ k ] );
 			}
 
 			boxMins[ 1 ] -= 10;

--- a/src/sgame/botlib/bot_nav_edit.cpp
+++ b/src/sgame/botlib/bot_nav_edit.cpp
@@ -433,7 +433,7 @@ public:
 static std::tuple< int, bool > findClosestNavcon( OffMeshConnections &cons, rVec &targetPoint )
 {
 	int resultIndex = -1;
-	float resultDistance = std::numeric_limits<float>::max();
+	float resultDistanceSquare = std::numeric_limits<float>::max();
 	bool resultIsStart = true;
 	for ( int i = 0; i < cons.offMeshConCount; i++ )
 	{
@@ -441,14 +441,12 @@ static std::tuple< int, bool > findClosestNavcon( OffMeshConnections &cons, rVec
 		// look at start and end points
 		for ( int count = 0; count < 2; count++ )
 		{
-			float distanceX = targetPoint[ 0 ] - cons.verts[ n + count * 3 ];
-			float distanceZ = targetPoint[ 1 ] - cons.verts[ n + count * 3 + 1 ];
-			float distanceY = targetPoint[ 2 ] - cons.verts[ n + count * 3 + 2 ];
-			float distance = sqrt( Square( distanceX ) + Square( distanceY ) + Square( distanceZ ) );
-			if ( distance <= cons.rad[ i ] && distance < resultDistance )
+			rVec navconVertex = rVec::Load( &cons.verts[ n + count * 3 ] );
+			float distanceSquare = DistanceSquared( targetPoint, navconVertex );
+			if ( distanceSquare <= Square( cons.rad[ i ] ) && distanceSquare < resultDistanceSquare )
 			{
 				resultIndex = i;
-				resultDistance = distance;
+				resultDistanceSquare = distanceSquare;
 				resultIsStart = count == 0;
 			}
 		}
@@ -529,15 +527,9 @@ public:
 				return;
 			}
 
-			rVec start;
-			rVec end;
 			int n = i * 6;
-			start[ 0 ] = cons.verts[ n ];
-			start[ 1 ] = cons.verts[ n + 1 ];
-			start[ 2 ] = cons.verts[ n + 2 ];
-			end[ 0 ] = cons.verts[ n + 3 ];
-			end[ 1 ] = cons.verts[ n + 4 ];
-			end[ 2 ] = cons.verts[ n + 5 ];
+			rVec start = rVec::Load( &cons.verts[ n ] );
+			rVec end = rVec::Load( &cons.verts[ n + 3 ] );
 
 			cons.delConnection( i );
 


### PR DESCRIPTION
Add two commands to maintain navcons. Both require navedit to be enabled, and the user looking at either the start or the end point.

Command `viewcon` displays a line like

```
navcon start, from ( 449, -3979, -918 ) to ( 596, -3995, -750 ), oneway, radius 15
```

Or for jetpack navcons:
```
navcon start, from ( 449, -3979, -918 ) to ( 596, -3995, -750 ), oneway, radius 15, jetpack
```

This is currently the only way to identify jetpack navcons.

Command `delcon` deletes a navcon.

This is required for 0.55.2.