### PR TITLE
Fix invisible download bar

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/transition_downloading.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/transition_downloading.rml
@@ -23,6 +23,7 @@
 			progress {
 				width: 100%;
 				height: 100%;
+				z-index: 30;
 			}
 
 			percentage {


### PR DESCRIPTION
Alternative to #3198 that doesn't use a 100% transparent elements hack.

Fixes #2164.

See the bottom left:
![unvanquished_2024-12-13_173318_000](https://github.com/user-attachments/assets/bc4ef9db-5aa2-4625-bfff-877c77bc175c)
