### PR TITLE
cmake: re-add the generic `nacl-vms` target, it is used by the dockerized build script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,8 @@ if (BUILD_SGAME)
     )
 
     if (BUILD_GAME_NACL AND NOT (FORK EQUAL 2))
+        add_dependencies(nacl-vms src-sgame-entities.yaml)
+
         include(ExternalProject)
         foreach(NACL_VMS_PROJECT ${NACL_VMS_PROJECTS})
             ExternalProject_Add_Step(${NACL_VMS_PROJECT} cbse-trigger


### PR DESCRIPTION
Re-add the generic `nacl-vms` target, it is used by the dockerized build script.