### PR TITLE
Bots: rebuild reactor/overmind

### DIFF
--- a/pkg/unvanquished_src.dpkdir/bots/build.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/build.bt
@@ -29,7 +29,7 @@ selector
 				{
 					behavior subroutine_become_builder_humans
 
-					condition distanceTo( E_H_REACTOR ) <= 700
+					condition distanceTo( E_H_REACTOR ) <= 700 || distanceTo( E_H_REACTOR ) > 999999
 					{
 						decorator return( STATUS_FAILURE )
 						{
@@ -86,7 +86,7 @@ selector
 				{
 					behavior subroutine_become_builder_aliens
 
-					condition distanceTo( E_A_OVERMIND) <= 700
+					condition distanceTo( E_A_OVERMIND) <= 700 || distanceTo( E_A_OVERMIND ) > 999999
 					{
 						decorator return( STATUS_FAILURE )
 						{

--- a/pkg/unvanquished_src.dpkdir/bots/build.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/build.bt
@@ -29,6 +29,7 @@ selector
 				{
 					behavior subroutine_become_builder_humans
 
+					// if reactor is close or does not exist
 					condition distanceTo( E_H_REACTOR ) <= 700 || distanceTo( E_H_REACTOR ) > 999999
 					{
 						decorator return( STATUS_FAILURE )
@@ -86,6 +87,7 @@ selector
 				{
 					behavior subroutine_become_builder_aliens
 
+					// if overmind is close or does not exist
 					condition distanceTo( E_A_OVERMIND) <= 700 || distanceTo( E_A_OVERMIND ) > 999999
 					{
 						decorator return( STATUS_FAILURE )

--- a/pkg/unvanquished_src.dpkdir/bots/default.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/default.bt
@@ -75,7 +75,7 @@ selector
 
 					behavior subroutine_become_builder_aliens
 
-					condition distanceTo( E_A_OVERMIND ) <= 700
+					condition distanceTo( E_A_OVERMIND ) <= 700 || distanceTo( E_A_OVERMIND ) > 999999
 					{
 						decorator return( STATUS_FAILURE )
 						{
@@ -124,7 +124,7 @@ selector
 
 					behavior subroutine_become_builder_humans
 
-					condition distanceTo( E_H_REACTOR ) <= 700
+					condition distanceTo( E_H_REACTOR ) <= 700 || distanceTo( E_H_REACTOR ) > 999999
 					{
 						decorator return( STATUS_FAILURE )
 						{

--- a/pkg/unvanquished_src.dpkdir/bots/default.bt
+++ b/pkg/unvanquished_src.dpkdir/bots/default.bt
@@ -75,6 +75,7 @@ selector
 
 					behavior subroutine_become_builder_aliens
 
+					// if overmind is close or does not exist
 					condition distanceTo( E_A_OVERMIND ) <= 700 || distanceTo( E_A_OVERMIND ) > 999999
 					{
 						decorator return( STATUS_FAILURE )
@@ -124,6 +125,7 @@ selector
 
 					behavior subroutine_become_builder_humans
 
+					// if reactor is close or does not exist
 					condition distanceTo( E_H_REACTOR ) <= 700 || distanceTo( E_H_REACTOR ) > 999999
 					{
 						decorator return( STATUS_FAILURE )


### PR DESCRIPTION
Bots do not rebuild these once destroyed. Oops, fix this.