### PR TITLE
Fix bots without jetpack using jetpack navcons

### DIFF
--- a/src/sgame/botlib/bot_local.cpp
+++ b/src/sgame/botlib/bot_local.cpp
@@ -90,7 +90,7 @@ void FindWaypoints( Bot_t *bot, float *corners, unsigned char *cornerFlags, dtPo
 		return;
 	}
 
-	*numCorners = bot->corridor.findCorners( corners, cornerFlags, cornerPolys, maxCorners, bot->nav->query, &bot->nav->filter );
+	*numCorners = bot->corridor.findCorners( corners, cornerFlags, cornerPolys, maxCorners, bot->nav->query, &bot->filter );
 }
 
 bool PointInPolyExtents( Bot_t *bot, dtPolyRef ref, rVec point, rVec extents )
@@ -131,7 +131,7 @@ bool BotFindNearestPoly( Bot_t *bot, rVec coord, dtPolyRef *nearestPoly, rVec &n
 	rVec extents( 640, 96, 640 );
 	dtStatus status;
 	dtNavMeshQuery* navQuery = bot->nav->query;
-	dtQueryFilter* navFilter = &bot->nav->filter;
+	dtQueryFilter* navFilter = &bot->filter;
 
 	status = navQuery->findNearestPoly( start, extents, navFilter, nearestPoly, nearPoint );
 	if ( dtStatusFailed( status ) || *nearestPoly == 0 )
@@ -164,13 +164,13 @@ static void InvalidateRouteResults( Bot_t *bot )
 			continue;
 		}
 
-		if ( !bot->nav->query->isValidPolyRef( res.startRef, &bot->nav->filter ) )
+		if ( !bot->nav->query->isValidPolyRef( res.startRef, &bot->filter ) )
 		{
 			res.invalid = true;
 			continue;
 		}
 
-		if ( !bot->nav->query->isValidPolyRef( res.endRef, &bot->nav->filter ) )
+		if ( !bot->nav->query->isValidPolyRef( res.endRef, &bot->filter ) )
 		{
 			res.invalid = true;
 			continue;
@@ -255,7 +255,7 @@ bool FindRoute( Bot_t *bot, rVec s, botRouteTargetInternal rtarget, bool allowPa
 	}
 
 	status = bot->nav->query->findNearestPoly( rtarget.pos, rtarget.polyExtents,
-	                                           &bot->nav->filter, &endRef, end );
+	                                           &bot->filter, &endRef, end );
 
 	if ( dtStatusFailed( status ) || !endRef )
 	{
@@ -278,7 +278,7 @@ bool FindRoute( Bot_t *bot, rVec s, botRouteTargetInternal rtarget, bool allowPa
 		}
 	}
 
-	status = bot->nav->query->findPath( startRef, endRef, start, end, &bot->nav->filter, pathPolys, &pathNumPolys, MAX_BOT_PATH );
+	status = bot->nav->query->findPath( startRef, endRef, start, end, &bot->filter, pathPolys, &pathNumPolys, MAX_BOT_PATH );
 
 	AddRouteResult( bot, startRef, endRef, status );
 

--- a/src/sgame/botlib/bot_local.h
+++ b/src/sgame/botlib/bot_local.h
@@ -169,7 +169,6 @@ struct NavData_t
 	dtTileCache      *cache;
 	dtNavMesh        *mesh;
 	dtNavMeshQuery   *query;
-	dtQueryFilter    filter;
 	NavconMeshProcess process;
 	class_t species;
 };
@@ -177,6 +176,7 @@ struct NavData_t
 struct Bot_t
 {
 	NavData_t         *nav;
+	dtQueryFilter     filter;
 	dtPathCorridor    corridor;
 	int               clientNum;
 	bool              needReplan;

--- a/src/sgame/botlib/bot_nav.cpp
+++ b/src/sgame/botlib/bot_nav.cpp
@@ -135,7 +135,7 @@ void G_BotSetNavMesh( gentity_t *ent )
 	{
 		polyflags |= POLYFLAGS_JETPACK;
 	}
-	nav->filter.setIncludeFlags( polyflags );
+	bot.filter.setIncludeFlags( polyflags );
 
 	bot.nav = nav;
 	float clearVec[3]{};
@@ -204,16 +204,16 @@ bool G_IsBotOverNavcon( int botClientNum )
 
 static void G_UpdatePathCorridor( Bot_t *bot, rVec spos, botRouteTargetInternal target )
 {
-	bot->corridor.movePosition( spos, bot->nav->query, &bot->nav->filter );
+	bot->corridor.movePosition( spos, bot->nav->query, &bot->filter );
 
 	if ( target.type == botRouteTargetType_t::BOT_TARGET_DYNAMIC )
 	{
-		bot->corridor.moveTargetPosition( target.pos, bot->nav->query, &bot->nav->filter );
+		bot->corridor.moveTargetPosition( target.pos, bot->nav->query, &bot->filter );
 	}
 
-	if ( !bot->corridor.isValid( MAX_PATH_LOOKAHEAD, bot->nav->query, &bot->nav->filter ) )
+	if ( !bot->corridor.isValid( MAX_PATH_LOOKAHEAD, bot->nav->query, &bot->filter ) )
 	{
-		bot->corridor.trimInvalidPath( bot->corridor.getFirstPoly(), spos, bot->nav->query, &bot->nav->filter );
+		bot->corridor.trimInvalidPath( bot->corridor.getFirstPoly(), spos, bot->nav->query, &bot->filter );
 		bot->needReplan = true;
 	}
 
@@ -389,7 +389,7 @@ bool BotFindRandomPointInRadius( int botClientNum, const glm::vec3 &origin, glm:
 	}
 
 	dtPolyRef randRef;
-	dtStatus status = bot->nav->query->findRandomPointAroundCircle( nearPoly, rorigin, radius, &bot->nav->filter, frand, &randRef, nearPoint );
+	dtStatus status = bot->nav->query->findRandomPointAroundCircle( nearPoly, rorigin, radius, &bot->filter, frand, &randRef, nearPoint );
 
 	if ( dtStatusFailed( status ) )
 	{
@@ -412,12 +412,12 @@ bool G_BotNavTrace( int botClientNum, botTrace_t *trace, const glm::vec3& start,
 
 	Bot_t *bot = &agents[ botClientNum ];
 
-	status = bot->nav->query->findNearestPoly( spos, extents, &bot->nav->filter, &startRef, nullptr );
+	status = bot->nav->query->findNearestPoly( spos, extents, &bot->filter, &startRef, nullptr );
 	if ( dtStatusFailed( status ) || startRef == 0 )
 	{
 		//try larger extents
 		extents[ 1 ] += 500;
-		status = bot->nav->query->findNearestPoly( spos, extents, &bot->nav->filter, &startRef, nullptr );
+		status = bot->nav->query->findNearestPoly( spos, extents, &bot->filter, &startRef, nullptr );
 		if ( dtStatusFailed( status ) || startRef == 0 )
 		{
 			return false;
@@ -425,7 +425,7 @@ bool G_BotNavTrace( int botClientNum, botTrace_t *trace, const glm::vec3& start,
 	}
 
 	rVec unusedNormal;
-	status = bot->nav->query->raycast( startRef, spos, epos, &bot->nav->filter, &trace->frac, unusedNormal, nullptr, nullptr, 0 );
+	status = bot->nav->query->raycast( startRef, spos, epos, &bot->filter, &trace->frac, unusedNormal, nullptr, nullptr, 0 );
 	return !dtStatusFailed( status );
 }
 


### PR DESCRIPTION
The dtQueryFilter object was mistakenly set for all members of a PCL_ class, rather than on a per-bot level. So bots with a jetpack would step on the polyflags filter used by bots without jetpack or bsuit, and vice versa.

Fixes #3253.