### PR TITLE
Fix env_afx_gravity

### DIFF
--- a/src/sgame/sg_spawn_afx.cpp
+++ b/src/sgame/sg_spawn_afx.cpp
@@ -282,6 +282,7 @@ SP_trigger_gravity
 void SP_env_afx_gravity( gentity_t *self )
 {
 	int* amount = &self->mapEntity.config.amount;
+	self->mapEntity.amount = *amount;
 	if ( !( G_SpawnInt( "amount", "0", amount ) || G_SpawnInt( "gravity", "0", amount ) ) )
 	{
 		//TODO: it is highly possible that other situations are broken.


### PR DESCRIPTION
It seems our gravity entities always end up using 0 as gravity. This seems to fix that. I found the problem when looking at the function `env_afx_gravity_touch`.

I do not really understand what I am doing here. But I do provide a test map with several gravity zones (rename it from `.zip` to `.dpk`).

[map-blackhole_0.zip](https://github.com/user-attachments/files/18251555/map-blackhole_0.zip)
