### PR TITLE
Refactor game build configuration and build dll as subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,8 +94,9 @@ endif()
 # Configuration for Recast
 set(RC_MAX_LAYERS 63 CACHE STRING "Must be 255 or smaller.")
 set(RC_MAX_NEIS 16 CACHE STRING "")
+
 # This does not set the cache variable but rather a normal variable that shadows it.
-set(NACL_VM_INHERITED_OPTIONS ${NACL_VM_INHERITED_OPTIONS} RC_MAX_LAYERS RC_MAX_NEIS)
+set(VMS_INHERITED_OPTIONS ${VMS_INHERITED_OPTIONS} RC_MAX_LAYERS RC_MAX_NEIS)
 
 if (BUILDING_ANY_GAMELOGIC)
     if (BUILD_CGAME)
@@ -192,7 +193,7 @@ endif()
 if (BUILD_SGAME)
     include(tools/cbse/CBSE.cmake)
 
-    # Avoid generating CBSE in the NaCl subproject.
+    # Avoid generating CBSE in the subproject.
     if (FORK EQUAL 2)
         CBSEFileList("${GAMELOGIC_DIR}/sgame/" sgame_GENERATED_CBSE)
     else()
@@ -218,9 +219,9 @@ if (BUILD_SGAME)
 
     if (BUILD_GAME_NACL AND NOT (FORK EQUAL 2))
         include(ExternalProject)
-        foreach(NACL_VMS_PROJECT ${NACL_VMS_PROJECTS})
-            ExternalProject_Add_Step(${NACL_VMS_PROJECT} cbse-trigger
-                COMMENT "Finished CBSE generation, ready to build NaCl ${NACL_VMS_PROJECT}"
+        foreach(VMS_PROJECT ${VMS_PROJECTS})
+            ExternalProject_Add_Step(${VMS_PROJECT} cbse-trigger
+                COMMENT "Finished CBSE generation, ready to build ${VMS_PROJECT}"
                 DEPENDS ${sgame_GENERATED_CBSE}
                 DEPENDERS build)
         endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ if (BUILD_SGAME)
             srclibs-fastlz
     )
 
-    if (BUILD_GAME_NACL AND NOT (FORK EQUAL 2))
+    if ((BUILD_GAME_NATIVE_DLL OR BUILD_GAME_NACL) AND NOT (FORK EQUAL 2))
         include(ExternalProject)
         foreach(VMS_PROJECT ${VMS_PROJECTS})
             ExternalProject_Add_Step(${VMS_PROJECT} cbse-trigger


### PR DESCRIPTION
Refactor game build configuration to reuse the same code in parent build or subproject build and mutualize code between vm type build.

Also build hardened dll game with sub cmake to use different compilation flags.

Requires:

- https://github.com/DaemonEngine/Daemon/pull/1484