### PR TITLE
Cancel rant trample when using +attack

### DIFF
--- a/src/sgame/sg_bot_util.cpp
+++ b/src/sgame/sg_bot_util.cpp
@@ -2194,10 +2194,6 @@ void BotFireWeaponAI( gentity_t *self )
 			}
 			else
 			{
-				if ( self->client->ps.stats[ STAT_STATE ] & SS_CHARGING )
-				{
-					self->client->ps.weaponCharge = 0;
-				}
 				BotFireWeapon( WPM_PRIMARY, botCmdBuffer );    //rant swipe
 			}
 			break;

--- a/src/shared/bg_pmove.cpp
+++ b/src/shared/bg_pmove.cpp
@@ -3645,6 +3645,11 @@ static void PM_Weapon()
 	// Trample charge mechanics
 	if ( pm->ps->weapon == WP_ALEVEL4 )
 	{
+		// Cancel trample when using +attack
+		if ( attack1 ) {
+			pm->ps->weaponCharge = 0;
+		}
+
 		// Charging up
 		if ( !( pm->ps->stats[ STAT_STATE ] & SS_CHARGING ) )
 		{


### PR DESCRIPTION
This was a really annoying behaviour that required momentarily moving backwards in order to attack an enemy or enemy building while trampling, to cancel trample. That never made any sense, so now the trample will just be cancelled when +attack is used. Also removes the hack that was used to make bots do the above, since this fix also makes them cancel trample when attacking.