### PR TITLE
Fix incorrect MDV animation frames

### DIFF
--- a/src/cgame/cg_animmapobj.cpp
+++ b/src/cgame/cg_animmapobj.cpp
@@ -198,7 +198,7 @@ void CG_AnimMapObj( centity_t *cent )
 
 	cent->lerpFrame.animation = &anim;
 
-	if ( !anim.loopFrames )
+	if ( !anim.loopFrames && anim.numFrames > 1 )
 	{
 		// add one frame to allow the animation to play the last frame
 		// add another to get it to stop playing at the first frame
@@ -223,8 +223,16 @@ void CG_AnimMapObj( centity_t *cent )
 		cent->animLastState = !( cent->currentState.eFlags & EF_MOVER_STOP );
 	}
 
-	//run animation
-	CG_AMOAnimation( cent, &ent.oldframe, &ent.frame, &ent.backlerp );
+	if ( anim.numFrames > 1 )
+	{
+		//run animation
+		CG_AMOAnimation( cent, &ent.oldframe, &ent.frame, &ent.backlerp );
+	}
+	else
+	{
+		ent.frame = 0;
+		ent.oldframe = 0;
+	}
 
 	// add to refresh list
 	trap_R_AddRefEntityToScene( &ent );


### PR DESCRIPTION
Fixes #1312. I'm not entirely sure that the fix is correct, but it does fix the problem on `chasm`. Also note that we no longer have md3 models in assets, so we can't really test those.