### PR TITLE
dist: update the server config sample

### DIFF
--- a/dist/configs/config/server.cfg
+++ b/dist/configs/config/server.cfg
@@ -4,8 +4,17 @@
 // 0 - advertise everything, the server will be added to the public server list and information about it will be displayed to players
 // 1 - don't advertise but reply to status queries, this allows players to join and see what map is being played, how many people are playing, etc.
 // 2 - don't reply to status queries but accept connections, players can connect but not see server information
-// 3 - only accept LAN connections
 set server.private 0
+
+// allow source networks for incoming packets
+// 0 - loopback only
+// 1 - LAN
+// 2 - Internet
+set sv_networkScope 2
+
+// contact information to reach out to the server admin when needed: forum or chat nickname, mail address…
+// it is requested to be non-empty for public servers
+//set contact ""
 
 // server can be joined without password
 // set 1 to require password (see g_password below)


### PR DESCRIPTION
Update the server config sample.

The primary purpose was to document how to set the new `contact` cvar.

See this PR for the new `contact` cvar:

- https://github.com/DaemonEngine/Daemon/pull/1465

While it is not commented out, that cvar is still kept as empty string because we cannot set there a default and if we would set an example, that would defeat the purpose of the engine printing a warning because it is not set.

But then by testing the code I noticed my test server complained that I was trying to do a public server but it was not announced to the master because of `sv_networkScope` being `0`.

So this also documents this and gives the right value expected to be used with a public server.