### PR TITLE
Vampire mode: do not abuse the g_BPInitialBudget* cvars

### DIFF
--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -2212,8 +2212,8 @@ buildLog_t *G_BuildLogNew( gentity_t *actor, buildFate_t fate )
 	log->actor = actor && actor->client ? actor->client->pers.namelog : nullptr;
 
 	if ( g_BPTransfer.Get() ) {
-		log->humanBP = g_BPInitialBudgetHumans.Get();
-		log->alienBP = g_BPInitialBudgetAliens.Get();
+		log->humanBP = level.team[ TEAM_HUMANS ].totalBudget;
+		log->alienBP = level.team[ TEAM_ALIENS ].totalBudget;
 	}
 
 	return log;
@@ -2384,8 +2384,8 @@ void G_BuildLogRevert( int id )
 	}
 
 	if ( g_BPTransfer.Get() && log != nullptr ) {
-		g_BPInitialBudgetHumans.Set( log->humanBP );
-		g_BPInitialBudgetAliens.Set( log->alienBP );
+		level.team[ TEAM_HUMANS ].totalBudget = log->humanBP;
+		level.team[ TEAM_ALIENS ].totalBudget = log->alienBP;
 
 		G_UpdateBPVampire( -1 );
 	}

--- a/src/sgame/sg_buildpoints.cpp
+++ b/src/sgame/sg_buildpoints.cpp
@@ -83,7 +83,6 @@ void G_UpdateBPVampire( int client ) // -1 to update everyone
 void G_UpdateBuildPointBudgets() {
 	int abp = g_BPInitialBudgetAliens.Get();
 	int hbp = g_BPInitialBudgetHumans.Get();
-	// TODO: maybe make vampire mode consider the current BP budgets
 	for (team_t team = TEAM_NONE; (team = G_IterateTeams(team)); ) {
 		if ( team == TEAM_ALIENS && abp >= 0 )
 		{
@@ -97,13 +96,17 @@ void G_UpdateBuildPointBudgets() {
 		{
 			level.team[team].totalBudget = g_buildPointInitialBudget.Get();
 		}
+		if ( g_BPTransfer.Get() )
+		{
+			level.team[ team ].totalBudget += level.team[ team ].vampireBudgetSurplus;
+		}
 	}
 
 	ForEntities<MiningComponent>([&] (Entity& entity, MiningComponent& miningComponent) {
 		level.team[G_Team(entity.oldEnt)].totalBudget += miningComponent.Efficiency() *
 		                                                 g_buildPointBudgetPerMiner.Get();
 	});
-	//G_UpdateBPVampire( -1 );
+	G_UpdateBPVampire( -1 );
 }
 
 void G_RecoverBuildPoints() {

--- a/src/sgame/sg_buildpoints.cpp
+++ b/src/sgame/sg_buildpoints.cpp
@@ -77,20 +77,27 @@ void G_UpdateBPVampire( int client ) // -1 to update everyone
 		return;
 	}
 
-	trap_SendServerCommand( client, va( "bpvampire %d %d", g_BPInitialBudgetHumans.Get(), g_BPInitialBudgetAliens.Get() ) );
+	trap_SendServerCommand( client, va( "bpvampire %d %d", static_cast<int>( level.team[ TEAM_HUMANS ].totalBudget ), static_cast<int>( level.team[ TEAM_ALIENS ].totalBudget ) ) );
 }
 
 void G_UpdateBuildPointBudgets() {
 	int abp = g_BPInitialBudgetAliens.Get();
 	int hbp = g_BPInitialBudgetHumans.Get();
+	int alienSurplus = 0;  // vampire mode
+	int humanSurplus = 0;  // vampire mode
+	if ( g_BPTransfer.Get() )
+	{
+		alienSurplus = level.team[ TEAM_ALIENS ].totalBudget - abp;
+		humanSurplus = level.team[ TEAM_HUMANS ].totalBudget - hbp;
+	}
 	for (team_t team = TEAM_NONE; (team = G_IterateTeams(team)); ) {
 		if ( team == TEAM_ALIENS && abp >= 0 )
 		{
-			level.team[team].totalBudget = abp;
+			level.team[team].totalBudget = abp + alienSurplus;
 		}
 		else if ( team == TEAM_HUMANS && hbp >= 0 )
 		{
-			level.team[team].totalBudget = hbp;
+			level.team[team].totalBudget = hbp + humanSurplus;
 		}
 		else
 		{

--- a/src/sgame/sg_buildpoints.cpp
+++ b/src/sgame/sg_buildpoints.cpp
@@ -84,11 +84,11 @@ void G_UpdateBuildPointBudgets() {
 	int abp = g_BPInitialBudgetAliens.Get();
 	int hbp = g_BPInitialBudgetHumans.Get();
 	for (team_t team = TEAM_NONE; (team = G_IterateTeams(team)); ) {
-		if ( team == TEAM_ALIENS && abp > -32768 )
+		if ( team == TEAM_ALIENS && abp >= 0 )
 		{
 			level.team[team].totalBudget = abp;
 		}
-		else if ( team == TEAM_HUMANS && hbp > -32768 )
+		else if ( team == TEAM_HUMANS && hbp >= 0 )
 		{
 			level.team[team].totalBudget = hbp;
 		}

--- a/src/sgame/sg_buildpoints.cpp
+++ b/src/sgame/sg_buildpoints.cpp
@@ -83,21 +83,15 @@ void G_UpdateBPVampire( int client ) // -1 to update everyone
 void G_UpdateBuildPointBudgets() {
 	int abp = g_BPInitialBudgetAliens.Get();
 	int hbp = g_BPInitialBudgetHumans.Get();
-	int alienSurplus = 0;  // vampire mode
-	int humanSurplus = 0;  // vampire mode
-	if ( g_BPTransfer.Get() )
-	{
-		alienSurplus = level.team[ TEAM_ALIENS ].totalBudget - abp;
-		humanSurplus = level.team[ TEAM_HUMANS ].totalBudget - hbp;
-	}
+	// TODO: maybe make vampire mode consider the current BP budgets
 	for (team_t team = TEAM_NONE; (team = G_IterateTeams(team)); ) {
 		if ( team == TEAM_ALIENS && abp >= 0 )
 		{
-			level.team[team].totalBudget = abp + alienSurplus;
+			level.team[team].totalBudget = abp;
 		}
 		else if ( team == TEAM_HUMANS && hbp >= 0 )
 		{
-			level.team[team].totalBudget = hbp + humanSurplus;
+			level.team[team].totalBudget = hbp;
 		}
 		else
 		{

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -352,6 +352,8 @@ static void TransferBPToEnemyTeam( gentity_t *self )
 	default:
 		break;
 	}
+	// keep track of the budget surplus
+	// this is only required when the initial BP settings change during a game
 	for ( auto tup : { std::tuple< team_t, int >( TEAM_HUMANS, g_BPInitialBudgetHumans.Get() ),
 	                   std::tuple< team_t, int >( TEAM_ALIENS, g_BPInitialBudgetAliens.Get() ) } )
 	{

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -340,13 +340,13 @@ static void TransferBPToEnemyTeam( gentity_t *self )
 	switch ( otherTeam )
 	{
 	case TEAM_ALIENS:
-		g_BPInitialBudgetHumans.Set( g_BPInitialBudgetHumans.Get() - bpToTransfer );
-		g_BPInitialBudgetAliens.Set( g_BPInitialBudgetAliens.Get() + bpToTransfer );
+		level.team[ TEAM_HUMANS ].totalBudget -= bpToTransfer;
+		level.team[ TEAM_ALIENS ].totalBudget += bpToTransfer;
 		bpStolenAtThisFrame[ TEAM_ALIENS ] += bpToTransfer;
 		break;
 	case TEAM_HUMANS:
-		g_BPInitialBudgetHumans.Set( g_BPInitialBudgetHumans.Get() + bpToTransfer );
-		g_BPInitialBudgetAliens.Set( g_BPInitialBudgetAliens.Get() - bpToTransfer );
+		level.team[ TEAM_HUMANS ].totalBudget += bpToTransfer;
+		level.team[ TEAM_ALIENS ].totalBudget -= bpToTransfer;
 		bpStolenAtThisFrame[ TEAM_HUMANS ] += bpToTransfer;
 		break;
 	default:

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -350,7 +350,19 @@ static void TransferBPToEnemyTeam( gentity_t *self )
 		bpStolenAtThisFrame[ TEAM_HUMANS ] += bpToTransfer;
 		break;
 	default:
-		return;
+		break;
+	}
+	for ( auto tup : { std::tuple< team_t, int >( TEAM_HUMANS, g_BPInitialBudgetHumans.Get() ),
+	                   std::tuple< team_t, int >( TEAM_ALIENS, g_BPInitialBudgetAliens.Get() ) } )
+	{
+		team_t team;
+		int initialBP;
+		std::tie( team, initialBP ) = tup;
+		if ( initialBP < 0 )
+		{
+			initialBP = g_buildPointInitialBudget.Get();
+		}
+		level.team[ team ].vampireBudgetSurplus = level.team[ team ].totalBudget - initialBP;
 	}
 }
 

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -113,7 +113,7 @@ Cvar::Callback<Cvar::Cvar<int>> g_BPInitialBudgetHumans(
 		"g_BPInitialBudgetHumans",
 		"Initial build points count for humans",
 		Cvar::SERVERINFO,
-		-32768,
+		-1,
 		[](int) {
 			G_UpdateBuildPointBudgets();
 		});
@@ -121,7 +121,7 @@ Cvar::Callback<Cvar::Cvar<int>> g_BPInitialBudgetAliens(
 		"g_BPInitialBudgetAliens",
 		"Initial build points count for humans",
 		Cvar::SERVERINFO,
-		-32768,
+		-1,
 		[](int) {
 			G_UpdateBuildPointBudgets();
 		});

--- a/src/sgame/sg_spawn.cpp
+++ b/src/sgame/sg_spawn.cpp
@@ -1109,9 +1109,6 @@ static void SP_worldspawn()
 	InitDisabledItemCvars();
 	InitTacticBehaviorsCvar();
 
-	g_BPInitialBudgetAliens.Set( g_buildPointInitialBudget.Get() );
-	g_BPInitialBudgetHumans.Set( g_buildPointInitialBudget.Get() );
-
 	g_entities[ ENTITYNUM_WORLD ].s.number = ENTITYNUM_WORLD;
 	g_entities[ ENTITYNUM_WORLD ].r.ownerNum = ENTITYNUM_NONE;
 	g_entities[ ENTITYNUM_WORLD ].classname = S_WORLDSPAWN;

--- a/src/sgame/sg_struct.h
+++ b/src/sgame/sg_struct.h
@@ -662,6 +662,7 @@ struct level_locals_t
 		float            totalBudget; // Read access always rounds towards zero.
 		int              spentBudget;
 		int              queuedBudget;
+		int              vampireBudgetSurplus;
 		spawnQueue_t     spawnQueue;
 		bool             locked;
 		float            momentum;


### PR DESCRIPTION
Fix the ugly hack I had started with. Do not modify the cvars `g_BPInitialBudgetAliens` and `g_BPInitialBudgetHumans` anymore. Doing this is probably dangerous, as these are serverinfo cvars.

This also reverts a hacky commit I had added to temporarily allow negative values for said cvars.

Directly modify `level.team[ team ].totalBudget` instead.