### PR TITLE
Fix Freetype mess, MinGW native gamelogic build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,18 +99,12 @@ set(NACL_VM_INHERITED_OPTIONS ${NACL_VM_INHERITED_OPTIONS} RC_MAX_LAYERS RC_MAX_
 
 if (BUILDING_ANY_GAMELOGIC)
     if (BUILD_CGAME)
-        # Freetype (RmlUi dependency), already found for a native game when the client is built.
-        if (NACL)
-            include(${DAEMON_DIR}/freetype.cmake)
-        elseif (NOT BUILD_CLIENT)
-            prefer_package(Freetype ${DAEMON_DIR}/freetype.cmake)
-
-            if (Freetype_FOUND AND (APPLE OR WIN32))
-                find_package(ZLIB REQUIRED)
-                set(FREETYPE_LIBRARIES ${FREETYPE_LIBRARIES} ${ZLIB_LIBRARIES})
-            endif()
+        # Freetype (RmlUi dependency)
+        prefer_package(Freetype ${DAEMON_DIR}/freetype.cmake)
+        if (Freetype_FOUND AND (APPLE OR WIN32))
+            find_package(ZLIB REQUIRED)
+            set(FREETYPE_LIBRARIES ${FREETYPE_LIBRARIES} ${ZLIB_LIBRARIES})
         endif()
-
         include_directories(${FREETYPE_INCLUDE_DIRS})
 
         # RmlUi

--- a/rmlui.cmake
+++ b/rmlui.cmake
@@ -566,12 +566,6 @@ set_source_files_properties(
     ${RMLUI_DIR}/Source/Core/SystemInterface.cpp # includes windows.h
     PROPERTIES SKIP_UNITY_BUILD_INCLUSION 1)
 
-if (NOT FREETYPE_INCLUDE_DIRS)
-    find_package(Freetype REQUIRED)
-endif()
-
-include_directories(${FREETYPE_INCLUDE_DIRS})
-
 set(RMLUI_INCLUDE_DIRS ${RMLUI_DIR}/Include)
 
 include_directories(${RMLUI_INCLUDE_DIRS})


### PR DESCRIPTION
06453a8c96118b09b300c402e0d86d62e5d32b16 does a regression of finding Freetype (and populating the variables) only if "NOT BUILD_CLIENT". We always need to find and set it regardless of what happened in Daemon's CMakeLists! It still worked sometimes because rmlui.cmake had a duplicate call to find_package(Freetype). But rmlui.cmake does not link zlib which is supposed to be a dependency of the external_deps Freetype builds used on Windows and Mac.

Note: with some toolchains the build can succeed even if the zlib dependency is not provided. This happens with Visual Studio and I've seen it on Mac too. I think it must depend on whether the linker removes unused symbols or resolves dependencies first. For MinGW you actually have to link zlib to build.