### PR TITLE
Vampire mode: fix bug when recently damaged building is marked and replaced

### DIFF
--- a/src/sgame/components/AlienBuildableComponent.cpp
+++ b/src/sgame/components/AlienBuildableComponent.cpp
@@ -64,7 +64,7 @@ void AlienBuildableComponent::Blast(int /*timeDelta*/) {
 	Entities::AntiHumanRadiusDamage(entity, ba->splashDamage, ba->splashRadius, ba->meansOfDeath);
 
 	// Reward attackers.
-	G_RewardAttackers(entity.oldEnt);
+	G_RewardAttackers(entity.oldEnt, true);
 
 	// Stop collisions, add blast event and update buildable state.
 	entity.oldEnt->r.contents = 0; trap_LinkEntity(entity.oldEnt);

--- a/src/sgame/components/HumanBuildableComponent.cpp
+++ b/src/sgame/components/HumanBuildableComponent.cpp
@@ -9,7 +9,7 @@ HumanBuildableComponent::HumanBuildableComponent(Entity& entity, BuildableCompon
 	: HumanBuildableComponentBase(entity, r_BuildableComponent, r_TeamComponent)
 {}
 
-void HumanBuildableComponent::HandleDie(gentity_t* /*killer*/, meansOfDeath_t /*meansOfDeath*/) {
+void HumanBuildableComponent::HandleDie(gentity_t* /*killer*/, meansOfDeath_t meansOfDeath) {
 	switch (GetBuildableComponent().GetState()) {
 		// Regular death, fully constructed.
 		case BuildableComponent::CONSTRUCTED:
@@ -35,7 +35,7 @@ void HumanBuildableComponent::HandleDie(gentity_t* /*killer*/, meansOfDeath_t /*
 
 		// Construction was canceled.
 		case BuildableComponent::CONSTRUCTING:
-			G_RewardAttackers(entity.oldEnt);
+			G_RewardAttackers(entity.oldEnt, meansOfDeath != MOD_DECONSTRUCT && meansOfDeath != MOD_REPLACE && meansOfDeath != MOD_BUILDLOG_REVERT);
 			entity.FreeAt(DeferredFreeingComponent::FREE_AFTER_THINKING);
 			humanBuildableLogger.Notice("Human buildable was canceled.");
 			break;
@@ -53,7 +53,7 @@ void HumanBuildableComponent::Blast(int /*timeDelta*/) {
 	Entities::KnockbackRadiusDamage(entity, ba->splashDamage, ba->splashRadius, ba->meansOfDeath);
 
 	// Reward attackers.
-	G_RewardAttackers(entity.oldEnt);
+	G_RewardAttackers(entity.oldEnt, true);
 
 	// Stop collisions, add blast event and update buildable state.
 	entity.oldEnt->r.contents = 0;

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -750,7 +750,7 @@ bool G_DeconstructDead( gentity_t *buildable )
 	// Always let the builder prevent the explosion of a buildable.
 	if ( Entities::IsDead( buildable ) )
 	{
-		G_RewardAttackers( buildable );
+		G_RewardAttackers( buildable, false );
 		G_FreeEntity( buildable );
 		return true;
 	}
@@ -777,7 +777,7 @@ static void G_Deconstruct( gentity_t *self, gentity_t *deconner, meansOfDeath_t 
 
 	// reward attackers if the structure was hurt before deconstruction
 	float healthFraction = self->entity->Get<HealthComponent>()->HealthFraction();
-	if ( healthFraction < 1.0f ) G_RewardAttackers( self );
+	if ( healthFraction < 1.0f ) G_RewardAttackers( self, false );
 
 	// deconstruct
 	Entities::Kill(self, deconner, deconType);

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -319,7 +319,7 @@ void G_AnnounceStolenBP()
 	}
 }
 
-static void TransferBPToEnemyTeam( gentity_t *self )
+static void TransferBPToEnemyTeam( gentity_t *self, bool freeBP )
 {
 	if ( !g_BPVampire.Get() )
 	{
@@ -370,14 +370,17 @@ static void TransferBPToEnemyTeam( gentity_t *self )
 	// reason: HandleDie is called when the building dies, but we are here
 	// when the building explodes (or vanishes)
 	// the explosion happens several seconds after the death
-	G_FreeBudget( self->buildableTeam, 0, BG_Buildable( self->s.modelindex )->buildPoints );
+	if ( freeBP )
+	{
+		G_FreeBudget( self->buildableTeam, 0, BG_Buildable( self->s.modelindex )->buildPoints );
+	}
 }
 
 /**
  * @brief Function to distribute rewards to entities that killed this one.
  * @param self
  */
-void G_RewardAttackers( gentity_t *self )
+void G_RewardAttackers( gentity_t *self, bool freeBP )
 {
 	float     value, share, reward, enemyDamage, damageShare;
 	int       playerNum, maxHealth;
@@ -500,7 +503,7 @@ void G_RewardAttackers( gentity_t *self )
 
 	if ( enemyDamagedBuildable )
 	{
-		TransferBPToEnemyTeam( self );
+		TransferBPToEnemyTeam( self, freeBP );
 	}
 }
 
@@ -650,7 +653,7 @@ void G_PlayerDie( gentity_t *self, gentity_t *inflictor, gentity_t *attacker, in
 	}
 
 	// give credits for killing this player
-	G_RewardAttackers( self );
+	G_RewardAttackers( self, meansOfDeath != MOD_DECONSTRUCT && meansOfDeath != MOD_REPLACE && meansOfDeath != MOD_BUILDLOG_REVERT );
 
 	VectorCopy( self->s.origin, self->client->pers.lastDeathLocation );
 

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -183,7 +183,7 @@ bool          G_CanDamage( gentity_t *targ, const vec3_t origin );
 void              G_SelectiveDamage( gentity_t *targ, gentity_t *inflictor, gentity_t *attacker, const vec3_t dir, const vec3_t point, int damage, int dflags, int mod, int team );
 bool          G_RadiusDamage( const vec3_t origin, gentity_t *attacker, float damage, float radius, gentity_t *ignore, int dflags, int mod, team_t testHit = TEAM_NONE );
 bool          G_SelectiveRadiusDamage( const vec3_t origin, gentity_t *attacker, float damage, float radius, gentity_t *ignore, int mod, int ignoreTeam );
-void              G_RewardAttackers( gentity_t *self );
+void              G_RewardAttackers( gentity_t *self, bool freeBP );
 void              G_AddCreditsToScore( gentity_t *self, int credits );
 void              G_AddMomentumToScore( gentity_t *self, float momentum );
 void              G_LogDestruction( gentity_t *self, gentity_t *actor, int mod );


### PR DESCRIPTION
Vampire mode does the call to `G_FreeBudget` when the enemy team is rewarded, and not when the building dies (reaches zero health). However, for historic reasons, this call must not be done when the means of death is one of `MOD_DECONSTRUCT, MOD_REPLACE, MOD_BUILDLOG_REVERT`. Fix this by excluding these cases.