### PR TITLE
Fix realLight keyword for particle coloring

### DIFF
--- a/src/cgame/cg_particles.cpp
+++ b/src/cgame/cg_particles.cpp
@@ -2507,7 +2507,16 @@ static void CG_RenderParticle( particle_t *p )
 		if ( bp->realLight )
 		{
 			vec3_t alight, dlight, lightdir;
+
+			// FIXME: at the time of writing, this API is broken with full-range overbright as it
+			// does not include the lightFactor
+			// But clamp it in case that is fixed later (which could lead to values greater than 1.)
+			// This FIXME also applies to trail realLight.
 			trap_R_LightForPoint( p->origin, alight, dlight, lightdir );
+			for ( float &val : alight )
+			{
+				val = std::min( val, 1.0f ) * 255.0f;
+			}
 
 			re.shaderRGBA.SetRed( alight[0] );
 			re.shaderRGBA.SetGreen( alight[1] );

--- a/src/cgame/cg_trails.cpp
+++ b/src/cgame/cg_trails.cpp
@@ -147,6 +147,11 @@ static void CG_LightVertex( vec3_t point, byte alpha, byte *rgba )
 
 	trap_R_LightForPoint( point, alight, dlight, lightdir );
 
+	for ( float &val : alight )
+	{
+		val = std::min( val, 1.0f ) * 255.0f;
+	}
+
 	for ( i = 0; i <= 2; i++ )
 	{
 		rgba[ i ] = ( int ) alight[ i ];


### PR DESCRIPTION
A 0-1 color needed to be rescaled to 0-255. This regression may have been caused by Daemon 07251fce, which appears to change the R_LightForPoint results from a 0-255 scale to a 0-1 scale. But I didn't verify.

For now, realLight is only really fixed with overbright clamping enabled, as R_LightForPoint does not scale with the light factor as it should.

Before and after (both with `r_overbrightDefaultClamp 1`):
![unvanquished-sectorb17-smoke-particle-reallight](https://github.com/user-attachments/assets/c01bf8d3-9cef-46e6-94e9-cf9663021ac2)
![unvanquished-sectorb17-smoke-particle-reallight](https://github.com/user-attachments/assets/3946f969-bcce-4739-b1bd-d71cc09d2b60)
