### PR TITLE
vampire mode: re-enable the BP queue, free BP as in mining

### DIFF
--- a/src/sgame/components/BuildableComponent.cpp
+++ b/src/sgame/components/BuildableComponent.cpp
@@ -86,9 +86,7 @@ void BuildableComponent::HandleDie(gentity_t* killer, meansOfDeath_t meansOfDeat
 
 	// If destroyed violently, add all build points to queue.
 	if (meansOfDeath != MOD_DECONSTRUCT && meansOfDeath != MOD_REPLACE && meansOfDeath != MOD_BUILDLOG_REVERT) {
-		if (!g_BPVampire.Get()) {
-			G_FreeBudget(team, 0, BG_Buildable(entity.oldEnt->s.modelindex)->buildPoints);
-		}
+		G_FreeBudget(team, 0, BG_Buildable(entity.oldEnt->s.modelindex)->buildPoints);
 	}
 }
 

--- a/src/sgame/sg_buildpoints.cpp
+++ b/src/sgame/sg_buildpoints.cpp
@@ -180,10 +180,7 @@ void G_FreeBudget( team_t team, int immediateAmount, int queuedAmount )
 	if ( G_IsPlayableTeam( team ) )
 	{
 		level.team[ team ].spentBudget  -= (immediateAmount + queuedAmount);
-		if ( !g_BPVampire.Get() )
-		{
-			level.team[ team ].queuedBudget += queuedAmount;
-		}
+		level.team[ team ].queuedBudget += queuedAmount;
 
 		// Note that there can be more build points in queue than total - spent.
 

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -365,12 +365,6 @@ static void TransferBPToEnemyTeam( gentity_t *self )
 		}
 		level.team[ team ].vampireBudgetSurplus = level.team[ team ].totalBudget - initialBP;
 	}
-	// vampire mode disables the call to G_FreeBudget in the component's
-	// HandleDie method, and does it here instead
-	// reason: HandleDie is called when the building dies, but we are here
-	// when the building explodes (or vanishes)
-	// the explosion happens several seconds after the death
-	G_FreeBudget( self->buildableTeam, 0, BG_Buildable( self->s.modelindex )->buildPoints );
 }
 
 /**


### PR DESCRIPTION
There is a bug in the vampire mode. When a building under construction is destroyed, its BP are not handled correctly. Not even https://github.com/Unvanquished/Unvanquished/pull/3302 seems to fix this. I observed a case where the available budget shown to a builder was 3, but the total budget minus the budget used by existing buildings was 33. So the builder should have had 33 BP available. I do not know the exact cause.

The first vampire commit was too ambitious: we disable the BP queue completely when vampire mode is enabled. Sadly, the vampire branch has been squashed down to a single commit, so we cannot revert the problematic commits anymore.

I propose we re-enable the BP queue for now. This makes the vampire mode playable.  A good value for the BP regen rate is 90 per minute. Any value that does not regen 8 or more BP in 4 seconds will not result in problems. 4 seconds is the time between a building's death and its explosion. 8 BP is the cost of the cheapest buliding.