### PR TITLE
Use RSF_FORCE_LIGHTMAP

### DIFF
--- a/src/cgame/cg_consolecmds.cpp
+++ b/src/cgame/cg_consolecmds.cpp
@@ -351,8 +351,7 @@ static void CG_CompleteItem()
 
 static void CG_TestCGrade_f()
 {
-	qhandle_t shader = trap_R_RegisterShader(CG_Argv(1),
-						 (RegisterShaderFlags_t) ( RSF_NOMIP | RSF_NOLIGHTSCALE ) );
+	qhandle_t shader = trap_R_RegisterShader( CG_Argv(1), RSF_NOMIP );
 
 	// override shader 0
 	cgs.gameGradingTextures[ 0 ] = shader;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -675,7 +675,7 @@ void CG_RegisterGrading( int slot, const char *str )
 	}
 
 	cgs.gameGradingTextures[ slot ] =
-		trap_R_RegisterShader(texture, (RegisterShaderFlags_t) ( RSF_NOMIP | RSF_NOLIGHTSCALE ) );
+		trap_R_RegisterShader(texture, RSF_NOMIP );
 	cgs.gameGradingModels[ slot ] = model;
 	cgs.gameGradingDistances[ slot ] = dist;
 }
@@ -798,10 +798,10 @@ static void CG_RegisterGraphics()
 	cgs.media.healthCrossMedkit = trap_R_RegisterShader("ui/assets/neutral/cross_medkit", RSF_2D | RSF_FITSCREEN);
 	cgs.media.healthCrossPoisoned = trap_R_RegisterShader("ui/assets/neutral/cross_poison", RSF_2D | RSF_FITSCREEN);
 
-	cgs.media.desaturatedCgrade = trap_R_RegisterShader("gfx/cgrading/desaturated", (RegisterShaderFlags_t) ( RSF_NOMIP | RSF_NOLIGHTSCALE ) );
-	cgs.media.neutralCgrade = trap_R_RegisterShader("gfx/cgrading/neutral", (RegisterShaderFlags_t) ( RSF_NOMIP | RSF_NOLIGHTSCALE ) );
-	cgs.media.redCgrade = trap_R_RegisterShader("gfx/cgrading/red-only", (RegisterShaderFlags_t) ( RSF_NOMIP | RSF_NOLIGHTSCALE ) );
-	cgs.media.tealCgrade = trap_R_RegisterShader("gfx/cgrading/teal-only", (RegisterShaderFlags_t) ( RSF_NOMIP | RSF_NOLIGHTSCALE ) );
+	cgs.media.desaturatedCgrade = trap_R_RegisterShader("gfx/cgrading/desaturated", RSF_NOMIP );
+	cgs.media.neutralCgrade = trap_R_RegisterShader("gfx/cgrading/neutral", RSF_NOMIP );
+	cgs.media.redCgrade = trap_R_RegisterShader("gfx/cgrading/red-only", RSF_NOMIP );
+	cgs.media.tealCgrade = trap_R_RegisterShader("gfx/cgrading/teal-only", RSF_NOMIP );
 
 	cgs.media.balloonShader = trap_R_RegisterShader("gfx/feedback/chatballoon", (RegisterShaderFlags_t) ( RSF_2D | RSF_FITSCREEN ) );
 

--- a/src/cgame/cg_particles.cpp
+++ b/src/cgame/cg_particles.cpp
@@ -811,7 +811,7 @@ CG_ParseParticle
 Parse a particle section
 ===============
 */
-static bool CG_ParseParticle( baseParticle_t *bp, const char **text_p )
+static bool CG_ParseParticle( baseParticle_t *bp, const char* name, const char **text_p )
 {
 	// read optional parameters
 	while ( 1 )
@@ -1209,6 +1209,8 @@ static bool CG_ParseParticle( baseParticle_t *bp, const char **text_p )
 		}
 		else if ( !Q_stricmp( token, "realLight" ) )
 		{
+			Log::Warn( "Particle system %s: realLight keyword is deprecated, use a diffuseMap stage to light particles instead",
+				name );
 			bp->realLight = true;
 		}
 		else if ( !Q_stricmp( token, "dynamicLight" ) )
@@ -1501,7 +1503,7 @@ CG_ParseParticleEjector
 Parse a particle ejector section
 ===============
 */
-static bool CG_ParseParticleEjector( baseParticleEjector_t *bpe, const char **text_p )
+static bool CG_ParseParticleEjector( baseParticleEjector_t *bpe, const char* name, const char **text_p )
 {
 	// read optional parameters
 	while ( 1 )
@@ -1517,7 +1519,7 @@ static bool CG_ParseParticleEjector( baseParticleEjector_t *bpe, const char **te
 		{
 			CG_InitialiseBaseParticle( &baseParticles[ numBaseParticles ] );
 
-			if ( !CG_ParseParticle( &baseParticles[ numBaseParticles ], text_p ) )
+			if ( !CG_ParseParticle( &baseParticles[ numBaseParticles ], name, text_p ) )
 			{
 				logger.Warn( "failed to parse particle" );
 				return false;
@@ -1649,7 +1651,7 @@ static bool CG_ParseParticleSystem( baseParticleSystem_t *bps, const char **text
 
 		if ( !Q_stricmp( token, "{" ) )
 		{
-			if ( !CG_ParseParticleEjector( &baseParticleEjectors[ numBaseParticleEjectors ], text_p ) )
+			if ( !CG_ParseParticleEjector( &baseParticleEjectors[ numBaseParticleEjectors ], name, text_p ) )
 			{
 				logger.Warn( "failed to parse particle ejector" );
 				return false;

--- a/src/cgame/cg_trails.cpp
+++ b/src/cgame/cg_trails.cpp
@@ -705,7 +705,7 @@ CG_ParseTrailBeam
 Parse a trail beam
 ===============
 */
-static bool CG_ParseTrailBeam( baseTrailBeam_t *btb, const char **text_p )
+static bool CG_ParseTrailBeam( baseTrailBeam_t *btb, const char* name, const char **text_p )
 {
 	// read optional parameters
 	while ( 1 )
@@ -957,7 +957,8 @@ static bool CG_ParseTrailBeam( baseTrailBeam_t *btb, const char **text_p )
 		else if ( !Q_stricmp( token, "realLight" ) )
 		{
 			btb->realLight = true;
-
+			Log::Warn( "Trail system %s: realLight keyword is deprecated, use a diffuseMap stage to light particles instead",
+				name );
 			continue;
 		}
 		else if ( !Q_stricmp( token, "jitter" ) )
@@ -1083,7 +1084,7 @@ static bool CG_ParseTrailSystem( baseTrailSystem_t *bts, const char **text_p, co
 		{
 			CG_InitialiseBaseTrailBeam( &baseTrailBeams[ numBaseTrailBeams ] );
 
-			if ( !CG_ParseTrailBeam( &baseTrailBeams[ numBaseTrailBeams ], text_p ) )
+			if ( !CG_ParseTrailBeam( &baseTrailBeams[ numBaseTrailBeams ], name, text_p ) )
 			{
 				logs.Warn( "failed to parse trail beam" );
 				return false;

--- a/src/cgame/cg_trails.cpp
+++ b/src/cgame/cg_trails.cpp
@@ -135,33 +135,6 @@ alphaRange = tb->class_->backAlpha -
 
 /*
 ===============
-CG_LightVertex
-
-Lights a particular vertex
-===============
-*/
-static void CG_LightVertex( vec3_t point, byte alpha, byte *rgba )
-{
-	int    i;
-	vec3_t alight, dlight, lightdir;
-
-	trap_R_LightForPoint( point, alight, dlight, lightdir );
-
-	for ( float &val : alight )
-	{
-		val = std::min( val, 1.0f ) * 255.0f;
-	}
-
-	for ( i = 0; i <= 2; i++ )
-	{
-		rgba[ i ] = ( int ) alight[ i ];
-	}
-
-	rgba[ 3 ] = alpha;
-}
-
-/*
-===============
 CG_RenderBeam
 
 Renders a beam
@@ -231,15 +204,8 @@ static void CG_RenderBeam( trailBeam_t *tb )
 			verts[ numVerts ].st[ 0 ] = i->textureCoord;
 			verts[ numVerts ].st[ 1 ] = 1.0f;
 
-			if ( btb->realLight )
-			{
-				CG_LightVertex( verts[ numVerts ].xyz, i->alpha, verts[ numVerts ].modulate );
-			}
-			else
-			{
-				VectorCopy( i->color, verts[ numVerts ].modulate );
-				verts[ numVerts ].modulate[ 3 ] = i->alpha;
-			}
+			VectorCopy( i->color, verts[ numVerts ].modulate );
+			verts[ numVerts ].modulate[ 3 ] = i->alpha;
 
 			numVerts++;
 
@@ -247,15 +213,8 @@ static void CG_RenderBeam( trailBeam_t *tb )
 			verts[ numVerts ].st[ 0 ] = i->textureCoord;
 			verts[ numVerts ].st[ 1 ] = 0.0f;
 
-			if ( btb->realLight )
-			{
-				CG_LightVertex( verts[ numVerts ].xyz, i->alpha, verts[ numVerts ].modulate );
-			}
-			else
-			{
-				VectorCopy( i->color, verts[ numVerts ].modulate );
-				verts[ numVerts ].modulate[ 3 ] = i->alpha;
-			}
+			VectorCopy( i->color, verts[ numVerts ].modulate );
+			verts[ numVerts ].modulate[ 3 ] = i->alpha;
 
 			numVerts++;
 		}
@@ -266,15 +225,8 @@ static void CG_RenderBeam( trailBeam_t *tb )
 			verts[ numVerts ].st[ 0 ] = i->textureCoord;
 			verts[ numVerts ].st[ 1 ] = 0.0f;
 
-			if ( btb->realLight )
-			{
-				CG_LightVertex( verts[ numVerts ].xyz, i->alpha, verts[ numVerts ].modulate );
-			}
-			else
-			{
-				VectorCopy( i->color, verts[ numVerts ].modulate );
-				verts[ numVerts ].modulate[ 3 ] = i->alpha;
-			}
+			VectorCopy( i->color, verts[ numVerts ].modulate );
+			verts[ numVerts ].modulate[ 3 ] = i->alpha;
 
 			numVerts++;
 
@@ -282,15 +234,8 @@ static void CG_RenderBeam( trailBeam_t *tb )
 			verts[ numVerts ].st[ 0 ] = i->textureCoord;
 			verts[ numVerts ].st[ 1 ] = 1.0f;
 
-			if ( btb->realLight )
-			{
-				CG_LightVertex( verts[ numVerts ].xyz, i->alpha, verts[ numVerts ].modulate );
-			}
-			else
-			{
-				VectorCopy( i->color, verts[ numVerts ].modulate );
-				verts[ numVerts ].modulate[ 3 ] = i->alpha;
-			}
+			VectorCopy( i->color, verts[ numVerts ].modulate );
+			verts[ numVerts ].modulate[ 3 ] = i->alpha;
 
 			numVerts++;
 		}
@@ -1369,8 +1314,8 @@ qhandle_t CG_RegisterTrailSystem( const char *name )
 			{
 				btb = bts->beams[ j ];
 
-				btb->shader = trap_R_RegisterShader(btb->shaderName,
-								    RSF_DEFAULT);
+				const int extraFlags = btb->realLight ? RSF_FORCE_LIGHTMAP : 0;
+				btb->shader = trap_R_RegisterShader( btb->shaderName, extraFlags );
 			}
 
 			logs.WithoutSuppression().Verbose( "Registered trail system %s", name );


### PR DESCRIPTION
Engine-side pr: https://github.com/DaemonEngine/Daemon/pull/1523

If this flag is used when registering a shader, all `ST_COLORMAP` stages will be changed to `ST_DIFFUSEMAP`. Use it for particles and trails, to make them use the lightGrid in the GLSL code.

Improves performance with particle systems and trails, e. g. with firebombs, and a massive performance improvement on map https://users.unvanquished.net/~sweet/pkg/map-jota_3.0.dpk in the outside area.

There's for the most part no difference in how the particles/trails look, the only differences are due to the GLSL lightGrid being more precise.

Also NUKED the now unused lightGrid code that involved IPC calls.