### PR TITLE
NUKE stupid random delay in weapon reload animation

### DIFF
--- a/src/shared/bg_pmove.cpp
+++ b/src/shared/bg_pmove.cpp
@@ -3876,7 +3876,6 @@ static void PM_Weapon()
 		//allow some time for the weapon to be raised
 		pm->ps->weaponstate = WEAPON_RAISING;
 		PM_StartTorsoAnim( TORSO_RAISE );
-		pm->ps->weaponTime += 250;
 		return;
 	}
 


### PR DESCRIPTION
This is already accounted for in the reload time, extra 250ms makes it not line up correctly. That code originates from Tremulous, however Tremulous did not have any proper reload animations, so it was lining up properly there. The change itself has a minimal impact on gameplay if noticeable, but removes the annoyance from reload animation.