### PR TITLE
Show server versions and a mismatch pop-up

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/rocket.txt
+++ b/pkg/unvanquished_src.dpkdir/ui/rocket.txt
@@ -51,6 +51,7 @@
 		ui/help_gameplay.rml
 
 		ui/server_browser.rml
+		ui/server_mismatch.rml
 		ui/callvote_map.rml
 		ui/server_create.rml
 

--- a/pkg/unvanquished_src.dpkdir/ui/server_browser.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/server_browser.rml
@@ -41,6 +41,7 @@
 				<datagrid id="iServers" source="server_browser.internet">
 					<col fields="label" width="3%" class="label"></col>
 					<col fields="name" width="50%" class="name"><ilink style="text-align:left;" onclick='Events.pushcmd("sortDS server_browser internet name")'><translate>Name:</translate></ilink></col>
+					<col fields="version" width="11%" class="version"><ilink onclick='Events.pushcmd("sortDS server_browser internet version")'><translate>Version:</translate></ilink></col>
 					<col fields="map" width="18%" class="map"><ilink onclick='Events.pushcmd("sortDS server_browser internet map")'><translate>Map:</translate></ilink></col>
 					<col fields="players,bots,maxClients" width="18%" formatter="ServerPlayers" class="players"><ilink onclick='Events.pushcmd("sortDS server_browser internet players")'><translate>Players (Bots)</translate></ilink></col>
 					<col fields="ping" width="11%" formatter="ServerPing" class="ping"><ilink onclick='Events.pushcmd("sortDS server_browser internet ping")'><translate>Ping</translate></ilink></col>
@@ -57,6 +58,7 @@
 				<datagrid source="server_browser.local">
 					<col fields="label" width="3%" class="label" formatter="ServerLabel"></col>
 					<col fields="name" width="50%" class="name"><translate>Name:</translate></col>
+					<col fields="version" width="11%" class="version"><ilink onclick='Events.pushcmd("sortDS server_browser local version")'><translate>Version:</translate></ilink></col>
 					<col fields="map" width="18%" class="map"><ilink onclick='Events.pushcmd("sortDS server_browser local map")'><translate>Map:</translate></ilink></col>
 					<col fields="players,bots,maxClients" width="18%" formatter="ServerPlayers" class="players"><ilink onclick='Events.pushcmd("sortDS server_browser local players")'><translate>Players (Bots)</translate></ilink></col>
 					<col fields="ping" width="11%" formatter="ServerPing" class="ping"><ilink onclick='Events.pushcmd("sortDS server_browser local ping")'><translate>Ping</translate></ilink></col>

--- a/pkg/unvanquished_src.dpkdir/ui/server_browser.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/server_browser.rml
@@ -57,7 +57,7 @@
 			<panel>
 				<datagrid source="server_browser.local">
 					<col fields="label" width="3%" class="label" formatter="ServerLabel"></col>
-					<col fields="name" width="50%" class="name"><translate>Name:</translate></col>
+					<col fields="name" width="50%" class="name"><ilink style="text-align:left;" onclick='Events.pushcmd("sortDS server_browser local name")'><translate>Name:</translate></ilink></col>
 					<col fields="version" width="11%" class="version"><ilink onclick='Events.pushcmd("sortDS server_browser local version")'><translate>Version:</translate></ilink></col>
 					<col fields="map" width="18%" class="map"><ilink onclick='Events.pushcmd("sortDS server_browser local map")'><translate>Map:</translate></ilink></col>
 					<col fields="players,bots,maxClients" width="18%" formatter="ServerPlayers" class="players"><ilink onclick='Events.pushcmd("sortDS server_browser local players")'><translate>Players (Bots)</translate></ilink></col>

--- a/pkg/unvanquished_src.dpkdir/ui/server_mismatch.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/server_mismatch.rml
@@ -6,9 +6,9 @@
 	</head>
 	<body id="server_mismatch" template="window" class="window-options" style="width: 40%; margin-top: 40%; text-align: center; z-index: 30">
 		<h1 style="text-align: center"><translate>Engine version mismatch</translate></h1>
-		<span ><translate>This server uses a different Daemon engine version and may not be compatible.</translate></span>
+		<span ><translate>This server uses a different Daemon engine version, which is not compatible.</translate></span>
 		<br/>
-		<span><translate>The latest Daemon release can be downloaded through the Updater app, at <web dest="download"/>, or in one of the official package repositories.</translate></span>
+		<span><translate>The latest Unvanquished release can be downloaded through the Updater app, at <web dest="download"/>, or in one of the official package repositories.</translate></span>
 		<button style="width:100%; margin-top: 2%;" onclick='Cmd.exec("connectToCurrentSelectedServer")'><translate>Connect anyway</translate></button>
 	</body>
 </rml>

--- a/pkg/unvanquished_src.dpkdir/ui/server_mismatch.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/server_mismatch.rml
@@ -1,0 +1,14 @@
+<rml>
+	<head>
+		<link type="text/rcss" href="/ui/shared/basics.rcss" />
+		<link type="text/template" href="/ui/shared/window.rml" />
+		<link type="text/rcss" href="menu.rcss" />
+	</head>
+	<body id="server_mismatch" template="window" class="window-options" style="width: 40%; margin-top: 40%; text-align: center; z-index: 30">
+		<h1 style="text-align: center"><translate>Engine version mismatch</translate></h1>
+		<span ><translate>This server uses a different Daemon engine version and may not be compatible.</translate></span>
+		<br/>
+		<span><translate>The latest Daemon release can be downloaded through the Updater app, at <web dest="download"/>, or in one of the official package repositories.</translate></span>
+		<button style="width:100%; margin-top: 2%;" onclick='Cmd.exec("connectToCurrentSelectedServer")'><translate>Connect anyway</translate></button>
+	</body>
+</rml>

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1372,8 +1372,8 @@ struct server_t
 {
 	char *name;
 	char *label;
-	char* version;
-	char* abiVersion;
+	std::string version;
+	std::string abiVersion;
 	int clients;
 	int bots;
 	int ping;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1372,6 +1372,8 @@ struct server_t
 {
 	char *name;
 	char *label;
+	char* version;
+	char* abiVersion;
 	int clients;
 	int bots;
 	int ping;

--- a/src/cgame/cg_rocket_datasource.cpp
+++ b/src/cgame/cg_rocket_datasource.cpp
@@ -510,7 +510,7 @@ static std::string cg_currentSelectedServer;
 class ConnectToCurrentSelectedServerCmd : public Cmd::StaticCmd {
 	public:
 	ConnectToCurrentSelectedServerCmd() : StaticCmd( "connectToCurrentSelectedServer",
-		Cmd::CLIENT, "Connect to cg_currentSelectedServer" ) {}
+		Cmd::CLIENT, "For internal use" ) {}
 
 	void Run( const Cmd::Args& ) const override {
 		Rocket_DocumentAction( "server_mismatch", "close" );

--- a/src/cgame/cg_rocket_datasource.cpp
+++ b/src/cgame/cg_rocket_datasource.cpp
@@ -505,7 +505,7 @@ static void CG_Rocket_FilterServerList( const char *table, const char *filter )
 	}
 }
 
-static int cg_currentSelectedServer;
+static std::string cg_currentSelectedServer;
 
 class ConnectToCurrentSelectedServerCmd : public Cmd::StaticCmd {
 	public:
@@ -513,10 +513,9 @@ class ConnectToCurrentSelectedServerCmd : public Cmd::StaticCmd {
 		Cmd::CLIENT, "Connect to cg_currentSelectedServer" ) {}
 
 	void Run( const Cmd::Args& ) const override {
-		const int netSrc = cg_currentSelectedServer;
 		Rocket_DocumentAction( "server_mismatch", "close" );
 		trap_SendConsoleCommand(
-			Str::Format( "connect %s", rocketInfo.data.servers[netSrc][rocketInfo.data.serverIndex[netSrc]].addr ).c_str()
+			Str::Format( "connect %s", cg_currentSelectedServer ).c_str()
 		);
 	}
 };
@@ -526,7 +525,7 @@ static void CG_Rocket_ExecServerList( const char *table )
 {
 	int netSrc = CG_StringToNetSource( table );
 	if ( Q_stricmp( rocketInfo.data.servers[netSrc]->abiVersion.c_str(), IPC::SYSCALL_ABI_VERSION ) ) {
-		cg_currentSelectedServer = netSrc;
+		cg_currentSelectedServer = rocketInfo.data.servers[netSrc][rocketInfo.data.serverIndex[netSrc]].addr;
 		Rocket_DocumentAction( "server_mismatch", "show" );
 	} else {
 		trap_SendConsoleCommand( va( "connect %s", rocketInfo.data.servers[netSrc][rocketInfo.data.serverIndex[netSrc]].addr ) );

--- a/src/cgame/cg_rocket_datasource.cpp
+++ b/src/cgame/cg_rocket_datasource.cpp
@@ -36,7 +36,8 @@ Maryland 20850 USA.
 #include "cg_local.h"
 #include "shared/parse.h"
 
-static bool AddToServerList( const char *name, const char *label, int clients, int bots, int ping, int maxClients, char *mapName, char *addr, int netSrc )
+static bool AddToServerList( const char *name, const char *label, const char* version, const char* abiVersion, int clients, int bots,
+	int ping, int maxClients, char *mapName, char *addr, int netSrc )
 {
 	server_t *node;
 
@@ -59,8 +60,9 @@ static bool AddToServerList( const char *name, const char *label, int clients, i
 	node->maxClients = maxClients;
 	node->addr = BG_strdup( addr );
 	node->label = BG_strdup( label );
+	node->version = BG_strdup( version );
 	node->mapName = BG_strdup( mapName );
-
+	node->abiVersion = BG_strdup( abiVersion );
 	rocketInfo.data.serverCount[ netSrc ]++;
 	return true;
 }
@@ -313,9 +315,12 @@ void CG_Rocket_BuildServerList()
 			clients = atoi( Info_ValueForKey( info.c_str(), "clients" ) );
 			maxClients = atoi( Info_ValueForKey( info.c_str(), "sv_maxclients" ) );
 			Q_strncpyz( mapname, Info_ValueForKey( info.c_str(), "mapname" ), sizeof( mapname ) );
+
+			const std::string version = Info_ValueForKey( info.c_str(), "daemonver" );
+			const std::string abiVersion = Info_ValueForKey( info.c_str(), "abi" );
 			rocketInfo.data.haveServerInfo[ netSrc ][ i ] =
 				AddToServerList( Info_ValueForKey( info.c_str(), "hostname" ), trustedInfo.featuredLabel,
-					clients, bots, ping, maxClients, mapname, trustedInfo.addr, netSrc );
+					version.c_str(), abiVersion.c_str(), clients, bots, ping, maxClients, mapname, trustedInfo.addr, netSrc );
 		}
 	}
 
@@ -336,6 +341,16 @@ void CG_Rocket_BuildServerList()
 		Info_SetValueForKey( data, "maxClients", va( "%d", rocketInfo.data.servers[ netSrc ][ i ].maxClients ), false );
 		Info_SetValueForKey( data, "addr", rocketInfo.data.servers[ netSrc ][ i ].addr, false );
 		Info_SetValueForKey( data, "label", rocketInfo.data.servers[ netSrc ][ i ].label, false );
+
+		std::string version;
+		if ( !Q_stricmp( rocketInfo.data.servers[netSrc][i].abiVersion, IPC::SYSCALL_ABI_VERSION ) ) {
+			version = rocketInfo.data.servers[netSrc][i].version;
+		} else {
+			version = Str::Format( "^1!%s!", rocketInfo.data.servers[netSrc][i].version );
+			Log::Warn( rocketInfo.data.servers[netSrc][i].abiVersion );
+		}
+
+		Info_SetValueForKey( data, "version", version.c_str(), false);
 		Info_SetValueForKey( data, "map", rocketInfo.data.servers[ netSrc ][ i ].mapName, false );
 
 		Rocket_DSAddRow( "server_browser", srcName, data );
@@ -430,6 +445,7 @@ static void CG_Rocket_SortServerList( const char *name, const char *sortBy )
 		Info_SetValueForKey( data, "maxClients", va( "%d", rocketInfo.data.servers[ netSrc ][ i ].maxClients ), false );
 		Info_SetValueForKey( data, "addr", rocketInfo.data.servers[ netSrc ][ i ].addr, false );
 		Info_SetValueForKey( data, "label", rocketInfo.data.servers[ netSrc ][ i ].label, false );
+		Info_SetValueForKey( data, "version", rocketInfo.data.servers[netSrc][i].version, false );
 		Info_SetValueForKey( data, "map", rocketInfo.data.servers[ netSrc ][ i ].mapName, false );
 
 		Rocket_DSAddRow( "server_browser", name, data );
@@ -483,16 +499,40 @@ static void CG_Rocket_FilterServerList( const char *table, const char *filter )
 			Info_SetValueForKey( data, "maxClients", va( "%d", rocketInfo.data.servers[ netSrc ][ i ].maxClients ), false );
 			Info_SetValueForKey( data, "addr", rocketInfo.data.servers[ netSrc ][ i ].addr, false );
 			Info_SetValueForKey( data, "label", rocketInfo.data.servers[ netSrc ][ i ].label, false );
+			Info_SetValueForKey( data, "version", rocketInfo.data.servers[netSrc][i].version, false );
 
 			Rocket_DSAddRow( "server_browser", str, data );
 		}
 	}
 }
 
+static Cvar::Cvar<int> cg_currentSelectedServer( "cg_currentSelectedServer",
+	"Current server selected in the server browser; for internal use", Cvar::CHEAT, 0 );
+
+class ConnectToCurrentSelectedServerCmd : public Cmd::StaticCmd {
+	public:
+	ConnectToCurrentSelectedServerCmd() : StaticCmd( "connectToCurrentSelectedServer",
+		Cmd::CLIENT, "Connect to cg_currentSelectedServer" ) {}
+
+	void Run( const Cmd::Args& ) const override {
+		const int netSrc = cg_currentSelectedServer.Get();
+		Rocket_DocumentAction( "server_mismatch", "close" );
+		trap_SendConsoleCommand(
+			Str::Format( "connect %s", rocketInfo.data.servers[netSrc][rocketInfo.data.serverIndex[netSrc]].addr ).c_str()
+		);
+	}
+};
+static ConnectToCurrentSelectedServerCmd ConnectToCurrentSelectedServerCmdRegistration;
+
 static void CG_Rocket_ExecServerList( const char *table )
 {
 	int netSrc = CG_StringToNetSource( table );
-	trap_SendConsoleCommand( va( "connect %s", rocketInfo.data.servers[ netSrc ][ rocketInfo.data.serverIndex[ netSrc ] ].addr ) );
+	if ( Q_stricmp( rocketInfo.data.servers[netSrc]->abiVersion, IPC::SYSCALL_ABI_VERSION ) ) {
+		cg_currentSelectedServer.Set( netSrc );
+		Rocket_DocumentAction( "server_mismatch", "show" );
+	} else {
+		trap_SendConsoleCommand( va( "connect %s", rocketInfo.data.servers[netSrc][rocketInfo.data.serverIndex[netSrc]].addr ) );
+	}
 }
 
 static void CG_Rocket_SetResolutionListResolution( const char*, int index )

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -110,6 +110,7 @@ private:
 	const std::unordered_map<std::string, std::string> webUrls = {
 		{ "bugs", "bugs.unvanquished.net" },
 		{ "chat", "unvanquished.net/chat" },
+		{ "download", "unvanquished.net/download" },
 		{ "forums", "forums.unvanquished.net" },
 		{ "wiki", "wiki.unvanquished.net" },
 	};

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -474,6 +474,7 @@ void G_InitGame( int levelTime, int randomSeed, bool inClient )
 
 	Log::Notice( "------- Game Initialization -------" );
 	Log::Notice( "gamename: %s", GAME_VERSION );
+	Log::Notice( "Engine version: %s", ENGINE_VERSION );
 	Log::Notice( "gamedate: %s", __DATE__ );
 
 	// set some level globals

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -474,7 +474,6 @@ void G_InitGame( int levelTime, int randomSeed, bool inClient )
 
 	Log::Notice( "------- Game Initialization -------" );
 	Log::Notice( "gamename: %s", GAME_VERSION );
-	Log::Notice( "Engine version: %s", ENGINE_VERSION );
 	Log::Notice( "gamedate: %s", __DATE__ );
 
 	// set some level globals


### PR DESCRIPTION
Fixes #3158, #3138, #726, and potentially #405.

Add a `version` field to the server list, which is the engine version used to build the server. If the version is not compatible, show it as `^1!version!` instead, and show a pop-up about version mismatch. Also fixed sort by name for local servers.

Here's how this looks in the server browser when the versions match:
![srvb0](https://github.com/user-attachments/assets/f959f533-4499-40a8-818b-0e2044ab6df4)
If they don't match:
![srvb1](https://github.com/user-attachments/assets/1704f38d-6d52-4725-bb68-d0ddf7cc3694)
And a pop-up if trying to connect to such a server:
![srvb2](https://github.com/user-attachments/assets/b3d8ef9a-7af2-417c-824b-cfc63d5d4c23)