### PR TITLE
presets: disable bloom for now

### DIFF
--- a/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
@@ -11,7 +11,7 @@ seta r_specularMapping 1
 seta r_physicalMapping 1
 seta r_reliefMapping 0
 seta r_heatHaze 1
-seta r_bloom 1
+seta r_bloom 0
 seta r_ssao 1
 seta r_subdivisions 4
 seta r_imageFitScreen 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
@@ -11,7 +11,7 @@ seta r_specularMapping 1
 seta r_physicalMapping 1
 seta r_reliefMapping 0
 seta r_heatHaze 0
-seta r_bloom 1
+seta r_bloom 0
 seta r_ssao 0
 seta r_subdivisions 8
 seta r_imageFitScreen 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
@@ -11,7 +11,7 @@ seta r_specularMapping 1
 seta r_physicalMapping 1
 seta r_reliefMapping 1
 seta r_heatHaze 1
-seta r_bloom 1
+seta r_bloom 0
 seta r_ssao 1
 seta r_subdivisions 1
 seta r_imageFitScreen 1


### PR DESCRIPTION
Disable bloom because it is not usable with none of our current maps.

It was enabled by mistake because it didn't looked bad while the light was mistakenly clamped. The buggy clamping prevented bloom to happen most of the time. A bad computation was breaking another bad computation and they were cancelling themselves together.

The future of bloom is either:

- We NUKE bloom entirely.
- We enable bloom on maps having lights computed in linear space, and we disable it on maps having lights not computed in non-linear space.
- We enable bloom on maps having lights computed in linear space, and we enable it on maps having lights not computed in non-linear space BUT with a different set of default values specially crafted for such maps.

The current bloom option and values have no future with all maps that have been already published and that will be published before maps use lights computed in linear space.