### PR TITLE
add command botObstacle

### DIFF
--- a/src/sgame/sg_svcmds.cpp
+++ b/src/sgame/sg_svcmds.cpp
@@ -106,6 +106,54 @@ public:
 };
 static ShowBehaviorCmd showBehaviorRegistration;
 
+class BotObstacleCmd : public Cmd::StaticCmd
+{
+public:
+	BotObstacleCmd() : StaticCmd( "botObstacle", 0, "add or remove a bot obstacle for a given entity" ) {}
+	void Run( const Cmd::Args& args ) const override
+	{
+		if ( args.Argc() != 3 )
+		{
+			PrintUsage( args, "<entity> (on | off)" );
+			return;
+		}
+
+		int entityNum = 0;
+		if ( !Str::ParseInt( entityNum, args.Argv( 1 ) )
+		     || entityNum < MAX_CLIENTS
+		     || entityNum >= level.num_entities )
+		{
+			Print( "invalid entity number" );
+			return;
+		}
+
+		gentity_t *door = &g_entities[ entityNum ];
+		if ( door->s.eType != entityType_t::ET_MOVER )
+		{
+			Log::Notice( "not a ^5MOVER ^*entity " );
+			return;
+		}
+
+		if ( Q_stricmp( args.Argv( 2 ).c_str(), "on" ) == 0 )
+		{
+			glm::vec3 mins = VEC2GLM( door->mapEntity.restingPosition ) + VEC2GLM( door->r.mins );
+			glm::vec3 maxs = VEC2GLM( door->mapEntity.restingPosition ) + VEC2GLM( door->r.maxs );
+			G_BotAddObstacle( mins, maxs, door->num() );
+			Print( "obstacle for entity ^5%d ^*is ^5on^*", entityNum );
+		}
+		else if ( Q_stricmp( args.Argv( 2 ).c_str(), "off" ) == 0 )
+		{
+			G_BotRemoveObstacle( door->num() );
+			Print( "obstacle for entity ^5%d ^*is ^5off^*", entityNum );
+		}
+		else
+		{
+			Print( "argument must be ^5on ^*or ^5off^*" );
+		}
+	}
+};
+static BotObstacleCmd botObstacleRegistration;
+
 static void Svcmd_EntityFire_f()
 {
 	char argument[ MAX_STRING_CHARS ];


### PR DESCRIPTION
Just a simple low level command to enable or disable bot obstacles. Currently, this only works for movers like doors, buttons or platforms. We might extend it to other kinds of entities later.

A few possible use cases:

- Vertically moving doors that sink into the floor, but not completely. If a little bit of the doors sticks out, that will leave an obstacle on the navmesh. We can at least `entityLock` such doors in the open position and remove the obstacle with this command.
- Uncommon causes for obstacles such as the destructable wall on map blackout at `-1870 -444 -185 178 -1`. Destroying it will make a mover appear on the floor, creating an unneccessary obstacle. We want to be able to remove this.
- Debugging bots.