### PR TITLE
add command entityWhenFired

### DIFF
--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -160,6 +160,8 @@ gentity_t *G_NewEntity( initEntityStyle_t style )
 	return ent;
 }
 
+static std::string *onFireCommands[ MAX_GENTITIES ];
+
 /*
 =================
 G_FreeEntity
@@ -184,6 +186,12 @@ void G_FreeEntity( gentity_t *entity )
 	{
 		// It's possible that this happened before, but we need to be sure.
 		BaseClustering::Remove(entity);
+	}
+
+	if ( onFireCommands[ entity->num() ] != nullptr )
+	{
+		delete onFireCommands[ entity->num() ];
+		onFireCommands[ entity->num() ] = nullptr;
 	}
 
 	delete entity->entity;
@@ -748,8 +756,20 @@ void G_EventFireEntity( gentity_t *self, gentity_t *activator, gentityCallEvent_
 	}
 }
 
+void G_CustomCommandOnFire( int entityNum, const char *command )
+{
+	std::string *cmd = new std::string( command );
+	onFireCommands[ entityNum ] = cmd;
+}
+
 void G_FireEntity( gentity_t *self, gentity_t *activator )
 {
+	int entityNum = self->num();
+	if ( onFireCommands[ entityNum ] != nullptr )
+	{
+		Log::Notice( "executing custom command for entity %d", entityNum );
+		trap_SendConsoleCommand( onFireCommands[ entityNum ]->c_str() );
+	}
 	G_EventFireEntity( self, activator, ON_DEFAULT );
 }
 

--- a/src/sgame/sg_entities.h
+++ b/src/sgame/sg_entities.h
@@ -163,6 +163,7 @@ gentity_t  *G_IterateCallEndpoints( gentity_t *entity, int *calltargetIndex, gen
 gentity_t  *G_PickRandomTargetFor( gentity_t *self );
 void       G_FireEntityRandomly( gentity_t *entity, gentity_t *activator );
 void       G_FireEntity( gentity_t *ent, gentity_t *activator );
+void G_CustomCommandOnFire( int entityNum, const char *command );
 
 void       G_CallEntity(gentity_t *targetedEntity, gentityCall_t *call);
 void       G_HandleActCall( gentity_t *entity, gentityCall_t *call );

--- a/src/sgame/sg_svcmds.cpp
+++ b/src/sgame/sg_svcmds.cpp
@@ -106,10 +106,10 @@ public:
 };
 static ShowBehaviorCmd showBehaviorRegistration;
 
-class EntityOnFireCmd : public Cmd::StaticCmd
+class EntityFiredCmd : public Cmd::StaticCmd
 {
 public:
-	EntityOnFireCmd() : StaticCmd( "entityOnFire", 0, "execute a command when an entity is fired" ) {}
+	EntityFiredCmd() : StaticCmd( "entityFired", 0, "execute a command when an entity is fired" ) {}
 	void Run( const Cmd::Args& args ) const override
 	{
 		if ( args.Argc() != 3 )
@@ -131,7 +131,7 @@ public:
 		G_CustomCommandOnFire( entityNum, args.Argv( 2 ).c_str() );
 	}
 };
-static EntityOnFireCmd entityOnFireRegistration;
+static EntityFiredCmd entityFiredRegistration;
 
 static void Svcmd_EntityFire_f()
 {

--- a/src/sgame/sg_svcmds.cpp
+++ b/src/sgame/sg_svcmds.cpp
@@ -106,10 +106,10 @@ public:
 };
 static ShowBehaviorCmd showBehaviorRegistration;
 
-class EntityFiredCmd : public Cmd::StaticCmd
+class EntityWhenFiredCmd : public Cmd::StaticCmd
 {
 public:
-	EntityFiredCmd() : StaticCmd( "entityFired", 0, "execute a command when an entity is fired" ) {}
+	EntityWhenFiredCmd() : StaticCmd( "entityWhenFired", 0, "execute a command when an entity is fired" ) {}
 	void Run( const Cmd::Args& args ) const override
 	{
 		if ( args.Argc() != 3 )
@@ -131,7 +131,7 @@ public:
 		G_CustomCommandOnFire( entityNum, args.Argv( 2 ).c_str() );
 	}
 };
-static EntityFiredCmd entityFiredRegistration;
+static EntityWhenFiredCmd entityWhenFiredRegistration;
 
 static void Svcmd_EntityFire_f()
 {

--- a/src/sgame/sg_svcmds.cpp
+++ b/src/sgame/sg_svcmds.cpp
@@ -106,6 +106,33 @@ public:
 };
 static ShowBehaviorCmd showBehaviorRegistration;
 
+class EntityOnFireCmd : public Cmd::StaticCmd
+{
+public:
+	EntityOnFireCmd() : StaticCmd( "entityOnFire", 0, "execute a command when an entity is fired" ) {}
+	void Run( const Cmd::Args& args ) const override
+	{
+		if ( args.Argc() != 3 )
+		{
+			PrintUsage( args, "<entity> <command>" );
+			return;
+		}
+
+		int entityNum = 0;
+		if ( !Str::ParseInt( entityNum, args.Argv( 1 ) )
+		     || entityNum < MAX_CLIENTS
+		     || entityNum >= level.num_entities
+		     || !g_entities[ entityNum ].inuse )
+		{
+			Print( "invalid entity number" );
+			return;
+		}
+
+		G_CustomCommandOnFire( entityNum, args.Argv( 2 ).c_str() );
+	}
+};
+static EntityOnFireCmd entityOnFireRegistration;
+
 static void Svcmd_EntityFire_f()
 {
 	char argument[ MAX_STRING_CHARS ];


### PR DESCRIPTION
Add a simple mechanism to register a command to be executed when an entity is fired. This is a surprisingly versatile method to control how a map works.

### Example: bot obstacle control

Using https://github.com/Unvanquished/Unvanquished/pull/3321 and map blackout, execute `entityOnFire 118 "botObstacle 119 off"`. Then go to `-1870 -444 -185 178 -1`, destroy the wall and observe that there is no bot obstacle.

### Example: AMP emulation

Using map statues-clash, execute this:

```
set pressed 0
set sweet_head "if "
set sweet_tail " = 1111 \"/cp Door opening!; entityFire 76; entityFire 77\""
alias sweet_reset "set pressed 0"
entityOnFire 136 "math pressed + 1; delay 10s \"sweet_reset\"; concat sweet_cmd sweet_head pressed sweet_tail; vstr sweet_cmd"
entityOnFire 137 "math pressed + 10; delay 10s \"sweet_reset\"; concat sweet_cmd sweet_head pressed sweet_tail; vstr sweet_cmd"
entityOnFire 138 "math pressed + 100; delay 10s \"sweet_reset\"; concat sweet_cmd sweet_head pressed sweet_tail; vstr sweet_cmd"
entityOnFire 139 "math pressed + 1000; delay 10s \"sweet_reset\"; concat sweet_cmd sweet_head pressed sweet_tail; vstr sweet_cmd"
```

Then spawn as human and press each of the 4 buttons in front of the reactor exactly once, in a time span of ten seconds. This will open the door to the reactor.

AMP tries to do this using its cumbersome AND logic gate entities. Even though our console language is not perfect, this is a somewhat accurate emulation. It can be extended to be perfectly accurate.