### PR TITLE
Implement pedantic shutdown options for gamelogic processes

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1398,8 +1398,24 @@ CG_Shutdown
 Called before every level change or subsystem restart
 =================
 */
+#ifndef BUILD_VM_IN_PROCESS
+#ifdef USING_SANITIZER
+constexpr bool pedanticShutdownDefault = true;
+#else
+constexpr bool pedanticShutdownDefault = false;
+#endif
+static Cvar::Cvar<bool> cg_pedanticShutdown(
+	"cg_pedanticShutdown", "run useless shutdown procedures in cgame process", Cvar::NONE, pedanticShutdownDefault);
+#endif // !BUILD_VM_IN_PROCESS
 void CG_Shutdown()
 {
+#ifndef BUILD_VM_IN_PROCESS
+	if ( !cg_pedanticShutdown.Get() )
+	{
+		return;
+	}
+#endif
+
 	// some mods may need to do cleanup work here,
 	// like closing files or archiving session data
 	CG_Rocket_CleanUpDataSources();

--- a/src/sgame/sg_bot.cpp
+++ b/src/sgame/sg_bot.cpp
@@ -685,13 +685,7 @@ bool G_BotInit()
 
 void G_BotCleanup()
 {
-	for ( int i = 0; i < MAX_CLIENTS; ++i )
-	{
-		if ( g_entities[i].r.svFlags & SVF_BOT && level.clients[i].pers.connected != CON_DISCONNECTED )
-		{
-			G_BotDel( i );
-		}
-	}
+	G_BotDelAllBots();
 
 	G_BotClearNames();
 


### PR DESCRIPTION
When `g_pedanticShutdown`/`cg_pedanticShutdown` is off (default) and the gamelogic is running in a separate process, skip shutdown code whose only purpose is to deallocate memory. This saves time and avoids spamming anyone with shutdown errors in production for cleanup issues like with Lua (#3078) or RmlUi (#1693).
