### PR TITLE
add support for lua table Entities.handlers

### DIFF
--- a/src.cmake
+++ b/src.cmake
@@ -342,9 +342,11 @@ set(SGAMELIST
 
     ${GAMELOGIC_DIR}/sgame/lua/Interpreter.cpp
     ${GAMELOGIC_DIR}/sgame/lua/Interpreter.h
-
     ${GAMELOGIC_DIR}/sgame/lua/Entities.cpp
     ${GAMELOGIC_DIR}/sgame/lua/Entities.h
+    ${GAMELOGIC_DIR}/sgame/lua/Clients.cpp
+    ${GAMELOGIC_DIR}/sgame/lua/Clients.h
+
 
     ${ENGINE_DIR}/server/sg_api.h
     ${ENGINE_DIR}/server/sg_msgdef.h

--- a/src.cmake
+++ b/src.cmake
@@ -343,6 +343,9 @@ set(SGAMELIST
     ${GAMELOGIC_DIR}/sgame/lua/Interpreter.cpp
     ${GAMELOGIC_DIR}/sgame/lua/Interpreter.h
 
+    ${GAMELOGIC_DIR}/sgame/lua/Entities.cpp
+    ${GAMELOGIC_DIR}/sgame/lua/Entities.h
+
     ${ENGINE_DIR}/server/sg_api.h
     ${ENGINE_DIR}/server/sg_msgdef.h
 

--- a/src/sgame/lua/Clients.cpp
+++ b/src/sgame/lua/Clients.cpp
@@ -47,7 +47,7 @@ int isNum( lua_State *L )
 	lua_pushboolean( L,
 	                 num >= 0
 	                 && num < MAX_CLIENTS
-	                 && g_entities[ num ].client != nullptr );
+	                 && g_entities[ num ].inuse );
 	return 1;
 }
 

--- a/src/sgame/lua/Clients.cpp
+++ b/src/sgame/lua/Clients.cpp
@@ -1,0 +1,94 @@
+/*
+===========================================================================
+
+Unvanquished GPL Source Code
+Copyright (C) 2025 Unvanquished Developers
+
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
+
+Unvanquished Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Unvanquished Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+
+#include "shared/bg_lua.h"
+#include "common/Common.h"
+#include "sgame/sg_local.h"
+#include "sgame/sg_entities.h"
+
+namespace Lua {
+
+namespace {
+
+int isNum( lua_State *L )
+{
+	int num = luaL_checkinteger( L, 1 );
+	lua_pushboolean( L,
+	                 num >= 0
+	                 && num < MAX_CLIENTS
+	                 && g_entities[ num ].client != nullptr );
+	return 1;
+}
+
+int team( lua_State *L )
+{
+	int num = luaL_checkinteger( L, 1 );
+	if ( num < 0 || num >= MAX_CLIENTS || g_entities[ num ].client == nullptr )
+	{
+		lua_pushnil( L );
+	}
+	else
+	{
+		switch ( g_entities[ num ].client->pers.team )
+		{
+		case TEAM_ALIENS:
+			lua_pushstring( L, "aliens" );
+			break;
+		case TEAM_HUMANS:
+			lua_pushstring( L, "humans" );
+			break;
+		default:
+			lua_pushnil( L );
+			break;
+		}
+	}
+	return 1;
+}
+	
+}  // namespace
+
+void RegisterClients( lua_State* L )
+{
+	lua_newtable(L);
+
+	lua_pushcfunction(L, isNum);
+	lua_setfield(L, -2, "isNum");
+
+	lua_pushcfunction(L, team);
+	lua_setfield(L, -2, "team");
+
+	lua_setglobal( L, "Clients" );
+}
+
+}  // namespace Lua

--- a/src/sgame/lua/Clients.h
+++ b/src/sgame/lua/Clients.h
@@ -1,0 +1,46 @@
+/*
+===========================================================================
+
+Unvanquished GPL Source Code
+Copyright (C) 2025 Unvanquished Developers
+
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
+
+Unvanquished Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Unvanquished Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+
+#ifndef LUA_CLIENTS_H_
+#define LUA_CLIENTS_H_
+
+#include "shared/bg_lua.h"
+
+namespace Lua {
+
+void RegisterClients( lua_State* L );
+
+} // namespace Lua
+
+#endif

--- a/src/sgame/lua/Entities.cpp
+++ b/src/sgame/lua/Entities.cpp
@@ -41,7 +41,7 @@ namespace Lua {
 
 namespace {
 
-int getEntityById( lua_State *L )
+int idToNum( lua_State *L )
 {
 	const char *id = luaL_checkstring(L, 1);
 	int entityNum = G_IdToEntityNum( id );
@@ -56,6 +56,23 @@ int getEntityById( lua_State *L )
 	return 1;
 }
 
+int numToId( lua_State *L )
+{
+	int entityNum = luaL_checkinteger( L, 1 );
+	if ( entityNum < MAX_CLIENTS
+	     || entityNum > level.num_entities
+	     || !g_entities[ entityNum ].inuse
+	     || g_entities[ entityNum ].id == nullptr )
+	{
+		lua_pushnil( L );
+	}
+	else
+	{
+		lua_pushstring( L, g_entities[ entityNum ].id );
+	}
+	return 1;
+}
+
 }  // namespace
 
 int EntityHandlersRegistryHandle = 0;
@@ -63,8 +80,12 @@ int EntityHandlersRegistryHandle = 0;
 void RegisterEntities( lua_State* L )
 {
 	lua_newtable(L);
-	lua_pushcfunction(L, getEntityById);
-	lua_setfield(L, -2, "getById");
+
+	lua_pushcfunction(L, idToNum);
+	lua_setfield(L, -2, "idToNum");
+
+	lua_pushcfunction(L, numToId);
+	lua_setfield(L, -2, "numToId");
 
 	lua_newtable( L );
 	lua_setfield( L, -2, "handlers" );

--- a/src/sgame/lua/Entities.cpp
+++ b/src/sgame/lua/Entities.cpp
@@ -73,6 +73,16 @@ int numToId( lua_State *L )
 	return 1;
 }
 
+int isNum( lua_State *L )
+{
+	int num = luaL_checkinteger( L, 1 );
+	lua_pushboolean( L,
+	                 num >= MAX_CLIENTS
+	                 && num < level.num_entities
+	                 && g_entities[ num ].inuse );
+	return 1;
+}
+
 }  // namespace
 
 int EntityHandlersRegistryHandle = 0;
@@ -86,6 +96,9 @@ void RegisterEntities( lua_State* L )
 
 	lua_pushcfunction(L, numToId);
 	lua_setfield(L, -2, "numToId");
+
+	lua_pushcfunction(L, isNum);
+	lua_setfield(L, -2, "isNum");
 
 	lua_newtable( L );
 	lua_setfield( L, -2, "handlers" );

--- a/src/sgame/lua/Entities.cpp
+++ b/src/sgame/lua/Entities.cpp
@@ -1,0 +1,83 @@
+/*
+===========================================================================
+
+Unvanquished GPL Source Code
+Copyright (C) 2025 Unvanquished Developers
+
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
+
+Unvanquished Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Unvanquished Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+
+// #include "shared/register_lua_extensions.h"
+#include "shared/bg_lua.h"
+#include "common/Common.h"
+#include "sgame/sg_local.h"
+#include "sgame/sg_entities.h"
+
+namespace Lua {
+
+namespace {
+
+int getEntityById( lua_State *L )
+{
+	const char *id = luaL_checkstring(L, 1);
+	int entityNum = G_IdToEntityNum( id );
+	if ( entityNum >= 0 )
+	{
+		lua_pushinteger( L, entityNum );
+	}
+	else
+	{
+		lua_pushnil( L );
+	}
+	return 1;
+}
+
+}  // namespace
+
+int EntityHandlersRegistryHandle = 0;
+
+void RegisterEntities( lua_State* L )
+{
+	lua_newtable(L);
+	lua_pushcfunction(L, getEntityById);
+	lua_setfield(L, -2, "getById");
+
+	lua_newtable( L );
+	lua_setfield( L, -2, "handlers" );
+
+	lua_setglobal( L, "Entities" );
+
+	// put Entities.handlers in the registry
+	lua_getglobal( L, "Entities" );
+	lua_pushstring( L, "handlers" );
+	lua_gettable( L, -2 );
+	EntityHandlersRegistryHandle = luaL_ref(L, LUA_REGISTRYINDEX );
+	lua_pop( L, 1 );
+}
+
+}  // namespace Lua

--- a/src/sgame/lua/Entities.cpp
+++ b/src/sgame/lua/Entities.cpp
@@ -32,7 +32,6 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
-// #include "shared/register_lua_extensions.h"
 #include "shared/bg_lua.h"
 #include "common/Common.h"
 #include "sgame/sg_local.h"

--- a/src/sgame/lua/Entities.h
+++ b/src/sgame/lua/Entities.h
@@ -1,0 +1,48 @@
+/*
+===========================================================================
+
+Unvanquished GPL Source Code
+Copyright (C) 2025 Unvanquished Developers
+
+This file is part of the Unvanquished GPL Source Code (Unvanquished Source Code).
+
+Unvanquished Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Unvanquished Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Unvanquished Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Unvanquished
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+
+#ifndef LUA_ENTITIES_H_
+#define LUA_ENTITIES_H_
+
+#include "shared/bg_lua.h"
+
+namespace Lua {
+
+extern int EntityHandlersRegistryHandle;
+
+void RegisterEntities( lua_State* L );
+
+} // namespace Lua
+
+#endif

--- a/src/sgame/lua/Interpreter.cpp
+++ b/src/sgame/lua/Interpreter.cpp
@@ -42,6 +42,7 @@ Maryland 20850 USA.
 #include "shared/lua/Utils.h"
 #include "sgame/sg_local.h"
 #include "Entities.h"
+#include "Clients.h"
 
 using Shared::Lua::LuaLib;
 
@@ -185,6 +186,7 @@ void Initialize()
 	OverrideGlobalLuaFunctions();
 	BG_InitializeLuaConstants( L );
 	RegisterEntities( L );
+	RegisterClients( L );
 }
 
 void Shutdown()

--- a/src/sgame/lua/Interpreter.cpp
+++ b/src/sgame/lua/Interpreter.cpp
@@ -41,6 +41,7 @@ Maryland 20850 USA.
 #include "shared/lua/LuaLib.h"
 #include "shared/lua/Utils.h"
 #include "sgame/sg_local.h"
+#include "Entities.h"
 
 using Shared::Lua::LuaLib;
 
@@ -183,6 +184,7 @@ void Initialize()
 	luaL_openlibs( L );
 	OverrideGlobalLuaFunctions();
 	BG_InitializeLuaConstants( L );
+	RegisterEntities( L );
 }
 
 void Shutdown()

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -73,7 +73,8 @@ static void CallLuaEntityHandler( gentity_t *self, Str::StringRef eventName )
 		if ( lua_istable( L, -1 ) )
 		{
 			lua_pushstring( L, self->id );
-			if ( lua_gettable( L, -2 ) == LUA_TFUNCTION )
+			lua_gettable( L, -2 );
+			if ( lua_type( L, -1 ) == LUA_TFUNCTION )
 			{
 				lua_pushstring( L, eventName.c_str() );
 				Log::Verbose( "executing lua handler for entity %d with ID %s", self->num(), self->id );
@@ -84,6 +85,7 @@ static void CallLuaEntityHandler( gentity_t *self, Str::StringRef eventName )
 			}
 			else
 			{
+				Log::Warn( "lua entity handler entity %d with ID %s is not a function", self->num(), self->id );
 				lua_pop( L, 1 );
 			}
 		}

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -84,9 +84,12 @@ static void CallLuaEntityHandler( gentity_t *self, Str::StringRef eventName )
 					Log::Warn( lua_tostring( L, -1 ) );
 				}
 			}
-			else if ( type != LUA_TNIL )
+			else
 			{
-				Log::Warn( "lua handler for entity %d with ID %s is not a function", self->num(), self->id );
+				if ( type != LUA_TNIL )
+				{
+					Log::Warn( "lua handler for entity %d with ID %s is not a function", self->num(), self->id );
+				}
 				lua_pop( L, 1 );
 			}
 		}

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -75,7 +75,7 @@ static void CallLuaEntityHandler( gentity_t *self, Str::StringRef eventName )
 	lua_getglobal( L, "EntityHandlers" );
 	if ( lua_istable( L, -1 ) )
 	{
-		lua_pushstring( L, self->id );
+		lua_pushinteger( L, self->num() );
 		lua_gettable( L, -2 );
 		int type = lua_type( L, -1 );
 		if ( type == LUA_TFUNCTION )
@@ -111,7 +111,7 @@ static void DeleteLuaEntityHandler( gentity_t *self )
 	lua_getglobal( L, "EntityHandlers" );
 	if ( lua_istable( L, -1 ) )
 	{
-		lua_pushstring( L, self->id );
+		lua_pushinteger( L, self->num() );
 		lua_pushnil( L );
 		lua_settable( L, -3 );
 	}

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -85,7 +85,7 @@ static void CallLuaEntityHandler( gentity_t *self, Str::StringRef eventName )
 			}
 			else
 			{
-				Log::Warn( "lua entity handler entity %d with ID %s is not a function", self->num(), self->id );
+				Log::Warn( "lua handler for entity %d with ID %s is not a function", self->num(), self->id );
 				lua_pop( L, 1 );
 			}
 		}

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -67,16 +67,16 @@ static void CallLuaEntityHandler( gentity_t *self, Str::StringRef eventName )
 {
 	lua_State *L = Lua::State();
 	// the lua state might not be ready yet
-	if ( L != nullptr )
+	if ( L != nullptr && self->id != nullptr )
 	{
 		lua_getglobal( L, "EntityHandlers" );
 		if ( lua_istable( L, -1 ) )
 		{
-			int entityNum = self->num();
-			if ( lua_geti( L, -1, entityNum ) == LUA_TFUNCTION )
+			lua_pushstring( L, self->id );
+			if ( lua_gettable( L, -2 ) == LUA_TFUNCTION )
 			{
 				lua_pushstring( L, eventName.c_str() );
-				Log::Notice( "executing lua handler for entity %d", entityNum );
+				Log::Verbose( "executing lua handler for entity %d with ID %s", self->num(), self->id );
 				if ( lua_pcall( L, 1, 0, 0 ) != 0 )
 				{
 					Log::Warn( lua_tostring( L, -1 ) );
@@ -94,13 +94,12 @@ static void CallLuaEntityHandler( gentity_t *self, Str::StringRef eventName )
 static void DeleteLuaEntityHandler( gentity_t *self )
 {
 	lua_State *L = Lua::State();
-	if ( L != nullptr )
+	if ( L != nullptr && self->id != nullptr )
 	{
 		lua_getglobal( L, "EntityHandlers" );
 		if ( lua_istable( L, -1 ) )
 		{
-			int entityNum = self->num();
-			lua_pushinteger( L, entityNum );
+			lua_pushstring( L, self->id );
 			lua_pushnil( L );
 			lua_settable( L, -3 );
 		}

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -37,6 +37,7 @@ Maryland 20850 USA.
 #include "sg_entities.h"
 #include "CBSE.h"
 #include "sgame/lua/Interpreter.h"
+#include "sgame/lua/Entities.h"
 
 #include <glm/geometric.hpp>
 #include <glm/gtx/norm.hpp>
@@ -72,7 +73,7 @@ static void CallLuaEntityHandler( gentity_t *self, Str::StringRef eventName )
 		return;
 	}
 
-	lua_getglobal( L, "EntityHandlers" );
+	lua_rawgeti( L, LUA_REGISTRYINDEX, Lua::EntityHandlersRegistryHandle );
 	if ( lua_istable( L, -1 ) )
 	{
 		lua_pushinteger( L, self->num() );
@@ -108,7 +109,7 @@ static void DeleteLuaEntityHandler( gentity_t *self )
 		return;
 	}
 
-	lua_getglobal( L, "EntityHandlers" );
+	lua_rawgeti( L, LUA_REGISTRYINDEX, Lua::EntityHandlersRegistryHandle );
 	if ( lua_istable( L, -1 ) )
 	{
 		lua_pushinteger( L, self->num() );

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -74,7 +74,8 @@ static void CallLuaEntityHandler( gentity_t *self, Str::StringRef eventName )
 		{
 			lua_pushstring( L, self->id );
 			lua_gettable( L, -2 );
-			if ( lua_type( L, -1 ) == LUA_TFUNCTION )
+			int type = lua_type( L, -1 );
+			if ( type == LUA_TFUNCTION )
 			{
 				lua_pushstring( L, eventName.c_str() );
 				Log::Verbose( "executing lua handler for entity %d with ID %s", self->num(), self->id );
@@ -83,7 +84,7 @@ static void CallLuaEntityHandler( gentity_t *self, Str::StringRef eventName )
 					Log::Warn( lua_tostring( L, -1 ) );
 				}
 			}
-			else
+			else if ( type != LUA_TNIL )
 			{
 				Log::Warn( "lua handler for entity %d with ID %s is not a function", self->num(), self->id );
 				lua_pop( L, 1 );

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -68,7 +68,7 @@ static void CallLuaEntityHandler( gentity_t *self, Str::StringRef eventName )
 {
 	lua_State *L = Lua::State();
 
-	if ( L == nullptr || self->id == nullptr )
+	if ( L == nullptr )
 	{
 		return;
 	}
@@ -82,7 +82,7 @@ static void CallLuaEntityHandler( gentity_t *self, Str::StringRef eventName )
 		if ( type == LUA_TFUNCTION )
 		{
 			lua_pushstring( L, eventName.c_str() );
-			Log::Verbose( "executing lua handler for entity %d with ID %s", self->num(), self->id );
+			Log::Verbose( "executing lua handler for entity %d", self->num() );
 			if ( lua_pcall( L, 1, 0, 0 ) != 0 )
 			{
 				Log::Warn( lua_tostring( L, -1 ) );
@@ -92,7 +92,7 @@ static void CallLuaEntityHandler( gentity_t *self, Str::StringRef eventName )
 		{
 			if ( type != LUA_TNIL )
 			{
-				Log::Warn( "lua handler for entity %d with ID %s is not a function", self->num(), self->id );
+				Log::Warn( "lua handler for entity %d is not a function", self->num() );
 			}
 			lua_pop( L, 1 );
 		}
@@ -104,7 +104,7 @@ static void DeleteLuaEntityHandler( gentity_t *self )
 {
 	lua_State *L = Lua::State();
 
-	if ( L == nullptr || self->id == nullptr )
+	if ( L == nullptr )
 	{
 		return;
 	}

--- a/src/shared/bg_lua.cpp
+++ b/src/shared/bg_lua.cpp
@@ -126,7 +126,4 @@ void BG_InitializeLuaConstants( lua_State* L )
 	LuaLib< UpgradeProxy >::Register( L );
 	LuaLib< UnvGlobal>::push( L, &global );
 	lua_setglobal( L, "Unv" );
-
-	lua_newtable( L );
-	lua_setglobal( L, "EntityHandlers" );
 }

--- a/src/shared/bg_lua.cpp
+++ b/src/shared/bg_lua.cpp
@@ -126,4 +126,7 @@ void BG_InitializeLuaConstants( lua_State* L )
 	LuaLib< UpgradeProxy >::Register( L );
 	LuaLib< UnvGlobal>::push( L, &global );
 	lua_setglobal( L, "Unv" );
+
+	lua_newtable( L );
+	lua_setglobal( L, "EntityHandlers" );
 }


### PR DESCRIPTION
2024-03-20: This PR has evolved considerably. Please keep that in mind when reading the older comments.

Currently, this is added to Lua:

- library `Entities`
  - event handler table `Entities.handlers`
    An event handler is a Lua function.
    The first argument is a string denoting the event.
    The second argument is the client/entity number of the activator.
    If the function returns true, the game own firing of target entities is disabled.
  - function `Entities.idToNum`
    Converts IDs to entity numbers.
  - function `Entities.numToId`
    Converts entity numbers to IDs.
  - function `Entities.isNum`
    Tests whether an number references an existing entity.
- library `Clients`
  - function `Clients.isNum`
    Tests whether an number references an existing client.
  - function `Clients.team`
    Returns a client's team: either `"aliens"`, `"humans"` or `nil`.

<hr>

An alternative to https://github.com/Unvanquished/Unvanquished/pull/3323.

I realized that, in practice, custom event handlers for entities will almost always be Lua functions. The console language is just not powerful enough. So there is no need to use console commands as event handlers, as https://github.com/Unvanquished/Unvanquished/pull/3323 does. Lua code an execute console commands anyway.

The method proposed here is quite simple: when an Entity is fired, the server looks at an optional Lua table `EntityHandlers`. Users may create this table and populate it with lua functions. It is indexed with entity numbers, but we can change or extend the index type later. If a function for a fired entity exists, it is called.

For example, a user can execute this on map chasm:

```lua
EntityHandlers = {}

EntityHandlers[74] = function()
   Cmd.exec("cp The door has been opened!")
end
```

Walking through the door from the human base to the outside area will print the text.

Here is the AMP example for map statues-clash from https://github.com/Unvanquished/Unvanquished/pull/3323:

```lua
local bt0 = 0
local bt1 = 0
local bt2 = 0
local bt3 = 0

function reset_counters()
   bt0 = 0
   bt1 = 0
   bt2 = 0
   bt3 = 0
end
Cmd.exec("alias reset_counters \"lua reset_counters()\"")

local function maybe_open_door()
   if bt0 > 0 and bt1 > 0 and bt2 > 0 and bt3 > 0 then
      Cmd.exec("entityFire 76")
      Cmd.exec("entityFire 77")
   end
   Cmd.exec("delay 10000 reset_counters")
end

EntityHandlers = {}

EntityHandlers[136] = function ()
   bt0 = bt0 + 1
   maybe_open_door()
end

EntityHandlers[137] = function ()
   bt1 = bt1 + 1
   maybe_open_door()
end

EntityHandlers[138] = function ()
   bt2 = bt2 + 1
   maybe_open_door()
end

EntityHandlers[139] = function ()
   bt3 = bt3 + 1
   maybe_open_door()
end
```

Compared to https://github.com/Unvanquished/Unvanquished/pull/3323, this is not only less cumbersome, but also more efficient: neither console nor Lua code is parsed at runtime (except for the delay command in this example).