### PR TITLE
add fast lookup for entity IDs, command entityShow: accept an entity ID as argument

### DIFF
--- a/src/sgame/sg_entities.h
+++ b/src/sgame/sg_entities.h
@@ -151,6 +151,10 @@ gentity_t  *G_PickRandomEntity( const char *classname, size_t fieldofs, const ch
 gentity_t  *G_PickRandomEntityOfClass( const char *classname );
 gentity_t  *G_PickRandomEntityWithField( size_t fieldofs, const char *match );
 
+void G_RegisterEntityId( int entityNum, Str::StringRef id );
+void G_ForgetEntityId( Str::StringRef id );
+int G_IdToEntityNum( Str::StringRef id );
+
 //test
 bool   G_MatchesName( gentity_t *entity, const char* name );
 bool   G_IsVisible( gentity_t *ent1, gentity_t *ent2, int contents );

--- a/src/sgame/sg_spawn.cpp
+++ b/src/sgame/sg_spawn.cpp
@@ -926,6 +926,11 @@ static void G_SpawnGEntityFromSpawnVars()
 	}
 
 	SetAutomaticEntityId( spawningEntity );
+
+	if ( spawningEntity->id != nullptr )
+	{
+		G_RegisterEntityId( spawningEntity->num(), spawningEntity->id );
+	}
 }
 
 bool G_WarnAboutDeprecatedEntityField( gentity_t *entity, const char *expectedFieldname, const char *actualFieldname, const int typeOfDeprecation  )

--- a/src/sgame/sg_svcmds.cpp
+++ b/src/sgame/sg_svcmds.cpp
@@ -175,17 +175,25 @@ static void Svcmd_EntityShow_f()
 	int       lastTargetIndex, targetIndex;
 	gentity_t *selection;
 	gentity_t *possibleTarget = nullptr;
-	char argument[ 6 ];
+	char argument[ 128 ];
 
 
 	if (trap_Argc() != 2)
 	{
-		Log::Notice("usage: entityShow <entityNum>");
+		Log::Notice("usage: entityShow <entityNum or entityID>");
 		return;
 	}
 
 	trap_Argv( 1, argument, sizeof( argument ) );
-	entityNum = atoi( argument );
+	if ( !Str::ParseInt( entityNum, argument ) )
+	{
+		entityNum = G_IdToEntityNum( argument );
+		if ( entityNum < 0 )
+		{
+			Log::Notice( "entity ID `%s` does not exist", argument );
+			return;
+		}
+	}
 
 	if (entityNum >= level.num_entities || entityNum < MAX_CLIENTS)
 	{
@@ -209,6 +217,10 @@ static void Svcmd_EntityShow_f()
 	}
 	Log::Notice( "⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼" );
 	Log::Notice( "Classname: ^5%s^*", selection->classname );
+	if ( selection->id != nullptr )
+	{
+		Log::Notice( "ID: ^5%s^*", selection->id );
+	}
 	Log::Notice( "Capabilities:%s%s%s%s%s%s%s",
 			selection->act ? " acts" : "",
 			selection->think ? " thinks" : "",


### PR DESCRIPTION
This is my proposal for supporting the recently introduced entity IDs in game commands and Lua code.

Add a data structure to map entity ID strings to entity numbers efficiently, update it whenever an entity with ID is created or destroyed.

If a user only creates entity IDs that do not parse as integers, an extension to existing commands is straightforward. An integer denotes an entity number as usual, everything else denotes an entity ID. This PR extends the command `entityShow` as an example. Recall that `entityShow` is used like in

```
]/entityShow 227 
⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼ 
#227:            MOVER 
⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼⎼ 
Classname: func_door 
Capabilities: acts thinks resets 
Names:  
{ trigger_bridge_01 } 
State: enabled
```

Assume this entity 227 has id `bridge`. With this PR, this command is equivalent:
```
]/entityShow bridge
```

The ID is now shown by `entityShow`, if it exists.

Lua mechanisms like https://github.com/Unvanquished/Unvanquished/pull/3330 can be extended similarly. In Lua scripts, we can use the types `number` and `string` to distinguish entity number and ID.

To test the example given above, use `map-prometheus_0.6.dpk`, create a file `maps/prometheus.ent` with 

```
q3map2 -exportents prometheus
```

and then edit the .ent file to add the `id` as shown here:

```
{
"classname" "func_door"
"spawnflags" "260"
"noise" "sounds/prometheus_custom/platform_01_working.opus"
"speed" "30"
"targetname" "trigger_bridge_01"
"soundPos1" "sounds/prometheus_custom/platform_01_stop_01.opus"
"soundPos2" "sounds/prometheus_custom/platform_01_stop_01.opus"
"angle" "-2"
"lip" "134"
"dmg" "99999"
"model" "*54"
"id" "bridge"
}
```