### PR TITLE
luarocket: add player.crosshairEntityNum

### DIFF
--- a/src/cgame/rocket/lua/Player.cpp
+++ b/src/cgame/rocket/lua/Player.cpp
@@ -90,6 +90,12 @@ static int Getscore( lua_State* L )
 	return 1;
 }
 
+static int GetcrosshairEntityNum( lua_State* L )
+{
+	lua_pushinteger( L, cg.crosshairEntityNum );
+	return 1;
+}
+
 }  // namespace
 
 namespace Shared {
@@ -112,6 +118,7 @@ luaL_Reg PlayerGetters[] =
 	GETTER(clips),
 	GETTER(credits),
 	GETTER(score),
+	GETTER(crosshairEntityNum),
 
 	{ nullptr, nullptr }
 };


### PR DESCRIPTION
This is useful in devmap mode. When inspecting maps, typing entity numbers (or entity IDs) is cumbersome. So I am using binds like this one:

```
/bind o "luarocket \"if player.crosshairEntityNum > 0 then Cmd.exec(string.format('entityShow %d', player.crosshairEntityNum)) end\""
```

This executes command `entityShow N`, where N is the number of the entity I am currently looking at.