### PR TITLE
Skip pointless fraction=0 BlendSkeleton calls

### DIFF
--- a/src/cgame/cg_animation.cpp
+++ b/src/cgame/cg_animation.cpp
@@ -157,7 +157,17 @@ void CG_BlendLerpFrame( lerpFrame_t *lf )
 		return;
 	}
 
-	if ( ( lf->blendlerp > 0.0f ) && ( cg.time > lf->blendtime ) )
+	if ( lf->blendlerp < 1.0e-6f )
+	{
+		// Truncate to 0 to avoid wasting CPU/IPC on blending operations for
+		// invisibly small differences.
+		// 1e-6 is intended as a conservative value that would definitely not be visibly different;
+		// it would probably be fine to use 1e-4 and be slightly more efficient.
+		lf->blendlerp = 0.0f;
+		return;
+	}
+
+	if ( cg.time > lf->blendtime )
 	{
 		//exp blending
 		lf->blendlerp -= lf->blendlerp / cg_animBlend.Get();

--- a/src/cgame/cg_animation.cpp
+++ b/src/cgame/cg_animation.cpp
@@ -183,8 +183,6 @@ void CG_BlendLerpFrame( lerpFrame_t *lf )
 		}
 
 		lf->blendtime = cg.time + 10;
-
-		debug_anim_blend = lf->blendlerp;
 	}
 }
 

--- a/src/cgame/cg_animation.cpp
+++ b/src/cgame/cg_animation.cpp
@@ -27,6 +27,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "common/Common.h"
 #include "cg_local.h"
 
+// This shouldn't be much longer than 100 because then short animations (e.g. barricade raise/lower)
+// still won't be fully blended in before they finish.
+// FIXME: detect short animations and accelerate convergence of blend fraction to make
+// sure it's close to 0 by the time the anim finishes?
+static Cvar::Cvar<float> cg_animBlendHalfLife(
+	"cg_animBlendHalfLife", "inter-animation transition time (higher:slower, 0:instant)", Cvar::NONE, 100);
+
 /*
 ===============
 CG_AnimNumber
@@ -146,12 +153,12 @@ void CG_RunMD5LerpFrame( lerpFrame_t *lf, bool animChanged )
 ===============
 CG_BlendLerpFrame
 
-Sets lf->blendlerp and lf->blendtime
+Sets lf->blendlerp
 ===============
 */
 void CG_BlendLerpFrame( lerpFrame_t *lf )
 {
-	if ( cg_animBlend.Get() <= 0.0f )
+	if ( cg_animBlendHalfLife.Get() <= 0.0f )
 	{
 		lf->blendlerp = 0.0f;
 		return;
@@ -167,23 +174,9 @@ void CG_BlendLerpFrame( lerpFrame_t *lf )
 		return;
 	}
 
-	if ( cg.time > lf->blendtime )
-	{
-		//exp blending
-		lf->blendlerp -= lf->blendlerp / cg_animBlend.Get();
-
-		if ( lf->blendlerp <= 0.0f )
-		{
-			lf->blendlerp = 0.0f;
-		}
-
-		if ( lf->blendlerp >= 1.0f )
-		{
-			lf->blendlerp = 1.0f;
-		}
-
-		lf->blendtime = cg.time + 10;
-	}
+	//exp blending
+	lf->blendlerp *= exp2f( -cg.frametime / cg_animBlendHalfLife.Get() );
+	lf->blendlerp = Math::Clamp( lf->blendlerp, 0.0f, 1.0f );
 }
 
 /*

--- a/src/cgame/cg_animation.cpp
+++ b/src/cgame/cg_animation.cpp
@@ -209,7 +209,7 @@ void CG_BuildAnimSkeleton( const lerpFrame_t *lf, refSkeleton_t *newSkeleton, co
 	}
 
 	// lerp between old and new animation if possible
-	if ( lf->blendlerp >= 0.0f )
+	if ( lf->blendlerp > 0.0f )
 	{
 		if ( newSkeleton->type != refSkeletonType_t::SK_INVALID && oldSkeleton->type != refSkeletonType_t::SK_INVALID && newSkeleton->numBones == oldSkeleton->numBones )
 		{

--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -906,6 +906,11 @@ static void CG_SetBuildableLerpFrameAnimation( buildable_t buildable, lerpFrame_
 	else
 	{
 		lf->blendlerp = 1.0f - lf->blendlerp; //use old blending for smooth blending between two blended animations
+		// Is this really a good idea? We have to discontinuously jump from blending A->B to blending B->C.
+		// This replaces the fraction of A with the same amount of C while keeping the fraction of B constant.
+		// Would help if the current frame of A and the beginning of C are similar; could be worse
+		// (as opposed to starting the fraction at 1) in other cases.
+		// FIXME: consider blending A->C instead of B->C if prior fraction was close to 1?
 	}
 }
 

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -135,7 +135,6 @@ struct lerpFrame_t
 	animation_t *old_animation;
 
 	float       blendlerp;
-	float       blendtime;
 };
 
 //======================================================================
@@ -1904,8 +1903,6 @@ extern Cvar::Cvar<bool> cg_projectileNudge;
 extern Cvar::Cvar<bool> cg_emoticonsInMessages;
 
 extern Cvar::Cvar<bool> cg_chatTeamPrefix;
-
-extern Cvar::Cvar<float> cg_animBlend;
 
 extern Cvar::Cvar<float> cg_motionblur;
 extern Cvar::Cvar<float> cg_motionblurMinSpeed;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -138,12 +138,6 @@ struct lerpFrame_t
 	float       blendtime;
 };
 
-// debugging values:
-
-extern int   debug_anim_current;
-extern int   debug_anim_old;
-extern float debug_anim_blend;
-
 //======================================================================
 
 //attachment system

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -154,7 +154,6 @@ Cvar::Cvar<bool> cg_emoticonsInMessages("cg_emoticonsInMessages", "render emotic
 Cvar::Cvar<bool> cg_chatTeamPrefix("cg_chatTeamPrefix", "show [H] or [A] before names in chat", Cvar::NONE, true);
 
 Cvar::Cvar<bool> cg_animSpeed("cg_animspeed", "run animations? (for debugging)", Cvar::CHEAT, true);
-Cvar::Cvar<float> cg_animBlend("cg_animblend", "inter-animation transition time (higher:slower, <=1:instant)", Cvar::NONE, 5.0);
 
 Cvar::Cvar<float> cg_motionblur("cg_motionblur", "strength of motion blur", Cvar::NONE, 0.05);
 Cvar::Cvar<float> cg_motionblurMinSpeed("cg_motionblurMinSpeed", "minimum speed to trigger motion blur", Cvar::NONE, 600);

--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -33,11 +33,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "cg_animdelta.h"
 #include "cg_segmented_skeleton.h"
 
-// debugging
-int   debug_anim_current;
-int   debug_anim_old;
-float debug_anim_blend;
-
 static refSkeleton_t legsSkeleton;
 static refSkeleton_t torsoSkeleton;
 static refSkeleton_t oldSkeleton;
@@ -1569,9 +1564,6 @@ static void CG_SetLerpFrameAnimation( clientInfo_t *ci, lerpFrame_t *lf, int new
 
 	if ( ci->skeletal )
 	{
-		debug_anim_current = lf->animationNumber;
-		debug_anim_old = lf->old_animationNumber;
-
 		if ( lf->old_animationNumber <= 0 )
 		{
 			// skip initial / invalid blending


### PR DESCRIPTION
I noticed that buildables were doing a lot of trap_R_BlendSkeleton with interpolation fraction 0, which is the same as not blending. With this commit, buildables generally avoid blending if they are not being attacked or used.