### PR TITLE
add command entitySetId

### DIFF
--- a/src/sgame/sg_spawn.h
+++ b/src/sgame/sg_spawn.h
@@ -146,4 +146,6 @@ void     SP_Nothing( gentity_t *self );
 void     SP_ConditionFields( gentity_t *self );
 void     SP_WaitFields( gentity_t *self, float defaultWait, float defaultWaitVariance );
 
+char *G_NewString( const char *string );
+
 #endif /* SG_SPAWN_H_ */


### PR DESCRIPTION
Add a command `entitySetId <num> <ID>`. It can be used to give IDs to entities that do not have an ID.

When all else fails, this can be used in cases where people are using raw entity numbers. One example is buildable entities.