### PR TITLE
UI: avoid shader handle->name->handle round trips

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2313,7 +2313,6 @@ enum {
 // cg_utils.c
 //
 bool   CG_ParseColor( byte *c, const char **text_p );
-const char *CG_GetShaderNameFromHandle( const qhandle_t shader );
 void       CG_ReadableSize( char *buf, int bufsize, int value );
 void       CG_PrintTime( char *buf, int bufsize, int time );
 void CG_SetKeyCatcher( int catcher );

--- a/src/cgame/cg_rocket_dataformatter.cpp
+++ b/src/cgame/cg_rocket_dataformatter.cpp
@@ -144,12 +144,12 @@ static void CG_Rocket_DFGearOrReady( int handle, const char *data )
 
 		if ( s && ( s->team == CG_MyTeam() || CG_MyTeam() == TEAM_NONE ) && s->weapon != WP_NONE )
 		{
-			rml = va( "<img src='/%s'/>", CG_GetShaderNameFromHandle( cg_weapons[ s->weapon ].weaponIcon ) );
+			rml = va( "<img src='/$handle/%d'/>", cg_weapons[ s->weapon ].weaponIcon );
 		}
 
 		if ( s && ( s->team == CG_MyTeam() || CG_MyTeam() == TEAM_NONE ) && s->team == TEAM_HUMANS && s->upgrade != UP_NONE )
 		{
-			rml = va( "%s<img src='/%s'/>", rml, CG_GetShaderNameFromHandle( cg_upgrades[ s->upgrade ].upgradeIcon ) );
+			rml = va( "%s<img src='/$handle/%d'/>", rml, cg_upgrades[ s->upgrade ].upgradeIcon );
 		}
 
 		Rocket_DataFormatterFormattedData( handle, rml, false );

--- a/src/cgame/cg_rocket_datasource.cpp
+++ b/src/cgame/cg_rocket_datasource.cpp
@@ -1132,7 +1132,7 @@ static void AddWeaponToBuyList( int i, const char *table, int tblIndex )
 		Info_SetValueForKey( buf, "name", BG_Weapon( i )->humanName, false );
 		Info_SetValueForKey( buf, "price", va( "%d", BG_Weapon( i )->price ), false );
 		Info_SetValueForKey( buf, "description", BG_Weapon( i )->info, false );
-		Info_SetValueForKey( buf, "icon", CG_GetShaderNameFromHandle( cg_weapons[ i ].ammoIcon ), false );
+		Info_SetValueForKey( buf, "icon", va( "$handle/%d", cg_weapons[i].ammoIcon ), false);
 		Info_SetValueForKey( buf, "availability", WeaponAvailability( i ).c_str(), false );
 		Info_SetValueForKey( buf, "cmdName", BG_Weapon( i )->name, false );
 		Info_SetValueForKey( buf, "damage", WeaponDamage( weapon_t(i) ), false );
@@ -1200,7 +1200,7 @@ static void AddUpgradeToBuyList( int i, const char *table, int tblIndex )
 		Info_SetValueForKey( buf, "description", BG_Upgrade( i )->info, false );
 		Info_SetValueForKey( buf, "availability", UpgradeAvailability( upgrade_t(i) ).c_str(), false );
 		Info_SetValueForKey( buf, "cmdName", BG_Upgrade( i )->name, false );
-		Info_SetValueForKey( buf, "icon", CG_GetShaderNameFromHandle( cg_upgrades[ i ].upgradeIcon ), false );
+		Info_SetValueForKey( buf, "icon", va( "$handle/%d", cg_upgrades[ i ].upgradeIcon ), false );
 
 		Rocket_DSAddRow( "armouryBuyList", table, buf );
 
@@ -1438,7 +1438,7 @@ static void CG_Rocket_BuildBeaconList( const char *table )
 			Info_SetValueForKey( buf, "num", va( "%d", i ), false );
 			Info_SetValueForKey( buf, "name", ba->humanName, false );
 			Info_SetValueForKey( buf, "desc", ba->desc, false );
-			Info_SetValueForKey( buf, "icon", CG_GetShaderNameFromHandle( ba->icon[ 0 ][ 0 ] ), false );
+			Info_SetValueForKey( buf, "icon", va( "$handle/%d", ba->icon[ 0 ][ 0 ] ), false );
 
 			Rocket_DSAddRow( "beaconList", "default", buf );
 		}

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -1181,7 +1181,7 @@ public:
 				return;
 			}
 
-			SetInnerRML( va( "<img src='/%s' />", CG_GetShaderNameFromHandle( cg_weapons[ weapon_ ].weaponIcon ) ) );
+			SetInnerRML( va( "<img src='/$handle/%d' />", cg_weapons[ weapon_ ].weaponIcon ) );
 			SetProperty( "display", "block" );
 		}
 

--- a/src/cgame/cg_utils.cpp
+++ b/src/cgame/cg_utils.cpp
@@ -62,22 +62,6 @@ bool CG_ParseColor( byte *c, const char **text_p )
 	return true;
 }
 
-/*
-==========================
-CG_GetShaderNameFromHandle
-
-Gets the name of a shader from the qhandle_t
-==========================
-*/
-
-const char *CG_GetShaderNameFromHandle( const qhandle_t shader )
-{
-	static char out[ MAX_STRING_CHARS ];
-
-	trap_R_GetShaderNameFromHandle( shader, out, sizeof( out ) );
-	return out;
-}
-
 //
 // UI Helper Function
 //

--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -1925,7 +1925,7 @@ void CG_DrawHumanInventory()
 	for ( i = 0; i < numItems; ++i )
 	{
 		const char *rmlClass;
-		const char *src =  CG_GetShaderNameFromHandle( items[ i ] < 32 ? cg_weapons[ items[ i ] ].weaponIcon : cg_upgrades[ items[ i ] - 32 ].upgradeIcon );
+		qhandle_t icon = items[ i ] < 32 ? cg_weapons[ items[ i ] ].weaponIcon : cg_upgrades[ items[ i ] - 32 ].upgradeIcon;
 
 		switch( colinfo[ i ] )
 		{
@@ -1949,7 +1949,7 @@ void CG_DrawHumanInventory()
 		}
 
 
-		Q_strcat( RML, sizeof( RML ), va( "<img class='%s' src='/%s' />", rmlClass, src ) );
+		Q_strcat( RML, sizeof( RML ), va( "<img class='%s' src='/$handle/%d' />", rmlClass, icon ) );
 	}
 	Q_strcat( RML, sizeof( RML ), "</div>" );
 

--- a/src/cgame/rocket/rocket.cpp
+++ b/src/cgame/rocket/rocket.cpp
@@ -290,7 +290,13 @@ private:
 	{
 		constexpr int flags = RSF_2D | RSF_FITSCREEN;
 
-		if ( Str::IsPrefix( "$levelshot/", source ) )
+		if ( Str::IsPrefix( "$handle/", source ) )
+		{
+			const char *num = source.c_str() + 8;
+			qhandle_t h;
+			return Str::ParseInt( h, num ) ? h : 0;
+		}
+		else if ( Str::IsPrefix( "$levelshot/", source ) )
 		{
 			const char *map = source.c_str() + 11;
 			qhandle_t h = trap_R_RegisterShader(

--- a/src/cgame/rocket/rocket.cpp
+++ b/src/cgame/rocket/rocket.cpp
@@ -286,6 +286,15 @@ public:
 	}
 
 private:
+
+	// Resolves the possible <img> "src"s, listed below:
+	// - Any q3shader name (includes images from VFS with no shader, which get a default shader created)
+	// - $handle/<num>: an int shader handle, as obtained from trap_R_RegisterShader
+	// - $levelshot/<mapname>: levelshot for the specified map
+	//
+	// Note that in RML you usually need to prepend a / to all paths (including magic $ ones)
+	// to avoid them being interpreted as relative paths. But this function receives the "path"
+	// without the leading slash.
 	qhandle_t GetShaderHandle( const Rml::String& source )
 	{
 		constexpr int flags = RSF_2D | RSF_FITSCREEN;


### PR DESCRIPTION
For some UI elements (e.g. weapon and upgrade icons) a round trip of trap_R_RegisterShader( trap_R_ShaderNameFromHandle( handle ) ) was done each time the shader was used, incurring 2 IPC calls. Avoid this by introducing a magic syntax for RML image paths, for example "/$handle/123", which allows a handle to be plumbed through RmlUi.

This gets rid of one of the IPC calls listed in #3157.
