### PR TITLE
addition of the botTacticMenu bind option in options_keys.rml

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/options_keys.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_keys.rml
@@ -155,6 +155,10 @@
 					<p><translate>Beacon menu:</translate></p>
 				</row>
 				<row>
+					<keybind cmd='botTacticMenu' />
+					<p><translate>Bot Tactic menu:</translate></p>
+				</row>
+				<row>
 					<keybind cmd="<console>" />
 					<p><translate>Toggle console:</translate></p>
 				</row>

--- a/pkg/unvanquished_src.dpkdir/ui/options_keys.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_keys.rml
@@ -156,7 +156,7 @@
 				</row>
 				<row>
 					<keybind cmd='botTacticMenu' />
-					<p><translate>Bot Tactic menu:</translate></p>
+					<p><translate>Bot tactic menu:</translate></p>
 				</row>
 				<row>
 					<keybind cmd="<console>" />


### PR DESCRIPTION
Allow the user to bind the botTacticMenu on another key from the "Option Keys" menu