### PR TITLE
readme: add explicit link for the “Compiling the source” wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The Unvanquished game is translated on the [Weblate](https://hosted.weblate.org/
 
 ## Requirements to build the game binaries
 
+Detailed instructions for compiling the sources can be found on the wiki: [wiki:Compiling_the_source](https://wiki.unvanquished.net/wiki/Compiling_the_source).
+
 To fetch and build Unvanquished, you'll need:
 `git`,
 `cmake`,


### PR DESCRIPTION
Add explicit link to the “Compiling the source” wiki page.

Obsoletes #3368:

- https://github.com/Unvanquished/Unvanquished/pull/3368