### PR TITLE
Chat field improvements

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/options_ui.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_ui.rml
@@ -56,6 +56,11 @@
 					<p><translate>Show how long a match has lasted.</translate></p>
 				</row>
 				<row>
+					<h3><translate>Chat field auto-clear</translate></h3>
+					<input cvar="cg_chatAutoClear" type="checkbox" />
+					<p><translate>Clear chat field when closed.</translate></p>
+				</row>
+				<row>
 					<!-- BUG: This should be a lag-o-meter, not a ping control -->
 					<h3><translate>Show ping</translate></h3>
 					<input cvar="cg_lagometer" type="checkbox" />

--- a/src/cgame/rocket/rocketChatField.h
+++ b/src/cgame/rocket/rocketChatField.h
@@ -327,6 +327,12 @@ protected:
 		if ( !text.empty() )
 		{
 			q2rml( text, text_element );
+
+			Rml::ElementPtr child = Rml::Factory::InstanceElement( text_element, "#text", "span", Rml::XMLAttributes() );
+			static_cast< Rml::ElementText* >( child.get() )->SetText( " Ctrl + C: clear" );
+			child->SetProperty( "color", "#007F7F" );
+
+			text_element->AppendChild( std::move( child ) );
 		}
 	}
 

--- a/src/cgame/rocket/rocketChatField.h
+++ b/src/cgame/rocket/rocketChatField.h
@@ -148,6 +148,7 @@ public:
 						break;
 
 					case Rml::Input::KI_C:
+					case Rml::Input::KI_U:
 						if ( event.GetParameter< int >( "ctrl_key", 0 ) == 1 )
 						{
 							text.clear();
@@ -329,7 +330,7 @@ protected:
 			q2rml( text, text_element );
 
 			Rml::ElementPtr child = Rml::Factory::InstanceElement( text_element, "#text", "span", Rml::XMLAttributes() );
-			static_cast< Rml::ElementText* >( child.get() )->SetText( " Ctrl + C: clear" );
+			static_cast< Rml::ElementText* >( child.get() )->SetText( " Ctrl + C / Ctrl + U: clear" );
 			child->SetProperty( "color", "#007F7F" );
 
 			text_element->AppendChild( std::move( child ) );

--- a/src/cgame/rocket/rocketChatField.h
+++ b/src/cgame/rocket/rocketChatField.h
@@ -39,6 +39,8 @@ Maryland 20850 USA.
 #include "../cg_local.h"
 #include "rocket.h"
 
+static Cvar::Cvar<bool> cg_chatAutoClear( "cg_chatAutoClear", "Clear chat field when closed", Cvar::NONE, false );
+
 class RocketChatField : public Rml::Element, Rml::EventListener
 {
 public:
@@ -97,6 +99,12 @@ public:
 		if ( event == "focus" )
 		{
 			CG_Rocket_EnableCursor( false );
+
+			if ( cg_chatAutoClear.Get() ) {
+				text.clear();
+				cursor_character_index = 0;
+				UpdateText();
+			}
 		}
 
 		{


### PR DESCRIPTION
- Implement `cg_chatAutoClear`: Automatically clear the chat field when closed if `cg_chatAutoClear` is enabled.
- Add a hint to chat field about `Ctrl + C` to clear