### PR TITLE
Fix #3080 (callvote allows invalid map names)

### DIFF
--- a/src/sgame/sg_maprotation.cpp
+++ b/src/sgame/sg_maprotation.cpp
@@ -108,7 +108,8 @@ bool G_MapExists( const char *name )
 {
 	// Due to filesystem changes, checking whether "maps/$name.bsp" exists in the
 	// VFS is no longer the correct way to check whether a map exists
-	return trap_FindPak( va( "map-%s", name ) );
+	// Legacy paks not supported here.
+	return *name && FS::Path::BaseName( name ) == name && trap_FindPak( va( "map-%s", name ) );
 }
 
 /*

--- a/src/sgame/sg_votes.cpp
+++ b/src/sgame/sg_votes.cpp
@@ -202,7 +202,7 @@ static bool HandleMapVote( gentity_t* ent, team_t team, const std::string& cmd, 
 	{
 		trap_SendServerCommand(
 			ent->num(), va( "print_tr %s %s %s",
-		                    QQ( N_( "$1$: 'maps/$2$.bsp' could not be found on the server" ) ),
+		                    QQ( N_( "$1$: map '$2$' could not be found on the server" ) ),
 		                    cmd.c_str(), Quote( arg ) ) );
 		return false;
 	}
@@ -277,7 +277,7 @@ static bool HandleNextMapVote( gentity_t* ent, team_t team, const std::string& c
 	{
 		trap_SendServerCommand(
 			ent->num(), va( "print_tr %s %s %s",
-		                    QQ( N_( "$1$: 'maps/$2$.bsp' could not be found on the server" ) ),
+		                    QQ( N_( "$1$: map '$2$' could not be found on the server" ) ),
 		                    cmd.c_str(), Quote( arg ) ) );
 		return false;
 	}


### PR DESCRIPTION
Don't allow voting map names that contain a directory.

See also https://github.com/DaemonEngine/Daemon/pull/1693 for an additional engine-side fix.