### PR TITLE
presets/graphics: set r_accurateSRGB

### DIFF
--- a/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
@@ -1,5 +1,6 @@
 reset r_clear
 reset r_picmip
+seta r_accurateSRGB on
 seta r_colorGrading on
 seta r_lightMode 3
 seta r_lightStyles 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
@@ -1,5 +1,6 @@
 reset r_clear
 reset r_picmip
+seta r_accurateSRGB off
 seta r_colorGrading off
 seta r_lightMode 3
 seta r_lightStyles 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
@@ -1,5 +1,6 @@
 reset r_clear
 reset r_picmip
+seta r_accurateSRGB off
 seta r_colorGrading off
 seta r_lightMode 1
 seta r_lightStyles 0

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
@@ -1,5 +1,6 @@
 reset r_clear
 reset r_picmip
+seta r_accurateSRGB on
 seta r_colorGrading on
 seta r_lightMode 3
 seta r_lightStyles 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
@@ -1,5 +1,6 @@
 reset r_clear
 reset r_picmip
+seta r_accurateSRGB on
 seta r_colorGrading on
 seta r_lightMode 3
 seta r_lightStyles 1


### PR DESCRIPTION
Set `r_accurateSRGB` in graphics presets.

It becomes meaningful once this is merged:

- https://github.com/DaemonEngine/Daemon/pull/1687

When using a linear graphics pipeline, delinearizations and linearizations of colors may even use the accurate operations, or use a cheaper and approximate “good enough” but faster operations.

After this is merged, `low` and `lowest` presets don't use the accurate operations (and then use the cheaper and faster ones), while all other presets use the accurate operations.

The non-accurate operation are only used on data that should be converted at render time, that mostly includes colorgen expressions, and the delinearization of the render after rendering and before some special effect that should be done after.

The faster operation used when delinearizing the render also results in a smaller GLSL code, which benefits hardware requiring `low` or `lowest` presets.

All data that should be converted at load time always use the accurate operation and then this option has no effect on them, this includes vertex colors, color grid, etc.

Some other data (texture sampling) relies on OpenGL builtin operations and then this option has no effect on them, this includes textures.