### PR TITLE
Fix autosprite log spam

### DIFF
--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -695,6 +695,11 @@ static void CG_LightFlare( centity_t *cent )
 	flare.customShader = cgs.gameShaders[ es->modelindex ];
 	flare.shaderRGBA = Color::White;
 
+	/* This will stop the engine from spamming logs about incorrect autosprite setup if it's detected
+	We have to do this here because the engine doesn't keep track of entities,
+	so the skinNum will tell to not log autosprite issues again for this entity */
+	flare.skinNum = es->modelindex;
+
 	//flares always drawn before the rest of the scene
 	flare.renderfx |= RF_DEPTHHACK;
 


### PR DESCRIPTION
Engine-side pr: https://github.com/DaemonEngine/Daemon/pull/1748

Fixes performance regression on map `assault` caused by log spam from https://github.com/DaemonEngine/Daemon/commit/6b7a7dd23fd414eda97c39f71a754d4c43d02d93