### PR TITLE
Fix /setviewpos <entityNum>

### DIFF
--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -31,6 +31,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "common/Common.h"
 #include "sg_local.h"
+#include "sg_entities.h"
 #include "engine/qcommon/q_unicode.h"
 #include "botlib/bot_api.h"
 #include <common/FileSystem.h>
@@ -1667,7 +1668,7 @@ static void Cmd_SetViewpos_f( gentity_t *ent )
 			return;
 		}
 
-		VectorCopy( selection->s.origin, origin );
+		G_GetEntityOrigin( selection, origin );
 		VectorCopy( selection->s.angles, angles );
 	}
 	else

--- a/src/sgame/sg_entities.cpp
+++ b/src/sgame/sg_entities.cpp
@@ -411,6 +411,15 @@ int G_IdToEntityNum( Str::StringRef id )
 	}
 }
 
+void G_GetEntityOrigin( const gentity_t* entity, vec3_t origin ) {
+	if ( !entity->r.linked ) {
+		VectorCopy( entity->s.origin, origin );
+	} else {
+		VectorAdd( entity->r.absmin, entity->r.absmax, origin );
+		VectorScale( origin, 0.5f, origin );
+	}
+}
+
 void G_RegisterEntityId( int entityNum, Str::StringRef id )
 {
 	auto it = idToEntityNumMap.find( id );

--- a/src/sgame/sg_entities.h
+++ b/src/sgame/sg_entities.h
@@ -155,6 +155,8 @@ void G_RegisterEntityId( int entityNum, Str::StringRef id );
 void G_ForgetEntityId( Str::StringRef id );
 int G_IdToEntityNum( Str::StringRef id );
 
+void G_GetEntityOrigin( const gentity_t* entity, vec3_t origin );
+
 //test
 bool   G_MatchesName( gentity_t *entity, const char* name );
 bool   G_IsVisible( gentity_t *ent1, gentity_t *ent2, int contents );


### PR DESCRIPTION
Fixes `/setviewpos <entityNum>` when used with entities that don't store their position in `selection->s.origin`, like `func_door_sensor`, `func_door`, `func_plat` etc.