### PR TITLE
Implement some sound priorities

### DIFF
--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1294,7 +1294,7 @@ void CG_Init( int serverMessageNum, int clientNum, const WindowConfig& windowCon
 	BG_InitUnlockackables();
 
 	CG_InitConsoleCommands();
-	trap_S_BeginRegistration();
+	trap_S_BeginRegistration( clientNum );
 
 	cg.weaponSelect = WP_NONE;
 


### PR DESCRIPTION
Requires #3407

Engine-side pr: https://github.com/DaemonEngine/Daemon/pull/1760

Use the sound's volume and distance to determine which sounds to replace. Player/bot sounds get a higher priority within `a_clientSoundPriorityMaxDistance` distance, with the multiplier `a_clientSoundPriorityMultiplier`.

This is helpful when there are a lot of sound-emitting entities around (like buildings) which take priority over player/bot sounds. The latter are generally more important.