### PR TITLE
Load binary shaders only when enabled

### DIFF
--- a/src/cgame/cg_drawtools.cpp
+++ b/src/cgame/cg_drawtools.cpp
@@ -570,6 +570,11 @@ void CG_DrawRangeMarker( rangeMarker_t rmType, const vec3_t origin, float range,
 
 	if ( cg_rangeMarkerDrawIntersection.Get() || cg_rangeMarkerDrawFrontline.Get() )
 	{
+		if ( !cgs.media.binaryShadersLoaded )
+		{
+			CG_RegisterBinaryShaders();
+		}
+
 		float                       lineOpacity, lineThickness;
 		const cgMediaBinaryShader_t *mbsh;
 		cgBinaryShaderSetting_t     *bshs;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1527,6 +1527,7 @@ struct cgMedia_t
 	qhandle_t             sphericalCone240Model;
 
 	qhandle_t             plainColorShader;
+	bool binaryShadersLoaded;
 	qhandle_t             binaryAlpha1Shader;
 	cgMediaBinaryShader_t binaryShaders[ NUM_BINARY_SHADERS ];
 
@@ -1945,6 +1946,7 @@ void       CG_BuildSpectatorString();
 
 void       CG_UpdateBuildableRangeMarkerMask();
 void       CG_RegisterGrading( int slot, const char *str );
+void CG_RegisterBinaryShaders();
 
 void CG_Init( int serverMessageNum, int clientNum, const glconfig_t& gl, const GameStateCSs& gameState );
 void CG_Shutdown();

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -714,6 +714,22 @@ static void CG_RegisterReverb( int slot, const char *str )
 	cgs.gameReverbIntensities[ slot ] = intensity;
 }
 
+void CG_RegisterBinaryShaders()
+{
+	cgs.media.binaryShadersLoaded = true;
+	cgs.media.binaryAlpha1Shader = trap_R_RegisterShader("gfx/binary/alpha1", RSF_DEFAULT);
+
+	for ( int i = 0; i < NUM_BINARY_SHADERS; ++i )
+	{
+		cgs.media.binaryShaders[ i ].f1 = trap_R_RegisterShader(va("gfx/binary/%03i_F1", i), RSF_DEFAULT);
+		cgs.media.binaryShaders[ i ].f2 = trap_R_RegisterShader(va("gfx/binary/%03i_F2", i), RSF_DEFAULT);
+		cgs.media.binaryShaders[ i ].f3 = trap_R_RegisterShader(va("gfx/binary/%03i_F3", i), RSF_DEFAULT);
+		cgs.media.binaryShaders[ i ].b1 = trap_R_RegisterShader(va("gfx/binary/%03i_B1", i), RSF_DEFAULT);
+		cgs.media.binaryShaders[ i ].b2 = trap_R_RegisterShader(va("gfx/binary/%03i_B2", i), RSF_DEFAULT);
+		cgs.media.binaryShaders[ i ].b3 = trap_R_RegisterShader(va("gfx/binary/%03i_B3", i), RSF_DEFAULT);
+	}
+}
+
 /*
 =================
 CG_RegisterGraphics
@@ -840,16 +856,10 @@ static void CG_RegisterGraphics()
 	cgs.media.sphericalCone240Model = trap_R_RegisterModel( "models/generic/sphericalCone240.md3" );
 
 	cgs.media.plainColorShader = trap_R_RegisterShader("gfx/colors/plain", RSF_DEFAULT);
-	cgs.media.binaryAlpha1Shader = trap_R_RegisterShader("gfx/binary/alpha1", RSF_DEFAULT);
-
-	for ( i = 0; i < NUM_BINARY_SHADERS; ++i )
+	
+	if ( cg_rangeMarkerDrawFrontline.Get() || cg_rangeMarkerDrawIntersection.Get() )
 	{
-		cgs.media.binaryShaders[ i ].f1 = trap_R_RegisterShader(va("gfx/binary/%03i_F1", i), RSF_DEFAULT);
-		cgs.media.binaryShaders[ i ].f2 = trap_R_RegisterShader(va("gfx/binary/%03i_F2", i), RSF_DEFAULT);
-		cgs.media.binaryShaders[ i ].f3 = trap_R_RegisterShader(va("gfx/binary/%03i_F3", i), RSF_DEFAULT);
-		cgs.media.binaryShaders[ i ].b1 = trap_R_RegisterShader(va("gfx/binary/%03i_B1", i), RSF_DEFAULT);
-		cgs.media.binaryShaders[ i ].b2 = trap_R_RegisterShader(va("gfx/binary/%03i_B2", i), RSF_DEFAULT);
-		cgs.media.binaryShaders[ i ].b3 = trap_R_RegisterShader(va("gfx/binary/%03i_B3", i), RSF_DEFAULT);
+		CG_RegisterBinaryShaders();
 	}
 
 	CG_BuildableStatusParse( "ui/assets/human/buildstat.cfg", &cgs.humanBuildStat );


### PR DESCRIPTION
This should save 10.4 MB of memory (`256 * 6 * (sizeof shader_t + sizeof shaderStage_t)`).