### PR TITLE
fix TOGGLE not working for rotating doors

### DIFF
--- a/src/sgame/sg_spawn_mover.cpp
+++ b/src/sgame/sg_spawn_mover.cpp
@@ -1018,8 +1018,6 @@ static void BinaryMover_reached( gentity_t *ent )
 			master->nextthink = std::max( master->nextthink, level.time + static_cast<int>( ent->mapEntity.config.wait.time ) );
 		}
 
-		master->nextthink = std::max( master->nextthink, level.time + (int) ent->mapEntity.config.wait.time );
-
 		// fire targets
 		if ( !ent->activator )
 		{


### PR DESCRIPTION
(by bmorel, PR with his permission)

This fixes a bug where rotating doors flagged with `TOGGLE` will instantly return to their original position.