### PR TITLE
ui: reword a sentence to make it easier to understand and translate

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/options_ui.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_ui.rml
@@ -56,7 +56,7 @@
 					<p><translate>Show how long a match has lasted.</translate></p>
 				</row>
 				<row>
-					<h3><translate>map change-persistent console input</translate></h3>
+					<h3><translate>Console input persistence on map change</translate></h3>
 					<input cvar="con_persistOnMapChange " type="checkbox" />
 					<p><translate>Current console input will be restored the first time the console is opened after a new map is loaded.</translate></p>
 				</row>


### PR DESCRIPTION
I had no idea what that sentence meant when I tried to translate it in Weblate, especially because it relies on specific English construction (the `<object><dash><adjective>` one), not just English words, and it also makes use of homonyms. For example if we don`t read `map change` as the object, but we read `change` as the object being qualified as persistent, and if we confuse `map` the verb with `map` the name, then “map change-persistent console input” can be understood “to map the input with changes that are persistent” instead of “console input being persistent to map change”. 🙃