### PR TITLE
Fix keynum_t binds in bind menu

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1469,6 +1469,7 @@ struct rocketInfo_t
 	rocketDataSource_t data;
 	bool renderCursor;
 	qhandle_t cursor;
+	int keyBindingTime = -1; // enable bindable key events and disable normal key events when keyBindingTime = realtime
 	int cursorFreezeTime = -1; // mouse input is ignored and cursor is locked in place when cursorFreezeTime = realtime
 	int cursorFreezeX, cursorFreezeY;
 	rectDef_t cursor_pos;

--- a/src/cgame/rocket/rocket_keys.cpp
+++ b/src/cgame/rocket/rocket_keys.cpp
@@ -284,21 +284,23 @@ bool Rocket_ProcessKeyInput( Keyboard::Key key, bool down )
 		return false;
 	}
 
-	if ( ProcessNormalInput( key, down ) )
-	{
-		return true;
-	}
+	bool consumed = false;
 
-	// Send bindable keys after the rocket key event so that if Escape is pressed,
-	// it will cancel the binding and not bind Escape.
-	if ( down )
+	if ( rocketInfo.keyBindingTime == rocketInfo.realtime )
 	{
-		Rml::Element* focus = menuContext->GetFocusElement();
-		if ( focus != nullptr ) {
-			Rml::Dictionary dict;
-			dict[ BINDABLE_KEY_KEY ] = key.PackIntoInt();
-			focus->DispatchEvent( BINDABLE_KEY_EVENT, dict );
+		if ( down )
+		{
+			Rml::Element* focus = menuContext->GetFocusElement();
+			if ( focus != nullptr ) {
+				Rml::Dictionary dict;
+				dict[ BINDABLE_KEY_KEY ] = key.PackIntoInt();
+				consumed = focus->DispatchEvent( BINDABLE_KEY_EVENT, dict );
+			}
 		}
+	}
+	else
+	{
+		consumed = ProcessNormalInput( key, down );
 	}
 
 	if ( rocketInfo.keyCatcher & KEYCATCH_UI_MOUSE )
@@ -308,13 +310,11 @@ bool Rocket_ProcessKeyInput( Keyboard::Key key, bool down )
 		// passthrough menu. Not sure about MOUSE2
 		if ( key == Keyboard::Key(K_MOUSE1) || key == Keyboard::Key(K_MOUSE2) )
 		{
-			return true;
+			consumed = true;
 		}
 	}
 
-	// This does not consider whether a bindable key was consumed, but the bind
-	// menu should have KEYCATCH_UI_KEY on so it doesn't matter.
-	return false;
+	return consumed;
 }
 
 


### PR DESCRIPTION
A regression caused bindable key events not to be sent for any Keyboard::Key that can be translated to an RmlUi key. This is because the bindable key event started being disabled if the normal key event was consumed, but the normal key event was always consumed. This just affected keynum_t Key's since character ones are ignored anyway.

Instead of sending both normal RmlUi key events and bindable key events all the time, send only bindable key events during key binding and only normal key events otherwise. This should be a more reliable design anyway since some keys such as Tab and Enter could be interpreted as ones for navigating the document. So now Escape for canceling a bind will be detected through the bindable key event instead of the normal key event.

Fixes #3454.