### PR TITLE
Enable realtime lighting in medium graphics preset

### DIFF
--- a/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
@@ -4,7 +4,7 @@ seta r_accurateSRGB on
 seta r_colorGrading on
 seta r_lightMode 3
 seta r_lightStyles 1
-seta r_realtimeLighting off
+seta r_realtimeLighting on
 seta r_rimLighting 1
 seta r_normalMapping 1
 seta r_deluxeMapping 1

--- a/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
@@ -29,11 +29,11 @@
 				</row>
 				<row>
 					<button onclick='Cmd.exec("preset presets/graphics/high.cfg")'><translate>High</translate></button>
-					<span><translate>Dynamic lights, special effects, large textures…</translate></span>
+					<span><translate>Special effects, large textures…</translate></span>
 				</row>
 				<row>
 					<button onclick='Cmd.exec("preset presets/graphics/medium.cfg")'><translate>Medium</translate></button>
-					<span><translate>Surface details, good textures…</translate></span>
+					<span><translate>Dynamic lights, surface details, good textures…</translate></span>
 				</row>
 				<row>
 					<button onclick='Cmd.exec("preset presets/graphics/low.cfg")'><translate>Low</translate></button>


### PR DESCRIPTION
Dynamic lights seem like a pretty basic feature. I was surprised to see them disabled in the medium preset.