### PR TITLE
Don't set sv_killserver upon CA_DISCONNECTED state

### DIFF
--- a/src/cgame/cg_rocket.cpp
+++ b/src/cgame/cg_rocket.cpp
@@ -536,14 +536,6 @@ void CG_Rocket_Frame( cgClientState_t state )
 	{
 		switch ( rocketInfo.cstate.connState )
 		{
-			case connstate_t::CA_DISCONNECTED:
-				// Kill the server if its still running
-				if ( trap_Cvar_VariableIntegerValue( "sv_running" ) )
-				{
-					trap_Cvar_Set( "sv_killserver", "1" );
-				}
-				break;
-
 			case connstate_t::CA_CONNECTING:
 			case connstate_t::CA_CHALLENGING:
 			case connstate_t::CA_CONNECTED:


### PR DESCRIPTION
The engine always shuts down a running cgame upon changing state to CA_DISCONNECTED. So the case of changing to CA_DISCONNECTED should not be reachable in the cgame.