### PR TITLE
Pre-build shader variants for spawning buildables

### DIFF
--- a/pkg/unvanquished_src.dpkdir/gfx/buildables/common/human_constructing.skin
+++ b/pkg/unvanquished_src.dpkdir/gfx/buildables/common/human_constructing.skin
@@ -1,0 +1,1 @@
+x,gfx/buildables/human_base/spawning

--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -2079,7 +2079,7 @@ void CG_Buildable( centity_t *cent )
 		switch ( team )
 		{
 		case TEAM_HUMANS:
-			ent.customShader = cgs.media.humanSpawningShader;
+			ent.customShader = cgs.media.humanConstructingSkin;
 			prebuildSound = cgs.media.humanBuildablePrebuild;
 			break;
 		case TEAM_ALIENS:

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1520,7 +1520,7 @@ struct cgMedia_t
 	qhandle_t             greenBuildShader;
 	qhandle_t             yellowBuildShader;
 	qhandle_t             redBuildShader;
-	qhandle_t             humanSpawningShader;
+	qhandle_t             humanConstructingSkin;
 
 	qhandle_t             sphereModel;
 	qhandle_t             sphericalCone64Model;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -793,7 +793,8 @@ static void CG_RegisterGraphics()
 	cgs.media.greenBuildShader = trap_R_RegisterShader("gfx/buildables/common/greenbuild", RSF_DEFAULT );
 	cgs.media.yellowBuildShader = trap_R_RegisterShader("gfx/buildables/common/yellowbuild", RSF_DEFAULT );
 	cgs.media.redBuildShader = trap_R_RegisterShader("gfx/buildables/common/redbuild", RSF_DEFAULT );
-	cgs.media.humanSpawningShader = trap_R_RegisterShader("gfx/buildables/human_base/spawning", RSF_DEFAULT );
+	// could also be a customShader, but using a skin gets the engine to pre-build the GLSL shader variant
+	cgs.media.humanConstructingSkin = trap_R_RegisterSkin("gfx/buildables/common/human_constructing.skin" );
 
 	for ( i = 0; i < 8; i++ )
 	{


### PR DESCRIPTION
Use a skin instead of a refEntity_t.customShader for the human buildable under construction, so that the engine will pre-build the necessary GLSL variants based on loading the skin at load time.