### PR TITLE
ui: reword the brightness graphics options

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
@@ -106,28 +106,31 @@
 
 			<tab><translate>Brightness</translate></tab>
 			<panel>
+				<h2><translate>Brightness</translate></h2>
 				<row>
-					<h3><translate>Gamma</translate></h3>
-					<p><translate>Ugly method for increasing brightness. (Consider resetting and using tone mapping instead.)</translate></p>
-					<input type="range" min="0" max="2" step="0.01" cvar="r_gamma"/>
-					<p class="inline">
-						<translate>Gamma:</translate>&nbsp;<inlinecvar cvar="r_gamma" type="number" format="%.2f"/>
-						&nbsp;<ilink onclick='Cmd.exec("reset r_gamma")'>(<translate>reset</translate>)</ilink>
-					</p>
-				</row>
-				<row>
-					<h3><translate>Exposure (world brightness level)</translate></h3>
+					<h3><translate>Exposure</translate></h3>
+					<p><translate>World brightness level.</translate></p>
 					<input type="range" min="0.3" max="2.5" step="0.01" cvar="r_exposure" />
 					<p class="inline">
 						<translate>Current:</translate>&nbsp;<inlinecvar cvar="r_exposure" type="number" format="%.2f" />
 						&nbsp;<ilink onclick='Cmd.exec("reset r_exposure")'>(<translate>reset</translate>)</ilink>
 					</p>
 				</row>
+				<row>
+					<h3><translate>Gamma</translate></h3>
+					<p><translate>Ugly method for increasing brightness.</translate>&nbsp;<translate>Obsolete.</translate><br/>
+					<translate>Consider resetting and using exposure instead.</translate></p>
+					<input type="range" min="0" max="2" step="0.01" cvar="r_gamma"/>
+					<p class="inline">
+						<translate>Current:</translate>&nbsp;<inlinecvar cvar="r_gamma" type="number" format="%.2f"/>
+						&nbsp;<ilink onclick='Cmd.exec("reset r_gamma")'>(<translate>reset</translate>)</ilink>
+					</p>
+				</row>
 				<h2><translate>Tone mapping</translate></h2>
 				<p><translate>Manage dynamic range to alleviate washed-out or too-dark areas.</translate></p>
 				<row>
 					<input cvar="r_toneMapping" type="checkbox"/>
-					<h3><translate>Enable tone mapping</translate></h3>
+					<h3><translate>Tone mapping</translate></h3>
 				</row>
 			</panel>
 


### PR DESCRIPTION
Reword the brightness panel in the graphics options.

First, our panels usually have a title, add one for consistency.

Then, we have a convention of listing best options before less good options. We usually do this in drop-down lists, but here it applies too.

Also do some rewording changes.

Before:

![unvanquished_2026-03-14_234929_000](https://github.com/user-attachments/assets/274aeb81-d82b-4c9f-9365-2e8b20e6daf6)

After:

![unvanquished_2026-03-14_235000_000](https://github.com/user-attachments/assets/1d7d8ad6-be9a-4b57-9c41-8fc6998ba014)
