### PR TITLE
Fix human buildable under construction shader

### DIFF
--- a/src/cgame/cg_buildable.cpp
+++ b/src/cgame/cg_buildable.cpp
@@ -2077,7 +2077,7 @@ void CG_Buildable( centity_t *cent )
 		switch ( team )
 		{
 		case TEAM_HUMANS:
-			ent.customShader = cgs.media.humanConstructingSkin;
+			ent.customShader = cgs.media.humanConstructingShader;
 			prebuildSound = cgs.media.humanBuildablePrebuild;
 			break;
 		case TEAM_ALIENS:

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1527,7 +1527,7 @@ struct cgMedia_t
 	qhandle_t             greenBuildShader;
 	qhandle_t             yellowBuildShader;
 	qhandle_t             redBuildShader;
-	qhandle_t             humanConstructingSkin;
+	qhandle_t             humanConstructingShader;
 
 	qhandle_t             sphereModel;
 	qhandle_t             sphericalCone64Model;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -795,8 +795,10 @@ static void CG_RegisterGraphics()
 	cgs.media.greenBuildShader = trap_R_RegisterShader("gfx/buildables/common/greenbuild", RSF_DEFAULT );
 	cgs.media.yellowBuildShader = trap_R_RegisterShader("gfx/buildables/common/yellowbuild", RSF_DEFAULT );
 	cgs.media.redBuildShader = trap_R_RegisterShader("gfx/buildables/common/redbuild", RSF_DEFAULT );
-	// could also be a customShader, but using a skin gets the engine to pre-build the GLSL shader variant
-	cgs.media.humanConstructingSkin = trap_R_RegisterSkin("gfx/buildables/common/human_constructing.skin" );
+	cgs.media.humanConstructingShader = trap_R_RegisterShader("gfx/buildables/human_base/spawning", RSF_DEFAULT);
+
+	// make the renderer prebuild the GLSL for the under construction shader applied to models
+	trap_R_RegisterSkin( "gfx/buildables/common/human_constructing.skin" );
 
 	for ( i = 0; i < 8; i++ )
 	{


### PR DESCRIPTION
Fix regression in e8861c448bfd22cbc41198c8251d2070a7be219d. There was a typo setting customShader to the skin number instead of customSkin. But using a skin doesn't work well in the first place because it doesn't always cover all the model surfaces; I guess the skin must need to have as many entries as the model with the most surfaces. So go back to using a shader for rendering and only use the skin for tricking the renderer into pre-building the GLSL variants.