### PR TITLE
Remove Tamil from language list

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/options_ui.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_ui.rml
@@ -38,7 +38,6 @@
 						<option value="pt_BR">Português (Brasil)</option>
 						<option value="pt">Português</option>
 						<option value="ru">Русский</option>
-						<option value="ta">தமிழ்</option>
 						<option value="zh_Hans">中文（简体）</option>
 						<option value="zh_Hant_HK">中文（香港）</option>
 						<option value="zh_Hant">中文（正體）</option>

--- a/pkg/unvanquished_src.dpkdir/ui/options_welcome.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_welcome.rml
@@ -32,7 +32,6 @@
 			<option value="pt_BR">Português (Brasil)</option>
 			<option value="pt">Português</option>
 			<option value="ru">Русский</option>
-			<option value="ta">தமிழ்</option>
 			<option value="zh_Hans">中文（简体）</option>
 			<option value="zh_Hant_HK">中文（香港）</option>
 			<option value="zh_Hant">中文（正體）</option>


### PR DESCRIPTION
It is supposed to be unusable without text shaping.