### PR TITLE
removed field 'label' in the server_browser.rml file

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/server_browser.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/server_browser.rml
@@ -39,8 +39,7 @@
 			<tab><translate>Internet</translate></tab>
 			<panel>
 				<datagrid id="iServers" source="server_browser.internet">
-					<col fields="label" width="3%" class="label"></col>
-					<col fields="name" width="50%" class="name"><ilink style="text-align:left;" onclick='Events.pushcmd("sortDS server_browser internet name")'><translate>Name:</translate></ilink></col>
+					<col fields="name" width="53%" class="name"><ilink style="text-align:left;" onclick='Events.pushcmd("sortDS server_browser internet name")'><translate>Name:</translate></ilink></col>
 					<col fields="version" width="11%" class="version"><ilink onclick='Events.pushcmd("sortDS server_browser internet version")'><translate>Version:</translate></ilink></col>
 					<col fields="map" width="18%" class="map"><ilink onclick='Events.pushcmd("sortDS server_browser internet map")'><translate>Map:</translate></ilink></col>
 					<col fields="players,bots,maxClients" width="18%" formatter="ServerPlayers" class="players"><ilink onclick='Events.pushcmd("sortDS server_browser internet players")'><translate>Players (Bots)</translate></ilink></col>
@@ -56,8 +55,7 @@
 			<tab onclick='Events.pushcmd("init_servers local;buildDS server_browser local")'><translate>LAN</translate></tab>
 			<panel>
 				<datagrid source="server_browser.local">
-					<col fields="label" width="3%" class="label" formatter="ServerLabel"></col>
-					<col fields="name" width="50%" class="name"><ilink style="text-align:left;" onclick='Events.pushcmd("sortDS server_browser local name")'><translate>Name:</translate></ilink></col>
+					<col fields="name" width="53%" class="name"><ilink style="text-align:left;" onclick='Events.pushcmd("sortDS server_browser local name")'><translate>Name:</translate></ilink></col>
 					<col fields="version" width="11%" class="version"><ilink onclick='Events.pushcmd("sortDS server_browser local version")'><translate>Version:</translate></ilink></col>
 					<col fields="map" width="18%" class="map"><ilink onclick='Events.pushcmd("sortDS server_browser local map")'><translate>Map:</translate></ilink></col>
 					<col fields="players,bots,maxClients" width="18%" formatter="ServerPlayers" class="players"><ilink onclick='Events.pushcmd("sortDS server_browser local players")'><translate>Players (Bots)</translate></ilink></col>


### PR DESCRIPTION
This pull request follows https://github.com/Unvanquished/Unvanquished/issues/3503#issuecomment-4126358961.
It was made using the changes freem introduced in his mod.
I won’t use the commit name he used, because it could give the project maintainers an excuse to close this pull request (I'm sure that they'll find a lot of stupid reasons to close it).
However, I would like to propose a commit name (which is freem’s commit name, with part of it removed because I excluded the column reorganization):

> get rid of dictator label, rmlgruik style