### PR TITLE
Move gameplay cvars out from serverinfo to another configstring

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2188,6 +2188,7 @@ void     CG_ShowScores_f();
 void CG_ExecuteServerCommands( snapshot_t* snap );
 void CG_SetMapNameFromServerinfo();
 void CG_ParseServerinfo();
+void CG_ParseGameplayCvars();
 void CG_SetConfigValues();
 void CG_ShaderStateChanged();
 void CG_CenterPrint_f();

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1363,10 +1363,9 @@ void CG_Init( int serverMessageNum, int clientNum, const WindowConfig& windowCon
 	// load configs after initializing particles and trails since it registers some
 	CG_UpdateLoadingStep( LOAD_CONFIGS );
 	BG_InitAllConfigs();
-	// parse the serverinfo only now because infos such as
-	// disabledEquipment wouldn't be parsed correctly before
-	// loading the configs
 	CG_ParseServerinfo();
+
+	CG_ParseGameplayCvars();
 
 	CG_UpdateLoadingStep( LOAD_SOUNDS );
 	CG_RegisterSounds();

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -343,10 +343,7 @@ static void CG_ConfigStringModified()
 	else if ( num == CS_INTERMISSION )
 	{
 		cg.intermissionStarted = atoi( str );
-		if ( cg.intermissionStarted )
-		{
-			Rocket_ShowScoreboard( "scoreboard", true );
-		}
+		Rocket_ShowScoreboard( "scoreboard", cg.intermissionStarted );
 	}
 	else if ( num >= CS_MODELS && num < CS_MODELS + MAX_MODELS )
 	{

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -177,6 +177,11 @@ void CG_ParseServerinfo()
 
 	cgs.timelimit          = atoi( Info_ValueForKey( info, "timelimit" ) );
 	cgs.maxclients         = atoi( Info_ValueForKey( info, "sv_maxclients" ) );
+}
+
+void CG_ParseGameplayCvars()
+{
+	const char *info = CG_ConfigString( CS_GAMEPLAY_CVARS );
 
 	cgs.devolveMaxBaseDistance = atof( Info_ValueForKey( info, "g_devolveMaxBaseDistance" ) );
 
@@ -187,6 +192,7 @@ void CG_ParseServerinfo()
 	cgs.buildPointRecoveryInitialRate  = atof( Info_ValueForKey( info, "g_BPRecoveryInitialRate" ) );
 	cgs.buildPointRecoveryRateHalfLife = atof( Info_ValueForKey( info, "g_BPRecoveryRateHalfLife" ) );
 
+	// weapons/equipment/etc. must be parsed first for this to work!
 	BG_SetForbiddenEquipment(  std::string( Info_ValueForKey( info, "g_disabledEquipment"  ) ) );
 	BG_SetForbiddenClasses(    std::string( Info_ValueForKey( info, "g_disabledClasses"    ) ) );
 	BG_SetForbiddenBuildables( std::string( Info_ValueForKey( info, "g_disabledBuildables" ) ) );
@@ -306,6 +312,10 @@ static void CG_ConfigStringModified()
 	{
 		CG_SetMapNameFromServerinfo();
 		CG_ParseServerinfo();
+	}
+	else if ( num == CS_GAMEPLAY_CVARS )
+	{
+		CG_ParseGameplayCvars();
 	}
 	else if ( num == CS_WARMUP )
 	{

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -1265,6 +1265,28 @@ const char *ClientBotConnect( int clientNum, bool firstTime )
 	return nullptr;
 }
 
+// Resend configstrings that could be affected by https://github.com/Unvanquished/Unvanquished/issues/1102.
+// TODO(0.57): remove since with the new version we have well-behaved clients.
+static void ResendPossiblyWrongConfigstrings( int clientNum )
+{
+	for ( int cs = CS_PLAYERS + level.maxclients; cs--; )
+	{
+		char configstring[ 1022 ];
+		trap_GetConfigstring( cs, configstring, sizeof( configstring ) );
+		std::string command = Str::Format( "cs %d %s", cs, Cmd::Escape( configstring ) );
+		if ( command.size() > 1022 )
+		{
+			// don't want to re-implement all of the bcs0 bcs1 bcs2 junk for this band-aid
+			Log::Warn( "Disabling configstring update workaround for client %d string %d due to length",
+			           clientNum, cs );
+		}
+		else
+		{
+			trap_SendServerCommand( clientNum, command.c_str() );
+		}
+	}
+}
+
 /*
 ===========
 ClientBegin
@@ -1321,6 +1343,8 @@ void ClientBegin( int clientNum )
 
 	// locate ent at a spawn point
 	ClientSpawn( ent, nullptr, nullptr, nullptr );
+
+	ResendPossiblyWrongConfigstrings( clientNum );
 
 	trap_SendServerCommand( -1, va( "print_tr %s %s", QQ( N_("$1$^* entered the game") ), Quote( client->pers.netname ) ) );
 

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -128,7 +128,7 @@ Cvar::Callback<Cvar::Cvar<int>> g_BPInitialBudgetAliens(
 Cvar::Callback<Cvar::Cvar<int>> g_buildPointBudgetPerMiner(
 		"g_BPBudgetPerMiner",
 		"Budget per Miner",
-		Cvar::SERVERINFO,
+		Cvar::NONE,
 		DEFAULT_BP_BUDGET_PER_MINER,
 		[](int) {
 			G_UpdateBuildPointBudgets();
@@ -136,18 +136,18 @@ Cvar::Callback<Cvar::Cvar<int>> g_buildPointBudgetPerMiner(
 Cvar::Cvar<int> g_buildPointRecoveryInitialRate(
 		"g_BPRecoveryInitialRate",
 		"The initial speed at which BP will be recovered (in BP per minute)",
-		Cvar::SERVERINFO,
+		Cvar::NONE,
 		DEFAULT_BP_RECOVERY_INITIAL_RATE);
 Cvar::Cvar<int> g_buildPointRecoveryRateHalfLife(
 		"g_BPRecoveryRateHalfLife",
 		"The duration one will wait before BP recovery gets twice as slow (in minutes)",
-		Cvar::SERVERINFO,
+		Cvar::NONE,
 		DEFAULT_BP_RECOVERY_RATE_HALF_LIFE);
 
 Cvar::Range<Cvar::Cvar<int>> g_debugMomentum("g_debugMomentum", "momentum debug level", Cvar::NONE, 0, 0, 2);
-Cvar::Cvar<float> g_momentumHalfLife("g_momentumHalfLife", "minutes for momentum to decrease 50%", Cvar::SERVERINFO, DEFAULT_MOMENTUM_HALF_LIFE);
+Cvar::Cvar<float> g_momentumHalfLife("g_momentumHalfLife", "minutes for momentum to decrease 50%", Cvar::NONE, DEFAULT_MOMENTUM_HALF_LIFE);
 Cvar::Cvar<float> g_momentumRewardDoubleTime("g_momentumRewardDoubleTime", "some momentum rewards double after x minutes", Cvar::NONE, DEFAULT_CONF_REWARD_DOUBLE_TIME);
-Cvar::Cvar<float> g_unlockableMinTime("g_unlockableMinTime", "an unlock is lost after x seconds without further momentum rewards", Cvar::SERVERINFO, DEFAULT_UNLOCKABLE_MIN_TIME);
+Cvar::Cvar<float> g_unlockableMinTime("g_unlockableMinTime", "an unlock is lost after x seconds without further momentum rewards", Cvar::NONE, DEFAULT_UNLOCKABLE_MIN_TIME);
 Cvar::Cvar<float> g_momentumBaseMod("g_momentumBaseMod", "generic momentum reward multiplier", Cvar::NONE, DEFAULT_MOMENTUM_BASE_MOD);
 Cvar::Cvar<float> g_momentumKillMod("g_momentumKillMod", "momentum reward multiplier for kills", Cvar::NONE, DEFAULT_MOMENTUM_KILL_MOD);
 Cvar::Cvar<float> g_momentumBuildMod("g_momentumBuildMod", "momentum reward multiplier for construction", Cvar::NONE, DEFAULT_MOMENTUM_BUILD_MOD);
@@ -266,7 +266,7 @@ Cvar::Cvar<int> g_emptyTeamsSkipMapTime("g_emptyTeamsSkipMapTime", "end game ove
 Cvar::Cvar<bool>   g_neverEnd("g_neverEnd", "cheat to never end a game, helpful to load a map without spawn for testing purpose", Cvar::NONE, false);
 
 Cvar::Cvar<float>  g_evolveAroundHumans("g_evolveAroundHumans", "Ratio of alien buildings to human entities that always allow evolution", Cvar::NONE, 1.5f);
-Cvar::Cvar<float>  g_devolveMaxBaseDistance("g_devolveMaxBaseDistance", "Max Overmind distance to allow devolving", Cvar::SERVERINFO, 1000.0f);
+Cvar::Cvar<float>  g_devolveMaxBaseDistance("g_devolveMaxBaseDistance", "Max Overmind distance to allow devolving", Cvar::NONE, 1000.0f);
 
 Cvar::Cvar<bool>   g_autoPause("g_autoPause", "pause empty server", Cvar::NONE, false);
 
@@ -2181,6 +2181,31 @@ static void G_EvaluateAcceleration( gentity_t *ent, int msec )
 	VectorCopy( ent->acceleration, ent->oldAccel );
 }
 
+static void G_TransmitGameplayCvars()
+{
+	char info[ BIG_INFO_STRING ];
+	*info = '\0';
+
+	auto AddCvar = [ & ]( const auto& cvar )
+	{
+		Info_SetValueForKey( info, cvar.Name().c_str(),
+		                     Cvar::SerializeCvarValue( cvar.Get() ).c_str(), true );
+	};
+
+	AddCvar( g_devolveMaxBaseDistance );
+	AddCvar( g_momentumHalfLife );
+	AddCvar( g_unlockableMinTime );
+	AddCvar( g_buildPointBudgetPerMiner );
+	AddCvar( g_buildPointRecoveryInitialRate );
+	AddCvar( g_buildPointRecoveryRateHalfLife );
+
+	Info_SetValueForKey( info, "g_disabledEquipment", Cvar::GetValue( "g_disabledEquipment" ).c_str(), true );
+	Info_SetValueForKey( info, "g_disabledClasses", Cvar::GetValue( "g_disabledClasses" ).c_str(), true );
+	Info_SetValueForKey( info, "g_disabledBuildables", Cvar::GetValue( "g_disabledBuildables" ).c_str(), true );
+
+	trap_SetConfigstring( CS_GAMEPLAY_CVARS, info );
+}
+
 /*
 ================
 G_RunFrame
@@ -2415,6 +2440,8 @@ void G_RunFrame( int levelTime )
 	G_BotUpdateObstacles();
 
 	level.numBuildablesEstimate = numBuildables;
+
+	G_TransmitGameplayCvars();
 }
 
 void G_PrepareEntityNetCode() {

--- a/src/sgame/sg_spawn.cpp
+++ b/src/sgame/sg_spawn.cpp
@@ -1022,21 +1022,21 @@ static void InitDisabledItemCvars()
 	static Cvar::Callback<Cvar::Cvar<std::string>> g_disabledEquipment(
 		"g_disabledEquipment",
 		"Forbidden weapons and gear humans can buy, example: " QQ("lcannon, flamer, gren, firebomb, bsuit, larmour"),
-		Cvar::SERVERINFO,
+		Cvar::NONE,
 		"", // everything is allowed by default
 		BG_SetForbiddenEquipment
 		);
 	static Cvar::Callback<Cvar::Cvar<std::string>> g_disabledClasses(
 		"g_disabledClasses",
 		"Forbidden alien classes, like " QQ("level3,level3upg,builder"),
-		Cvar::SERVERINFO,
+		Cvar::NONE,
 		"", // everything is allowed by default
 		BG_SetForbiddenClasses
 		);
 	static Cvar::Callback<Cvar::Cvar<std::string>> g_disabledBuildables(
 		"g_disabledBuildables",
 		"Forbidden (human and alien) buildings, like " QQ("acid_tube, barricade, medistat, drill, mgturret, rocketpod"),
-		Cvar::SERVERINFO,
+		Cvar::NONE,
 		"", // everything is allowed by default
 		BG_SetForbiddenBuildables
 		);

--- a/src/shared/bg_gameplay.cpp
+++ b/src/shared/bg_gameplay.cpp
@@ -48,7 +48,7 @@ along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>
  * A value can be shared between cgame and sgame in three ways:
  * 1. Here, using a constant symbol that will be included in both VM files
  * 2. Using config files
- * 3. Using a SERVERINFO cvar
+ * 3. Using cvars transmitted via configstring
  *
  * This file has the upside of being simple, but doesn't allow runtime
  * modification, and needs a recompilation at every change.
@@ -63,8 +63,9 @@ along with Unvanquished Source Code.  If not, see <http://www.gnu.org/licenses/>
  * file packaging.
  *
  * Cvars have the upside of allowing runtime edits. The process of adding one
- * is more complicated: after creating the cvar with the SERVERINFO, you must
- * parse it in cgame (see g_devolveMaxBaseDistance for an example).
+ * is more complicated: after adding the cvar to the CS_GAMEPLAY_CVARS
+ * configstring in G_TransmitGameplayCvars(), you must parse it in cgame (see
+ * g_devolveMaxBaseDistance for an example).
  * Use this solution if you expect server admins to want to change this value.
  * This solution has downsides too. One is that large scale modifications are
  * pretty unpractical and one loses the ability to have proper tools such as

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -242,9 +242,7 @@ enum team_t
 // CS_SERVERINFO and CS_SYSTEMINFO are defined in q_shared.h
 enum
 {
-  CS_MUSIC = RESERVED_CONFIGSTRINGS,
-  CS_MESSAGE, // from the map worldspawn's message field
-  CS_MOTD, // g_motd string for server message of the day
+  CS_MOTD = RESERVED_CONFIGSTRINGS, // g_motd string for server message of the day
   CS_WARMUP, // server time when the match will be restarted
 
   CS_VOTE_TIME, // Vote stuff each needs NUM_TEAMS slots
@@ -260,6 +258,13 @@ enum
   CS_SHADERSTATE,
   CS_CLIENTS_READY,
 
+  CS_PLAYERS,
+
+  // Stuff below this normally never changes after the match starts
+
+  CS_MUSIC = CS_PLAYERS + MAX_CLIENTS,
+  CS_MESSAGE, // from the map worldspawn's message field
+
   CS_MODELS,
   CS_SOUNDS = CS_MODELS + MAX_MODELS,
   CS_SHADERS = CS_SOUNDS + MAX_SOUNDS,
@@ -267,8 +272,7 @@ enum
   CS_REVERB_EFFECTS = CS_GRADING_TEXTURES + MAX_GRADING_TEXTURES,
   CS_PARTICLE_SYSTEMS = CS_REVERB_EFFECTS + MAX_REVERB_EFFECTS,
 
-  CS_PLAYERS = CS_PARTICLE_SYSTEMS + MAX_GAME_PARTICLE_SYSTEMS,
-  CS_LOCATIONS = CS_PLAYERS + MAX_CLIENTS,
+  CS_LOCATIONS = CS_PARTICLE_SYSTEMS + MAX_GAME_PARTICLE_SYSTEMS,
   CS_MAX = CS_LOCATIONS + MAX_LOCATIONS
 };
 

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -256,6 +256,7 @@ enum
   CS_INTERMISSION, // when 1, timelimit has been hit and intermission will start in a second or two
   CS_WINNER, // string indicating round winner
   CS_SHADERSTATE,
+  CS_GAMEPLAY_CVARS,
   CS_CLIENTS_READY,
 
   CS_PLAYERS,


### PR DESCRIPTION
Remove some gameplay cvars which need to be mirrored to the cgame, but are not especially relevant for deciding which server to join, from the server info. Add a new configstring to use instead of the server info one for transmitting these. This helps to avoid size limitation issues on the server info as in https://github.com/DaemonEngine/Daemon/issues/1215, since the other configstrings' limits are 8k instead of server info's 1k.

Also add a gamelogic-side workaround for https://github.com/Unvanquished/Unvanquished/issues/1102 to ensure that configstrings are reliably mirrored to the client. The server info configstring frequently changes (for example whenever someone changes teams), so I want to ensure that the cvars aren't more exposed to the configstring syncing bug by being moved to a less frequently changed cvar. This is temporary until clients are fixed with https://github.com/DaemonEngine/Daemon/pull/1954. 

I tested the #1102 workaround using a setup like the one described by @DolceTriade in the issue. I tested the gameplay cvar mirroring by changing the BP recovery rate cvar during a game.