### PR TITLE
Make the radar model visible

### DIFF
--- a/src/cgame/cg_players.cpp
+++ b/src/cgame/cg_players.cpp
@@ -2476,7 +2476,7 @@ static void CG_PlayerUpgrades( centity_t *cent, refEntity_t *torso, const uint16
 		AxisCopy( axisDefault, radar.axis );
 
 		//FIXME: change to tag_back when it exists
-		CG_PositionRotatedEntityOnTag( &radar, upgradeAttachmentEntityID, "tag_head" );
+		CG_PositionRotatedEntityOnTag( &radar, upgradeAttachmentEntityID, "head_tag" );
 
 		ents.push_back( radar );
 	}


### PR DESCRIPTION
Cherry-pick from https://codeberg.org/unvmods/Unvanquished

Fixes https://github.com/Unvanquished/Unvanquished/issues/3139.

In fact, the patch was [already written](https://github.com/Unvanquished/Unvanquished/issues/3139#issuecomment-2426102693) by @DolceTriade in 2024 but sadly no one bothered to apply it until now! 