### PR TITLE
Remove barrel model from /testgun

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1241,9 +1241,7 @@ struct cg_t
 
 	// development tool
 	refEntity_t             testModelEntity;
-	refEntity_t             testModelBarrelEntity;
 	char                    testModelName[ MAX_QPATH ];
-	char                    testModelBarrelName[ MAX_QPATH ];
 	bool                testGun;
 	qhandle_t hTestShader;
 	polyVert_t testShaderPoly[ 4 ];

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -83,9 +83,6 @@ void CG_TestModel_f()
 	cg.testModelEntity.~refEntity_t();
 	new(&cg.testModelEntity) refEntity_t{};
 
-	cg.testModelBarrelEntity.~refEntity_t();
-	new(&cg.testModelBarrelEntity) refEntity_t{};
-
 	if ( trap_Argc() < 2 )
 	{
 		return;
@@ -93,11 +90,6 @@ void CG_TestModel_f()
 
 	Q_strncpyz( cg.testModelName, CG_Argv( 1 ), MAX_QPATH );
 	cg.testModelEntity.hModel = trap_R_RegisterModel( cg.testModelName );
-
-	Q_strncpyz( cg.testModelBarrelName, CG_Argv( 1 ), MAX_QPATH );
-	cg.testModelBarrelName[ strlen( cg.testModelBarrelName ) - 4 ] = '\0';
-	Q_strcat( cg.testModelBarrelName, MAX_QPATH, "_barrel.md3" );
-	cg.testModelBarrelEntity.hModel = trap_R_RegisterModel( cg.testModelBarrelName );
 
 	if ( trap_Argc() == 3 )
 	{
@@ -120,14 +112,6 @@ void CG_TestModel_f()
 
 	AnglesToAxis( angles, cg.testModelEntity.axis );
 	cg.testGun = false;
-
-	if ( cg.testModelBarrelEntity.hModel )
-	{
-		angles[ YAW ] = 0;
-		angles[ PITCH ] = 0;
-		angles[ ROLL ] = 0;
-		AnglesToAxis( angles, cg.testModelBarrelEntity.axis );
-	}
 
 	cg.testModelEntity.scale = 1.0f;
 }
@@ -188,7 +172,6 @@ static void CG_AddTestModel()
 
 	// re-register the model, because the level may have changed
 	cg.testModelEntity.hModel = trap_R_RegisterModel( cg.testModelName );
-	cg.testModelBarrelEntity.hModel = trap_R_RegisterModel( cg.testModelBarrelName );
 
 	if ( !cg.testModelEntity.hModel )
 	{
@@ -213,15 +196,7 @@ static void CG_AddTestModel()
 		}
 	}
 
-	const int testModel = trap_R_AddRefEntityToScene( &cg.testModelEntity );
-
-	if ( cg.testModelBarrelEntity.hModel )
-	{
-		CG_PositionEntityOnTag( &cg.testModelBarrelEntity, testModel,
-		                        "tag_barrel" );
-
-		trap_R_AddRefEntityToScene( &cg.testModelBarrelEntity );
-	}
+	trap_R_AddRefEntityToScene( &cg.testModelEntity );
 }
 
 // Textures may be subject to the map's light grid


### PR DESCRIPTION
/testgun attempted to add a barrel model formed by adding "_barrel.md3" to the name of the gun model. NUKE this because first, we don't use any barrel models, and second, it won't work any more after the skeleton changes.