### PR TITLE
Configstring-related cleanup

### DIFF
--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -2184,9 +2184,7 @@ void     CG_ShowScores_f();
 //
 void CG_ExecuteServerCommands( snapshot_t* snap );
 void CG_SetMapNameFromServerinfo();
-void CG_ParseGameplayCvars();
-void CG_SetConfigValues();
-void CG_ShaderStateChanged();
+void CG_ConfigStringModified( int num );
 void CG_CenterPrint_f();
 
 //

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -1697,8 +1697,6 @@ struct cgs_t
 	int         processedSnapshotNum; // the number of snapshots cgame has requested
 
 	// parsed from serverinfo
-	int      timelimit;
-	int      maxclients;
 	char     mapname[ MAX_QPATH ];
 
 	float    devolveMaxBaseDistance; // used for evolve/devolve ui
@@ -2186,7 +2184,6 @@ void     CG_ShowScores_f();
 //
 void CG_ExecuteServerCommands( snapshot_t* snap );
 void CG_SetMapNameFromServerinfo();
-void CG_ParseServerinfo();
 void CG_ParseGameplayCvars();
 void CG_SetConfigValues();
 void CG_ShaderStateChanged();

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1258,8 +1258,6 @@ Will perform callbacks to make the loading info screen update.
 
 void CG_Init( int serverMessageNum, int clientNum, const WindowConfig& windowConfig, const GameStateCSs& gameState)
 {
-	const char *s;
-
 	bool fullscreen;
 	if ( Cvar::ParseCvarValue( Cvar::GetValue( "r_fullscreen" ), fullscreen ) && !fullscreen )
 	{
@@ -1316,21 +1314,6 @@ void CG_Init( int serverMessageNum, int clientNum, const WindowConfig& windowCon
 
 	cg.weaponSelect = WP_NONE;
 
-	// copy vote display strings so they don't show up blank if we see
-	// the same one directly after connecting
-	Q_strncpyz( cgs.voteString[ TEAM_NONE ],
-	            CG_ConfigString( CS_VOTE_STRING + TEAM_NONE ),
-	            sizeof( cgs.voteString ) );
-	Q_strncpyz( cgs.voteString[ TEAM_ALIENS ],
-	            CG_ConfigString( CS_VOTE_STRING + TEAM_ALIENS ),
-	            sizeof( cgs.voteString[ TEAM_ALIENS ] ) );
-	Q_strncpyz( cgs.voteString[ TEAM_HUMANS ],
-	            CG_ConfigString( CS_VOTE_STRING + TEAM_HUMANS ),
-	            sizeof( cgs.voteString[ TEAM_HUMANS ] ) );
-
-	s = CG_ConfigString( CS_LEVEL_START_TIME );
-	cgs.levelStartTime = atoi( s );
-
 	CG_SetMapNameFromServerinfo();
 
 	CG_UpdateLoadingStep( LOAD_GEOMETRY );
@@ -1359,8 +1342,6 @@ void CG_Init( int serverMessageNum, int clientNum, const WindowConfig& windowCon
 	CG_UpdateLoadingStep( LOAD_CONFIGS );
 	BG_InitAllConfigs();
 
-	CG_ParseGameplayCvars();
-
 	CG_UpdateLoadingStep( LOAD_SOUNDS );
 	CG_RegisterSounds();
 
@@ -1386,6 +1367,12 @@ void CG_Init( int serverMessageNum, int clientNum, const WindowConfig& windowCon
 	CG_Rocket_LoadHuds();
 	CG_LoadBeaconsConfig();
 
+	// update state from configstrings
+	for ( int cs = 0; cs < CS_PLAYERS; cs++ )
+	{
+		CG_ConfigStringModified( cs );
+	}
+
 	trap_S_EndRegistration();
 
 	if ( cg_navgenOnLoad.Get() && Cvar::GetValue( "sv_running" ) == "1" )
@@ -1403,13 +1390,6 @@ void CG_Init( int serverMessageNum, int clientNum, const WindowConfig& windowCon
 	{
 		CG_UpdateLoadingStep( LOAD_DONE );
 	}
-
-	// Make sure we have update values (scores)
-	CG_SetConfigValues();
-
-	CG_ShaderStateChanged();
-
-	ui_winner.Set( "" ); // Clear the previous round's winner.
 
 	// Request server to resend pmoveParams.
 	trap_SendClientCommand( "client_ready" );

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1358,7 +1358,6 @@ void CG_Init( int serverMessageNum, int clientNum, const WindowConfig& windowCon
 	// load configs after initializing particles and trails since it registers some
 	CG_UpdateLoadingStep( LOAD_CONFIGS );
 	BG_InitAllConfigs();
-	CG_ParseServerinfo();
 
 	CG_ParseGameplayCvars();
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1328,11 +1328,6 @@ void CG_Init( int serverMessageNum, int clientNum, const WindowConfig& windowCon
 	            CG_ConfigString( CS_VOTE_STRING + TEAM_HUMANS ),
 	            sizeof( cgs.voteString[ TEAM_HUMANS ] ) );
 
-	// check version
-	s = CG_ConfigString( CS_GAME_VERSION );
-	//   if( strcmp( s, GAME_VERSION ) )
-	//     Sys::Drop( "Client/Server game mismatch: %s/%s", GAME_VERSION, s );
-
 	s = CG_ConfigString( CS_LEVEL_START_TIME );
 	cgs.levelStartTime = atoi( s );
 

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1296,14 +1296,6 @@ void CG_Init( int serverMessageNum, int clientNum, const WindowConfig& windowCon
 	// let's do it now.
 	trap_UpdateScreen();
 
-	// Set up the pmove params with sensible default values, the server params will
-	// be communicated with the "pmove_params" server commands.
-	// These values are the same as the default values of the servers to preserve
-	// compatibility with official Alpha 34 servers, but shouldn't be necessary anymore for Alpha 35
-	cg.pmoveParams.fixed = cg.pmoveParams.synchronous = 0;
-	cg.pmoveParams.accurate = 1;
-	cg.pmoveParams.msec = 8;
-
 	cg.clientNum = clientNum;
 
 	// Initialize item locking state
@@ -1390,9 +1382,6 @@ void CG_Init( int serverMessageNum, int clientNum, const WindowConfig& windowCon
 	{
 		CG_UpdateLoadingStep( LOAD_DONE );
 	}
-
-	// Request server to resend pmoveParams.
-	trap_SendClientCommand( "client_ready" );
 }
 
 /*

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -32,6 +32,19 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "cg_local.h"
 #include "shared/CommonProxies.h"
 
+static void ParsePmoveParams() {
+	Cmd::Args args(CG_ConfigString( CS_PMOVE_PARAMS ));
+	if (args.Argc() != 4) {
+		Log::Warn( "ParsePmoveParams: bad configstring" );
+		return;
+	}
+
+	cg.pmoveParams.synchronous = atoi(args.Argv(0).c_str());
+	cg.pmoveParams.fixed = atoi(args.Argv(1).c_str());
+	cg.pmoveParams.msec = Math::Clamp( atoi(args.Argv(2).c_str()), 8, 33 );
+	cg.pmoveParams.accurate = atoi(args.Argv(3).c_str());
+}
+
 /*
 =================
 CG_ParseScores
@@ -260,6 +273,10 @@ void CG_ConfigStringModified( int num )
 	else if ( num == CS_GAMEPLAY_CVARS )
 	{
 		CG_ParseGameplayCvars();
+	}
+	else if ( num == CS_PMOVE_PARAMS )
+	{
+		ParsePmoveParams();
 	}
 	else if ( num == CS_WARMUP )
 	{
@@ -1303,24 +1320,6 @@ static void CG_GameCmds_f()
 	}
 }
 
-static void CG_PmoveParams_f() {
-	char arg1[64], arg2[64], arg3[64], arg4[64];
-
-	if (trap_Argc() != 5) {
-		return;
-	}
-
-	trap_Argv(1, arg1, sizeof(arg1));
-	trap_Argv(2, arg2, sizeof(arg2));
-	trap_Argv(3, arg3, sizeof(arg3));
-	trap_Argv(4, arg4, sizeof(arg4));
-
-	cg.pmoveParams.synchronous = atoi(arg1);
-	cg.pmoveParams.fixed = atoi(arg2);
-	cg.pmoveParams.msec = Math::Clamp( atoi(arg3), 8, 33 );
-	cg.pmoveParams.accurate = atoi(arg4);
-}
-
 static const consoleCommand_t svcommands[] =
 {	// sorting: use 'sort -f'
 	{ "achat",            CG_AdminChat_f          },
@@ -1334,7 +1333,6 @@ static const consoleCommand_t svcommands[] =
 	{ "cp_tr_p",          CG_CenterPrintTR_plural_f },
 	{ "cs",               CG_ConfigStringModified_f },
 	{ "map_restart",      CG_MapRestart           },
-	{ "pmove_params",     CG_PmoveParams_f        },
 	{ "print",            CG_Print_f              },
 	{ "print_bp_message", CG_PrintBPMessage_f     },
 	{ "print_tr",         CG_PrintTR_f            },

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -286,11 +286,7 @@ static void CG_ConfigStringModified()
 	//Log::Debug("configstring modification %i: %s", num, str);
 
 	// do something with it if necessary
-	if ( num == CS_MUSIC )
-	{
-		CG_StartMusic();
-	}
-	else if ( num == CS_SERVERINFO )
+	if ( num == CS_SERVERINFO )
 	{
 		CG_SetMapNameFromServerinfo();
 	}

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -161,24 +161,6 @@ void CG_SetMapNameFromServerinfo()
 	Q_strncpyz( cgs.mapname, Info_ValueForKey( info, "mapname" ), sizeof(cgs.mapname) );
 }
 
-/*
-================
-CG_ParseServerinfo
-
-This is called explicitly when the gamestate is first received,
-and whenever the server updates any serverinfo flagged cvars
-================
-*/
-void CG_ParseServerinfo()
-{
-	const char *info;
-
-	info = CG_ConfigString( CS_SERVERINFO );
-
-	cgs.timelimit          = atoi( Info_ValueForKey( info, "timelimit" ) );
-	cgs.maxclients         = atoi( Info_ValueForKey( info, "sv_maxclients" ) );
-}
-
 void CG_ParseGameplayCvars()
 {
 	const char *info = CG_ConfigString( CS_GAMEPLAY_CVARS );
@@ -311,7 +293,6 @@ static void CG_ConfigStringModified()
 	else if ( num == CS_SERVERINFO )
 	{
 		CG_SetMapNameFromServerinfo();
-		CG_ParseServerinfo();
 	}
 	else if ( num == CS_GAMEPLAY_CVARS )
 	{

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -161,7 +161,7 @@ void CG_SetMapNameFromServerinfo()
 	Q_strncpyz( cgs.mapname, Info_ValueForKey( info, "mapname" ), sizeof(cgs.mapname) );
 }
 
-void CG_ParseGameplayCvars()
+static void CG_ParseGameplayCvars()
 {
 	const char *info = CG_ConfigString( CS_GAMEPLAY_CVARS );
 
@@ -181,40 +181,11 @@ void CG_ParseGameplayCvars()
 }
 
 /*
-==================
-CG_ParseWarmup
-==================
-*/
-static void CG_ParseWarmup()
-{
-	const char *info;
-	int        warmup;
-
-	info = CG_ConfigString( CS_WARMUP );
-
-	warmup = atoi( info );
-	cg.warmupTime = warmup;
-}
-
-/*
-================
-CG_SetConfigValues
-
-Called on load to set the initial values from configure strings
-================
-*/
-void CG_SetConfigValues()
-{
-	cgs.levelStartTime = atoi( CG_ConfigString( CS_LEVEL_START_TIME ) );
-	cg.warmupTime = atoi( CG_ConfigString( CS_WARMUP ) );
-}
-
-/*
 =====================
 CG_ShaderStateChanged
 =====================
 */
-void CG_ShaderStateChanged()
+static void CG_ShaderStateChanged()
 {
 	char       originalShader[ MAX_QPATH ];
 	char       newShader[ MAX_QPATH ];
@@ -263,27 +234,23 @@ void CG_ShaderStateChanged()
 	}
 }
 
-/*
-================
-CG_ConfigStringModified
 
-================
-*/
-static void CG_ConfigStringModified()
+static void CG_ConfigStringModified_f()
 {
-	const char *str;
-	int        num;
-
 	// update the config string state with the new data, keeping in sync
 	// with the config strings in the engine.
 	// The engine already checked the inputs
-	num = atoi( CG_Argv( 1 ) );
+	int num = atoi( CG_Argv( 1 ) );
 	cgs.gameState[num] = CG_Argv(2);
 
-	// look up the individual string that was modified
-	str = CG_ConfigString( num );
+	// react to new value
+	CG_ConfigStringModified( num );
+}
 
-	//Log::Debug("configstring modification %i: %s", num, str);
+void CG_ConfigStringModified( int num )
+{
+	// look up the individual string that was modified
+	const char *str = CG_ConfigString( num );
 
 	// do something with it if necessary
 	if ( num == CS_SERVERINFO )
@@ -296,7 +263,7 @@ static void CG_ConfigStringModified()
 	}
 	else if ( num == CS_WARMUP )
 	{
-		CG_ParseWarmup();
+		cg.warmupTime = atoi( CG_ConfigString( CS_WARMUP ) );
 	}
 	else if ( num == CS_LEVEL_START_TIME )
 	{
@@ -1365,7 +1332,7 @@ static const consoleCommand_t svcommands[] =
 	{ "cpd_tr",           CG_CenterPrintTR_Delay_f},
 	{ "cp_tr",            CG_CenterPrintTR_f      },
 	{ "cp_tr_p",          CG_CenterPrintTR_plural_f },
-	{ "cs",               CG_ConfigStringModified },
+	{ "cs",               CG_ConfigStringModified_f },
 	{ "map_restart",      CG_MapRestart           },
 	{ "pmove_params",     CG_PmoveParams_f        },
 	{ "print",            CG_Print_f              },

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -1189,8 +1189,6 @@ const char *ClientConnect( int clientNum, bool firstTime )
 	             client->pers.netname,
 	             client->pers.netname );
 
-	G_SendClientPmoveParams(clientNum);
-
 	// don't do the "xxx connected" messages if they were caried over from previous level
 	if ( firstTime )
 	{

--- a/src/sgame/sg_cmds.cpp
+++ b/src/sgame/sg_cmds.cpp
@@ -2232,11 +2232,6 @@ static void Cmd_Class_f( gentity_t *ent )
 	}
 }
 
-static void Cmd_ClientReady_f( gentity_t *ent )
-{
-	G_SendClientPmoveParams( ent->num() );
-}
-
 static void Cmd_Deconstruct_f( gentity_t *ent )
 {
 	// Check for valid build weapon.
@@ -4275,7 +4270,6 @@ static const commands_t cmds[] =
 	{ "callteamvote",    CMD_MESSAGE | CMD_TEAM,              Cmd_CallVote_f         },
 	{ "callvote",        CMD_MESSAGE,                         Cmd_CallVote_f         },
 	{ "class",           CMD_TEAM,                            Cmd_Class_f            },
-	{ "client_ready",    0,                                   Cmd_ClientReady_f      },
 	{ "damage",          CMD_CHEAT | CMD_ALIVE,               Cmd_Damage_f           },
 	{ "deconstruct",     CMD_TEAM | CMD_ALIVE,                Cmd_Deconstruct_f      },
 	{ "devteam",         CMD_CHEAT,                           Cmd_Devteam_f          },

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -812,15 +812,13 @@ void G_CheckPmoveParamChanges() {
 		level.pmoveParams.msec = pmove_msec.Get();
 		level.pmoveParams.fixed = pmove_fixed.Get();
 		level.pmoveParams.accurate = pmove_accurate.Get();
-		G_SendClientPmoveParams(-1);
+		trap_SetConfigstring( CS_PMOVE_PARAMS, va(
+			"%i %i %i %i",
+			level.pmoveParams.synchronous,
+			+level.pmoveParams.fixed,
+			level.pmoveParams.msec,
+			+level.pmoveParams.accurate ) );
 	}
-}
-void G_SendClientPmoveParams(int client) {
-	trap_SendServerCommand(client, va("pmove_params %i %i %i %i",
-		level.pmoveParams.synchronous,
-		+level.pmoveParams.fixed,
-		level.pmoveParams.msec,
-		+level.pmoveParams.accurate));
 }
 
 /*

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -230,7 +230,6 @@ void              G_InitGame( int levelTime, int randomSeed, bool inClient );
 void              G_RunFrame( int levelTime );
 void              G_ShutdownGame( int restart );
 void              G_CheckPmoveParamChanges();
-void              G_SendClientPmoveParams(int client);
 void              G_PrepareEntityNetCode();
 Str::StringRef G_NextMapCommand();
 

--- a/src/sgame/sg_spawn.cpp
+++ b/src/sgame/sg_spawn.cpp
@@ -1095,7 +1095,6 @@ static void SP_worldspawn()
 	}
 
 	// make some data visible to connecting client
-	trap_SetConfigstring( CS_GAME_VERSION, GAME_VERSION );
 
 	trap_SetConfigstring( CS_LEVEL_START_TIME, va( "%i", level.startTime ) );
 

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -255,6 +255,7 @@ enum
   CS_INTERMISSION, // when 1, timelimit has been hit and intermission will start in a second or two
   CS_WINNER, // string indicating round winner
   CS_SHADERSTATE,
+  CS_PMOVE_PARAMS,
   CS_GAMEPLAY_CVARS,
   CS_CLIENTS_READY,
 

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -251,8 +251,7 @@ enum
   CS_VOTE_NO = CS_VOTE_YES + NUM_TEAMS,
   CS_VOTE_CALLER = CS_VOTE_NO + NUM_TEAMS,
 
-  CS_GAME_VERSION = CS_VOTE_CALLER + NUM_TEAMS,
-  CS_LEVEL_START_TIME, // so the timer only shows the current level
+  CS_LEVEL_START_TIME = CS_VOTE_CALLER + NUM_TEAMS, // so the timer only shows the current level
   CS_INTERMISSION, // when 1, timelimit has been hit and intermission will start in a second or two
   CS_WINNER, // string indicating round winner
   CS_SHADERSTATE,

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -258,6 +258,8 @@ enum
   CS_GAMEPLAY_CVARS,
   CS_CLIENTS_READY,
 
+  // Everything before CS_PLAYERS gets a CG_ConfigStringModified(n) event generated in CG_Init
+
   CS_PLAYERS,
 
   // Stuff below this normally never changes after the match starts


### PR DESCRIPTION
- Remove unused stuff
- Fix the bug that you can't see a vote that started before you entered the game.
- Use configstrings for sending pmove params since the desired semantics are the same, and now we have fixed configstrings to be reliable enough.