### PR TITLE
Fix more entity cache-related regressions

### DIFF
--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -1250,19 +1250,8 @@ void CG_AddPacketEntities()
 	centity_t* playerEnt = &cg.predictedPlayerEntity;
 
 	BG_PlayerStateToEntityState( ps, &playerEnt->currentState, false );
-	playerEnt->valid = true;
-
-	playerEnt->refEntitiesFrame ^= 1;
-	playerEnt->refEntitiesFrameCount[playerEnt->refEntitiesFrame] = 0;
 
 	CG_AddCEntity( playerEnt );
-
-	uint8_t lastFrameCount = playerEnt->refEntitiesFrameCount[playerEnt->refEntitiesFrame];
-
-	if ( playerEnt->refEntitiesCount > lastFrameCount ) {
-		entityCache.Free( playerEnt->refEntitiesOffset + lastFrameCount, playerEnt->refEntitiesCount - lastFrameCount, true );
-		playerEnt->refEntitiesCount = lastFrameCount;
-	}
 
 	// lerp the non-predicted value for lightning gun origins
 	CG_CalcEntityLerpPositions( &cg_entities[ cg.snap->ps.clientNum ] );
@@ -1293,7 +1282,7 @@ void CG_AddPacketEntities()
 		cent->refEntitiesFrameCount[cent->refEntitiesFrame] = 0;
 		CG_AddCEntity( cent );
 
-		lastFrameCount = cent->refEntitiesFrameCount[cent->refEntitiesFrame];
+		const uint8_t lastFrameCount = cent->refEntitiesFrameCount[cent->refEntitiesFrame];
 
 		if ( cent->refEntitiesCount > lastFrameCount ) {
 			entityCache.Free( cent->refEntitiesOffset + lastFrameCount, cent->refEntitiesCount - lastFrameCount, true );

--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -1247,11 +1247,22 @@ void CG_AddPacketEntities()
 
 	// generate and add the entity from the playerstate
 	ps = &cg.predictedPlayerState;
-	BG_PlayerStateToEntityState( ps, &cg.predictedPlayerEntity.currentState, false );
-	cg.predictedPlayerEntity.valid = true;
-	cg.predictedPlayerEntity.refEntitiesFrame ^= 1;
-	cg.predictedPlayerEntity.refEntitiesFrameCount[cg.predictedPlayerEntity.refEntitiesFrame] = 0;
-	CG_AddCEntity( &cg.predictedPlayerEntity );
+	centity_t* playerEnt = &cg.predictedPlayerEntity;
+
+	BG_PlayerStateToEntityState( ps, &playerEnt->currentState, false );
+	playerEnt->valid = true;
+
+	playerEnt->refEntitiesFrame ^= 1;
+	playerEnt->refEntitiesFrameCount[playerEnt->refEntitiesFrame] = 0;
+
+	CG_AddCEntity( playerEnt );
+
+	uint8_t lastFrameCount = playerEnt->refEntitiesFrameCount[playerEnt->refEntitiesFrame];
+
+	if ( playerEnt->refEntitiesCount > lastFrameCount ) {
+		entityCache.Free( playerEnt->refEntitiesOffset + lastFrameCount, playerEnt->refEntitiesCount - lastFrameCount, true );
+		playerEnt->refEntitiesCount = lastFrameCount;
+	}
 
 	// lerp the non-predicted value for lightning gun origins
 	CG_CalcEntityLerpPositions( &cg_entities[ cg.snap->ps.clientNum ] );
@@ -1282,13 +1293,11 @@ void CG_AddPacketEntities()
 		cent->refEntitiesFrameCount[cent->refEntitiesFrame] = 0;
 		CG_AddCEntity( cent );
 
-		if ( cent != &cg.predictedPlayerEntity ) {
-			uint8_t lastFrameCount = cent->refEntitiesFrameCount[cent->refEntitiesFrame];
+		lastFrameCount = cent->refEntitiesFrameCount[cent->refEntitiesFrame];
 
-			if ( cent->refEntitiesCount > lastFrameCount ) {
-				entityCache.Free( cent->refEntitiesOffset + lastFrameCount, cent->refEntitiesCount - lastFrameCount, true );
-				cent->refEntitiesCount = lastFrameCount;
-			}
+		if ( cent->refEntitiesCount > lastFrameCount ) {
+			entityCache.Free( cent->refEntitiesOffset + lastFrameCount, cent->refEntitiesCount - lastFrameCount, true );
+			cent->refEntitiesCount = lastFrameCount;
 		}
 
 		done[ num ] = true;

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -765,10 +765,12 @@ struct centity_t
 
 	playerEntity_t pe;
 
+	// position and size of the currently allocated contiguous range in the entity cache
 	uint16_t refEntitiesOffset        = 0;
 	uint8_t  refEntitiesCount         = 0;
-	uint8_t  refEntitiesFrame         = 0;
-	uint8_t  refEntitiesFrameCount[2] { 0, 0 };
+
+	uint8_t  refEntitiesFrame         = 0; // toggles between 0 and 1
+	uint8_t  refEntitiesFrameCount[2] { 0, 0 }; // number of ref entities associated with this centity_t
 
 	bool       extrapolated; // false if origin / angles is an interpolation
 	vec3_t         rawOrigin;

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -1883,6 +1883,13 @@ void CG_DrawActiveFrame( int serverTime, bool demoPlayback )
 	//build culling planes
 	CG_SetupFrustum();
 
+	/* Cache invalidation for predictedPlayerEntity must be done here
+	to avoid allocating increasingly large amounts of entities to it during teleports */
+	centity_t* playerEnt = &cg.predictedPlayerEntity;
+
+	playerEnt->refEntitiesFrame ^= 1;
+	playerEnt->refEntitiesFrameCount[playerEnt->refEntitiesFrame] = 0;
+
 	// build the render lists
 	if ( !cg.hyperspace )
 	{
@@ -1891,16 +1898,14 @@ void CG_DrawActiveFrame( int serverTime, bool demoPlayback )
 		CG_AddMarkPolys();
 	}
 
-	CG_AddViewWeapon( &cg.predictedPlayerState );
+	const uint8_t lastFrameCount = playerEnt->refEntitiesFrameCount[playerEnt->refEntitiesFrame];
 
-	centity_t* cent = &cg.predictedPlayerEntity;
-
-	uint8_t lastFrameCount = cent->refEntitiesFrameCount[cent->refEntitiesFrame];
-
-	if ( cent->refEntitiesCount > lastFrameCount ) {
-		entityCache.Free( cent->refEntitiesOffset + lastFrameCount, cent->refEntitiesCount - lastFrameCount, true );
-		cent->refEntitiesCount = lastFrameCount;
+	if ( playerEnt->refEntitiesCount > lastFrameCount ) {
+		entityCache.Free( playerEnt->refEntitiesOffset + lastFrameCount, playerEnt->refEntitiesCount - lastFrameCount, true );
+		playerEnt->refEntitiesCount = lastFrameCount;
 	}
+
+	CG_AddViewWeapon( &cg.predictedPlayerState );
 
 	SyncEntityCacheToEngine();
 	SyncEntityCacheFromEngine();


### PR DESCRIPTION
Fixes #3516, and a bug where you could get disconnected if you lag during a teleport.

The first two commits are picked from https://codeberg.org/unvmods/Unvanquished/commits/branch/unvmods-0.56 and are LGTMed by me.