### PR TITLE
Fix muzzlePS particle system corruption

### DIFF
--- a/src/cgame/cg_weapons.cpp
+++ b/src/cgame/cg_weapons.cpp
@@ -1493,19 +1493,6 @@ void CG_AddPlayerWeapon( refEntity_t* parent, playerState_t* ps, centity_t* cent
 
 	if ( CG_IsParticleSystemValid( &cent->muzzlePS ) )
 	{
-		if ( ps || cg.renderingThirdPerson ||
-		     cent->currentState.number != cg.predictedPlayerState.clientNum )
-		{
-			if ( noGunModel )
-			{
-				CG_SetAttachmentTag( &cent->muzzlePS->attachment, cent, weaponAttachmentEntityID, parent->hModel, "tag_weapon" );
-			}
-			else
-			{
-				CG_SetAttachmentTag( &cent->muzzlePS->attachment, cent, weaponAttachmentEntityID + 1, gun.hModel, "tag_flash" );
-			}
-		}
-
 		//if the PS is infinite disable it when not firing
 		if ( !firing && CG_IsParticleSystemInfinite( cent->muzzlePS ) )
 		{
@@ -1568,23 +1555,22 @@ void CG_AddPlayerWeapon( refEntity_t* parent, playerState_t* ps, centity_t* cent
 		if ( weapon->wim[ weaponMode ].muzzleParticleSystem && cent->muzzlePsTrigger )
 		{
 			cent->muzzlePS = CG_SpawnNewParticleSystem( weapon->wim[ weaponMode ].muzzleParticleSystem );
+			cent->muzzlePsTrigger = false;
+		}
 
-			if ( CG_IsParticleSystemValid( &cent->muzzlePS ) )
+		if ( CG_IsParticleSystemValid( &cent->muzzlePS ) )
+		{
+			if ( noGunModel )
 			{
-				if ( noGunModel )
-				{
-					CG_SetAttachmentTag( &cent->muzzlePS->attachment, cent, weaponAttachmentEntityID, parent->hModel, "tag_weapon" );
-				}
-				else
-				{
-					CG_SetAttachmentTag( &cent->muzzlePS->attachment, cent, weaponAttachmentEntityID + 1, gun.hModel, "tag_flash" );
-				}
-
-				CG_SetAttachmentCent( &cent->muzzlePS->attachment, cent );
-				CG_AttachToTag( &cent->muzzlePS->attachment );
+				CG_SetAttachmentTag( &cent->muzzlePS->attachment, cent, weaponAttachmentEntityID, parent->hModel, "tag_weapon" );
+			}
+			else
+			{
+				CG_SetAttachmentTag( &cent->muzzlePS->attachment, cent, weaponAttachmentEntityID + 1, gun.hModel, "tag_flash" );
 			}
 
-			cent->muzzlePsTrigger = false;
+			CG_SetAttachmentCent( &cent->muzzlePS->attachment, cent );
+			CG_AttachToTag( &cent->muzzlePS->attachment );
 		}
 
 		// make a dlight for the flash


### PR DESCRIPTION
Due to CG_AddPlayerWeapon updating muzzlePS before creating and/or destroying it, attachment updates could be issued for an already deleted particle system and then corrupt a different particle system that was created in the same slot. Fix this by removing duplicated update code and doing things in the right order.

Fixes https://github.com/DaemonEngine/Daemon/issues/1950