### PR TITLE
Add mission gameplay preset

### DIFF
--- a/pkg/unvanquished_src.dpkdir/presets/gameplay/mission.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/gameplay/mission.cfg
@@ -1,0 +1,3 @@
+seta g_BPVampire off
+seta g_maxMiners 1
+seta g_BPInitialBudget 999


### PR DESCRIPTION
Add mission gameplay preset.

Other cvars may be needed, like forbidding the joining of some team, and we may want to split them (human mission, alien mission).