### PR TITLE
Add blend regime option in graphics presets and in graphics option window

### DIFF
--- a/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/high.cfg
@@ -1,6 +1,7 @@
 reset r_clear
 reset r_picmip
 reset r_rimLighting
+seta r_forceBlendRegime 0
 seta r_accurateSRGB on
 seta r_colorGrading on
 seta r_lightMode 3

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/low.cfg
@@ -1,6 +1,7 @@
 reset r_clear
 reset r_picmip
 reset r_rimLighting
+seta r_forceBlendRegime 1
 seta r_accurateSRGB off
 seta r_colorGrading off
 seta r_lightMode 3

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/lowest.cfg
@@ -1,6 +1,7 @@
 reset r_clear
 reset r_picmip
 reset r_rimLighting
+seta r_forceBlendRegime 1
 seta r_accurateSRGB off
 seta r_colorGrading off
 seta r_lightMode 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
@@ -2,7 +2,7 @@ reset r_clear
 reset r_picmip
 reset r_rimLighting
 seta r_forceBlendRegime 0
-seta r_accurateSRGB on
+seta r_accurateSRGB off
 seta r_colorGrading on
 seta r_lightMode 3
 seta r_lightStyles 1

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/medium.cfg
@@ -1,6 +1,7 @@
 reset r_clear
 reset r_picmip
 reset r_rimLighting
+seta r_forceBlendRegime 0
 seta r_accurateSRGB on
 seta r_colorGrading on
 seta r_lightMode 3

--- a/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
+++ b/pkg/unvanquished_src.dpkdir/presets/graphics/ultra.cfg
@@ -1,6 +1,7 @@
 reset r_clear
 reset r_picmip
 reset r_rimLighting
+seta r_forceBlendRegime 0
 seta r_accurateSRGB on
 seta r_colorGrading on
 seta r_lightMode 3

--- a/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
@@ -160,6 +160,13 @@
 					<p><translate>Non-physical lighting technique to make models less dark.</translate></p>
 				</row>
 				<row>
+					<select cvar="r_forceBlendRegime" style="width:20em;">
+						<option value="0"><translate>Detect</translate></option>
+						<option value="1"><translate>Forced naive blend (cheap approximation)</translate></option>
+					</select>
+					<h3><translate>Blend regime</translate></h3>
+				</row>
+				<row>
 					<select cvar="cg_shadows" style="width:20em;">
 						<option value="1"><translate>Blobs</translate>&nbsp;(<translate>low</translate>)</option>
 						<option value="0"><translate>None</translate></option>

--- a/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/options_graphics.rml
@@ -160,6 +160,11 @@
 					<p><translate>Non-physical lighting technique to make models less dark.</translate></p>
 				</row>
 				<row>
+					<h3><translate>sRGB conversion accuracy</translate></h3>
+					<input cvar="r_accurateSRGB" type="checkbox" />
+					<p><translate>Disabling accuracy makes color conversions faster but less accurate.</translate></p>
+				</row>
+				<row>
 					<select cvar="r_forceBlendRegime" style="width:20em;">
 						<option value="0"><translate>Detect</translate></option>
 						<option value="1"><translate>Forced naive blend (cheap approximation)</translate></option>


### PR DESCRIPTION
Add blend regime option in graphics presets and in graphics option window.

It forces the naive blend regime in `low` and `lowest` presets. Blending sRGB textures with sRGB lightmaps without conversions is a good enough approximation for low presets, especially when specular and normal mapping is disabled (which is in low preset). This also avoids conversion round trips that lose a lot of precisions when high precision framebuffers aren't used, which aren't used in low presets. So all of that put together means smaller and faster code in low presets, while looking more pleasant.

This requires:

- https://github.com/DaemonEngine/Daemon/pull/1869

I also added the option for the sRGB accuracy in the graphics option window. We missed it for 0.56.

I'm thinking about also disabling the sRGB accuracy in `medium` preset (which is the default one), because the approximation is good enough, seriously.