### PR TITLE
BP vampire UI - turn on/off from the menu

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/server_setup.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/server_setup.rml
@@ -159,6 +159,16 @@
 				<input type="range" min="0" max="400" step="10" cvar="g_BPInitialBudget"/>
 				<p><inlinecvar cvar="g_BPInitialBudget" type="number" format="%g"/>&nbsp; bp<ilink onclick='Cmd.exec("reset g_BPInitialBudget")'> (reset) </ilink></p>
 			</row>
+			<h2><translate>Presets</translate></h2>
+			<row class="presets">
+				<button onclick='Cmd.exec("preset presets/gameplay/vampire.cfg")'><translate>BP Vampire</translate></button>
+				<span><translate>Bleed build points from the enemy team by killing buildables.</translate></span>
+			</row>
+			<row class="presets">
+				<button onclick='Cmd.exec("preset presets/gameplay/mining.cfg")'><translate>Mining</translate></button>
+				<span><translate>Increase build budget by building mining structures. BP returns slowly when a buildable is lost.</translate></span>
+			</row>
+			<h2><translate>Mining mode options</translate></h2>
 			<row>
 				<parent>
 					<h3><translate>Miner bonus</translate></h3>

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -2037,6 +2037,7 @@ public:
 	{
 		if ( !cg.bpVampireTime )
 		{
+			SetInnerRML( "" );
 			return; // bp vampire mode not enabled
 		}
 

--- a/src/cgame/cg_servercmds.cpp
+++ b/src/cgame/cg_servercmds.cpp
@@ -98,13 +98,23 @@ CG_BPVampire
 */
 static void CG_BPVampire()
 {
-	cg.bpVampireTime = cg.time;
+	int bpA, bpH;
 
-	cg.bpVampireOld[ TEAM_HUMANS ] = cg.bpVampire[ TEAM_HUMANS ];
-	cg.bpVampireOld[ TEAM_ALIENS ] = cg.bpVampire[ TEAM_ALIENS ];
+	if ( 2 == sscanf( CG_ConfigString( CS_BP_VAMPIRE ), "%d %d", &bpA, &bpH ) )
+	{
+		cg.bpVampireTime = cg.time;
 
-	cg.bpVampire[ TEAM_HUMANS ] = atoi( CG_Argv( 1 ) );
-	cg.bpVampire[ TEAM_ALIENS ] = atoi( CG_Argv( 2 ) );
+		cg.bpVampireOld[ TEAM_HUMANS ] = cg.bpVampire[ TEAM_HUMANS ];
+		cg.bpVampireOld[ TEAM_ALIENS ] = cg.bpVampire[ TEAM_ALIENS ];
+
+		cg.bpVampire[ TEAM_HUMANS ] = bpH;
+		cg.bpVampire[ TEAM_ALIENS ] = bpA;
+	}
+	else
+	{
+		// Off. String should be empty
+		cg.bpVampireTime = 0;
+	}
 }
 
 static void CG_PrintBPMessage_f()
@@ -353,6 +363,10 @@ void CG_ConfigStringModified( int num )
 	else if ( num == CS_SHADERSTATE )
 	{
 		CG_ShaderStateChanged();
+	}
+	else if ( num == CS_BP_VAMPIRE )
+	{
+		CG_BPVampire();
 	}
 }
 
@@ -1323,7 +1337,6 @@ static void CG_GameCmds_f()
 static const consoleCommand_t svcommands[] =
 {	// sorting: use 'sort -f'
 	{ "achat",            CG_AdminChat_f          },
-	{ "bpvampire",        CG_BPVampire            },
 	{ "chat",             CG_Chat_f               },
 	{ "cmds",             CG_GameCmds_f           },
 	{ "cp",               CG_CenterPrint_f        },

--- a/src/sgame/sg_buildable.cpp
+++ b/src/sgame/sg_buildable.cpp
@@ -2377,7 +2377,6 @@ void G_BuildLogRevert( int id )
 		level.team[ TEAM_HUMANS ].totalBudget = log->humanBP;
 		level.team[ TEAM_ALIENS ].totalBudget = log->alienBP;
 
-		G_UpdateBPVampire( -1 );
 	}
 
 	for ( int team = TEAM_NONE + 1; team < NUM_TEAMS; ++team )

--- a/src/sgame/sg_buildpoints.cpp
+++ b/src/sgame/sg_buildpoints.cpp
@@ -70,16 +70,6 @@ float G_RGSPredictEfficiencyDelta(vec3_t origin, team_t team) {
  * @brief Calculate the build point budgets for both teams.
  */
 
-void G_UpdateBPVampire( int client ) // -1 to update everyone
-{
-	if ( !g_BPVampire.Get() )
-	{
-		return;
-	}
-
-	trap_SendServerCommand( client, va( "bpvampire %d %d", static_cast<int>( level.team[ TEAM_HUMANS ].totalBudget ), static_cast<int>( level.team[ TEAM_ALIENS ].totalBudget ) ) );
-}
-
 void G_UpdateBuildPointBudgets() {
 	int abp = g_BPInitialBudgetAliens.Get();
 	int hbp = g_BPInitialBudgetHumans.Get();
@@ -106,7 +96,6 @@ void G_UpdateBuildPointBudgets() {
 		level.team[G_Team(entity.oldEnt)].totalBudget += miningComponent.Efficiency() *
 		                                                 g_buildPointBudgetPerMiner.Get();
 	});
-	G_UpdateBPVampire( -1 );
 }
 
 void G_RecoverBuildPoints() {

--- a/src/sgame/sg_client.cpp
+++ b/src/sgame/sg_client.cpp
@@ -1359,8 +1359,6 @@ void ClientBegin( int clientNum )
 	// count current clients and rank for scoreboard
 	CalculateRanks();
 
-	G_UpdateBPVampire( client->num() );
-
 	// display the help menu, if connecting the first time
 	if ( !client->sess.seenWelcome  )
 	{

--- a/src/sgame/sg_combat.cpp
+++ b/src/sgame/sg_combat.cpp
@@ -309,8 +309,6 @@ void G_AnnounceStolenBP()
 		{
 			continue;
 		}
-		
-		G_UpdateBPVampire( -1 ); // update the BP bars for everyone
 
 		AnnounceDestructions( team );
 

--- a/src/sgame/sg_main.cpp
+++ b/src/sgame/sg_main.cpp
@@ -2204,6 +2204,21 @@ static void G_TransmitGameplayCvars()
 	trap_SetConfigstring( CS_GAMEPLAY_CVARS, info );
 }
 
+static void G_TransmitBPVampire()
+{
+	if ( g_BPVampire.Get() )
+	{
+		std::string string = Str::Format( "%d %d",
+			static_cast<int>( level.team[ TEAM_ALIENS ].totalBudget ),
+			static_cast<int>( level.team[ TEAM_HUMANS ].totalBudget ) );
+		trap_SetConfigstring( CS_BP_VAMPIRE, string.c_str() );
+	}
+	else
+	{
+		trap_SetConfigstring( CS_BP_VAMPIRE, "" );
+	}
+}
+
 /*
 ================
 G_RunFrame
@@ -2439,7 +2454,9 @@ void G_RunFrame( int levelTime )
 
 	level.numBuildablesEstimate = numBuildables;
 
+	// update some configstrings
 	G_TransmitGameplayCvars();
+	G_TransmitBPVampire();
 }
 
 void G_PrepareEntityNetCode() {

--- a/src/sgame/sg_public.h
+++ b/src/sgame/sg_public.h
@@ -117,7 +117,6 @@ void              G_FreeBudget(team_t team, int immediateAmount , int queuedAmou
 void              G_SpendBudget(team_t team, int amount);
 int               G_BuildableDeconValue(gentity_t *ent);
 void              G_GetTotalBuildableValues(int *buildableValuesByTeam);
-void              G_UpdateBPVampire( int client );
 
 // sg_client.c
 void              G_AddCreditToClient( gclient_t *client, short credit, bool cap );

--- a/src/shared/bg_public.h
+++ b/src/shared/bg_public.h
@@ -256,6 +256,7 @@ enum
   CS_WINNER, // string indicating round winner
   CS_SHADERSTATE,
   CS_PMOVE_PARAMS,
+  CS_BP_VAMPIRE,
   CS_GAMEPLAY_CVARS,
   CS_CLIENTS_READY,
 


### PR DESCRIPTION
Adjust the BP vampire network commands so the BP bar will immediately show or hide based on whether the game mode is enabled.  Add buttons for the gameplay presets in the menu.

I haven't tested what happens if you change the mode in the middle of the game, but the point is it should at least work if you change it at the beginning before anything happens.