### PR TITLE
admin: Fix segfault in bot skill

### DIFF
--- a/src/sgame/sg_admin.cpp
+++ b/src/sgame/sg_admin.cpp
@@ -6524,7 +6524,7 @@ bool G_admin_bot( gentity_t *ent )
 			const std::string& teamStr = args.Argv( 3 );
 			team = BG_PlayableTeamFromString( teamStr.c_str() );
 		}
-		for ( int i = 0; i < MAX_CLIENTS; ++i )
+		for ( int i = 0; i < level.maxclients; ++i )
 		{
 			if ( team != TEAM_NONE && G_Team( &g_entities[ i ] ) != team )
 			{


### PR DESCRIPTION
MAX_CLIENTS is wrong because only level.maxclients will be populated with a client. We could also optionally harden G_Bot_SetSkill to return early if bot->client is null...

repro:
- load map
- `/bot skill 5`