### PR TITLE
Fix entity cache bug: your human player invisible in mirrors + hall-of-mirrors

### DIFF
--- a/src/cgame/EntityCache.cpp
+++ b/src/cgame/EntityCache.cpp
@@ -159,7 +159,17 @@ void AddRefEntities( centity_t* cent, std::vector<refEntity_t>& ents ) {
 
 	if ( ents.size() + frameCount > cent->refEntitiesCount ) {
 		uint16_t newOffset = entityCache.Alloc( ents.size() + frameCount );
-		std::copy_n( entities + cent->refEntitiesOffset, frameCount, entities + newOffset );
+
+		if ( frameCount > 0 ) {
+			Log::Warn( "EntityCache: entity %d had to move its ref entity array", cent - cg_entities );
+			// This doesn't work in general because stuff referencing the entity id's will end up wrong
+			// The entityAttachment field within the same array could be fixed easily, but LerpTag
+			// queries cannot so just don't do it
+
+			// Halfheartedly attempt to move the array
+			std::copy_n( entities + cent->refEntitiesOffset, frameCount, entities + newOffset );
+		}
+
 		entityCache.Free( cent->refEntitiesOffset, cent->refEntitiesCount, true );
 		cent->refEntitiesOffset = newOffset;
 		cent->refEntitiesCount = ents.size() + frameCount;

--- a/src/cgame/EntityCache.cpp
+++ b/src/cgame/EntityCache.cpp
@@ -143,16 +143,15 @@ static void UpdateEntity( refEntity_t& ent, const uint16_t id ) {
 }
 
 void AddRefEntities( centity_t* cent, std::vector<refEntity_t>& ents ) {
-	uint8_t& frameCount     = cent->refEntitiesFrameCount[cent->refEntitiesFrame];
-	uint8_t  lastFrameCount = cent->refEntitiesFrameCount[cent->refEntitiesFrame ^ 1];
+	uint8_t& frameCount     = cent->refEntitiesFrameCount;
 
 	if ( cg_showEntityCacheUpdates.Get() && !( cg.clientFrame % cg_showEntityCacheUpdates.Get() ) ) {
 		const std::string centityID = cent == &cg.predictedPlayerEntity ? "predicted player entity" : Str::Format( "%u", cent - cg_entities );
 
 		Log::defaultLogger.WithoutSuppression().Notice(
-			Str::Format( "Cache add entities: centity: %s frame: %u "
-				"current entities: %u last frame entities: %u offset: %u count: %u new entities: %u",
-				centityID, cent->refEntitiesFrame, frameCount, lastFrameCount,
+			Str::Format( "Cache add entities: centity: %s "
+				"current entities: %u offset: %u count: %u new entities: %u",
+				centityID, frameCount,
 				cent->refEntitiesOffset, cent->refEntitiesCount,
 				ents.size() )
 		);

--- a/src/cgame/EntityCache.cpp
+++ b/src/cgame/EntityCache.cpp
@@ -348,10 +348,15 @@ void EntityCache::Free( const uint32_t offset, const uint32_t count, const bool 
 	block &= ~mask;
 
 	if ( update ) {
-		for ( refEntity_t* ent = entities + offset; ent < entities + offset + count; ent++ ) {
-			ent->active = false;
-			entityUpdates.push_back( EntityUpdate{ *ent, ( uint16_t ) ( ent - entities ) } );
-		}
+		Deactivate( offset, count );
+	}
+}
+
+void EntityCache::Deactivate( uint32_t offset, uint32_t count )
+{
+	for ( refEntity_t* ent = entities + offset; count--; ent++ ) {
+		ent->active = false;
+		entityUpdates.push_back( EntityUpdate{ *ent, ( uint16_t ) ( ent - entities ) } );
 	}
 }
 

--- a/src/cgame/EntityCache.h
+++ b/src/cgame/EntityCache.h
@@ -62,6 +62,7 @@ class EntityCache {
 	public:
 	uint32_t Alloc( const uint32_t count );
 	void Free( const uint32_t offset, const uint32_t count, const bool update );
+	void Deactivate( uint32_t offset, uint32_t count );
 
 	void Clear();
 

--- a/src/cgame/cg_attachment.cpp
+++ b/src/cgame/cg_attachment.cpp
@@ -423,7 +423,7 @@ void CG_SetAttachmentTag( attachment_t *a, centity_t* centity, const uint16_t en
 	}
 
 	a->centity = centity;
-	a->entity = entity + centity->refEntitiesFrameCount[centity->refEntitiesFrame];
+	a->entity = entity + centity->refEntitiesFrameCount;
 	a->model = model;
 	a->tagName = tagName;
 	a->tagValid = true;

--- a/src/cgame/cg_ents.cpp
+++ b/src/cgame/cg_ents.cpp
@@ -1278,11 +1278,10 @@ void CG_AddPacketEntities()
 
 		cent->valid = true;
 
-		cent->refEntitiesFrame ^= 1;
-		cent->refEntitiesFrameCount[cent->refEntitiesFrame] = 0;
+		cent->refEntitiesFrameCount = 0;
 		CG_AddCEntity( cent );
 
-		const uint8_t lastFrameCount = cent->refEntitiesFrameCount[cent->refEntitiesFrame];
+		const uint8_t lastFrameCount = cent->refEntitiesFrameCount;
 
 		if ( cent->refEntitiesCount > lastFrameCount ) {
 			entityCache.Free( cent->refEntitiesOffset + lastFrameCount, cent->refEntitiesCount - lastFrameCount, true );

--- a/src/cgame/cg_local.h
+++ b/src/cgame/cg_local.h
@@ -769,8 +769,7 @@ struct centity_t
 	uint16_t refEntitiesOffset        = 0;
 	uint8_t  refEntitiesCount         = 0;
 
-	uint8_t  refEntitiesFrame         = 0; // toggles between 0 and 1
-	uint8_t  refEntitiesFrameCount[2] { 0, 0 }; // number of ref entities associated with this centity_t
+	uint8_t  refEntitiesFrameCount; // number of ref entities associated with this centity_t
 
 	bool       extrapolated; // false if origin / angles is an interpolation
 	vec3_t         rawOrigin;

--- a/src/cgame/cg_main.cpp
+++ b/src/cgame/cg_main.cpp
@@ -1350,6 +1350,12 @@ void CG_Init( int serverMessageNum, int clientNum, const WindowConfig& windowCon
 	CG_InitClasses();
 	CG_RegisterClients(); // if low on memory, some clients will be deferred
 
+	// Human predicted player entity has stuff added from 2 different places. Reallocation
+	// when ref entities have already been added doesn't work, so allocate the
+	// maximum space beforehand
+	cg.predictedPlayerEntity.refEntitiesOffset = entityCache.Alloc( 64 );
+	cg.predictedPlayerEntity.refEntitiesCount = 64;
+
 	CG_UpdateLoadingStep( LOAD_HUDS );
 	CG_Rocket_LoadHuds();
 	CG_LoadBeaconsConfig();

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -1862,8 +1862,7 @@ void CG_DrawActiveFrame( int serverTime, bool demoPlayback )
 	to avoid allocating increasingly large amounts of entities to it during teleports */
 	centity_t* playerEnt = &cg.predictedPlayerEntity;
 
-	playerEnt->refEntitiesFrame ^= 1;
-	playerEnt->refEntitiesFrameCount[playerEnt->refEntitiesFrame] = 0;
+	playerEnt->refEntitiesFrameCount = 0;
 
 	// build the render lists
 	if ( !cg.hyperspace )
@@ -1873,7 +1872,7 @@ void CG_DrawActiveFrame( int serverTime, bool demoPlayback )
 		CG_AddMarkPolys();
 	}
 
-	const uint8_t lastFrameCount = playerEnt->refEntitiesFrameCount[playerEnt->refEntitiesFrame];
+	const uint8_t lastFrameCount = playerEnt->refEntitiesFrameCount;
 
 	if ( playerEnt->refEntitiesCount > lastFrameCount ) {
 		entityCache.Free( playerEnt->refEntitiesOffset + lastFrameCount, playerEnt->refEntitiesCount - lastFrameCount, true );

--- a/src/cgame/cg_view.cpp
+++ b/src/cgame/cg_view.cpp
@@ -1861,7 +1861,7 @@ void CG_DrawActiveFrame( int serverTime, bool demoPlayback )
 	/* Cache invalidation for predictedPlayerEntity must be done here
 	to avoid allocating increasingly large amounts of entities to it during teleports */
 	centity_t* playerEnt = &cg.predictedPlayerEntity;
-
+	int predictedPlayerPreviousFrameCount = playerEnt->refEntitiesFrameCount;
 	playerEnt->refEntitiesFrameCount = 0;
 
 	// build the render lists
@@ -1872,14 +1872,14 @@ void CG_DrawActiveFrame( int serverTime, bool demoPlayback )
 		CG_AddMarkPolys();
 	}
 
-	const uint8_t lastFrameCount = playerEnt->refEntitiesFrameCount;
-
-	if ( playerEnt->refEntitiesCount > lastFrameCount ) {
-		entityCache.Free( playerEnt->refEntitiesOffset + lastFrameCount, playerEnt->refEntitiesCount - lastFrameCount, true );
-		playerEnt->refEntitiesCount = lastFrameCount;
-	}
-
 	CG_AddViewWeapon( &cg.predictedPlayerState );
+
+	// Remove old predicted player ref entities but without shrinking the allocation
+	if ( playerEnt->refEntitiesFrameCount < predictedPlayerPreviousFrameCount )
+	{
+		entityCache.Deactivate( playerEnt->refEntitiesOffset + playerEnt->refEntitiesFrameCount,
+		                        predictedPlayerPreviousFrameCount - playerEnt->refEntitiesFrameCount );
+	}
 
 	SyncEntityCacheToEngine();
 	SyncEntityCacheFromEngine();


### PR DESCRIPTION
Thanks to yet another entity cache bug, the predicted player ref entities could get corrupted. This is because when AddRefEntities tries to reallocate the ref entities group, it does not take into account that there may be LerpTag queries or attachments pointing at the old offset. So some of the entity operations get pointed at a random wrong entity.

The bug had the following consequences:
- Your own human player model is invisible in mirrors/portals.
- Partial hall-of-mirrors effect in some circumstances. It is easiest to
  see like this: Stand in front of a mirror or portal with MSAA enabled,
  bloom enabled, and r_clear disabled, and fire the rifle. You will see
  white bloom garbage. With other settings it can manifest as darkening
  or blurring.

<img width="1152" height="864" alt="unvanquished_2026-05-17_233347_000" src="https://github.com/user-attachments/assets/797935f5-6356-4fbf-ba03-d43e70c6a723" />


The bug became more visible following https://github.com/Unvanquished/Unvanquished/commit/ee3406e7f8c360fd0a59ab17c59fd85ca2f978ce which abandons the
attempt to reallocate the entity range in-place if possible. This makes
sense since the bug occurs only if the entity IDs change.

Fix the bug by preallocating a large ref entities array for the
predicted player entity. That way when ref entities are added for the
predicted player from multiple places, there will be no resizing/moving
of the entity array. Fortunately, it seems that all other centity_t
besides predicted player always add their entities in a single
AddRefEntities call so they don't use resizing.

Add a warning to make sure no one is moving the entity allocations in the future.