### PR TITLE
tools/translate: create data.pot for map translatable strings

### DIFF
--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -3711,7 +3711,7 @@ static void CG_Rocket_DrawLevelAuthors()
 
 static void CG_Rocket_DrawLevelName()
 {
-	Rocket_SetInnerQuake( cg.mapLongName );
+	Rocket_SetInnerQuake( _( cg.mapLongName.c_str() ) );
 }
 
 static void CG_Rocket_DrawMOTD()

--- a/src/cgame/cg_rocket_draw.cpp
+++ b/src/cgame/cg_rocket_draw.cpp
@@ -1316,7 +1316,7 @@ public:
 			? CS_LOCATIONS + locent->currentState.generic1
 			: CS_LOCATIONS;
 
-		SetInnerRML( Rocket_QuakeToRML( CG_ConfigString( cs_index ) ) );
+		SetInnerRML( Rocket_QuakeToRML( _( CG_ConfigString( cs_index ) ) ) );
 	}
 
 private:

--- a/src/cgame/translation.cpp
+++ b/src/cgame/translation.cpp
@@ -280,6 +280,7 @@ void Trans_Init()
 	trans_manager.set_filesystem( Util::make_unique<DaemonFileSystem>() );
 
 	trans_manager.add_directory( "translation/game" );
+	trans_manager.add_directory( "translation/data" );
 
 	langs = trans_manager.get_languages();
 

--- a/tools/translation/common.sh
+++ b/tools/translation/common.sh
@@ -1,0 +1,117 @@
+#! /usr/bin/env bash
+
+# ===========================================================================
+#
+# Copyright (c) 2026 Unvanquished Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# ===========================================================================
+
+set -u -e -o pipefail
+
+error () {
+	echo "ERROR: ${1}" >&2
+	false
+}
+
+parse_options () {
+	if [[ -z ${options[@]} ]]
+	then
+		return
+	fi
+
+	if [[ -z ${known_options[@]} ]]
+	then
+		return
+	fi
+
+	local option
+	for option in "${options[@]}"
+	do
+		case "${option}" in
+			'--'*'='*)
+				local option_name="$(echo "${option}" | cut -f1 -d= | cut -c3-)"
+				local option_name="${option_name//-/_}"
+				local option_value="$(echo "${option}" | cut -f2 -d=)"
+
+				local found='false'
+				for known_option in "${known_options[@]}"
+				do
+					if [ "${option_name}" = "${known_option}" ]
+					then
+						found='true'
+					fi
+				done
+
+				if ! "${found}"
+				then
+					error "unknown option: ${option}"
+				fi
+
+				case "${option_name}" in
+					*'_dir')
+						case "${option_value}" in
+							'~'*)
+								option_value="${option_value/\~/${HOME}}"
+							;;
+						esac
+					;;
+				esac
+
+				eval "option_${option_name}='${option_value}'"
+			;;
+			*)
+				error "unknown option: ${option}"
+			;;
+		esac
+	done
+}
+
+parse_args () {
+	options=()
+	translations=()
+
+	while [ -n "${1:-}" ]
+	do
+		case "${1}" in
+			-*)
+				options+=("${1}")
+				shift
+			;;
+			*)
+				translations+=("${1}")
+				shift
+			;;
+		esac
+	done
+
+	if [[ -z ${translations[@]} ]]
+	then
+		. "${script_dir}/translation.conf"
+	fi
+
+	parse_options
+}
+
+set_paths () {
+	repo_dir="$(realpath "${script_dir}/../..")"
+	dpk_dir="${repo_dir}/pkg/unvanquished_src.dpkdir"
+	pot_dir="${dpk_dir}/translation"
+}

--- a/tools/translation/denoise_po_diff.sh
+++ b/tools/translation/denoise_po_diff.sh
@@ -24,7 +24,8 @@
 #
 # ===========================================================================
 
-set -u -e -o pipefail
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+. "${script_dir}/common.sh"
 
 erase_date () {
 	sed '/^"POT-Creation-Date:/d'
@@ -32,11 +33,6 @@ erase_date () {
 
 is_modified_file () {
 	diff -q <(git show "HEAD:./${1}" | erase_date) <(erase_date < "${1}") >/dev/null 2>&1
-}
-
-error () {
-	echo "ERROR: ${1}" >&2
-	false
 }
 
 if [ -z "${1:-}" ]

--- a/tools/translation/generate.sh
+++ b/tools/translation/generate.sh
@@ -24,10 +24,11 @@
 #
 # ===========================================================================
 
-set -u -e -o pipefail
-
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+. "${script_dir}/common.sh"
 
-"${script_dir}/generate_pot.sh"
-"${script_dir}/update_po.sh"
+parse_args "${@}"
+
+"${script_dir}/generate_pot.sh" "${options[@]}" "${translations[@]}"
+"${script_dir}/update_po.sh" "${translations[@]}"
 "${script_dir}/ignore_incomplete.sh"

--- a/tools/translation/generate_arena_pot.py
+++ b/tools/translation/generate_arena_pot.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+
+# ===========================================================================
+#
+# Copyright (c) 2026 Unvanquished Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# ===========================================================================
+
+import sys
+
+import pot_printer
+
+def process(translation_dict, content, filename, is_debug):
+    line = 1
+    errors = 0
+
+    def error(msg):
+        print(f"Error in file {filename} on line {line}: {msg}", file=sys.stderr)
+        nonlocal errors
+        errors += 1
+
+    def debug(msg):
+        if is_debug:
+            print(f"Debug in file {filename} on line {line}: {msg}", file=sys.stderr)
+
+    first_slash = False
+    in_comment = False
+    in_block = False
+    in_key = False
+    in_value = False
+    in_string = False
+    key = ""
+    value = ""
+    string = ""
+
+    for character in content:
+        if character == '\n':
+            line += 1
+
+            if in_comment:
+                in_comment = False
+
+            # TODO: Can a string overlap on next line like attr.cfg files?
+            if in_string:
+                string += " "
+                continue
+
+            if in_key:
+                error(f"missing value for key {key}")
+                in_key = False
+                key=""
+
+            continue
+
+        if in_comment:
+            continue
+
+        if character == "{":
+            if in_block:
+                error("opening block in block")
+
+            in_block = True
+            continue
+
+        if character == "}":
+            if in_block:
+                in_block = False
+                continue
+
+            error("closing block outside block")
+            continue
+
+        if in_block:
+            if character == '"':
+                if not key:
+                    error("'\"' in key")
+                    continue
+
+                if in_key:
+                    error("'\"' in key")
+                    continue
+
+                if in_string:
+                    debug(f"{key}=\"{string}\"")
+
+                    if key in ["longname"]:
+                        if string != "null":
+                            translation_dict[string].append(f"{filename}:{line}")
+
+                    in_string = False
+                    key = ""
+                    string = ""
+                else:
+                    in_string = True
+
+                continue
+
+            if in_string:
+                string += character
+                continue
+
+        if character in [' ', '\t']:
+            if first_slash:
+                first_slash = False
+
+            if in_key:
+                in_key = False
+
+            continue
+
+        if character == '/':
+            if first_slash:
+                first_slash = False
+                in_comment = True
+            else:
+                first_slash = True
+
+            continue
+
+        if in_block:
+            if in_key:
+                key += character
+                continue
+
+            if not key:
+                in_key = True
+                key += character
+                continue
+
+    if in_block:
+        error("block not closed")
+
+    return errors
+
+pot_printer.run(process)

--- a/tools/translation/generate_map_pot.py
+++ b/tools/translation/generate_map_pot.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+# ===========================================================================
+#
+# Copyright (c) 2026 Unvanquished Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# ===========================================================================
+
+import re
+import subprocess
+import sys
+
+import pot_printer
+
+def load(filename):
+    return subprocess.run(
+        ["esquirel", "map", "--input-map", filename, "--list-strings"],
+        capture_output=True, text=True).stdout.strip()
+
+def process(translation_dict, content, filename, is_debug):
+    line = 0
+    errors = 0
+
+    def error(msg):
+        print(f"Error in file {filename}#strings on line {line}: {msg}", file=sys.stderr)
+        nonlocal errors
+        errors += 1
+
+    def debug(msg):
+        if is_debug:
+            print(f"Debug in file {filename}#strings on line {line}: {msg}", file=sys.stderr)
+
+    lines = str(content).split('\n')
+
+    pattern = re.compile("(?P<num>[0-9]*): (?P<string>.*)")
+
+    for entry in lines:
+        line += 1
+
+        match = pattern.match(entry)
+        if not match:
+            error(f"malformed input: {entry}")
+            continue
+
+        num = match.group("num")
+        string = match.group("string")
+        debug(f"{num}: {string}")
+        translation_dict[string].append(f"{filename}:{num}")
+
+    return errors
+
+pot_printer.run(process, load=load)

--- a/tools/translation/generate_pot.sh
+++ b/tools/translation/generate_pot.sh
@@ -24,11 +24,38 @@
 #
 # ===========================================================================
 
+known_options=('data_dir')
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 . "${script_dir}/common.sh"
 
 parse_args "${@}"
 set_paths
+
+generate_data_pot () (
+	if [ -z "${option_data_dir:-}" ]
+	then
+		error "missing data directory"
+	fi
+
+	if [ ! -d "${option_data_dir}" ]
+	then
+		error "not a directory: ${option_data_dir}"
+	fi
+
+	for pak_dir in $(find "${option_data_dir}/pkg" -type d -name 'map-*.dpkdir')
+	do
+	(
+		cd "${pak_dir}"
+
+		find maps -type f -name '*.map' \
+		| sort \
+		| xargs -I{} \
+			"${script_dir}/generate_map_pot.py" {} \
+			>> "${temp_pot_file}"
+	)
+	done
+)
 
 generate_game_pot () (
 	(

--- a/tools/translation/generate_pot.sh
+++ b/tools/translation/generate_pot.sh
@@ -53,8 +53,19 @@ generate_data_pot () (
 		| xargs -I{} \
 			"${script_dir}/generate_map_pot.py" {} \
 			>> "${temp_pot_file}"
+
+		find meta -type f -name '*.arena' \
+		| sort \
+		| xargs -I{} \
+			"${script_dir}/generate_arena_pot.py" {} \
+			>> "${temp_pot_file}"
 	)
 	done
+
+	# HACK: Let xgettext reprocess the file to deduplicate comments.
+	echo '' | xgettext --from-code=UTF-8 \
+		-j -o "${temp_pot_file}" \
+		-f -
 )
 
 generate_game_pot () (

--- a/tools/translation/generate_pot.sh
+++ b/tools/translation/generate_pot.sh
@@ -24,14 +24,11 @@
 #
 # ===========================================================================
 
-set -u -e -o pipefail
-
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-repo_dir="$(realpath "${script_dir}/../..")"
-dpk_dir="${repo_dir}/pkg/unvanquished_src.dpkdir"
-pot_dir="${dpk_dir}/translation"
+. "${script_dir}/common.sh"
 
-. "${script_dir}/translation.conf"
+parse_args "${@}"
+set_paths
 
 generate_game_pot () (
 	(

--- a/tools/translation/ignore_incomplete.sh
+++ b/tools/translation/ignore_incomplete.sh
@@ -40,6 +40,11 @@ for pot_file in $(find . -maxdepth 1 -type f -name '*.pot')
 do
 	name="$(basename "${pot_file}" .pot)"
 
+	if [ ! -d "${name}" ]
+	then
+		continue
+	fi
+
 	for po_file in $(find "${name}" -name '*.po' | sort)
 	do
 		lang="$(echo "${po_file}" | cut -f2 -d'/' | cut -f1 -d'.')"

--- a/tools/translation/ignore_incomplete.sh
+++ b/tools/translation/ignore_incomplete.sh
@@ -36,39 +36,94 @@ echo "${action_list}" > "${action_file}"
 
 cd "${pot_dir}"
 
+compute_percentage () {
+	local name="${1}"; shift
+	local lang="${1}"; shift
+
+	local po_file="${name}/${lang}.po"
+
+	local po_entries="$(sed 'N;s/ ""\n"/ "/g;P;D;' "${po_file}" | grep -E '^msgid "|^msgstr "')"
+
+	count_source="$(echo "${po_entries}" | grep -c -E '^msgid "' || true)"
+	count_translation="$(echo "${po_entries}" | grep -c -E '^msgstr "' || true)"
+	count_empty_source="$(echo "${po_entries}" | grep -c -E '^msgid ""' || true)"
+	count_empty_translation="$(echo "${po_entries}" | grep -c -E '^msgstr ""' || true)"
+
+	total_source="$((${count_source} - ${count_empty_source}))"
+	total_translation="$((${count_translation} - ${count_empty_translation}))"
+
+	percentage="$((${total_translation} * 100 / ${total_source}))"
+}
+
+print_percentage () {
+	local name="${1}"; shift
+	local lang="${1}"; shift
+	local state="${1}"; shift
+
+	printf '%s/%s\t%+3s%%,\tsources: %s (%s-%s),\ttranslations: %-4s (%s-%s),\t%s\n' \
+		"${name}" "${lang}:" "${percentage}" \
+		"${total_source}" "${count_source}" "${count_empty_source}" \
+		"${total_translation}" "${count_translation}" "${count_empty_translation}" \
+		"${state}"
+}
+
+lang_list=()
 for pot_file in $(find . -maxdepth 1 -type f -name '*.pot')
 do
 	name="$(basename "${pot_file}" .pot)"
 
-	if [ ! -d "${name}" ]
+	for po_file in $(find "${name}" -name '*.po' | sort)
+	do
+		lang="$(echo "${po_file}" | cut -f2 -d'/' | cut -f1 -d'.')"
+		lang_list+=("${lang}")
+	done
+done
+
+lang_list=($(echo "${lang_list[@]}" | tr ' ' '\n' | sort -u))
+
+main_name='game'
+
+for lang in "${lang_list[@]}"
+do
+	main_po_file="${main_name}/${lang}.po"
+
+	if [ ! -f "${main_po_file}" ]
 	then
 		continue
 	fi
 
-	for po_file in $(find "${name}" -name '*.po' | sort)
+	compute_percentage "${main_name}" "${lang}"
+	main_percentage="${percentage}"
+
+	for pot_file in $(find . -maxdepth 1 -type f -name '*.pot')
 	do
-		lang="$(echo "${po_file}" | cut -f2 -d'/' | cut -f1 -d'.')"
+		name="$(basename "${pot_file}" .pot)"
 
-		po_entries="$(sed 'N;s/ ""\n"/ "/g;P;D;' "${po_file}" | grep -E '^msgid "|^msgstr "')"
+		if [ ! -d "${name}" ]
+		then
+			continue
+		fi
 
-		count_source="$(echo "${po_entries}" | grep -c -E '^msgid "' || true)"
-		count_translation="$(echo "${po_entries}" | grep -c -E '^msgstr "' || true)"
-		count_empty_source="$(echo "${po_entries}" | grep -c -E '^msgid ""' || true)"
-		count_empty_translation="$(echo "${po_entries}" | grep -c -E '^msgstr ""' || true)"
+		po_file="${name}/${lang}.po"
 
-		total_source="$((${count_source} - ${count_empty_source}))"
-		total_translation="$((${count_translation} - ${count_empty_translation}))"
+		if [ ! -f "${po_file}" ]
+		then
+			continue
+		fi
 
-		percentage="$((${total_translation} * 100 / ${total_source}))"
+		if [ "${main_percentage}" -lt 50 ]
+		then
+			state='ignored'
+		else
+			state='packaged'
+		fi
 
-		if [ "${percentage}" -lt 50 ]
+		compute_percentage "${name}" "${lang}"
+		print_percentage "${name}" "${lang}" "${state}"
+
+		if [ "${state}" = 'ignored' ]
 		then
 			printf 'ignore translation/%s\n' "${po_file}" >> "${action_file}"
 		fi
-
-		printf '%s/%s\t%+3s%%,\tsources: %s (%s-%s),\ttranslations: %-4s (%s-%s)\n' \
-			"${name}" "${lang}:" "${percentage}" \
-			"${total_source}" "${count_source}" "${count_empty_source}" \
-			"${total_translation}" "${count_translation}" "${count_empty_translation}"
 	done
 done | column -t -s $'\t' -o ' '

--- a/tools/translation/ignore_incomplete.sh
+++ b/tools/translation/ignore_incomplete.sh
@@ -24,14 +24,11 @@
 #
 # ===========================================================================
 
-set -u -e -o pipefail
-
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-repo_dir="$(realpath "${script_dir}/../..")"
-dpk_dir="${repo_dir}/pkg/unvanquished_src.dpkdir"
-pot_dir="${dpk_dir}/translation"
+. "${script_dir}/common.sh"
 
-. "${script_dir}/translation.conf"
+parse_args "${@}"
+set_paths
 
 action_file="${dpk_dir}/.urcheon/action/build.txt"
 action_list="$(grep -v -E '^ignore translation/' "${action_file}")"
@@ -39,8 +36,10 @@ echo "${action_list}" > "${action_file}"
 
 cd "${pot_dir}"
 
-for name in "${translations[@]}"
+for pot_file in $(find . -maxdepth 1 -type f -name '*.pot')
 do
+	name="$(basename "${pot_file}" .pot)"
+
 	for po_file in $(find "${name}" -name '*.po' | sort)
 	do
 		lang="$(echo "${po_file}" | cut -f2 -d'/' | cut -f1 -d'.')"

--- a/tools/translation/pot_printer.py
+++ b/tools/translation/pot_printer.py
@@ -35,7 +35,7 @@ def load(filename):
     file.close()
     return content
 
-def run(process):
+def run(process, load=load):
     parser = argparse.ArgumentParser()
     parser.add_argument("-s", action="store_true", help="sort strings")
     parser.add_argument("-d", action="store_true", help="print debug information")

--- a/tools/translation/translation.conf
+++ b/tools/translation/translation.conf
@@ -1,3 +1,3 @@
-# Implemented: game commands
+# Implemented: game commands data
 # Only a subset may be enabled.
 translations=('game')

--- a/tools/translation/update_po.sh
+++ b/tools/translation/update_po.sh
@@ -24,14 +24,11 @@
 #
 # ===========================================================================
 
-set -u -e -o pipefail
-
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-repo_dir="$(realpath "${script_dir}/../..")"
-dpk_dir="${repo_dir}/pkg/unvanquished_src.dpkdir"
-pot_dir="${dpk_dir}/translation"
+. "${script_dir}/common.sh"
 
-. "${script_dir}/translation.conf"
+parse_args "${@}"
+set_paths
 
 cd "${pot_dir}"
 


### PR DESCRIPTION
Create `data.pot` for map translatable strings

I added `generate_map_pot.py` and `generate_arena_pot.py` to extract translatable strings from `.map` and `.arena` files.

They are written in `data.pot`.

This requires Esquirel with this patch:

- https://github.com/DaemonEngine/Urcheon/pull/72

This also requires UnvanquishedAssets:

- https://github.com/UnvanquishedAssets/UnvanquishedAssets

The `generate.sh` tool only produces `game.pot` by default, because the data repository isn't known from this repository.

One can produce the `data.pot` this way, asking the `data` translation files to be generated explicitly, and passing the data path explicitly:

```sh
./generate.sh data --data-dir=~/Mapping/Unvanquished/UnvanquishedAssets
```