### PR TITLE
Improve translatable strings

### DIFF
--- a/pkg/unvanquished_src.dpkdir/configs/weapon/abuildupg.attr.cfg
+++ b/pkg/unvanquished_src.dpkdir/configs/weapon/abuildupg.attr.cfg
@@ -1,4 +1,4 @@
-humanName "Alien build weapon2"
+humanName "Alien build weapon"
 description "null"
 team aliens
 


### PR DESCRIPTION
The purpose is to make the strings easier to translate.

"Alien build weapon2" is obviously not meant to be translated, maybe it's not displayed (the description for this is even `null`), but we better have it right. It doesn't have to be different with non-advanced granger.