### PR TITLE
ui: make the the evo price string translatable

### DIFF
--- a/pkg/unvanquished_src.dpkdir/ui/alien_evo.rml
+++ b/pkg/unvanquished_src.dpkdir/ui/alien_evo.rml
@@ -144,10 +144,7 @@
 <div class="circlemenu-circle" id="evolveMenu"/>
 <div class="infobox">
 <h2 id="e_name"></h2>
-<p class="text">
-<!--Price: -->
-<!-- FIXME: We may want to include <span id="e_price"/> in the translatable string, maybe with a specific markup to make it easy. -->
-<span id="e_price"/>&nbsp;<translate>morph points</translate>
+<p class="text"><translate>Price:</translate>&nbsp;<span id="e_price"/>&nbsp;<translate>morph points</translate>
 <br /><span id="e_desc"/></p>
 </div>
 </panel>

--- a/src/cgame/cg_rocket_datasource.cpp
+++ b/src/cgame/cg_rocket_datasource.cpp
@@ -1368,7 +1368,7 @@ static void CG_Rocket_BuildAlienEvolveList( const char *table )
 			Info_SetValueForKey( buf, "icon", BG_Class( i )->icon, false );
 			Info_SetValueForKey( buf, "cmdName", BG_Class( i )->name, false );
 			if (price >= 0.0f) {
-				Info_SetValueForKey( buf, "price", va( "Price: %.1f", price / CREDITS_PER_EVO ), false );
+				Info_SetValueForKey( buf, "price", va( "%.1f", price / CREDITS_PER_EVO ), false );
 			}
 			else
 			{


### PR DESCRIPTION
Make the the evo price string translatable.

Other build menu files are crafted this way.

The `Price:` string is already translated, just not used there.