### PR TITLE
Tell daemon cmake to pass CBSE_PYTHON_PATH to the NaCl cmake subinvocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,7 @@ endif()
 
 if (BUILD_SGAME)
     include(tools/cbse/CBSE.cmake)
+	list(APPEND GAME_NACL_VM_INHERITED_OPTIONS "CBSE_PYTHON_PATH")
 
     # Avoid generating CBSE in the NaCl subproject.
     if (FORK EQUAL 2)


### PR DESCRIPTION
Tell daemon cmake to pass `CBSE_PYTHON_PATH` to the NaCl cmake subinvocation.

The branch names ends with `/sync` because there is an engine counterpart:

- https://github.com/DaemonEngine/Daemon/pull/1991

But since the feature is already broken, we can merge this in any order. This will start to work once it's merged on both side, but merging only on one side whatever the side will not add more breakage.